### PR TITLE
Add a temporary mesh source

### DIFF
--- a/src/core/renderer.ts
+++ b/src/core/renderer.ts
@@ -39,9 +39,12 @@ export abstract class Renderer {
     this.clear();
     this.layerManager_.layers.forEach((layer) => {
       layer.objects.forEach((obj) => {
+        // Before sending the object to the renderer backend, we must verify
+        // its visibility by checking its render state and location relative
+        // to the view frustum.
         switch (obj.type) {
           case "Mesh":
-            this.renderMesh(obj);
+            this.renderMesh(obj as Mesh);
             break;
           default:
             throw new Error(`Unknown renderable object "${obj.type}"`);

--- a/src/data/mesh_source.ts
+++ b/src/data/mesh_source.ts
@@ -29,7 +29,7 @@ type MeshSourceAttributeType = "vertices" | "normals" | "uvs";
 
 export class MeshSource {
   private attributes_: Map<MeshSourceAttributeType, MeshSourceAttribute>;
-  private index_: Float32Array | null = null;
+  private index_: Uint32Array | null = null;
 
   constructor() {
     this.attributes_ = new Map<MeshSourceAttributeType, MeshSourceAttribute>();
@@ -51,10 +51,10 @@ export class MeshSource {
   }
 
   public setIndex(data: number[]) {
-    this.index_ = new Float32Array(data);
+    this.index_ = new Uint32Array(data);
   }
 
-  public getIndex(): Readonly<Float32Array> | null {
+  public getIndex(): Readonly<Uint32Array> | null {
     return this.index_;
   }
 }

--- a/src/data/mesh_source.ts
+++ b/src/data/mesh_source.ts
@@ -1,0 +1,60 @@
+/*
+  This class is temporary. Data source classes will likely be observable proxy
+  objects that hold references to data. A mesh can be loaded from various file
+  types. File loaders (such as zarr or obj) are responsible for loading the
+  necessary data (possibly using a chunk manager) and returning a data source
+  type. This data source is then used to initialize renderable objects (like
+  Mesh or Volume). While renderable objects may request more data through the
+  data source, a loader or chunk manager will be responsible for providing this
+  data. As we're actively exploring this area, I anticipate more clarity in the
+  coming weeks.
+*/
+
+class MeshSourceAttribute {
+  private data_: Float32Array;
+
+  public itemSize: number;
+
+  constructor(data: number[], itemSize: number) {
+    this.data_ = new Float32Array(data);
+    this.itemSize = itemSize;
+  }
+
+  get data(): Readonly<Float32Array> {
+    return this.data_;
+  }
+}
+
+type MeshSourceAttributeType = "vertices" | "normals" | "uvs";
+
+export class MeshSource {
+  private attributes_: Map<MeshSourceAttributeType, MeshSourceAttribute>;
+  private index_: Float32Array | null = null;
+
+  constructor() {
+    this.attributes_ = new Map<MeshSourceAttributeType, MeshSourceAttribute>();
+  }
+
+  public setAttribute(
+    type: MeshSourceAttributeType,
+    data: number[],
+    itemSize: number
+  ) {
+    this.attributes_.set(type, new MeshSourceAttribute(data, itemSize));
+  }
+
+  public getAttribute(type: MeshSourceAttributeType) {
+    if (!this.attributes_.has(type)) {
+      throw Error(`Attribute ${type} was not set`);
+    }
+    return this.attributes_.get(type)!;
+  }
+
+  public setIndex(data: number[]) {
+    this.index_ = new Float32Array(data);
+  }
+
+  public getIndex(): Readonly<Float32Array> | null {
+    return this.index_;
+  }
+}

--- a/src/layers/single_mesh_layer.ts
+++ b/src/layers/single_mesh_layer.ts
@@ -1,11 +1,13 @@
 import { Layer } from "core/layer";
 import { Mesh } from "objects/renderable/mesh";
+import { PlaneGeometry } from "objects/geometry/plane_geometry";
 
 export class SingleMeshLayer extends Layer {
   constructor() {
     super();
 
-    const mesh = new Mesh();
+    const plane = new PlaneGeometry(5, 5, 1, 1);
+    const mesh = new Mesh(plane.meshSource);
     this.addObject(mesh);
   }
 }

--- a/src/objects/geometry/plane_geometry.ts
+++ b/src/objects/geometry/plane_geometry.ts
@@ -1,10 +1,10 @@
 import { MeshSource } from "data/mesh_source";
 
 export class PlaneGeometry {
-  private vertices: number[] = [];
-  private indices: number[] = [];
-  private normals: number[] = [];
-  private uvs: number[] = [];
+  private vertices_: number[] = [];
+  private indices_: number[] = [];
+  private normals_: number[] = [];
+  private uvs_: number[] = [];
   private meshSource_: MeshSource | null = null;
 
   constructor(
@@ -29,9 +29,9 @@ export class PlaneGeometry {
         const u = ix / gridX;
         const v = 1 - iy / gridY;
 
-        this.vertices.push(x, -y, 0);
-        this.normals.push(0, 1, 0);
-        this.uvs.push(u, v);
+        this.vertices_.push(x, -y, 0);
+        this.normals_.push(0, 1, 0);
+        this.uvs_.push(u, v);
       }
     }
 
@@ -42,8 +42,8 @@ export class PlaneGeometry {
         const c = ix + 1 + gridX1 * (iy + 1);
         const d = ix + 1 + gridX1 * iy;
 
-        this.indices.push(a, b, d);
-        this.indices.push(b, c, d);
+        this.indices_.push(a, b, d);
+        this.indices_.push(b, c, d);
       }
     }
   }
@@ -51,10 +51,10 @@ export class PlaneGeometry {
   public get meshSource() {
     if (!this.meshSource_) {
       this.meshSource_ = new MeshSource();
-      this.meshSource_.setAttribute("vertices", this.vertices, 3);
-      this.meshSource_.setAttribute("normals", this.normals, 3);
-      this.meshSource_.setAttribute("uvs", this.uvs, 2);
-      this.meshSource_.setIndex(this.indices);
+      this.meshSource_.setAttribute("vertices", this.vertices_, 3);
+      this.meshSource_.setAttribute("normals", this.normals_, 3);
+      this.meshSource_.setAttribute("uvs", this.uvs_, 2);
+      this.meshSource_.setIndex(this.indices_);
     }
     return this.meshSource_;
   }

--- a/src/objects/geometry/plane_geometry.ts
+++ b/src/objects/geometry/plane_geometry.ts
@@ -1,0 +1,61 @@
+import { MeshSource } from "data/mesh_source";
+
+export class PlaneGeometry {
+  private vertices: number[] = [];
+  private indices: number[] = [];
+  private normals: number[] = [];
+  private uvs: number[] = [];
+  private meshSource_: MeshSource | null = null;
+
+  constructor(
+    width: number,
+    height: number,
+    widthSegments: number,
+    heightSegments: number
+  ) {
+    const halfWidth = width / 2;
+    const halfHeight = height / 2;
+    const gridX = widthSegments;
+    const gridY = heightSegments;
+    const gridX1 = gridX + 1;
+    const gridY1 = gridY + 1;
+    const segmentW = width / gridX;
+    const segmentH = height / gridY;
+
+    for (let iy = 0; iy < gridY1; ++iy) {
+      const y = iy * segmentH - halfHeight;
+      for (let ix = 0; ix < gridX1; ++ix) {
+        const x = ix * segmentW - halfWidth;
+        const u = ix / gridX;
+        const v = 1 - iy / gridY;
+
+        this.vertices.push(x, -y, 0);
+        this.normals.push(0, 1, 0);
+        this.uvs.push(u, v);
+      }
+    }
+
+    for (let iy = 0; iy < gridY; ++iy) {
+      for (let ix = 0; ix < gridX; ++ix) {
+        const a = ix + gridX1 * iy;
+        const b = ix + gridX1 * (iy + 1);
+        const c = ix + 1 + gridX1 * (iy + 1);
+        const d = ix + 1 + gridX1 * iy;
+
+        this.indices.push(a, b, d);
+        this.indices.push(b, c, d);
+      }
+    }
+  }
+
+  public get meshSource() {
+    if (!this.meshSource_) {
+      this.meshSource_ = new MeshSource();
+      this.meshSource_.setAttribute("vertices", this.vertices, 3);
+      this.meshSource_.setAttribute("normals", this.normals, 3);
+      this.meshSource_.setAttribute("uvs", this.uvs, 2);
+      this.meshSource_.setIndex(this.indices);
+    }
+    return this.meshSource_;
+  }
+}

--- a/src/objects/renderable/mesh.ts
+++ b/src/objects/renderable/mesh.ts
@@ -1,7 +1,39 @@
+import { MeshSource } from "@/data/mesh_source";
 import { RenderableObject } from "core/renderable_object";
 
 export class Mesh extends RenderableObject {
+  private source_: MeshSource;
+
+  constructor(source: MeshSource) {
+    super();
+    this.source_ = source;
+  }
+
   public get type() {
     return "Mesh";
+  }
+
+  /*
+    The concept here is to decouple data sources from the renderer. Renderable
+    objects should expose data and configuration to the renderer through
+    accessor methods. This approach feels like a lot of boilerplate, and its
+    long-term stability and necessity are uncertain. For now, I'm treating
+    renderable objects and data sources as temporary components until we gain
+    more insight into efficient data loading patterns (such as chunking).
+  */
+  public get vertices() {
+    return this.source_.getAttribute("vertices");
+  }
+
+  public get normals() {
+    return this.source_.getAttribute("normals");
+  }
+
+  public get uvs() {
+    return this.source_.getAttribute("uvs");
+  }
+
+  public get index() {
+    return this.source_.getIndex();
   }
 }


### PR DESCRIPTION
### Summary

This PR adds a plane geometry generator that outputs a temporary data source
(`MeshSource`). The intention is to generate geometry in the mesh layer and make
it available to the renderer. I consider these changes entirely exploratory and
expect most of this code to change once we learn more about efficient data
fetching patterns. The goal of adding this component is to enable rendering of
a single mesh layer.

### Related Issue

Another component related to https://github.com/chanzuckerberg/imaging-active-learning/issues/4 which is still WIP.

### Tests & Checks

I manually tested this code, verifying that the renderer can access the mesh data without errors. However, I didn't add unit tests, as I consider these components temporary and didn't feel it would be beneficial.
