### PR TITLE
Add cubic spline interpolation

### DIFF
--- a/examples/bezier_spline/index.html
+++ b/examples/bezier_spline/index.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Web Viewer</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        display: flex;
+        width: 100%;
+        height: 100%;
+      }
+      canvas {
+        width: 100%;
+        height: 100%;
+      }
+    </style>
+  </head>
+  <body>
+    <canvas id="canvas"></canvas>
+    <script type="module" src="./main.ts"></script>
+  </body>
+</html>

--- a/examples/bezier_spline/main.ts
+++ b/examples/bezier_spline/main.ts
@@ -1,0 +1,44 @@
+import {
+  LayerManager,
+  PerspectiveCamera,
+  ProjectedLineLayer,
+  WebGLRenderer,
+} from "@";
+import { cubicBezierInterpolation } from "@/core/splines";
+
+const layersManager = new LayerManager();
+const layer = new ProjectedLineLayer();
+layersManager.add(layer);
+
+const starPath: [number, number, number][] = [
+  [-1.0, -1.0, -5.0],
+  [0.0, 1.0, -5.0],
+  [1.0, -1.0, -5.0],
+  [-1.0, 0.2, -5.0],
+  [1.0, 0.2, -5.0],
+  [-0.8, -0.9, -5.0],
+];
+layer.addLine({ path: starPath, color: [1.0, 0.0, 0.0], width: 0.05 });
+
+for (const f of [0.0, 0.1, 0.3, 0.5, 0.7, 1.0]) {
+  const interpolatedPath = cubicBezierInterpolation({
+    path: starPath,
+    pointsPerSegment: 100,
+    tangentFactor: f,
+  });
+  layer.addLine({
+    path: interpolatedPath as [number, number, number][],
+    color: [f, 1.0 - f, 1.0],
+    width: 0.1,
+  });
+}
+
+const renderer = new WebGLRenderer("#canvas");
+const camera = new PerspectiveCamera(60, renderer.width / renderer.height);
+
+animate();
+
+function animate() {
+  renderer.render(layersManager, camera);
+  requestAnimationFrame(animate);
+}

--- a/examples/index.html
+++ b/examples/index.html
@@ -40,6 +40,7 @@
       <li><a href="/single_mesh_layer/index.html">Single Mesh Layer</a></li>
       <li><a href="/projected_lines/index.html">Projected Lines</a></li>
       <li><a href="/layer_transform/index.html">Layer Transform</a></li>
+      <li><a href="/bezier_spline/index.html">Bezier Spline</a></li>
     </ul>
   </body>
 </html>

--- a/src/core/splines.ts
+++ b/src/core/splines.ts
@@ -1,0 +1,84 @@
+import { vec3 } from "gl-matrix";
+
+type BezierParams = {
+  path: vec3[];
+  n: number;
+  x?: number[];
+  fac?: number;
+};
+
+export function cubicHermiteInterpolation(params: BezierParams): vec3[] {
+  const { path, n } = params;
+  let { x, fac } = params;
+  if (!x) {
+    x = new Array(path.length).fill(0).map((_, i) => i);
+  }
+  if (!fac) {
+    fac = 1.0 / 3.0;
+  }
+  const tangents = pathTangents(path, x);
+
+  const out = Array((path.length - 1) * n);
+
+  // a cubic bezier curve is defined by 4 control points: a, b, c, d
+  // for interpolation of a segment:
+  // * a and d are the endpoints of the curve segment
+  // * b and c are control points that define curvature
+  // here we use 1/3 of the tangent at each endpoint as the control points
+  // this is equivalent to a cubic Hermite spline
+  for (let i = 0; i < path.length - 1; i++) {
+    const a = path[i];
+    const d = path[i + 1];
+    const b = vec3.clone(tangents[i]);
+    vec3.scaleAndAdd(b, a, b, fac);
+    const c = vec3.clone(tangents[i + 1]);
+    vec3.scaleAndAdd(c, d, c, -fac);
+    for (let t = 0; t < n; t++) {
+      const o = (out[i * n + t] = vec3.create());
+      vec3.bezier(o, a, b, c, d, t / n);
+    }
+  }
+
+  return out;
+}
+
+function pathTangents(path: vec3[], x: number[]): vec3[] {
+  if (path.length < 2) {
+    throw new Error("Path must contain at least 2 points");
+  }
+
+  const tangents: vec3[] = Array(path.length);
+  for (let i = 0; i < path.length; i++) {
+    const prev = path[i - 1] ?? path[i];
+    const curr = path[i];
+    const next = path[i + 1] ?? path[i];
+    const prevX = x[i - 1] ?? x[i];
+    const currX = x[i];
+    const nextX = x[i + 1] ?? x[i];
+
+    const m0 = vec3.create();
+    const m1 = vec3.create();
+    tangents[i] = vec3.create();
+
+    if (i !== 0) {
+      vec3.sub(m0, curr, prev);
+      vec3.scale(m0, m0, 1.0 / (currX - prevX));
+    }
+
+    if (i !== path.length - 1) {
+      vec3.sub(m1, next, curr);
+      vec3.scale(m1, m1, 1.0 / (nextX - currX));
+    }
+
+    if (i === 0) {
+      vec3.copy(tangents[i], m1);
+    } else if (i == path.length - 1) {
+      vec3.copy(tangents[i], m0);
+    } else {
+      vec3.add(tangents[i], m0, m1);
+      vec3.scale(tangents[i], tangents[i], 0.5);
+    }
+  }
+
+  return tangents;
+}

