### PR TITLE
Add immutable textures

### DIFF
--- a/src/data/image_chunk.ts
+++ b/src/data/image_chunk.ts
@@ -1,4 +1,5 @@
 import { Region } from "data/region";
+import { TextureUnpackRowAlignment } from "objects/textures/texture";
 
 // One 2D chunk of n-dimensional image data.
 // TODO: include the region of this chunk.
@@ -10,7 +11,7 @@ export type ImageChunk = {
     height: number;
   };
   rowStride: number;
-  rowAlignmentBytes: number;
+  rowAlignmentBytes: TextureUnpackRowAlignment;
 };
 
 export type ImageChunkSource = {

--- a/src/data/ome_zarr_image_loader.ts
+++ b/src/data/ome_zarr_image_loader.ts
@@ -3,6 +3,7 @@ import { Slice } from "@zarrita/indexing";
 
 import { Region } from "data/region";
 import { ImageChunk } from "data/image_chunk";
+import { isTextureUnpackRowAlignment } from "objects/textures/texture";
 
 type IdentityTransform = {
   type: "identity";
@@ -100,11 +101,18 @@ export class OmeZarrImageLoader {
       );
     }
 
+    const rowAlignment = subarray.data.BYTES_PER_ELEMENT;
+    if (!isTextureUnpackRowAlignment(rowAlignment)) {
+      throw new Error(
+        "Invalid row alignment value. Possible values are 1, 2, 4, or 8"
+      );
+    }
+
     const chunk = {
       data: subarray.data,
       shape: { width: subarray.shape[1], height: subarray.shape[0] },
       rowStride: subarray.stride[0],
-      rowAlignmentBytes: subarray.data.BYTES_PER_ELEMENT,
+      rowAlignmentBytes: rowAlignment,
     };
     console.debug("loaded chunk ", chunk);
     return chunk;

--- a/src/layers/image_layer.ts
+++ b/src/layers/image_layer.ts
@@ -4,7 +4,6 @@ import { PlaneGeometry } from "objects/geometry/plane_geometry";
 import { Region } from "data/region";
 import { ImageChunkSource } from "data/image_chunk";
 import { DataTexture2D } from "objects/textures/data_texture_2d";
-import { TextureUnpackRowAlignment } from "objects/textures/texture";
 
 // Loads data from an image source into renderable objects.
 export class ImageLayer extends Layer {
@@ -53,12 +52,11 @@ export class ImageLayer extends Layer {
 
     texture.dataFormat = "red_integer";
     if (chunk.data instanceof Uint16Array) {
-      texture.datatType = "unsigned_short";
+      texture.dataType = "unsigned_short";
     }
 
     texture.unpackRowLength = chunk.rowStride;
-    texture.unpackAlignment =
-      chunk.rowAlignmentBytes as TextureUnpackRowAlignment;
+    texture.unpackAlignment = chunk.rowAlignmentBytes;
 
     this.addObject(new Mesh(this.plane_, texture));
     this.setState("ready");

--- a/src/layers/image_layer.ts
+++ b/src/layers/image_layer.ts
@@ -4,6 +4,7 @@ import { PlaneGeometry } from "objects/geometry/plane_geometry";
 import { Region } from "data/region";
 import { ImageChunkSource } from "data/image_chunk";
 import { DataTexture2D } from "objects/textures/data_texture_2d";
+import { TextureUnpackRowAlignment } from "objects/textures/texture";
 
 // Loads data from an image source into renderable objects.
 export class ImageLayer extends Layer {
@@ -47,10 +48,18 @@ export class ImageLayer extends Layer {
     const texture = new DataTexture2D(
       chunk.data,
       chunk.shape.width,
-      chunk.shape.height,
-      chunk.rowStride,
-      chunk.rowAlignmentBytes
+      chunk.shape.height
     );
+
+    texture.dataFormat = "red_integer";
+    if (chunk.data instanceof Uint16Array) {
+      texture.datatType = "unsigned_short";
+    }
+
+    texture.unpackRowLength = chunk.rowStride;
+    texture.unpackAlignment =
+      chunk.rowAlignmentBytes as TextureUnpackRowAlignment;
+
     this.addObject(new Mesh(this.plane_, texture));
     this.setState("ready");
   }

--- a/src/layers/image_series_layer.ts
+++ b/src/layers/image_series_layer.ts
@@ -4,7 +4,6 @@ import { PlaneGeometry } from "objects/geometry/plane_geometry";
 import { Interval, Region } from "data/region";
 import { ImageChunk, ImageChunkSource } from "data/image_chunk";
 import { DataTexture2D } from "objects/textures/data_texture_2d";
-import { TextureUnpackRowAlignment } from "objects/textures/texture";
 
 // Loads 2D+t image data from an image source into renderable objects.
 export class ImageSeriesLayer extends Layer {
@@ -77,12 +76,11 @@ export class ImageSeriesLayer extends Layer {
 
     texture.dataFormat = "red_integer";
     if (chunk.data instanceof Uint16Array) {
-      texture.datatType = "unsigned_short";
+      texture.dataType = "unsigned_short";
     }
 
     texture.unpackRowLength = chunk.rowStride;
-    texture.unpackAlignment =
-      chunk.rowAlignmentBytes as TextureUnpackRowAlignment;
+    texture.unpackAlignment = chunk.rowAlignmentBytes;
 
     this.clearObjects();
     this.addObject(new Mesh(this.plane_, texture));

--- a/src/layers/image_series_layer.ts
+++ b/src/layers/image_series_layer.ts
@@ -4,6 +4,7 @@ import { PlaneGeometry } from "objects/geometry/plane_geometry";
 import { Interval, Region } from "data/region";
 import { ImageChunk, ImageChunkSource } from "data/image_chunk";
 import { DataTexture2D } from "objects/textures/data_texture_2d";
+import { TextureUnpackRowAlignment } from "objects/textures/texture";
 
 // Loads 2D+t image data from an image source into renderable objects.
 export class ImageSeriesLayer extends Layer {
@@ -71,10 +72,18 @@ export class ImageSeriesLayer extends Layer {
     const texture = new DataTexture2D(
       chunk.data,
       chunk.shape.width,
-      chunk.shape.height,
-      chunk.rowStride,
-      chunk.rowAlignmentBytes
+      chunk.shape.height
     );
+
+    texture.dataFormat = "red_integer";
+    if (chunk.data instanceof Uint16Array) {
+      texture.datatType = "unsigned_short";
+    }
+
+    texture.unpackRowLength = chunk.rowStride;
+    texture.unpackAlignment =
+      chunk.rowAlignmentBytes as TextureUnpackRowAlignment;
+
     this.clearObjects();
     this.addObject(new Mesh(this.plane_, texture));
   }

--- a/src/objects/textures/data_texture_2d.ts
+++ b/src/objects/textures/data_texture_2d.ts
@@ -1,35 +1,23 @@
 import { Texture } from "objects/textures/texture";
 
-type TextureDataType = Uint8Array | Uint16Array;
-
 export class DataTexture2D extends Texture {
-  private readonly data_: TextureDataType;
+  private readonly data_: ArrayBufferView;
   private readonly width_: number;
   private readonly height_: number;
-  private readonly rowStride_: number;
-  private readonly rowAlignmentBytes_: number;
 
-  constructor(
-    data: TextureDataType,
-    width: number,
-    height: number,
-    rowStride: number,
-    alignmentBytes: number
-  ) {
+  constructor(data: ArrayBufferView, width: number, height: number) {
     super();
     this.data_ = data;
     this.width_ = width;
     this.height_ = height;
-    this.rowStride_ = rowStride;
-    this.rowAlignmentBytes_ = alignmentBytes;
+  }
+
+  public get type() {
+    return "DataTexture2D";
   }
 
   public get data() {
     return this.data_;
-  }
-
-  public get dataType(): string {
-    return this.data.constructor.name;
   }
 
   public get width() {
@@ -38,17 +26,5 @@ export class DataTexture2D extends Texture {
 
   public get height() {
     return this.height_;
-  }
-
-  public get rowStride() {
-    return this.rowStride_;
-  }
-
-  public get rowAlignmentBytes() {
-    return this.rowAlignmentBytes_;
-  }
-
-  public get type() {
-    return "DataTexture2D";
   }
 }

--- a/src/objects/textures/texture.ts
+++ b/src/objects/textures/texture.ts
@@ -10,9 +10,15 @@ export type TextureDataType = "unsigned_byte" | "unsigned_short";
 
 export type TextureUnpackRowAlignment = 1 | 2 | 4 | 8;
 
+export function isTextureUnpackRowAlignment(
+  value: number
+): value is TextureUnpackRowAlignment {
+  return value === 1 || value === 2 || value === 4 || value === 8;
+}
+
 export abstract class Texture extends Node {
   public dataFormat: TextureDataFormat = "rgba";
-  public datatType: TextureDataType = "unsigned_byte";
+  public dataType: TextureDataType = "unsigned_byte";
   public maxFilter: TextureFilter = "nearest";
   public minFilter: TextureFilter = "nearest";
   public mipmapLevels = 1;
@@ -24,7 +30,7 @@ export abstract class Texture extends Node {
 
   public abstract get width(): number;
   public abstract get height(): number;
-  public abstract get data(): ArrayBufferView | HTMLImageElement | null;
+  public abstract get data(): TexImageSource | ArrayBufferView | null;
 
   public get type() {
     return "Texture";

--- a/src/objects/textures/texture.ts
+++ b/src/objects/textures/texture.ts
@@ -1,6 +1,31 @@
 import { Node } from "core/node";
 
-export class Texture extends Node {
+export type TextureFilter = "nearest" | "linear";
+
+export type TextureWrapMode = "repeat" | "clamp_to_edge";
+
+export type TextureDataFormat = "rgb" | "rgba" | "red_integer";
+
+export type TextureDataType = "unsigned_byte" | "unsigned_short";
+
+export type TextureUnpackRowAlignment = 1 | 2 | 4 | 8;
+
+export abstract class Texture extends Node {
+  public dataFormat: TextureDataFormat = "rgba";
+  public datatType: TextureDataType = "unsigned_byte";
+  public maxFilter: TextureFilter = "nearest";
+  public minFilter: TextureFilter = "nearest";
+  public mipmapLevels = 1;
+  public unpackAlignment: TextureUnpackRowAlignment = 4;
+  public unpackRowLength = 0;
+  public wrapR: TextureWrapMode = "repeat";
+  public wrapS: TextureWrapMode = "repeat";
+  public wrapT: TextureWrapMode = "repeat";
+
+  public abstract get width(): number;
+  public abstract get height(): number;
+  public abstract get data(): ArrayBufferView | HTMLImageElement | null;
+
   public get type() {
     return "Texture";
   }

--- a/src/objects/textures/texture_2d.ts
+++ b/src/objects/textures/texture_2d.ts
@@ -25,7 +25,15 @@ export class Texture2D extends Texture {
     throw new Error("Failed to load texture image");
   }
 
-  public get image() {
+  public get width() {
+    return this.image_.width;
+  }
+
+  public get height() {
+    return this.image_.height;
+  }
+
+  public get data() {
     return this.image_;
   }
 

--- a/src/renderers/webgl_textures.ts
+++ b/src/renderers/webgl_textures.ts
@@ -48,7 +48,7 @@ export class WebGLTextures {
   }
 
   private configureTexture(texture: Texture) {
-    this.configureTextureParamaters(texture);
+    this.configureTextureParameters(texture);
     this.allocateTextureStorage(texture);
 
     if (texture.data !== null) {
@@ -56,7 +56,7 @@ export class WebGLTextures {
     }
   }
 
-  private configureTextureParamaters(texture: Texture) {
+  private configureTextureParameters(texture: Texture) {
     const gl = this.gl_;
 
     gl.pixelStorei(gl.UNPACK_ALIGNMENT, texture.unpackAlignment);
@@ -97,7 +97,7 @@ export class WebGLTextures {
     this.gl_.texStorage2D(
       this.getGLTextureType(texture),
       texture.mipmapLevels,
-      this.getGLInternalFormat(texture.dataFormat, texture.datatType) as GLenum,
+      this.getGLInternalFormat(texture.dataFormat, texture.dataType),
       texture.width,
       texture.height
     );
@@ -116,8 +116,12 @@ export class WebGLTextures {
       texture.width,
       texture.height,
       this.getGLFormat(texture.dataFormat),
-      this.getGLType(texture.datatType),
-      texture.data as HTMLImageElement
+      this.getGLType(texture.dataType),
+      // This function has multiple overloads. We are temporarily casting it to
+      // ArrayBufferView to ensure the correct overload is called. Once we
+      // consolidate Texture2D and DataTexture2D, we can remove this cast.
+      // https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/texSubImage2D#syntax
+      texture.data as ArrayBufferView
     );
   }
 

--- a/src/renderers/webgl_textures.ts
+++ b/src/renderers/webgl_textures.ts
@@ -1,6 +1,10 @@
-import { Texture } from "objects/textures/texture";
-import { Texture2D } from "objects/textures/texture_2d";
-import { DataTexture2D } from "objects/textures/data_texture_2d";
+import {
+  Texture,
+  TextureFilter,
+  TextureWrapMode,
+  TextureDataType,
+  TextureDataFormat,
+} from "objects/textures/texture";
 
 export class WebGLTextures {
   private readonly gl_: WebGL2RenderingContext;
@@ -19,7 +23,7 @@ export class WebGLTextures {
       textureId = this.createTexture();
     }
 
-    this.gl_.bindTexture(this.textureType(texture), textureId);
+    this.gl_.bindTexture(this.getGLTextureType(texture), textureId);
     if (!this.textures_.has(texture.uuid)) {
       this.configureTexture(texture);
       this.textures_.set(texture.uuid, textureId);
@@ -35,7 +39,89 @@ export class WebGLTextures {
     return false;
   }
 
-  private textureType(texture: Texture) {
+  private createTexture() {
+    const texture = this.gl_.createTexture();
+    if (!texture) {
+      throw new Error(`Unable to generate a texture name`);
+    }
+    return texture;
+  }
+
+  private configureTexture(texture: Texture) {
+    this.configureTextureParamaters(texture);
+    this.allocateTextureStorage(texture);
+
+    if (texture.data !== null) {
+      this.uploadTextureSubData(texture, 0, { x: 0, y: 0 });
+    }
+  }
+
+  private configureTextureParamaters(texture: Texture) {
+    const gl = this.gl_;
+
+    gl.pixelStorei(gl.UNPACK_ALIGNMENT, texture.unpackAlignment);
+    gl.pixelStorei(gl.UNPACK_ROW_LENGTH, texture.unpackRowLength);
+
+    gl.texParameteri(
+      this.getGLTextureType(texture),
+      gl.TEXTURE_MIN_FILTER,
+      this.getGLFilter(texture.minFilter, texture.dataFormat)
+    );
+
+    gl.texParameteri(
+      this.getGLTextureType(texture),
+      gl.TEXTURE_MAG_FILTER,
+      this.getGLFilter(texture.maxFilter, texture.dataFormat)
+    );
+
+    gl.texParameteri(
+      this.getGLTextureType(texture),
+      gl.TEXTURE_WRAP_S,
+      this.getGLWrapMode(texture.wrapS)
+    );
+
+    gl.texParameteri(
+      this.getGLTextureType(texture),
+      gl.TEXTURE_WRAP_T,
+      this.getGLWrapMode(texture.wrapT)
+    );
+
+    gl.texParameteri(
+      this.getGLTextureType(texture),
+      gl.TEXTURE_WRAP_R,
+      this.getGLWrapMode(texture.wrapR)
+    );
+  }
+
+  private allocateTextureStorage(texture: Texture) {
+    this.gl_.texStorage2D(
+      this.getGLTextureType(texture),
+      texture.mipmapLevels,
+      this.getGLInternalFormat(texture.dataFormat, texture.datatType) as GLenum,
+      texture.width,
+      texture.height
+    );
+  }
+
+  private uploadTextureSubData(
+    texture: Texture,
+    mipmapLevel: number,
+    offset: { x: number; y: number }
+  ) {
+    this.gl_.texSubImage2D(
+      this.getGLTextureType(texture),
+      mipmapLevel,
+      offset.x,
+      offset.y,
+      texture.width,
+      texture.height,
+      this.getGLFormat(texture.dataFormat),
+      this.getGLType(texture.datatType),
+      texture.data as HTMLImageElement
+    );
+  }
+
+  private getGLTextureType(texture: Texture) {
     switch (texture.type) {
       case "Texture2D":
       case "DataTexture2D":
@@ -45,85 +131,66 @@ export class WebGLTextures {
     }
   }
 
-  private configureTexture(texture: Texture) {
-    switch (texture.type) {
-      case "Texture2D":
-        this.configureTexture2D(texture as Texture2D);
-        break;
-      case "DataTexture2D":
-        this.configureDataTexture2D(texture as DataTexture2D);
-        break;
-      default:
-        throw new Error(`Unknown texture type ${texture.type}`);
+  private getGLFilter(filter: TextureFilter, format: TextureDataFormat) {
+    if (format == "red_integer" && filter != "nearest") {
+      console.warn(
+        "Integer values are not filterable. Using gl.NEAREST instead."
+      );
+      return this.gl_.NEAREST;
+    }
+
+    switch (filter) {
+      case "nearest":
+        return this.gl_.NEAREST;
+      case "linear":
+        return this.gl_.LINEAR;
     }
   }
 
-  private createTexture() {
-    const texture = this.gl_.createTexture();
-    if (!texture) {
-      throw new Error(`Unable to generate a texture name`);
+  private getGLWrapMode(mode: TextureWrapMode) {
+    switch (mode) {
+      case "repeat":
+        return this.gl_.REPEAT;
+      case "clamp_to_edge":
+        return this.gl_.CLAMP_TO_EDGE;
     }
-    return texture;
   }
 
-  private configureTexture2D(texture: Texture2D) {
-    const gl = this.gl_;
-    const format = gl.RGBA;
-    const type = gl.UNSIGNED_BYTE;
-    const image = texture.image;
-
-    gl.texImage2D(gl.TEXTURE_2D, 0, format, format, type, image);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+  private getGLType(type: TextureDataType) {
+    switch (type) {
+      case "unsigned_byte":
+        return this.gl_.UNSIGNED_BYTE;
+      case "unsigned_short":
+        return this.gl_.UNSIGNED_SHORT;
+    }
   }
 
-  private configureDataTexture2D(texture: DataTexture2D) {
-    const gl = this.gl_;
-    gl.pixelStorei(gl.UNPACK_ALIGNMENT, texture.rowAlignmentBytes);
-    gl.pixelStorei(gl.UNPACK_ROW_LENGTH, texture.rowStride);
-    const level = 0;
-    const border = 0;
-    const { internalFormat, format, type } =
-      this.dataTexture2DGlTextureProps(texture);
+  private getGLFormat(type: TextureDataFormat) {
+    switch (type) {
+      case "rgb":
+        return this.gl_.RGB;
+      case "rgba":
+        return this.gl_.RGBA;
+      case "red_integer":
+        return this.gl_.RED_INTEGER;
+    }
+  }
 
-    gl.texImage2D(
-      gl.TEXTURE_2D,
-      level,
-      internalFormat,
-      texture.width,
-      texture.height,
-      border,
-      format,
-      type,
-      texture.data
+  private getGLInternalFormat(
+    format: TextureDataFormat,
+    type: TextureDataType
+  ) {
+    if (format === "rgba" && type === "unsigned_byte") {
+      return this.gl_.RGBA8;
+    } else if (format === "rgb" && type === "unsigned_byte") {
+      return this.gl_.RGB8;
+    } else if (format === "red_integer" && type === "unsigned_byte") {
+      return this.gl_.R8UI;
+    } else if (format === "red_integer" && type === "unsigned_short") {
+      return this.gl_.R16UI;
+    }
+    throw Error(
+      `Unsupported data format and type combination ${format}/${type}`
     );
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
-    // Use NEAREST because unsigned integer valued textures are not generally
-    // texture filterable.
-    // https://webgl2fundamentals.org/webgl/lessons/webgl-data-textures.html
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
-  }
-
-  private dataTexture2DGlTextureProps(texture: DataTexture2D) {
-    const gl = this.gl_;
-    if (texture.data instanceof Uint8Array) {
-      return {
-        internalFormat: gl.R8UI,
-        format: gl.RED_INTEGER,
-        type: gl.UNSIGNED_BYTE,
-      };
-    }
-    if (texture.data instanceof Uint16Array) {
-      return {
-        internalFormat: gl.R16UI,
-        format: gl.RED_INTEGER,
-        type: gl.UNSIGNED_SHORT,
-      };
-    }
-    const exhaustiveCheck: never = texture.data;
-    throw Error(`Unsupported data type: ${exhaustiveCheck}`);
   }
 }


### PR DESCRIPTION
### Summary

This PR introduces immutable textures, refactors the texture class to support
internal properties that can be configured by layers, and moves texture
property mapping to the GLTextures module.

### Related Issue
This PR doesn't close #69 but it's related to it. The following PR will address it directly.

### Tests & Checks

Manual verification

https://github.com/user-attachments/assets/89626ebd-f8f3-4ab0-9f13-8e5f7e58e86c

