### PR TITLE
Create shader programs and refactor

### DIFF
--- a/src/renderers/shaders/index.ts
+++ b/src/renderers/shaders/index.ts
@@ -1,0 +1,11 @@
+import meshVertexShader from "./mesh_vert.glsl";
+import meshFragmentShader from "./mesh_frag.glsl";
+
+export type Shader = "mesh";
+
+export const shaderCode = {
+  mesh: {
+    vertex: meshVertexShader,
+    fragment: meshFragmentShader,
+  },
+};

--- a/src/renderers/shaders/mesh_frag.glsl
+++ b/src/renderers/shaders/mesh_frag.glsl
@@ -1,0 +1,9 @@
+#version 300 es
+
+precision mediump float;
+
+layout (location = 0) out vec4 fragColor;
+
+void main() {
+    fragColor = vec4(1.0, 1.0, 1.0, 1.0);
+}

--- a/src/renderers/shaders/mesh_vert.glsl
+++ b/src/renderers/shaders/mesh_vert.glsl
@@ -1,0 +1,12 @@
+#version 300 es
+
+layout (location = 0) in vec3 inPosition;
+layout (location = 1) in vec3 inNormal;
+layout (location = 2) in vec2 inUV;
+
+uniform mat4 Projection;
+uniform mat4 ModelView;
+
+void main() {
+    gl_Position = Projection * ModelView * vec4(inPosition, 1.0);
+}

--- a/src/renderers/webgl_renderer.ts
+++ b/src/renderers/webgl_renderer.ts
@@ -1,12 +1,13 @@
 import { LayerManager } from "core/layer_manager";
 import { Renderer } from "core/renderer";
 import { Mesh } from "objects/renderable/mesh";
