### PR TITLE
Add PR template to .github directory

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+### Summary
+<!---
+  Please try to cover the following questions in your summary:
+  1. Describe the product (or technical) problem you are solving.
+  2. Explain the engineering solution you have chosen.
+  3. Discuss the implementation choices/tradeoffs you have made.
+-->
+
+### Related Issue
+Closes #<issue-number>
+
+### Tests & Checks
+<!---
+  How did you validate that your changes were implemented correctly?
+  
+  Please think about the following prompts:
+  1. I wrote automated tests.
+  2. I manually tested my changes, and here's what I did:
+-->


### PR DESCRIPTION
### Summary
This adds a PR template to the `.github` directory, which should automatically picked up according to the GitHub docs: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository#adding-a-pull-request-template

The template was suggested by @shlomnissan : https://github.com/chanzuckerberg/imaging-active-learning/issues/9#issuecomment-2297310351

### Related Issue
Closes #9

### Tests & Checks
I cannot test this until it is merged to `main`. Will do so immediately after it is merged and will post a comment to this PR.