### PR TITLE
Add data updates for textures

### DIFF
--- a/src/layers/image_series_layer.ts
+++ b/src/layers/image_series_layer.ts
@@ -14,6 +14,7 @@ export class ImageSeriesLayer extends Layer {
   private readonly region_: Region;
   private readonly timeInterval_: Interval;
   private readonly timeDimensionIndex_: number;
+  private texture_: DataTexture2D | null = null;
   private dataChunks_: ImageChunk[] = [];
 
   constructor(source: ImageChunkSource, region: Region, timeDimension: string) {
@@ -66,24 +67,12 @@ export class ImageSeriesLayer extends Layer {
       throw new Error(`Time index ${index} is after the stop time: ${stop}.`);
     }
     const chunk = this.dataChunks_[chunkIndex];
-    // TODO: create one object and update the texture in-place.
-    // Or use a texture array and update the index for the shader.
-    const texture = new DataTexture2D(
-      chunk.data,
-      chunk.shape.width,
-      chunk.shape.height
-    );
-
-    texture.dataFormat = "red_integer";
-    if (chunk.data instanceof Uint16Array) {
-      texture.dataType = "unsigned_short";
+    if (this.texture_ === null) {
+      this.initializeTexture(chunk);
+      this.addObject(new Mesh(this.plane_, this.texture_));
+    } else {
+      this.texture_.data = chunk.data;
     }
-
-    texture.unpackRowLength = chunk.rowStride;
-    texture.unpackAlignment = chunk.rowAlignmentBytes;
-
-    this.clearObjects();
-    this.addObject(new Mesh(this.plane_, texture));
   }
 
   private async load() {
@@ -112,5 +101,20 @@ export class ImageSeriesLayer extends Layer {
     await Promise.all(loadPromises);
 
     this.setState("ready");
+  }
+
+  private initializeTexture(chunk: ImageChunk) {
+    this.texture_ = new DataTexture2D(
+      chunk.data,
+      chunk.shape.width,
+      chunk.shape.height
+    );
+
+    this.texture_.unpackRowLength = chunk.rowStride;
+    this.texture_.unpackAlignment = chunk.rowAlignmentBytes;
+    this.texture_.dataFormat = "red_integer";
+    if (chunk.data instanceof Uint16Array) {
+      this.texture_.dataType = "unsigned_short";
+    }
   }
 }

--- a/src/objects/textures/data_texture_2d.ts
+++ b/src/objects/textures/data_texture_2d.ts
@@ -1,7 +1,7 @@
 import { Texture } from "objects/textures/texture";
 
 export class DataTexture2D extends Texture {
-  private readonly data_: ArrayBufferView;
+  private data_: ArrayBufferView;
   private readonly width_: number;
   private readonly height_: number;
 
@@ -10,6 +10,11 @@ export class DataTexture2D extends Texture {
     this.data_ = data;
     this.width_ = width;
     this.height_ = height;
+  }
+
+  public set data(data: ArrayBufferView) {
+    this.data_ = data;
+    this.needsUpdate = true;
   }
 
   public get type() {

--- a/src/objects/textures/texture.ts
+++ b/src/objects/textures/texture.ts
@@ -27,6 +27,7 @@ export abstract class Texture extends Node {
   public wrapR: TextureWrapMode = "repeat";
   public wrapS: TextureWrapMode = "repeat";
   public wrapT: TextureWrapMode = "repeat";
+  public needsUpdate = true;
 
   public abstract get width(): number;
   public abstract get height(): number;

--- a/src/renderers/webgl_textures.ts
+++ b/src/renderers/webgl_textures.ts
@@ -8,7 +8,7 @@ import {
 
 export class WebGLTextures {
   private readonly gl_: WebGL2RenderingContext;
-  private textures_: Map<string, WebGLTexture> = new Map();
+  private readonly textures_: Map<string, WebGLTexture> = new Map();
   private currentTexture_: WebGLTexture = 0;
 
   constructor(gl: WebGL2RenderingContext) {
@@ -16,7 +16,7 @@ export class WebGLTextures {
   }
 
   public bind(texture: Texture) {
-    if (this.alreadyActive(texture.uuid)) return;
+    if (this.alreadyActive(texture.uuid) && !texture.needsUpdate) return;
 
     let textureId = this.textures_.get(texture.uuid) || null;
     if (!textureId) {
@@ -27,6 +27,13 @@ export class WebGLTextures {
     if (!this.textures_.has(texture.uuid)) {
       this.configureTexture(texture);
       this.textures_.set(texture.uuid, textureId);
+    }
+
+    if (texture.needsUpdate && texture.data !== null) {
+      // Currently, we don't support mipmaps, so we always update the base level (0).
+      const mipmapLevel = 0;
+      this.uploadTextureSubData(texture, mipmapLevel, { x: 0, y: 0 });
+      texture.needsUpdate = false;
     }
 
     this.currentTexture_ = textureId;
@@ -50,10 +57,6 @@ export class WebGLTextures {
   private configureTexture(texture: Texture) {
     this.configureTextureParameters(texture);
     this.allocateTextureStorage(texture);
-
-    if (texture.data !== null) {
-      this.uploadTextureSubData(texture, 0, { x: 0, y: 0 });
-    }
   }
 
   private configureTextureParameters(texture: Texture) {


### PR DESCRIPTION
### Summary
This PR adds the ability to update texture data after the texture's creation.
It eliminates the need to create new textures and renderable objects each
time the time index changes in the image series layer.

### Notes
- This update doesn't support modifying sub-regions. It assumes we're always replacing the entire dataset. We can address sub-regions when there is a need for it.
- I consider this an intermediate step for the image series layer. Ideally, it will use a 2D texture array to load multiple layers simultaneously instead of loading layers individually when the time index changes.

### Related Issue
Closes #69

### Tests & Checks
- Visual verification (see video below.)
- I also manually verified that an "image series" allocates a texture only once and updates the data for each new time index.

https://github.com/user-attachments/assets/49197dc6-a314-4d96-869e-96e2233086ca