-import { WebGLShaders } from "./webgl_shaders";
+import { WebGLShaderProgram } from "./webgl_shader_program";
+
+import { Shader, shaderCode } from "./shaders";
 
 export class WebGLRenderer extends Renderer {
   private readonly gl_: WebGL2RenderingContext | null = null;
-  // @ts-expect-error TODO: use of shaders_ is not yet implemented
-  private readonly shaders_: WebGLShaders;
+  private readonly shaders_: Map<Shader, WebGLShaderProgram>;
 
   constructor(selector: string, layers: LayerManager) {
     super(selector, layers);
@@ -16,11 +17,14 @@ export class WebGLRenderer extends Renderer {
       throw new Error(`Failed to initialize WebGL2 context`);
     }
     console.log(`WebGL version ${this.gl.getParameter(this.gl.VERSION)}`);
-    this.shaders_ = new WebGLShaders(this.gl_);
+    this.shaders_ = new Map<Shader, WebGLShaderProgram>();
     this.gl.viewport(0, 0, this.width, this.height);
   }
 
   protected renderMesh(_: Mesh) {
+    this.getShaderProgram("mesh").use();
+    // TODO: set uniforms
+    // TODO: instantiate webgl_mesh_storage (if needed)
     // TODO: render mesh
   }
 
@@ -31,6 +35,20 @@ export class WebGLRenderer extends Renderer {
   protected clear() {
     this.gl.clearColor(0.12, 0.13, 0.25, 1.0);
     this.gl.clear(this.gl.COLOR_BUFFER_BIT);
+  }
+
+  private getShaderProgram(type: Shader) {
+    if (!this.shaders_.has(type)) {
+      this.shaders_.set(
+        type,
+        new WebGLShaderProgram(
+          this.gl,
+          shaderCode[type].vertex,
+          shaderCode[type].fragment
+        )
+      );
+    }
+    return this.shaders_.get(type)!;
   }
 
   private get gl() {

--- a/src/renderers/webgl_shader_program.ts
+++ b/src/renderers/webgl_shader_program.ts
@@ -7,81 +7,28 @@ type ShaderMap = {
 
 const regex = /^\s*uniform\s+(?:highp|mediump|lowp|)[\w\s]+\s+(\w+)\s*;\s*$/gm;
 
-export class WebGLShaders {
+export class WebGLShaderProgram {
   private readonly gl_: WebGL2RenderingContext;
   private readonly program_: WebGLProgram;
   private uniformLocations_: Map<string, WebGLUniformLocation>;
   private shaders_: ShaderMap = {};
-  private linked_ = false;
 
-  constructor(gl: WebGL2RenderingContext) {
+  constructor(
+    gl: WebGL2RenderingContext,
+    vertexShaderSource: string,
+    fragmentShaderSource: string
+  ) {
     this.gl_ = gl;
     const program = gl.createProgram();
     if (!program) {
       throw new Error(`Failed to create WebGL shader program`);
     }
     this.program_ = program;
-
     this.uniformLocations_ = new Map<string, WebGLUniformLocation>();
-  }
 
-  public addShader(source: string, type: number) {
-    if (this.linked_) {
-      throw new Error(
-        "The program is already linked. Create a new shader program to add shaders."
-      );
-    }
-
-    const shader = this.gl_.createShader(type);
-    if (!shader) {
-      throw new Error(`Failed to create a new shader of type ${type}`);
-    }
-
-    this.gl_.shaderSource(shader, source);
-    this.gl_.compileShader(shader);
-    if (!this.gl_.getShaderParameter(shader, this.gl_.COMPILE_STATUS)) {
-      const message = this.gl_.getShaderInfoLog(shader);
-      this.gl_.deleteShader(shader);
-      throw new Error(`Error compiling shader: ${message}`);
-    }
-
-    this.gl_.attachShader(this.program_, shader);
-    this.shaders_[type] = { shader: shader, source };
-  }
-
-  public link() {
-    if (this.linked_) {
-      throw new Error("The program is already linked.");
-    }
-
-    this.gl_.linkProgram(this.program_);
-    if (!this.getParameter(this.gl_.LINK_STATUS)) {
-      this.deleteShaders();
-      const message = this.gl_.getProgramInfoLog(this.program_);
-      throw new Error(`Error linking program: ${message}`);
-    }
-
-    this.linked_ = true;
-
-    this.gl_.validateProgram(this.program_);
-    if (!this.getParameter(this.gl_.VALIDATE_STATUS)) {
-      this.deleteShaders();
-      const message = this.gl_.getProgramInfoLog(this.program_);
-      throw new Error(`Error validating program: ${message}`);
-    }
-
-    for (const idx in this.shaders_) {
-      this.preprocessUniformLocations(this.shaders_[idx].source);
-    }
-    this.deleteShaders();
-  }
-
-  public use() {
-    this.gl_.useProgram(this.program_);
-    const error = this.gl_.getError();
-    if (error !== this.gl_.NO_ERROR) {
-      throw new Error(`Error using WebGL program: ${error}`);
-    }
+    this.addShader(vertexShaderSource, gl.VERTEX_SHADER);
+    this.addShader(fragmentShaderSource, gl.FRAGMENT_SHADER);
+    this.link();
   }
 
   public getUniformLoc(name: string) {
@@ -106,6 +53,53 @@ export class WebGLShaders {
       if (location) {
         this.uniformLocations_.set(name, location);
       }
+    }
+  }
+
+  private addShader(source: string, type: number) {
+    const shader = this.gl_.createShader(type);
+    if (!shader) {
+      throw new Error(`Failed to create a new shader of type ${type}`);
+    }
+
+    this.gl_.shaderSource(shader, source);
+    this.gl_.compileShader(shader);
+    if (!this.gl_.getShaderParameter(shader, this.gl_.COMPILE_STATUS)) {
+      const message = this.gl_.getShaderInfoLog(shader);
+      this.gl_.deleteShader(shader);
+      throw new Error(`Error compiling shader: ${message}`);
+    }
+
+    this.gl_.attachShader(this.program_, shader);
+    this.shaders_[type] = { shader: shader, source };
+  }
+
+  private link() {
+    this.gl_.linkProgram(this.program_);
+    if (!this.getParameter(this.gl_.LINK_STATUS)) {
+      this.deleteShaders();
+      const message = this.gl_.getProgramInfoLog(this.program_);
+      throw new Error(`Error linking program: ${message}`);
+    }
+
+    this.gl_.validateProgram(this.program_);
+    if (!this.getParameter(this.gl_.VALIDATE_STATUS)) {
+      this.deleteShaders();
+      const message = this.gl_.getProgramInfoLog(this.program_);
+      throw new Error(`Error validating program: ${message}`);
+    }
+
+    for (const idx in this.shaders_) {
+      this.preprocessUniformLocations(this.shaders_[idx].source);
+    }
+    this.deleteShaders();
+  }
+
+  public use() {
+    this.gl_.useProgram(this.program_);
+    const error = this.gl_.getError();
+    if (error !== this.gl_.NO_ERROR) {
+      throw new Error(`Error using WebGL program: ${error}`);
     }
   }
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,6 +2,7 @@
 import { defineConfig } from 'vite';
 import tsconfigPaths from 'vite-tsconfig-paths';
 import eslint from 'vite-plugin-eslint';
+import glsl from 'vite-plugin-glsl';
 import path from 'path';
 
 // __dirname is not available in ES6 modules
@@ -10,7 +11,7 @@ import { dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 const _dirname = dirname(fileURLToPath(import.meta.url));
 
-const plugins = [tsconfigPaths(), eslint()];
+const plugins = [tsconfigPaths(), eslint(), glsl()];
 
 export default defineConfig(({ mode }) => {
   return {


### PR DESCRIPTION
### Summary

This PR refactors the shader program class. It renames `WebGLShaders` to
`WebGLShaderProgram` and simplifies the API -- instead of adding shaders and
linking the program separately, you now supply the vertex and fragment source
codes to the constructor, and the program links automatically.
Additionally, this PR initializes the Vite GLSL plugin and creates a sample
shader program for meshes.

### Related Issue

Another component related to https://github.com/chanzuckerberg/imaging-active-learning/issues/4 which is still WIP.

### Tests & Checks

I manually tested this change, verifying that no errors occurred and confirming the shader program's validity.