### PR TITLE
ProjectedLine fixes

### DIFF
--- a/src/objects/geometry/projected_line_geometry.ts
+++ b/src/objects/geometry/projected_line_geometry.ts
@@ -45,12 +45,12 @@ export class ProjectedLineGoemetry extends Geometry {
         vertices[c++] = current[1];
         vertices[c++] = current[2];
 
-        const previous = path[i - 1] || path[i];
+        const previous = path[i - 1] ?? path[i];
         vertices[c++] = previous[0];
         vertices[c++] = previous[1];
         vertices[c++] = previous[2];
 
-        const next = path[i + 1] || path[i];
+        const next = path[i + 1] ?? path[i];
         vertices[c++] = next[0];
         vertices[c++] = next[1];
         vertices[c++] = next[2];

--- a/src/renderers/shaders/projected_line_vert.glsl
+++ b/src/renderers/shaders/projected_line_vert.glsl
@@ -22,13 +22,12 @@ void main() {
     vec2 prevScreen = (prevPos.xy / prevPos.w) * aspectVec;
     vec2 currScreen = (currPos.xy / currPos.w) * aspectVec;
     vec2 nextScreen = (nextPos.xy / nextPos.w) * aspectVec;
-    float currZ = currPos.z / currPos.w;
 
     vec2 diff;
-    if (prevScreen == currScreen) {
+    if (prevPos == currPos) {
         // first point on the path
         diff = nextScreen - currScreen;
-    } else if (nextScreen == currScreen) {
+    } else if (nextPos == currPos) {
         // last point on the path
         diff = currScreen - prevScreen;
     } else {
@@ -43,9 +42,9 @@ void main() {
     vec2 normal = normalize(vec2(-diff.y, diff.x));
 
     vec4 offset = vec4(
-        normal * direction * LineWidth / 2.0 / aspectVec.xy,
-        currZ,
-        1.0
+        normal * direction * LineWidth / 2.0 / aspectVec,
+        0.0,
+        0.0
     );
     gl_Position = currPos + offset;
 

--- a/src/renderers/webgl_buffers.ts
+++ b/src/renderers/webgl_buffers.ts
@@ -56,8 +56,8 @@ export class WebGLBuffers {
       if (attr.type === "position") idx = 0;
       if (attr.type === "normal") idx = 1;
       if (attr.type === "uv") idx = 2;
-      if (attr.type == "next_position") idx = 3;
-      if (attr.type == "previous_position") idx = 4;
+      if (attr.type == "previous_position") idx = 3;
+      if (attr.type == "next_position") idx = 4;
       if (attr.type == "direction") idx = 5;
 
       this.gl_.vertexAttribPointer(


### PR DESCRIPTION
### Summary
In developing #71 I encountered a problem with the `ProjectedLine` renderable object. The width of a line from `[-1, 0, 0]` to `[1, 0, 0]` did not match that of a unit-square (plane).

The problem here was the `offset` in the shader having a homogeneous component of 1.0. This would cause the line to shrink in screen space. Removing this also made `currZ` unnecessary - this makes sense to me as we only want to offset in `x` and/or `y` in screen space.

The other fix here is that the attribute locations for previous/next positions were reversed. This didn't make much of a difference except perhaps at the very endpoints of a line.

Finally - I think my pattern of `const previous = path[i - 1] || path[i];` should instead be `const previous = path[i - 1] ?? path[i];` because I was intending this to check for nullish values, non falsey ones.

### Related Issue
N/A

### Tests & Checks
Tested manually by drawing horizontal and vertical lines on a unit-square plane with an orthographic camera
