### PR TITLE
Ensure private properties end with an underscore

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -8,8 +8,17 @@ export default [
   pluginJs.configs.recommended,
   ...tseslint.configs.recommended,
   {rules: {
-    '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
     'no-duplicate-imports': 'error',
+    '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+    '@typescript-eslint/naming-convention': [
+      'error',
+      {
+        "selector": "classProperty",
+        "modifiers": ["private"],
+        "format": null,
+        "suffix": ["_"]
+      }
+    ]
   }},
   {ignores: ["node_modules", "dist", "coverage"]},
 ];


### PR DESCRIPTION
### Summary

This PR introduces an ESLint rule requiring private class members to end with
an underscore.

### Context

I'm adding this for consistency. While I don't feel strongly about it, the way accessor methods work in TypeScript makes this pattern sensible to me. To clarify, I don't believe every class property needs accessor methods—a public property is perfectly fine in some cases.

### Related Issue

I already closed this issue for some reason.

### Tests & Checks

I manually tested this by removing trailing underscores from private class members and confirming that the linter raises an error.