### PR TITLE
Add a shader program to the renderer

### DIFF
--- a/src/renderers/webgl_renderer.ts
+++ b/src/renderers/webgl_renderer.ts
@@ -1,9 +1,11 @@
 import { LayerManager } from "core/layer_manager";
 import { Renderer } from "core/renderer";
 import { Mesh } from "objects/renderable/mesh";
+import { WebGLShaders } from "./webgl_shaders";
 
 export class WebGLRenderer extends Renderer {
   private readonly gl_: WebGL2RenderingContext | null = null;
+  private readonly shaders_: WebGLShaders;
 
   constructor(selector: string, layers: LayerManager) {
     super(selector, layers);
@@ -13,6 +15,7 @@ export class WebGLRenderer extends Renderer {
       throw new Error(`Failed to initialize WebGL2 context`);
     }
     console.log(`WebGL version ${this.gl.getParameter(this.gl.VERSION)}`);
+    this.shaders_ = new WebGLShaders(this.gl_);
     this.gl.viewport(0, 0, this.width, this.height);
   }
 

--- a/src/renderers/webgl_shaders.ts
+++ b/src/renderers/webgl_shaders.ts
@@ -1,23 +1,37 @@
+type ShaderMap = {
+  [type: number]: {
+    shader: WebGLShader;
+    source: string;
+  };
+};
+
+const regex = /^\s*uniform\s+(?:highp|mediump|lowp|)[\w\s]+\s+(\w+)\s*;\s*$/gm;
+
 export class WebGLShaders {
   private readonly gl_: WebGL2RenderingContext;
-  private readonly program_: WebGLProgram | null;
-  private readonly uniformRegex_ =
-    /^\s*uniform\s+(?:highp|mediump|lowp|)[\w\s]+\s+(\w+)\s*;\s*$/gm;
-
+  private readonly program_: WebGLProgram;
   private uniformLocations_: Map<string, WebGLUniformLocation>;
-  private shaderSources: string[] = [];
-  private shaderObjects: WebGLShader[] = [];
+  private shaders_: ShaderMap = {};
+  private linked_ = false;
 
   constructor(gl: WebGL2RenderingContext) {
     this.gl_ = gl;
-    this.program_ = gl.createProgram();
-    if (!this.program_) {
+    const program = gl.createProgram();
+    if (!program) {
       throw new Error(`Failed to create WebGL shader program`);
     }
+    this.program_ = program;
+
     this.uniformLocations_ = new Map<string, WebGLUniformLocation>();
   }
 
   public addShader(source: string, type: number) {
+    if (this.linked_) {
+      throw new Error(
+        "The program is already linked. Create a new shader program to add shaders."
+      );
+    }
+
     const shader = this.gl_.createShader(type);
     if (!shader) {
       throw new Error(`Failed to create a new shader of type ${type}`);
@@ -31,34 +45,39 @@ export class WebGLShaders {
       throw new Error(`Error compiling shader: ${message}`);
     }
 
-    this.gl_.attachShader(this.program, shader);
-    this.shaderSources.push(source);
-    this.shaderObjects.push(shader);
+    this.gl_.attachShader(this.program_, shader);
+    this.shaders_[type] = { shader: shader, source };
   }
 
   public link() {
-    this.gl_.linkProgram(this.program);
-    if (!this.gl_.getProgramParameter(this.program, this.gl_.LINK_STATUS)) {
-      this.deleteShaderObjects();
-      this.deleteProgram();
-      const message = this.gl_.getProgramInfoLog(this.program);
+    if (this.linked_) {
+      throw new Error("The program is already linked.");
+    }
+
+    this.gl_.linkProgram(this.program_);
+    if (!this.getParameter(this.gl_.LINK_STATUS)) {
+      this.deleteShaders();
+      const message = this.gl_.getProgramInfoLog(this.program_);
       throw new Error(`Error linking program: ${message}`);
     }
 
-    this.gl_.validateProgram(this.program);
-    if (!this.gl_.getProgramParameter(this.program, this.gl_.VALIDATE_STATUS)) {
-      this.deleteShaderObjects();
-      this.deleteProgram();
-      const message = this.gl_.getProgramInfoLog(this.program);
+    this.linked_ = true;
+
+    this.gl_.validateProgram(this.program_);
+    if (!this.getParameter(this.gl_.VALIDATE_STATUS)) {
+      this.deleteShaders();
+      const message = this.gl_.getProgramInfoLog(this.program_);
       throw new Error(`Error validating program: ${message}`);
     }
 
-    this.deleteShaderObjects();
-    this.shaderSources.forEach(s => this.preprocessUniformLocations(s));
+    for (const idx in this.shaders_) {
+      this.preprocessUniformLocations(this.shaders_[idx].source);
+    }
+    this.deleteShaders();
   }
 
   public use() {
-    this.gl_.useProgram(this.program);
+    this.gl_.useProgram(this.program_);
     const error = this.gl_.getError();
     if (error !== this.gl_.NO_ERROR) {
       throw new Error(`Error using WebGL program: ${error}`);
@@ -69,7 +88,7 @@ export class WebGLShaders {
     // Preprocessing uniform locations doesn’t work for all use cases, so we
     // can’t assume all uniform locations are cached on initialization.
     if (!this.uniformLocations_.has(name)) {
-      const location = this.gl_.getUniformLocation(this.program, name);
+      const location = this.gl_.getUniformLocation(this.program_, name);
       if (location) {
         this.uniformLocations_.set(name, location);
       } else {
@@ -81,29 +100,23 @@ export class WebGLShaders {
 
   private preprocessUniformLocations(source: string) {
     let match;
-    while ((match = this.uniformRegex_.exec(source)) !== null) {
+    while ((match = regex.exec(source)) !== null) {
       const name = match[1];
-      const location = this.gl_.getUniformLocation(this.program, name);
+      const location = this.gl_.getUniformLocation(this.program_, name);
       if (location) {
         this.uniformLocations_.set(name, location);
       }
     }
   }
 
-  private deleteShaderObjects() {
-    if (this.shaderObjects.length) {
-      this.shaderObjects.forEach((s) => this.gl_.deleteShader(s));
-    }
+  private getParameter(parameter: number) {
+    return this.gl_.getProgramParameter(this.program_, parameter);
   }
 
-  private deleteProgram() {
-    this.gl_.deleteProgram(this.program);
-  }
-
-  private get program() {
-    if (!this.program_) {
-      throw new Error(`WebGL program is not initialized or has been deleted`);
+  private deleteShaders() {
+    for (const idx in this.shaders_) {
+      this.gl_.deleteShader(this.shaders_[idx].shader);
     }
-    return this.program_;
+    this.shaders_ = {};
   }
 }

--- a/src/renderers/webgl_shaders.ts
+++ b/src/renderers/webgl_shaders.ts
@@ -1,0 +1,109 @@
+export class WebGLShaders {
+  private readonly gl_: WebGL2RenderingContext;
+  private readonly program_: WebGLProgram | null;
+  private readonly uniformRegex_ =
+    /^\s*uniform\s+(?:highp|mediump|lowp|)[\w\s]+\s+(\w+)\s*;\s*$/gm;
+
+  private uniformLocations_: Map<string, WebGLUniformLocation>;
+  private shaderSources: string[] = [];
+  private shaderObjects: WebGLShader[] = [];
+
+  constructor(gl: WebGL2RenderingContext) {
+    this.gl_ = gl;
+    this.program_ = gl.createProgram();
+    if (!this.program_) {
+      throw new Error(`Failed to create WebGL shader program`);
+    }
+    this.uniformLocations_ = new Map<string, WebGLUniformLocation>();
+  }
+
+  public addShader(source: string, type: number) {
+    const shader = this.gl_.createShader(type);
+    if (!shader) {
+      throw new Error(`Failed to create a new shader of type ${type}`);
+    }
+
+    this.gl_.shaderSource(shader, source);
+    this.gl_.compileShader(shader);
+    if (!this.gl_.getShaderParameter(shader, this.gl_.COMPILE_STATUS)) {
+      const message = this.gl_.getShaderInfoLog(shader);
+      this.gl_.deleteShader(shader);
+      throw new Error(`Error compiling shader: ${message}`);
+    }
+
+    this.gl_.attachShader(this.program, shader);
+    this.shaderSources.push(source);
+    this.shaderObjects.push(shader);
+  }
+
+  public link() {
+    this.gl_.linkProgram(this.program);
+    if (!this.gl_.getProgramParameter(this.program, this.gl_.LINK_STATUS)) {
+      this.deleteShaderObjects();
+      this.deleteProgram();
+      const message = this.gl_.getProgramInfoLog(this.program);
+      throw new Error(`Error linking program: ${message}`);
+    }
+
+    this.gl_.validateProgram(this.program);
+    if (!this.gl_.getProgramParameter(this.program, this.gl_.VALIDATE_STATUS)) {
+      this.deleteShaderObjects();
+      this.deleteProgram();
+      const message = this.gl_.getProgramInfoLog(this.program);
+      throw new Error(`Error validating program: ${message}`);
+    }
+
+    this.deleteShaderObjects();
+    this.shaderSources.forEach(s => this.preprocessUniformLocations(s));
+  }
+
+  public use() {
+    this.gl_.useProgram(this.program);
+    const error = this.gl_.getError();
+    if (error !== this.gl_.NO_ERROR) {
+      throw new Error(`Error using WebGL program: ${error}`);
+    }
+  }
+
+  public getUniformLoc(name: string) {
+    // Preprocessing uniform locations doesn’t work for all use cases, so we
+    // can’t assume all uniform locations are cached on initialization.
+    if (!this.uniformLocations_.has(name)) {
+      const location = this.gl_.getUniformLocation(this.program, name);
+      if (location) {
+        this.uniformLocations_.set(name, location);
+      } else {
+        throw new Error(`Uniform ${name} not found in shader program`);
+      }
+    }
+    return this.uniformLocations_.get(name)!;
+  }
+
+  private preprocessUniformLocations(source: string) {
+    let match;
+    while ((match = this.uniformRegex_.exec(source)) !== null) {
+      const name = match[1];
+      const location = this.gl_.getUniformLocation(this.program, name);
+      if (location) {
+        this.uniformLocations_.set(name, location);
+      }
+    }
+  }
+
+  private deleteShaderObjects() {
+    if (this.shaderObjects.length) {
+      this.shaderObjects.forEach((s) => this.gl_.deleteShader(s));
+    }
+  }
+
+  private deleteProgram() {
+    this.gl_.deleteProgram(this.program);
+  }
+
+  private get program() {
+    if (!this.program_) {
+      throw new Error(`WebGL program is not initialized or has been deleted`);
+    }
+    return this.program_;
+  }
+}


### PR DESCRIPTION
### Summary

This PR adds a simple shader program to the WebGL renderer. It applies basic
caching by preloading uniform locations when the program is linked and again
on subsequent calls to `gl.getUniformLocation`, which may be necessary if the
uniform is a struct, for example.

### Related Issue

Another component related to https://github.com/chanzuckerberg/imaging-active-learning/issues/4 which is still WIP.

### API
```ts
program = new ShaderProgram(gl);
program.addShader(vertexShaderSrc, gl.VERTEX_SHADER);
program.addShader(fragmentShaderSrc, gl.FRAGMENT_SHADER);
program.link();

// 

program.use();
```

### Tests & Checks

This class offers a more flexible interface than the one in the [webgl-starter repo](https://github.com/shlomnissan/webgl-starter/tree/main). To test it, I integrated it into the webgl-starter repo to ensure everything works. Now that we have a PR for testing, it's worth considering mocking the gl context. I will write tests for this class in a future PR.