### PR TITLE
Add Layer.transform property and additional AffineTransform features

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -34,6 +34,7 @@
       </li>
       <li><a href="/single_mesh_layer/index.html">Single Mesh Layer</a></li>
       <li><a href="/projected_lines/index.html">Projected Lines</a></li>
+      <li><a href="/layer_transform/index.html">Layer Transform</a></li>
     </ul>
   </body>
 </html>

--- a/examples/layer_transform/index.html
+++ b/examples/layer_transform/index.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Web Viewer</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        display: flex;
+        width: 100%;
+        height: 100%;
+      }
+      canvas {
+        width: 100%;
+        height: 100%;
+      }
+    </style>
+  </head>
+  <body>
+    <canvas id="canvas"></canvas>
+    <script type="module" src="./main.ts"></script>
+  </body>
+</html>

--- a/examples/layer_transform/main.ts
+++ b/examples/layer_transform/main.ts
@@ -8,30 +8,52 @@ import {
 
 const layersManager = new LayerManager();
 
-const helixA = generateHelix({
-  radius: 1.0,
-  turns: 3.0,
-  pointsPerTurn: 100,
-  pitch: 1.5,
-  phase: 0.0,
-});
-
-const helixB = generateHelix({
-  radius: 1.0,
-  turns: 3.0,
-  pointsPerTurn: 100,
-  pitch: 1.5,
-  phase: 90.0,
-});
-
+const movingLayer = new ProjectedLineLayer([
+  {
+    path: [
+      [-1, 0, -5],
+      [0, -1, -5],
+      [1, 0, -5],
+      [0, 1, -5],
+      [-1, 0, -5],
+    ],
+    color: [0.7, 0.7, 0.0],
+    width: 0.1,
+  },
+]);
 const stationaryLayer = new ProjectedLineLayer([
-  { path: helixA, color: [1.0, 0.7, 0.0], width: 0.1 },
+  {
+    path: [
+      [-1, 0, -5],
+      [1, 0, -5],
+    ],
+    color: [0.7, 0.0, 0.0],
+    width: 0.1,
+  },
+  {
+    path: [
+      [0, -1, -5],
+      [0, 1, -5],
+    ],
+    color: [0.0, 0.7, 0.0],
+    width: 0.1,
+  },
+  {
+    path: [
+      [0, 0, -6],
+      [0, 0, -4],
+    ],
+    color: [0.0, 0.0, 0.7],
+    width: 0.1,
+  },
 ]);
-const transformedLayer = new ProjectedLineLayer([
-  { path: helixB, color: [0.0, 0.7, 0.0], width: 0.2 },
-]);
+stationaryLayer.transform.translate([0.0, 0.0, 5]);
+stationaryLayer.transform.rotate(
+  quat.fromEuler(quat.create(), 45.0, -45.0, 0.0)
+);
+stationaryLayer.transform.translate([0.0, 0.0, -5]);
 layersManager.add(stationaryLayer);
-layersManager.add(transformedLayer);
+layersManager.add(movingLayer);
 
 const renderer = new WebGLRenderer("#canvas");
 const camera = new PerspectiveCamera(60, renderer.width / renderer.height);
@@ -39,35 +61,13 @@ const camera = new PerspectiveCamera(60, renderer.width / renderer.height);
 animate();
 
 const rotate = () => {
-  transformedLayer.transform.rotate(
-    quat.fromEuler(quat.create(), 0.0, 0.0, 0.2)
-  );
+  movingLayer.transform.translate([0.0, 0.0, 5]);
+  movingLayer.transform.rotate(quat.fromEuler(quat.create(), 0.1, 0.2, 0.5));
+  movingLayer.transform.translate([0.0, 0.0, -5]);
 };
 setInterval(rotate, 5);
 
 function animate() {
   renderer.render(layersManager, camera);
   requestAnimationFrame(animate);
-}
-
-function generateHelix(params: {
-  radius: number;
-  turns: number;
-  pointsPerTurn: number;
-  pitch: number;
-  phase: number;
-}) {
-  const { radius, turns, pointsPerTurn, pitch, phase } = params;
-  const phaseRad = (phase * Math.PI) / 180;
-  const path: [number, number, number][] = [];
-  const totalPoints = turns * pointsPerTurn;
-
-  for (let i = 0; i < totalPoints; i++) {
-    const angle = (i / pointsPerTurn) * 2 * Math.PI;
-    const z = radius * Math.cos(angle + phaseRad) - 5.0;
-    const y = (i / pointsPerTurn) * pitch - (pitch * turns) / 2;
-    const x = radius * Math.sin(angle + phaseRad);
-    path.push([x, y, z]);
-  }
-  return path;
 }

--- a/examples/layer_transform/main.ts
+++ b/examples/layer_transform/main.ts
@@ -1,0 +1,73 @@
+import { quat } from "gl-matrix";
+import {
+  LayerManager,
+  PerspectiveCamera,
+  ProjectedLineLayer,
+  WebGLRenderer,
+} from "@";
+
+const layersManager = new LayerManager();
+
+const helixA = generateHelix({
+  radius: 1.0,
+  turns: 3.0,
+  pointsPerTurn: 100,
+  pitch: 1.5,
+  phase: 0.0,
+});
+
+const helixB = generateHelix({
+  radius: 1.0,
+  turns: 3.0,
+  pointsPerTurn: 100,
+  pitch: 1.5,
+  phase: 90.0,
+});
+
+const stationaryLayer = new ProjectedLineLayer([
+  { path: helixA, color: [1.0, 0.7, 0.0], width: 0.1 },
+]);
+const transformedLayer = new ProjectedLineLayer([
+  { path: helixB, color: [0.0, 0.7, 0.0], width: 0.2 },
+]);
+layersManager.add(stationaryLayer);
+layersManager.add(transformedLayer);
+
+const renderer = new WebGLRenderer("#canvas");
+const camera = new PerspectiveCamera(60, renderer.width / renderer.height);
+
+animate();
+
+const rotate = () => {
+  transformedLayer.transform.rotate(
+    quat.fromEuler(quat.create(), 0.0, 0.0, 0.2)
+  );
+};
+setInterval(rotate, 5);
+
+function animate() {
+  renderer.render(layersManager, camera);
+  requestAnimationFrame(animate);
+}
+
+function generateHelix(params: {
+  radius: number;
+  turns: number;
+  pointsPerTurn: number;
+  pitch: number;
+  phase: number;
+}) {
+  const { radius, turns, pointsPerTurn, pitch, phase } = params;
+  const phaseRad = (phase * Math.PI) / 180;
+  const path: [number, number, number][] = [];
+  const totalPoints = turns * pointsPerTurn;
+
+  for (let i = 0; i < totalPoints; i++) {
+    const angle = (i / pointsPerTurn) * 2 * Math.PI;
+    const z = radius * Math.cos(angle + phaseRad) - 5.0;
+    const y = (i / pointsPerTurn) * pitch - (pitch * turns) / 2;
+    const x = radius * Math.sin(angle + phaseRad);
+    path.push([x, y, z]);
+  }
+  return path;
+}

--- a/examples/layer_transform/main.ts
+++ b/examples/layer_transform/main.ts
@@ -1,5 +1,6 @@
 import { quat } from "gl-matrix";
 import {
+  Layer,
   LayerManager,
   PerspectiveCamera,
   ProjectedLineLayer,
@@ -47,11 +48,6 @@ const stationaryLayer = new ProjectedLineLayer([
     width: 0.1,
   },
 ]);
-stationaryLayer.transform.translate([0.0, 0.0, 5]);
-stationaryLayer.transform.rotate(
-  quat.fromEuler(quat.create(), 45.0, -45.0, 0.0)
-);
-stationaryLayer.transform.translate([0.0, 0.0, -5]);
 layersManager.add(stationaryLayer);
 layersManager.add(movingLayer);
 
@@ -60,12 +56,14 @@ const camera = new PerspectiveCamera(60, renderer.width / renderer.height);
 
 animate();
 
-const rotate = () => {
-  movingLayer.transform.translate([0.0, 0.0, 5]);
-  movingLayer.transform.rotate(quat.fromEuler(quat.create(), 0.1, 0.2, 0.5));
-  movingLayer.transform.translate([0.0, 0.0, -5]);
+const rotateAboutCenter = (layer: Layer, x: number, y: number, z: number) => {
+  layer.transform.translate([0.0, 0.0, 5]);
+  layer.transform.rotate(quat.fromEuler(quat.create(), x, y, z));
+  layer.transform.translate([0.0, 0.0, -5]);
 };
-setInterval(rotate, 5);
+
+rotateAboutCenter(stationaryLayer, 45.0, -45.0, 0.0);
+setInterval(rotateAboutCenter, 5, movingLayer, 0.1, 0.2, 0.5);
 
 function animate() {
   renderer.render(layersManager, camera);

--- a/src/core/layer.ts
+++ b/src/core/layer.ts
@@ -1,3 +1,4 @@
+import { AffineTransform } from "core/transforms";
 import { RenderableObject } from "./renderable_object";
 
 type LayerState = "initialized" | "loading" | "ready";
@@ -11,6 +12,7 @@ export abstract class Layer {
   private objects_: RenderableObject[] = [];
   private state_: LayerState = "initialized";
   private callbacks_: StateChangeCallback[] = [];
+  private transform_ = new AffineTransform();
 
   public abstract update(): void;
 
@@ -20,6 +22,10 @@ export abstract class Layer {
 
   public get state() {
     return this.state_;
+  }
+
+  public get transform() {
+    return this.transform_;
   }
 
   public onStateChange(callback: StateChangeCallback) {

--- a/src/core/renderer.ts
+++ b/src/core/renderer.ts
@@ -15,7 +15,7 @@ export abstract class Renderer {
   protected abstract resize(width: number, height: number): void;
   protected abstract renderObject(
     object: RenderableObject,
-    modelMatrix: mat4
+    modelView: mat4
   ): void;
   protected abstract clear(): void;
 
@@ -38,12 +38,18 @@ export abstract class Renderer {
       layer.update();
       if (layer.state === "ready") {
         layer.objects.forEach((obj) => {
-          const modelMatrix = mat4.multiply(
+          const modelView = mat4.multiply(
             mat4.create(),
             obj.transform.matrix,
             layer.transform.matrix
           );
-          this.renderObject(obj, modelMatrix);
+          mat4.multiply(
+            modelView,
+            modelView,
+            this.activeCamera.transform.inverse
+          );
+
+          this.renderObject(obj, modelView);
         });
       }
     });

--- a/src/core/renderer.ts
+++ b/src/core/renderer.ts
@@ -13,7 +13,10 @@ export abstract class Renderer {
   private activeCamera_: Camera | null = null;
 
   protected abstract resize(width: number, height: number): void;
-  protected abstract renderObject(object: RenderableObject, modelMatrix: mat4): void;
+  protected abstract renderObject(
+    object: RenderableObject,
+    modelMatrix: mat4
+  ): void;
   protected abstract clear(): void;
 
   constructor(selector: string) {
@@ -40,7 +43,7 @@ export abstract class Renderer {
             obj.transform.matrix,
             layer.transform.matrix
           );
-          this.renderObject(obj, modelMatrix)
+          this.renderObject(obj, modelMatrix);
         });
       }
     });

--- a/src/core/renderer.ts
+++ b/src/core/renderer.ts
@@ -1,3 +1,5 @@
+import { mat4 } from "gl-matrix";
+
 import { LayerManager } from "./layer_manager";
 import { Camera } from "objects/cameras/camera";
 import { RenderableObject } from "core/renderable_object";
@@ -11,7 +13,7 @@ export abstract class Renderer {
   private activeCamera_: Camera | null = null;
 
   protected abstract resize(width: number, height: number): void;
-  protected abstract renderObject(object: RenderableObject): void;
+  protected abstract renderObject(object: RenderableObject, modelMatrix: mat4): void;
   protected abstract clear(): void;
 
   constructor(selector: string) {
@@ -32,7 +34,14 @@ export abstract class Renderer {
     layerManager.layers.forEach((layer) => {
       layer.update();
       if (layer.state === "ready") {
-        layer.objects.forEach((obj) => this.renderObject(obj));
+        layer.objects.forEach((obj) => {
+          const modelMatrix = mat4.multiply(
+            mat4.create(),
+            obj.transform.matrix,
+            layer.transform.matrix
+          );
+          this.renderObject(obj, modelMatrix)
+        });
       }
     });
   }

--- a/src/core/renderer.ts
+++ b/src/core/renderer.ts
@@ -38,6 +38,8 @@ export abstract class Renderer {
       layer.update();
       if (layer.state === "ready") {
         layer.objects.forEach((obj) => {
+          // TODO: cache the modelView matrix
+          // https://github.com/chanzuckerberg/imaging-active-learning/issues/80
           const modelView = mat4.multiply(
             mat4.create(),
             obj.transform.matrix,

--- a/src/core/transforms.ts
+++ b/src/core/transforms.ts
@@ -42,7 +42,7 @@ export class AffineTransform {
   }
 
   public get inverse() {
-    if (this.inverse_ === null) {
+    if (this.dirty_ || this.inverse_ === null) {
       this.inverse_ = mat4.invert(mat4.create(), this.matrix);
     }
     return this.inverse_;

--- a/src/core/transforms.ts
+++ b/src/core/transforms.ts
@@ -1,24 +1,39 @@
-import { mat4, vec3 } from "gl-matrix";
+import { mat4, vec3, quat } from "gl-matrix";
 
 export class AffineTransform {
   private dirty_ = true;
   private matrix_ = mat4.create();
   private inverse_: mat4 | null = null;
+  private rotation_ = quat.create();
   private translation_ = vec3.create();
+  private scale_ = vec3.fromValues(1, 1, 1);
+
+  public rotate(q: quat) {
+    quat.multiply(this.rotation_, this.rotation_, q);
+    vec3.transformQuat(this.translation_, this.translation_, q);
+    this.dirty_ = true;
+  }
 
   public translate(vec: vec3) {
     vec3.add(this.translation_, this.translation_, vec);
     this.dirty_ = true;
   }
 
-  // TODO: add scale
-
-  // TODO: add rotate
+  public scale(vec: vec3) {
+    vec3.multiply(this.scale_, this.scale_, vec);
+    vec3.multiply(this.translation_, this.translation_, vec);
+    this.dirty_ = true;
+  }
 
   public get matrix() {
     if (this.dirty_) {
       this.matrix_ = mat4.create();
-      mat4.translate(this.matrix_, this.matrix_, this.translation_);
+      mat4.fromRotationTranslationScale(
+        this.matrix_,
+        this.rotation_,
+        this.translation_,
+        this.scale_
+      );
       this.inverse_ = null;
       this.dirty_ = false;
     }

--- a/src/core/transforms.ts
+++ b/src/core/transforms.ts
@@ -43,6 +43,7 @@ export class AffineTransform {
   public get inverse() {
     if (this.dirtyMatrix_ || this.dirtyInverse_) {
       mat4.invert(this.inverse_, this.matrix);
+      this.dirtyInverse_ = false;
     }
     return this.inverse_;
   }

--- a/src/core/transforms.ts
+++ b/src/core/transforms.ts
@@ -28,12 +28,7 @@ export class AffineTransform {
 
   public get matrix() {
     if (this.dirtyMatrix_) {
-      mat4.fromRotationTranslationScale(
-        this.matrix_,
-        this.rotation_,
-        this.translation_,
-        this.scale_
-      );
+      this.computeMatrix();
       this.dirtyMatrix_ = false;
       this.dirtyInverse_ = true;
     }
@@ -42,9 +37,22 @@ export class AffineTransform {
 
   public get inverse() {
     if (this.dirtyMatrix_ || this.dirtyInverse_) {
-      mat4.invert(this.inverse_, this.matrix);
+      this.computeInverse();
       this.dirtyInverse_ = false;
     }
     return this.inverse_;
+  }
+
+  private computeMatrix() {
+    mat4.fromRotationTranslationScale(
+      this.matrix_,
+      this.rotation_,
+      this.translation_,
+      this.scale_
+    );
+  }
+
+  private computeInverse() {
+    mat4.invert(this.inverse_, this.matrix);
   }
 }

--- a/src/core/transforms.ts
+++ b/src/core/transforms.ts
@@ -1,8 +1,9 @@
-import { vec3, mat4 } from "gl-matrix";
+import { mat4, vec3 } from "gl-matrix";
 
 export class AffineTransform {
   private dirty_ = true;
   private matrix_ = mat4.create();
+  private inverse_: mat4 | null = null;
   private translation_ = vec3.create();
 
   public translate(vec: vec3) {
@@ -18,9 +19,17 @@ export class AffineTransform {
     if (this.dirty_) {
       this.matrix_ = mat4.create();
       mat4.translate(this.matrix_, this.matrix_, this.translation_);
-
+      this.inverse_ = null;
       this.dirty_ = false;
     }
+    this.inverse_ = mat4.invert(mat4.create(), this.matrix_);
     return this.matrix_;
+  }
+
+  public get inverse() {
+    if (this.inverse_ === null) {
+      this.inverse_ = mat4.invert(mat4.create(), this.matrix);
+    }
+    return this.inverse_;
   }
 }

--- a/src/core/transforms.ts
+++ b/src/core/transforms.ts
@@ -1,9 +1,10 @@
 import { mat4, vec3, quat } from "gl-matrix";
 
 export class AffineTransform {
-  private dirty_ = true;
+  private dirtyMatrix_ = true;
+  private dirtyInverse_ = true;
   private matrix_ = mat4.create();
-  private inverse_: mat4 | null = null;
+  private inverse_ = mat4.create();
   private rotation_ = quat.create();
   private translation_ = vec3.create();
   private scale_ = vec3.fromValues(1, 1, 1);
@@ -11,38 +12,37 @@ export class AffineTransform {
   public rotate(q: quat) {
     quat.multiply(this.rotation_, this.rotation_, q);
     vec3.transformQuat(this.translation_, this.translation_, q);
-    this.dirty_ = true;
+    this.dirtyMatrix_ = true;
   }
 
   public translate(vec: vec3) {
     vec3.add(this.translation_, this.translation_, vec);
-    this.dirty_ = true;
+    this.dirtyMatrix_ = true;
   }
 
   public scale(vec: vec3) {
     vec3.multiply(this.scale_, this.scale_, vec);
     vec3.multiply(this.translation_, this.translation_, vec);
-    this.dirty_ = true;
+    this.dirtyMatrix_ = true;
   }
 
   public get matrix() {
-    if (this.dirty_) {
-      this.matrix_ = mat4.create();
+    if (this.dirtyMatrix_) {
       mat4.fromRotationTranslationScale(
         this.matrix_,
         this.rotation_,
         this.translation_,
         this.scale_
       );
-      this.inverse_ = null;
-      this.dirty_ = false;
+      this.dirtyMatrix_ = false;
+      this.dirtyInverse_ = true;
     }
     return this.matrix_;
   }
 
   public get inverse() {
-    if (this.dirty_ || this.inverse_ === null) {
-      this.inverse_ = mat4.invert(mat4.create(), this.matrix);
+    if (this.dirtyMatrix_ || this.dirtyInverse_) {
+      mat4.invert(this.inverse_, this.matrix);
     }
     return this.inverse_;
   }

--- a/src/core/transforms.ts
+++ b/src/core/transforms.ts
@@ -37,7 +37,6 @@ export class AffineTransform {
       this.inverse_ = null;
       this.dirty_ = false;
     }
-    this.inverse_ = mat4.invert(mat4.create(), this.matrix_);
     return this.matrix_;
   }
 

--- a/src/layers/projected_line_layer.ts
+++ b/src/layers/projected_line_layer.ts
@@ -1,6 +1,6 @@
 import { Layer } from "core/layer";
 import { ProjectedLine } from "objects/renderable/projected_line";
-import { ProjectedLineGoemetry } from "objects/geometry/projected_line_geometry";
+import { ProjectedLineGeometry } from "objects/geometry/projected_line_geometry";
 
 interface LineParameters {
   path: [number, number, number][];
@@ -17,7 +17,7 @@ export class ProjectedLineLayer extends Layer {
 
   public addLine(line: LineParameters) {
     const { path, color, width } = line;
-    const geometry = new ProjectedLineGoemetry(path);
+    const geometry = new ProjectedLineGeometry(path);
     this.addObject(new ProjectedLine({ geometry, color, width }));
   }
 

--- a/src/layers/projected_line_layer.ts
+++ b/src/layers/projected_line_layer.ts
@@ -11,7 +11,7 @@ interface LineParameters {
 export class ProjectedLineLayer extends Layer {
   constructor(lines: LineParameters[] = []) {
     super();
-    lines.forEach(this.addLine);
+    lines.forEach((line) => this.addLine(line));
     this.setState("ready");
   }
 

--- a/src/objects/geometry/projected_line_geometry.ts
+++ b/src/objects/geometry/projected_line_geometry.ts
@@ -1,6 +1,6 @@
 import { Geometry } from "core/geometry";
 
-export class ProjectedLineGoemetry extends Geometry {
+export class ProjectedLineGeometry extends Geometry {
   // this creates the geometry for a screen-space projected line
   // each point on the input path is split into two vertices
   // these are pushed in opposite directions in screen-space to create width

--- a/src/objects/renderable/projected_line.ts
+++ b/src/objects/renderable/projected_line.ts
@@ -1,8 +1,8 @@
 import { RenderableObject } from "core/renderable_object";
-import { ProjectedLineGoemetry } from "objects/geometry/projected_line_geometry";
+import { ProjectedLineGeometry } from "objects/geometry/projected_line_geometry";
 
 interface LineParameters {
-  geometry: ProjectedLineGoemetry;
+  geometry: ProjectedLineGeometry;
   color: [number, number, number];
   width: number;
 }

--- a/src/objects/renderable/projected_line.ts
+++ b/src/objects/renderable/projected_line.ts
@@ -5,7 +5,7 @@ interface LineParameters {
   geometry: ProjectedLineGeometry;
   color: [number, number, number];
   width: number;
-};
+}
 
 export class ProjectedLine extends RenderableObject {
   private color_: [number, number, number];

--- a/src/renderers/webgl_renderer.ts
+++ b/src/renderers/webgl_renderer.ts
@@ -30,17 +30,11 @@ export class WebGLRenderer extends Renderer {
     this.gl.viewport(0, 0, this.gl.canvas.width, this.gl.canvas.height);
   }
 
-  protected renderObject(object: RenderableObject, modelMatrix: mat4) {
+  protected renderObject(object: RenderableObject, modelView: mat4) {
     const program = this.getShaderProgram(this.getProgramName(object)).use();
 
-    const modelView = mat4.multiply(
-      mat4.create(),
-      modelMatrix,
-      this.activeCamera.transform.inverse
-    );
-
-    program.setUniform("Projection", this.activeCamera.projectionMatrix);
     program.setUniform("ModelView", modelView);
+    program.setUniform("Projection", this.activeCamera.projectionMatrix);
 
     switch (object.type) {
       case "ProjectedLine": {

--- a/src/renderers/webgl_renderer.ts
+++ b/src/renderers/webgl_renderer.ts
@@ -30,13 +30,13 @@ export class WebGLRenderer extends Renderer {
     this.gl.viewport(0, 0, this.gl.canvas.width, this.gl.canvas.height);
   }
 
-  protected renderObject(object: RenderableObject) {
+  protected renderObject(object: RenderableObject, modelMatrix: mat4) {
     const program = this.getShaderProgram(this.getProgramName(object)).use();
 
     const modelView = mat4.multiply(
       mat4.create(),
-      object.transform.matrix,
-      this.activeCamera.transform.matrix
+      modelMatrix,
+      this.activeCamera.transform.inverse
     );
 
     program.setUniform("Projection", this.activeCamera.projectionMatrix);

--- a/test/projected_line_layer.test.ts
+++ b/test/projected_line_layer.test.ts
@@ -1,0 +1,38 @@
+import { expect, test } from "vitest";
+
+import { ProjectedLineLayer } from "@";
+
+test("lines in constructor", () => {
+  const layer = new ProjectedLineLayer([
+    {
+      path: [
+        [0, 0, 0],
+        [1, 1, 1],
+      ],
+      color: [1, 0, 0],
+      width: 1,
+    },
+    {
+      path: [
+        [0, 0, 0],
+        [1, 1, 1],
+      ],
+      color: [1, 0, 0],
+      width: 1,
+    },
+  ]);
+  expect(layer.objects.length).toBe(2);
+});
+
+test("addLine", () => {
+  const layer = new ProjectedLineLayer();
+  layer.addLine({
+    path: [
+      [0, 0, 0],
+      [1, 1, 1],
+    ],
+    color: [1, 0, 0],
+    width: 1,
+  });
+  expect(layer.objects.length).toBe(1);
+});

--- a/test/transform.test.ts
+++ b/test/transform.test.ts
@@ -1,0 +1,134 @@
+import { mat4, vec3, quat } from "gl-matrix";
+
+import { expect, test } from "vitest";
+
+import { AffineTransform } from "@/core/transforms";
+
+// NOTES:
+// * mat4.fromValues is column-major
+// * use mat4.equals instead of expect(t.matrix).toEqual because it's better for comparing floats,
+// even though it provides worse output on failure
+
+test("rotate", () => {
+  const t = new AffineTransform();
+  const q = quat.rotateZ(quat.create(), quat.create(), Math.PI / 2);
+  t.rotate(q);
+  expect(
+    mat4.equals(
+      t.matrix,
+      mat4.fromValues(0, 1, 0, 0, -1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1)
+    )
+  ).toBe(true);
+  t.rotate(quat.invert(quat.create(), q));
+  expect(
+    mat4.equals(
+      t.matrix,
+      mat4.fromValues(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1)
+    )
+  ).toBe(true);
+});
+
+test("translate", () => {
+  const t = new AffineTransform();
+  const t0 = vec3.fromValues(1, 2, 3);
+  t.translate(t0);
+  expect(
+    mat4.equals(
+      t.matrix,
+      mat4.fromValues(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 1, 2, 3, 1)
+    )
+  ).toBe(true);
+  t.translate(t0);
+  expect(
+    mat4.equals(
+      t.matrix,
+      mat4.fromValues(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 2, 4, 6, 1)
+    )
+  ).toBe(true);
+});
+
+test("scale", () => {
+  const t = new AffineTransform();
+  t.scale(vec3.fromValues(2, 3, 4));
+  expect(
+    mat4.equals(
+      t.matrix,
+      mat4.fromValues(2, 0, 0, 0, 0, 3, 0, 0, 0, 0, 4, 0, 0, 0, 0, 1)
+    )
+  ).toBe(true);
+  t.scale(vec3.fromValues(2, 3, 4));
+  expect(
+    mat4.equals(
+      t.matrix,
+      mat4.fromValues(4, 0, 0, 0, 0, 9, 0, 0, 0, 0, 16, 0, 0, 0, 0, 1)
+    )
+  ).toBe(true);
+});
+
+test("scale then translate", () => {
+  const t = new AffineTransform();
+  t.scale(vec3.fromValues(2, 3, 4));
+  t.translate(vec3.fromValues(1, 2, 3));
+  expect(
+    mat4.equals(
+      t.matrix,
+      mat4.fromValues(2, 0, 0, 0, 0, 3, 0, 0, 0, 0, 4, 0, 1, 2, 3, 1)
+    )
+  ).toBe(true);
+});
+
+test("translate then scale", () => {
+  const t = new AffineTransform();
+  t.translate(vec3.fromValues(1, 2, 3));
+  t.scale(vec3.fromValues(2, 3, 4));
+  expect(
+    mat4.equals(
+      t.matrix,
+      mat4.fromValues(2, 0, 0, 0, 0, 3, 0, 0, 0, 0, 4, 0, 2, 6, 12, 1)
+    )
+  ).toBe(true);
+});
+
+test("rotate then translate", () => {
+  const t = new AffineTransform();
+  const q = quat.rotateZ(quat.create(), quat.create(), Math.PI / 2);
+  t.rotate(q);
+  t.translate(vec3.fromValues(1, 2, 3));
+  expect(
+    mat4.equals(
+      t.matrix,
+      mat4.fromValues(0, 1, 0, 0, -1, 0, 0, 0, 0, 0, 1, 0, 1, 2, 3, 1)
+    )
+  ).toBe(true);
+});
+
+test("translate then rotate", () => {
+  const t = new AffineTransform();
+  t.translate(vec3.fromValues(1, 2, 3));
+  const q = quat.rotateZ(quat.create(), quat.create(), Math.PI / 2);
+  t.rotate(q);
+  expect(
+    mat4.equals(
+      t.matrix,
+      mat4.fromValues(0, 1, 0, 0, -1, 0, 0, 0, 0, 0, 1, 0, -2, 1, 3, 1)
+    )
+  ).toBe(true);
+});
+
+test("inverse", () => {
+  // use two transforms to check inverse is correct without first accessing the matrix
+  const t0 = new AffineTransform();
+  const t1 = new AffineTransform();
+  const rotation = quat.rotateZ(quat.create(), quat.create(), Math.PI / 2);
+  const translation = vec3.fromValues(1, 2, 3);
+  const scale = vec3.fromValues(2, 3, 4);
+  t0.rotate(rotation);
+  t0.translate(translation);
+  t0.scale(scale);
+  t1.rotate(rotation);
+  t1.translate(translation);
+  t1.scale(scale);
+  expect(mat4.equals(t0.inverse, mat4.invert(mat4.create(), t1.matrix))).toBe(
+    true
+  );
+});

--- a/test/transform.test.ts
+++ b/test/transform.test.ts
@@ -1,92 +1,112 @@
 import { mat4, vec3, quat } from "gl-matrix";
 
-import { expect, test } from "vitest";
+import { expect, test, vi } from "vitest";
 
 import { AffineTransform } from "@/core/transforms";
 
 // NOTES:
-// * mat4.fromValues is column-major
+// * mat4 is column-major
 // * use mat4.equals instead of expect(t.matrix).toEqual because it's better for comparing floats,
 // even though it provides worse output on failure
+
+const expectMatrixEquals = (a: mat4, b: mat4) => {
+  expect(mat4.equals(a, b)).toBe(true);
+};
 
 test("rotate", () => {
   const t = new AffineTransform();
   const q = quat.rotateZ(quat.create(), quat.create(), Math.PI / 2);
   t.rotate(q);
-  expect(
-    mat4.equals(
-      t.matrix,
-      mat4.fromValues(0, 1, 0, 0, -1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1)
-    )
-  ).toBe(true);
+  // prettier-ignore
+  expectMatrixEquals(
+    t.matrix,
+    [ 0, 1, 0, 0,
+     -1, 0, 0, 0,
+      0, 0, 1, 0,
+      0, 0, 0, 1 ]
+  );
   t.rotate(quat.invert(quat.create(), q));
-  expect(
-    mat4.equals(
-      t.matrix,
-      mat4.fromValues(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1)
-    )
-  ).toBe(true);
+  // prettier-ignore
+  expectMatrixEquals(
+    t.matrix,
+    [ 1, 0, 0, 0,
+      0, 1, 0, 0,
+      0, 0, 1, 0,
+      0, 0, 0, 1 ]
+  );
 });
 
 test("translate", () => {
   const t = new AffineTransform();
   const t0 = vec3.fromValues(1, 2, 3);
   t.translate(t0);
-  expect(
-    mat4.equals(
-      t.matrix,
-      mat4.fromValues(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 1, 2, 3, 1)
-    )
-  ).toBe(true);
+  // prettier-ignore
+  expectMatrixEquals(
+    t.matrix,
+    [ 1, 0, 0, 0,
+      0, 1, 0, 0,
+      0, 0, 1, 0,
+      1, 2, 3, 1 ]
+  );
   t.translate(t0);
-  expect(
-    mat4.equals(
-      t.matrix,
-      mat4.fromValues(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 2, 4, 6, 1)
-    )
-  ).toBe(true);
+  // prettier-ignore
+  expectMatrixEquals(
+    t.matrix,
+    [ 1, 0, 0, 0,
+      0, 1, 0, 0,
+      0, 0, 1, 0,
+      2, 4, 6, 1 ]
+  );
 });
 
 test("scale", () => {
   const t = new AffineTransform();
   t.scale(vec3.fromValues(2, 3, 4));
-  expect(
-    mat4.equals(
-      t.matrix,
-      mat4.fromValues(2, 0, 0, 0, 0, 3, 0, 0, 0, 0, 4, 0, 0, 0, 0, 1)
-    )
-  ).toBe(true);
+  // prettier-ignore
+  expectMatrixEquals(
+    t.matrix,
+    [ 2, 0, 0, 0,
+      0, 3, 0, 0,
+      0, 0, 4, 0,
+      0, 0, 0, 1 ]
+  );
   t.scale(vec3.fromValues(2, 3, 4));
-  expect(
-    mat4.equals(
-      t.matrix,
-      mat4.fromValues(4, 0, 0, 0, 0, 9, 0, 0, 0, 0, 16, 0, 0, 0, 0, 1)
-    )
-  ).toBe(true);
+  // prettier-ignore
+  expectMatrixEquals(
+    t.matrix,
+    [ 4, 0, 0, 0,
+      0, 9, 0, 0,
+      0, 0, 16, 0,
+      0, 0, 0, 1 ]
+  );
 });
 
 test("scale then translate", () => {
   const t = new AffineTransform();
   t.scale(vec3.fromValues(2, 3, 4));
   t.translate(vec3.fromValues(1, 2, 3));
-  expect(
-    mat4.equals(
-      t.matrix,
-      mat4.fromValues(2, 0, 0, 0, 0, 3, 0, 0, 0, 0, 4, 0, 1, 2, 3, 1)
-    )
-  ).toBe(true);
+  // prettier-ignore
+  expectMatrixEquals(
+    t.matrix,
+    [ 2, 0, 0, 0,
+      0, 3, 0, 0,
+      0, 0, 4, 0,
+      1, 2, 3, 1 ]
+  );
 });
 
 test("translate then scale", () => {
   const t = new AffineTransform();
   t.translate(vec3.fromValues(1, 2, 3));
   t.scale(vec3.fromValues(2, 3, 4));
-  expect(
-    mat4.equals(
-      t.matrix,
-      mat4.fromValues(2, 0, 0, 0, 0, 3, 0, 0, 0, 0, 4, 0, 2, 6, 12, 1)
-    )
-  ).toBe(true);
+  // prettier-ignore
+  expectMatrixEquals(
+    t.matrix,
+    [ 2, 0, 0, 0,
+      0, 3, 0, 0,
+      0, 0, 4, 0,
+      2, 6, 12, 1 ]
+  );
 });
 
 test("rotate then translate", () => {
@@ -94,12 +114,14 @@ test("rotate then translate", () => {
   const q = quat.rotateZ(quat.create(), quat.create(), Math.PI / 2);
   t.rotate(q);
   t.translate(vec3.fromValues(1, 2, 3));
-  expect(
-    mat4.equals(
-      t.matrix,
-      mat4.fromValues(0, 1, 0, 0, -1, 0, 0, 0, 0, 0, 1, 0, 1, 2, 3, 1)
-    )
-  ).toBe(true);
+  // prettier-ignore
+  expectMatrixEquals(
+    t.matrix,
+    [ 0, 1, 0, 0,
+     -1, 0, 0, 0,
+      0, 0, 1, 0,
+      1, 2, 3, 1 ]
+  );
 });
 
 test("translate then rotate", () => {
@@ -107,12 +129,14 @@ test("translate then rotate", () => {
   t.translate(vec3.fromValues(1, 2, 3));
   const q = quat.rotateZ(quat.create(), quat.create(), Math.PI / 2);
   t.rotate(q);
-  expect(
-    mat4.equals(
-      t.matrix,
-      mat4.fromValues(0, 1, 0, 0, -1, 0, 0, 0, 0, 0, 1, 0, -2, 1, 3, 1)
-    )
-  ).toBe(true);
+  // prettier-ignore
+  expectMatrixEquals(
+    t.matrix,
+    [ 0, 1, 0, 0,
+     -1, 0, 0, 0,
+      0, 0, 1, 0,
+     -2, 1, 3, 1 ]
+  );
 });
 
 test("inverse", () => {
@@ -128,7 +152,23 @@ test("inverse", () => {
   t1.rotate(rotation);
   t1.translate(translation);
   t1.scale(scale);
-  expect(mat4.equals(t0.inverse, mat4.invert(mat4.create(), t1.matrix))).toBe(
-    true
-  );
+  expectMatrixEquals(t0.inverse, mat4.invert(mat4.create(), t1.matrix));
+});
+
+test("matrix is cached on repeat access", () => {
+  const t = new AffineTransform();
+  // @ts-expect-error TS2345 - spying on private method
+  const computeSpy = vi.spyOn(t, "computeMatrix");
+  t.translate(vec3.fromValues(1, 2, 3));
+  expect(t.matrix).toBe(t.matrix);
+  expect(computeSpy).toHaveBeenCalledTimes(1);
+});
+
+test("inverse is cached on repeat access", () => {
+  const t = new AffineTransform();
+  // @ts-expect-error TS2345 - spying on private method
+  const computeSpy = vi.spyOn(t, "computeInverse");
+  t.translate(vec3.fromValues(1, 2, 3));
+  expect(t.inverse).toBe(t.inverse);
+  expect(computeSpy).toHaveBeenCalledTimes(1);
 });

--- a/vite.config.js
+++ b/vite.config.js
@@ -19,8 +19,10 @@ function modeToRoot(mode) {
     return 'examples';
   } else if (mode === 'prototype') {
     return 'ultrack-prototype/frontend';
+  } else if (mode === 'production') {
+    // no root for production mode (library build)
   } else if (mode == 'test') {
-    // No root for test mode
+    // no root for test mode
   } else {
     console.error(`Unrecognized mode ${mode}`);
   }

--- a/vite.config.js
+++ b/vite.config.js
@@ -19,8 +19,11 @@ function modeToRoot(mode) {
     return 'examples';
   } else if (mode === 'prototype') {
     return 'ultrack-prototype/frontend';
+  } else if (mode == 'test') {
+    // No root for test mode
+  } else {
+    console.error(`Unrecognized mode ${mode}`);
   }
-  console.error(`Unrecognized mode ${mode}`);
   return undefined;
 }
 


### PR DESCRIPTION
### Summary
This adds a `transform` (`AffineTransform`) property to `Layer`.

In the current implementation this transform is composed with the `RenderableObject.transform` and the camera transform in the `Renderer` base class, and passed into `renderObject` as `modelView`. I don't think this is necessarily the right pattern/implementation but hopefully we can sort that out here.

Other options:
* Pass `layer.transform` directly to `renderObject` (perhaps default to identity)
* Introduce an `activeLayer` property similar to `activeCamera` on the renderer, and access the layer transform that way
* Pass the whole layer into `renderObject` along with its object
* Make sure any layer parameters are copied into/onto or passed through its renderable objects
* Give renderable objects a reference to their "parent" layer

This also adds `scale` and `rotate` method to `AffineTransform`. One thought after using this a little is that we may also want `setScale`, `setRotation`, and `setTranslation` methods that don't apply the new transform incrementally.

Finally, this adds an `inverse` property to `AffineTransform`. I use this to apply the inverse of the camera transform to the object to get the `modelView` matrix. This makes more sense to me than using `matrix` here but I could be thinking about it wrong.

### Related Issue
Closes #73 

### Tests & Checks
Tested manually and created a new example to show how it works.