--- a/src/core/splines.ts
+++ b/src/core/splines.ts
@@ -2,40 +2,41 @@ import { vec3 } from "gl-matrix";
 
 type BezierParams = {
   path: vec3[];
-  n: number;
+  pointsPerSegment: number;
   x?: number[];
-  fac?: number;
+  tangentFactor?: number;
 };
 
-export function cubicHermiteInterpolation(params: BezierParams): vec3[] {
-  const { path, n } = params;
-  let { x, fac } = params;
+export function cubicBezierInterpolation({
+  path,
+  pointsPerSegment,
+  x,
+  tangentFactor = 1.0 / 3.0,
+}: BezierParams): vec3[] {
   if (!x) {
     x = new Array(path.length).fill(0).map((_, i) => i);
   }
-  if (!fac) {
-    fac = 1.0 / 3.0;
-  }
   const tangents = pathTangents(path, x);
 
-  const out = Array((path.length - 1) * n);
+  const out = Array((path.length - 1) * pointsPerSegment);
 
   // a cubic bezier curve is defined by 4 control points: a, b, c, d
   // for interpolation of a segment:
   // * a and d are the endpoints of the curve segment
   // * b and c are control points that define curvature
-  // here we use 1/3 of the tangent at each endpoint as the control points
+  // default is 1/3 of the tangent at each endpoint as the control points
   // this is equivalent to a cubic Hermite spline
   for (let i = 0; i < path.length - 1; i++) {
     const a = path[i];
     const d = path[i + 1];
     const b = vec3.clone(tangents[i]);
-    vec3.scaleAndAdd(b, a, b, fac);
+    vec3.scaleAndAdd(b, a, b, tangentFactor);
     const c = vec3.clone(tangents[i + 1]);
-    vec3.scaleAndAdd(c, d, c, -fac);
-    for (let t = 0; t < n; t++) {
-      const o = (out[i * n + t] = vec3.create());
-      vec3.bezier(o, a, b, c, d, t / n);
+    vec3.scaleAndAdd(c, d, c, -tangentFactor);
+    for (let p = 0; p < pointsPerSegment; p++) {
+      const t = p / pointsPerSegment;
+      const o = (out[i * pointsPerSegment + p] = vec3.create());
+      vec3.bezier(o, a, b, c, d, t);
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,5 +19,3 @@ export { ImageSeriesLayer } from "layers/image_series_layer";
 export { OmeZarrImageSource } from "data/ome_zarr_image_source";
 
 export { WebGLRenderer } from "renderers/webgl_renderer";
-
-export { cubicHermiteInterpolation } from "core/splines";

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,3 +19,5 @@ export { ImageSeriesLayer } from "layers/image_series_layer";
 export { OmeZarrImageSource } from "data/ome_zarr_image_source";
 
 export { WebGLRenderer } from "renderers/webgl_renderer";
+
+export { cubicHermiteInterpolation } from "core/splines";


### PR DESCRIPTION
### Summary
This adds some pretty basic spline interpolation. Given the simplicity of the joins in `ProjectedLine` this offers a significant improvement in appearance.

The improvement is especially apparent for lines with few points and tight curves, where the line width can deviate significantly from what is specified due to the lack of miter joins (red line).

Simply adding more points along the line (linear interpolation) helps a lot with this, but the interpolation here offers some additional smoothing of the path.

![Screenshot 2024-10-11 at 10 20 10 AM](https://github.com/user-attachments/assets/a3d9afc1-e643-4663-8d49-8fb6410ed6b3)

### Related Issue
N/A

### Tests & Checks
I tested manually and made a new example to demonstrate usage.
