### PR TITLE
Load multiple channels from data source

### DIFF
--- a/examples/image_series_from_omezarr5d_u8/main.ts
+++ b/examples/image_series_from_omezarr5d_u8/main.ts
@@ -13,13 +13,14 @@ const layerManager = new LayerManager();
 const renderer = new WebGLRenderer("#canvas");
 const camera = new OrthographicCamera(0, 1920, 0, 1440);
 
-// Source is 5D, so provide an interval in T and scalar indices in C (first of
-// three channels) and Z (first of only depth) to get a 2D image series.
+// Source is 5D, so provide an interval in T and C (all three channels)
+// and scalar indices in Z (first of only depth) to get a 2D image series.
 const source = new OmeZarrImageSource(url);
 const timeInterval = { start: 100, stop: 120 };
+const channels = { start: 0, stop: 3 };
 const region = [
   { dimension: "T", index: timeInterval },
-  { dimension: "C", index: 0 },
+  { dimension: "C", index: channels },
   { dimension: "Z", index: 0 },
 ];
 const layer = new ImageSeriesLayer(source, region, "T");

--- a/examples/tracks/main.ts
+++ b/examples/tracks/main.ts
@@ -47,7 +47,7 @@ const source = new OmeZarrImageSource(url);
 const timeInterval = { start: 28, stop: 39 };
 const region = [
   { dimension: "T", index: timeInterval },
-  { dimension: "C", index: 0 },
+  { dimension: "C", index: { start: 0, stop: 3 } },
   { dimension: "Z", index: 0 },
 ];
 

--- a/src/data/image_chunk.ts
+++ b/src/data/image_chunk.ts
@@ -9,6 +9,7 @@ export type ImageChunk = {
   shape: {
     width: number;
     height: number;
+    channels: number;
   };
   rowStride: number;
   rowAlignmentBytes: TextureUnpackRowAlignment;

--- a/src/data/ome_zarr_image_loader.ts
+++ b/src/data/ome_zarr_image_loader.ts
@@ -89,15 +89,9 @@ export class OmeZarrImageLoader {
       );
     }
 
-    if (subarray.shape.length !== 2) {
+    if (subarray.shape.length !== 2 && subarray.shape.length !== 3) {
       throw new Error(
-        `Expected to receive a 2D subarray. Instead chunk has shape ${subarray.shape}`
-      );
-    }
-
-    if (subarray.stride[1] !== 1) {
-      throw new Error(
-        `Expected to find a column stride of 1. Instead found ${subarray.stride[1]}`
+        `Expected to receive a 2D or 3D subarray. Instead chunk has shape ${subarray.shape}`
       );
     }
 
@@ -110,8 +104,12 @@ export class OmeZarrImageLoader {
 
     const chunk = {
       data: subarray.data,
-      shape: { width: subarray.shape[1], height: subarray.shape[0] },
-      rowStride: subarray.stride[0],
+      shape: {
+        width: subarray.shape[subarray.shape.length - 1],
+        height: subarray.shape[subarray.shape.length - 2],
+        channels: subarray.shape.length === 3 ? subarray.shape[0] : 1,
+      },
+      rowStride: subarray.stride[subarray.stride.length - 2],
       rowAlignmentBytes: rowAlignment,
     };
     console.debug("loaded chunk ", chunk);

--- a/src/layers/image_series_layer.ts
+++ b/src/layers/image_series_layer.ts
@@ -3,7 +3,6 @@ import { Mesh } from "objects/renderable/mesh";
 import { PlaneGeometry } from "objects/geometry/plane_geometry";
 import { Interval, Region } from "data/region";
 import { ImageChunk, ImageChunkSource } from "data/image_chunk";
-import { DataTexture2D } from "objects/textures/data_texture_2d";
 import { Texture2DArray } from "objects/textures/texture_2d_array";
 
 // Loads 2D+t image data from an image source into renderable objects.
@@ -12,7 +11,7 @@ export class ImageSeriesLayer extends Layer {
   private readonly region_: Region;
   private readonly timeInterval_: Interval;
   private readonly timeDimensionIndex_: number;
-  private texture_: DataTexture2D | Texture2DArray | null = null;
+  private texture_: Texture2DArray | null = null;
   private dataChunks_: ImageChunk[] = [];
 
   constructor(source: ImageChunkSource, region: Region, timeDimension: string) {
@@ -104,19 +103,11 @@ export class ImageSeriesLayer extends Layer {
   }
 
   private initializeTexture(chunk: ImageChunk) {
-    if (chunk.shape.channels > 1) {
-      this.texture_ = new Texture2DArray(
-        chunk.data,
-        chunk.shape.width,
-        chunk.shape.height
-      );
-    } else {
-      this.texture_ = new DataTexture2D(
-        chunk.data,
-        chunk.shape.width,
-        chunk.shape.height
-      );
-    }
+    this.texture_ = new Texture2DArray(
+      chunk.data,
+      chunk.shape.width,
+      chunk.shape.height
+    );
 
     this.texture_.unpackRowLength = chunk.rowStride;
     this.texture_.unpackAlignment = chunk.rowAlignmentBytes;

--- a/src/layers/image_series_layer.ts
+++ b/src/layers/image_series_layer.ts
@@ -3,6 +3,7 @@ import { Mesh } from "objects/renderable/mesh";
 import { PlaneGeometry } from "objects/geometry/plane_geometry";
 import { Interval, Region } from "data/region";
 import { ImageChunk, ImageChunkSource } from "data/image_chunk";
+import { DataTexture2D } from "objects/textures/data_texture_2d";
 import { Texture2DArray } from "objects/textures/texture_2d_array";
 
 // Loads 2D+t image data from an image source into renderable objects.
@@ -11,7 +12,7 @@ export class ImageSeriesLayer extends Layer {
   private readonly region_: Region;
   private readonly timeInterval_: Interval;
   private readonly timeDimensionIndex_: number;
-  private texture_: Texture2DArray | null = null;
+  private texture_: DataTexture2D | Texture2DArray | null = null;
   private dataChunks_: ImageChunk[] = [];
 
   constructor(source: ImageChunkSource, region: Region, timeDimension: string) {
@@ -103,12 +104,19 @@ export class ImageSeriesLayer extends Layer {
   }
 
   private initializeTexture(chunk: ImageChunk) {
-    this.texture_ = new Texture2DArray(
-      chunk.data,
-      chunk.shape.width,
-      chunk.shape.height,
-      chunk.shape.width * chunk.shape.height
-    );
+    if (chunk.shape.channels > 1) {
+      this.texture_ = new Texture2DArray(
+        chunk.data,
+        chunk.shape.width,
+        chunk.shape.height
+      );
+    } else {
+      this.texture_ = new DataTexture2D(
+        chunk.data,
+        chunk.shape.width,
+        chunk.shape.height
+      );
+    }
 
     this.texture_.unpackRowLength = chunk.rowStride;
     this.texture_.unpackAlignment = chunk.rowAlignmentBytes;

--- a/src/layers/image_series_layer.ts
+++ b/src/layers/image_series_layer.ts
@@ -3,7 +3,7 @@ import { Mesh } from "objects/renderable/mesh";
 import { PlaneGeometry } from "objects/geometry/plane_geometry";
 import { Interval, Region } from "data/region";
 import { ImageChunk, ImageChunkSource } from "data/image_chunk";
-import { DataTexture2D } from "objects/textures/data_texture_2d";
+import { Texture2DArray } from "objects/textures/texture_2d_array";
 
 // Loads 2D+t image data from an image source into renderable objects.
 export class ImageSeriesLayer extends Layer {
@@ -11,7 +11,7 @@ export class ImageSeriesLayer extends Layer {
   private readonly region_: Region;
   private readonly timeInterval_: Interval;
   private readonly timeDimensionIndex_: number;
-  private texture_: DataTexture2D | null = null;
+  private texture_: Texture2DArray | null = null;
   private dataChunks_: ImageChunk[] = [];
 
   constructor(source: ImageChunkSource, region: Region, timeDimension: string) {
@@ -103,10 +103,11 @@ export class ImageSeriesLayer extends Layer {
   }
 
   private initializeTexture(chunk: ImageChunk) {
-    this.texture_ = new DataTexture2D(
+    this.texture_ = new Texture2DArray(
       chunk.data,
       chunk.shape.width,
-      chunk.shape.height
+      chunk.shape.height,
+      chunk.shape.width * chunk.shape.height
     );
 
     this.texture_.unpackRowLength = chunk.rowStride;

--- a/src/objects/textures/texture_2d_array.ts
+++ b/src/objects/textures/texture_2d_array.ts
@@ -1,0 +1,50 @@
+import { Texture } from "objects/textures/texture";
+
+export class Texture2DArray extends Texture {
+    private data_: ArrayBufferView;
+    private readonly width_: number;
+    private readonly height_: number;
+    private readonly layerByteLength_: number;
+
+    constructor(data: ArrayBufferView, width: number, height: number, layerByteLength: number) {
+        super();
+
+        if (layerByteLength < data.byteLength) {
+            // TODO: not enought for a single layer
+        }
+
+        if (data.byteLength % layerByteLength !== 0) {
+            // TODO: throw an error offset is not divisible
+        }
+
+        this.data_ = data;
+        this.width_ = width;
+        this.height_ = height;
+        this.layerByteLength_ = layerByteLength;
+    }
+
+    public get type() {
+        return "Texture2DArray";
+    }
+
+    public set data(data: ArrayBufferView) {
+        this.data_ = data;
+        this.needsUpdate = true;
+    }
+
+    public get data() {
+        return this.data_;
+    }
+
+    public get width() {
+        return this.width_;
+    }
+
+    public get height() {
+        return this.height_;
+    }
+
+    public get layerOffset() {
+        return this.layerByteLength_;
+    }
+}

--- a/src/objects/textures/texture_2d_array.ts
+++ b/src/objects/textures/texture_2d_array.ts
@@ -1,50 +1,65 @@
 import { Texture } from "objects/textures/texture";
 
 export class Texture2DArray extends Texture {
-    private data_: ArrayBufferView;
-    private readonly width_: number;
-    private readonly height_: number;
-    private readonly layerByteLength_: number;
+  private data_: ArrayBufferView;
+  private readonly width_: number;
+  private readonly height_: number;
+  private readonly depth_: number;
+  private readonly sliceByteLength_: number;
 
-    constructor(data: ArrayBufferView, width: number, height: number, layerByteLength: number) {
-        super();
+  constructor(
+    data: ArrayBufferView,
+    width: number,
+    height: number,
+    sliceByteLength: number
+  ) {
+    super();
 
-        if (layerByteLength < data.byteLength) {
-            // TODO: not enought for a single layer
-        }
-
-        if (data.byteLength % layerByteLength !== 0) {
-            // TODO: throw an error offset is not divisible
-        }
-
-        this.data_ = data;
-        this.width_ = width;
-        this.height_ = height;
-        this.layerByteLength_ = layerByteLength;
+    if (data.byteLength < sliceByteLength) {
+      throw new Error(
+        "The size of a slice must be greater than or equal to the size of the data"
+      );
     }
 
-    public get type() {
-        return "Texture2DArray";
+    if (data.byteLength % sliceByteLength !== 0) {
+      throw new Error(
+        "The size of a slice must be divisible by the size of the data"
+      );
     }
 
-    public set data(data: ArrayBufferView) {
-        this.data_ = data;
-        this.needsUpdate = true;
-    }
+    this.data_ = data;
+    this.width_ = width;
+    this.height_ = height;
+    this.sliceByteLength_ = sliceByteLength;
+    this.depth_ = data.byteLength / sliceByteLength;
+  }
 
-    public get data() {
-        return this.data_;
-    }
+  public get type() {
+    return "Texture2DArray";
+  }
 
-    public get width() {
-        return this.width_;
-    }
+  public set data(data: ArrayBufferView) {
+    this.data_ = data;
+    this.needsUpdate = true;
+  }
 
-    public get height() {
-        return this.height_;
-    }
+  public get data() {
+    return this.data_;
+  }
 
-    public get layerOffset() {
-        return this.layerByteLength_;
-    }
+  public get width() {
+    return this.width_;
+  }
+
+  public get height() {
+    return this.height_;
+  }
+
+  public get depth() {
+    return this.depth_;
+  }
+
+  public get layerOffset() {
+    return this.sliceByteLength_;
+  }
 }

--- a/src/objects/textures/texture_2d_array.ts
+++ b/src/objects/textures/texture_2d_array.ts
@@ -5,33 +5,15 @@ export class Texture2DArray extends Texture {
   private readonly width_: number;
   private readonly height_: number;
   private readonly depth_: number;
-  private readonly sliceByteLength_: number;
 
-  constructor(
-    data: ArrayBufferView,
-    width: number,
-    height: number,
-    sliceByteLength: number
-  ) {
+  constructor(data: ArrayBufferView, width: number, height: number) {
     super();
-
-    if (data.byteLength < sliceByteLength) {
-      throw new Error(
-        "The size of a slice must be greater than or equal to the size of the data"
-      );
-    }
-
-    if (data.byteLength % sliceByteLength !== 0) {
-      throw new Error(
-        "The size of a slice must be divisible by the size of the data"
-      );
-    }
 
     this.data_ = data;
     this.width_ = width;
     this.height_ = height;
-    this.sliceByteLength_ = sliceByteLength;
-    this.depth_ = data.byteLength / sliceByteLength;
+    // We currently assume that each slice's size is equal to the image's area
+    this.depth_ = data.byteLength / (width * height);
   }
 
   public get type() {
@@ -57,9 +39,5 @@ export class Texture2DArray extends Texture {
 
   public get depth() {
     return this.depth_;
-  }
-
-  public get layerOffset() {
-    return this.sliceByteLength_;
   }
 }

--- a/src/renderers/shaders/index.ts
+++ b/src/renderers/shaders/index.ts
@@ -3,8 +3,9 @@ import projectedLineFragmentShader from "./projected_line_frag.glsl";
 import meshVertexShader from "./mesh_vert.glsl";
 import meshFragmentShader from "./mesh_frag.glsl";
 import uintImageFragmentShader from "./uint_image_frag.glsl";
+import uintImageArrayFragmentShader from "./uint_image_array_frag.glsl";
 
-export type Shader = "projectedLine" | "mesh" | "uintImage";
+export type Shader = "projectedLine" | "mesh" | "uintImage" | "uintImageArray";
 
 export const shaderCode: Record<Shader, { vertex: string; fragment: string }> =
   {
@@ -19,5 +20,9 @@ export const shaderCode: Record<Shader, { vertex: string; fragment: string }> =
     uintImage: {
       vertex: meshVertexShader,
       fragment: uintImageFragmentShader,
+    },
+    uintImageArray: {
+      vertex: meshVertexShader,
+      fragment: uintImageArrayFragmentShader,
     },
   };

--- a/src/renderers/shaders/uint_image_array_frag.glsl
+++ b/src/renderers/shaders/uint_image_array_frag.glsl
@@ -1,0 +1,17 @@
+#version 300 es
+
+precision mediump float;
+
+layout (location = 0) out vec4 fragColor;
+
+uniform mediump usampler2DArray texture0;
+
+in vec2 TexCoords;
+
+void main() {
+    float red = float(texture(texture0, vec3(TexCoords, 0)).r) / 256.0;
+    float green = float(texture(texture0, vec3(TexCoords, 1)).r) / 256.0;
+    float blue = float(texture(texture0, vec3(TexCoords, 2)).r) / 256.0;
+
+    fragColor = vec4(red, green, blue, 1);
+}

--- a/src/renderers/shaders/uint_image_frag.glsl
+++ b/src/renderers/shaders/uint_image_frag.glsl
@@ -4,7 +4,7 @@ precision mediump float;
 
 layout (location = 0) out vec4 fragColor;
 
-uniform mediump usampler2DArray texture0;
+uniform mediump usampler2D texture0;
 
 in vec2 TexCoords;
 
@@ -12,8 +12,6 @@ void main() {
     // TODO: normalization of the value should be controlled by variable
     // parameters (e.g. contrast limits).
     // https://github.com/chanzuckerberg/imaging-active-learning/issues/32
-    float red = float(texture(texture0, vec3(TexCoords, 0)).r) / 256.0;
-    float green = float(texture(texture0, vec3(TexCoords, 1)).r) / 256.0;
-    float blue = float(texture(texture0, vec3(TexCoords, 2)).r) / 256.0;
-    fragColor = vec4(red, green, blue, 1);
+    float value = float(texture(texture0, TexCoords).r) / 256.0;
+    fragColor = vec4(value, value, value, 1);
 }

--- a/src/renderers/shaders/uint_image_frag.glsl
+++ b/src/renderers/shaders/uint_image_frag.glsl
@@ -4,7 +4,7 @@ precision mediump float;
 
 layout (location = 0) out vec4 fragColor;
 
-uniform mediump usampler2D texture0;
+uniform mediump usampler2DArray texture0;
 
 in vec2 TexCoords;
 
@@ -12,6 +12,8 @@ void main() {
     // TODO: normalization of the value should be controlled by variable
     // parameters (e.g. contrast limits).
     // https://github.com/chanzuckerberg/imaging-active-learning/issues/32
-    float value = float(texture(texture0, TexCoords).r) / 256.0;
-    fragColor = vec4(value, value, value, 1);
+    float red = float(texture(texture0, vec3(TexCoords, 0)).r) / 256.0;
+    float green = float(texture(texture0, vec3(TexCoords, 1)).r) / 256.0;
+    float blue = float(texture(texture0, vec3(TexCoords, 2)).r) / 256.0;
+    fragColor = vec4(red, green, blue, 1);
 }

--- a/src/renderers/webgl_renderer.ts
+++ b/src/renderers/webgl_renderer.ts
@@ -87,9 +87,10 @@ export class WebGLRenderer extends Renderer {
   // refactor textures first (consolidating the two programs below.)
   private getProgramName(object: RenderableObject) {
     if (object.type === "ProjectedLine") return "projectedLine";
-    return object.textures.length && object.textures[0].type === "DataTexture2D"
-      ? "uintImage"
-      : "mesh";
+    return object.textures.length === 0 ||
+      object.textures[0].type === "Texture2D"
+      ? "mesh"
+      : "uintImage";
   }
 
   private getShaderProgram(type: Shader) {

--- a/src/renderers/webgl_renderer.ts
+++ b/src/renderers/webgl_renderer.ts
@@ -87,10 +87,11 @@ export class WebGLRenderer extends Renderer {
   // refactor textures first (consolidating the two programs below.)
   private getProgramName(object: RenderableObject) {
     if (object.type === "ProjectedLine") return "projectedLine";
-    return object.textures.length === 0 ||
-      object.textures[0].type === "Texture2D"
-      ? "mesh"
-      : "uintImage";
+    if (object.textures.length > 0) {
+      if (object.textures[0].type === "DataTexture2D") return "uintImage";
+      if (object.textures[0].type === "Texture2DArray") return "uintImageArray";
+    }
+    return "mesh";
   }
 
   private getShaderProgram(type: Shader) {

--- a/src/renderers/webgl_textures.ts
+++ b/src/renderers/webgl_textures.ts
@@ -34,7 +34,7 @@ export class WebGLTextures {
     if (texture.needsUpdate && texture.data !== null) {
       // Currently, we don't support mipmaps, so we always update the base level (0).
       const mipmapLevel = 0;
-      this.uploadTextureSubData(texture, mipmapLevel, { x: 0, y: 0 });
+      this.uploadTextureSubData(texture, mipmapLevel, { x: 0, y: 0, z: 0 });
       texture.needsUpdate = false;
     }
 
@@ -126,7 +126,7 @@ export class WebGLTextures {
   private uploadTextureSubData(
     texture: Texture,
     mipmapLevel: number,
-    offset: { x: number; y: number }
+    offset: { x: number; y: number; z: number }
   ) {
     if (this.getGLTextureType(texture) === this.gl_.TEXTURE_2D) {
       this.gl_.texSubImage2D(
@@ -145,13 +145,12 @@ export class WebGLTextures {
         texture.data as ArrayBufferView
       );
     } else if (this.getGLTextureType(texture) === this.gl_.TEXTURE_2D_ARRAY) {
-      const zOffset = 0;
       this.gl_.texSubImage3D(
         this.getGLTextureType(texture),
         mipmapLevel,
         offset.x,
         offset.y,
-        zOffset,
+        offset.z,
         texture.width,
         texture.height,
         (texture as Texture2DArray).depth,

--- a/src/renderers/webgl_textures.ts
+++ b/src/renderers/webgl_textures.ts
@@ -6,6 +6,8 @@ import {
   TextureDataFormat,
 } from "objects/textures/texture";
 
+import { Texture2D } from "objects/textures/texture_2d";
+import { DataTexture2D } from "objects/textures/data_texture_2d";
 import { Texture2DArray } from "objects/textures/texture_2d_array";
 
 export class WebGLTextures {
@@ -103,7 +105,7 @@ export class WebGLTextures {
   }
 
   private allocateTextureStorage(texture: Texture) {
-    if (this.getGLTextureType(texture) === this.gl_.TEXTURE_2D) {
+    if (this.isTexture2D(texture) || this.isDataTexture2D(texture)) {
       this.gl_.texStorage2D(
         this.getGLTextureType(texture),
         texture.mipmapLevels,
@@ -111,14 +113,14 @@ export class WebGLTextures {
         texture.width,
         texture.height
       );
-    } else if (this.getGLTextureType(texture) === this.gl_.TEXTURE_2D_ARRAY) {
+    } else if (this.isTexture2DArray(texture)) {
       this.gl_.texStorage3D(
         this.getGLTextureType(texture),
         texture.mipmapLevels,
         this.getGLInternalFormat(texture.dataFormat, texture.dataType),
         texture.width,
         texture.height,
-        (texture as Texture2DArray).depth
+        texture.depth
       );
     } else {
       throw new Error(
@@ -132,7 +134,7 @@ export class WebGLTextures {
     mipmapLevel: number,
     offset: { x: number; y: number; z: number }
   ) {
-    if (this.getGLTextureType(texture) === this.gl_.TEXTURE_2D) {
+    if (this.isTexture2D(texture) || this.isDataTexture2D(texture)) {
       this.gl_.texSubImage2D(
         this.getGLTextureType(texture),
         mipmapLevel,
@@ -148,7 +150,7 @@ export class WebGLTextures {
         // https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/texSubImage2D#syntax
         texture.data as ArrayBufferView
       );
-    } else if (this.getGLTextureType(texture) === this.gl_.TEXTURE_2D_ARRAY) {
+    } else if (this.isTexture2DArray(texture)) {
       this.gl_.texSubImage3D(
         this.getGLTextureType(texture),
         mipmapLevel,
@@ -157,7 +159,7 @@ export class WebGLTextures {
         offset.z,
         texture.width,
         texture.height,
-        (texture as Texture2DArray).depth,
+        texture.depth,
         this.getGLFormat(texture.dataFormat),
         this.getGLType(texture.dataType),
         texture.data as ArrayBufferView
@@ -170,14 +172,12 @@ export class WebGLTextures {
   }
 
   private getGLTextureType(texture: Texture) {
-    switch (texture.type) {
-      case "Texture2D":
-      case "DataTexture2D":
-        return this.gl_.TEXTURE_2D;
-      case "Texture2DArray":
-        return this.gl_.TEXTURE_2D_ARRAY;
-      default:
-        throw new Error(`Unknown texture type ${texture.type}`);
+    if (this.isTexture2D(texture) || this.isDataTexture2D(texture)) {
+      return this.gl_.TEXTURE_2D;
+    } else if (this.isTexture2DArray(texture)) {
+      return this.gl_.TEXTURE_2D_ARRAY;
+    } else {
+      throw new Error(`Unknown texture type ${texture.type}`);
     }
   }
 
@@ -242,5 +242,17 @@ export class WebGLTextures {
     throw Error(
       `Unsupported data format and type combination ${format}/${type}`
     );
+  }
+
+  private isTexture2D(texture: Texture): texture is Texture2D {
+    return texture.type === "Texture2D";
+  }
+
+  private isDataTexture2D(texture: Texture): texture is DataTexture2D {
+    return texture.type === "DataTexture2D";
+  }
+
+  private isTexture2DArray(texture: Texture): texture is Texture2DArray {
+    return (texture as Texture2DArray).type === "Texture2DArray";
   }
 }

--- a/src/renderers/webgl_textures.ts
+++ b/src/renderers/webgl_textures.ts
@@ -6,6 +6,8 @@ import {
   TextureDataFormat,
 } from "objects/textures/texture";
 
+import { Texture2DArray } from "objects/textures/texture_2d_array";
+
 export class WebGLTextures {
   private readonly gl_: WebGL2RenderingContext;
   private readonly textures_: Map<string, WebGLTexture> = new Map();
@@ -97,13 +99,28 @@ export class WebGLTextures {
   }
 
   private allocateTextureStorage(texture: Texture) {
-    this.gl_.texStorage2D(
-      this.getGLTextureType(texture),
-      texture.mipmapLevels,
-      this.getGLInternalFormat(texture.dataFormat, texture.dataType),
-      texture.width,
-      texture.height
-    );
+    if (this.getGLTextureType(texture) === this.gl_.TEXTURE_2D) {
+      this.gl_.texStorage2D(
+        this.getGLTextureType(texture),
+        texture.mipmapLevels,
+        this.getGLInternalFormat(texture.dataFormat, texture.dataType),
+        texture.width,
+        texture.height
+      );
+    } else if (this.getGLTextureType(texture) === this.gl_.TEXTURE_2D_ARRAY) {
+      this.gl_.texStorage3D(
+        this.getGLTextureType(texture),
+        texture.mipmapLevels,
+        this.getGLInternalFormat(texture.dataFormat, texture.dataType),
+        texture.width,
+        texture.height,
+        (texture as Texture2DArray).depth
+      );
+    } else {
+      throw new Error(
+        "Attempting to allocate storage for an unsupported texture type"
+      );
+    }
   }
 
   private uploadTextureSubData(
@@ -111,21 +128,42 @@ export class WebGLTextures {
     mipmapLevel: number,
     offset: { x: number; y: number }
   ) {
-    this.gl_.texSubImage2D(
-      this.getGLTextureType(texture),
-      mipmapLevel,
-      offset.x,
-      offset.y,
-      texture.width,
-      texture.height,
-      this.getGLFormat(texture.dataFormat),
-      this.getGLType(texture.dataType),
-      // This function has multiple overloads. We are temporarily casting it to
-      // ArrayBufferView to ensure the correct overload is called. Once we
-      // consolidate Texture2D and DataTexture2D, we can remove this cast.
-      // https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/texSubImage2D#syntax
-      texture.data as ArrayBufferView
-    );
+    if (this.getGLTextureType(texture) === this.gl_.TEXTURE_2D) {
+      this.gl_.texSubImage2D(
+        this.getGLTextureType(texture),
+        mipmapLevel,
+        offset.x,
+        offset.y,
+        texture.width,
+        texture.height,
+        this.getGLFormat(texture.dataFormat),
+        this.getGLType(texture.dataType),
+        // This function has multiple overloads. We are temporarily casting it to
+        // ArrayBufferView to ensure the correct overload is called. Once we
+        // consolidate Texture2D and DataTexture2D, we can remove this cast.
+        // https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/texSubImage2D#syntax
+        texture.data as ArrayBufferView
+      );
+    } else if (this.getGLTextureType(texture) === this.gl_.TEXTURE_2D_ARRAY) {
+      const zOffset = 0;
+      this.gl_.texSubImage3D(
+        this.getGLTextureType(texture),
+        mipmapLevel,
+        offset.x,
+        offset.y,
+        zOffset,
+        texture.width,
+        texture.height,
+        (texture as Texture2DArray).depth,
+        this.getGLFormat(texture.dataFormat),
+        this.getGLType(texture.dataType),
+        texture.data as ArrayBufferView
+      );
+    } else {
+      throw new Error(
+        "Attempting to upload data for an unsupported texture type"
+      );
+    }
   }
 
   private getGLTextureType(texture: Texture) {
@@ -133,6 +171,8 @@ export class WebGLTextures {
       case "Texture2D":
       case "DataTexture2D":
         return this.gl_.TEXTURE_2D;
+      case "Texture2DArray":
+        return this.gl_.TEXTURE_2D_ARRAY;
       default:
         throw new Error(`Unknown texture type ${texture.type}`);
     }

--- a/src/renderers/webgl_textures.ts
+++ b/src/renderers/webgl_textures.ts
@@ -34,7 +34,11 @@ export class WebGLTextures {
     if (texture.needsUpdate && texture.data !== null) {
       // Currently, we don't support mipmaps, so we always update the base level (0).
       const mipmapLevel = 0;
-      this.uploadTextureSubData(texture, mipmapLevel, { x: 0, y: 0, z: 0 });
+
+      // The offsets are always set to zero because we are replacing the entire data set.
+      const offset = { x: 0, y: 0, z: 0 };
+
+      this.uploadTextureSubData(texture, mipmapLevel, offset);
       texture.needsUpdate = false;
     }
 


### PR DESCRIPTION
### Summary

This PR enhances the Zarr image loader and image series example to support multi-channel
data. It introduces a new texture type for 2D texture arrays, which is now the default for
multi-channel scenarios. Currently, the PR assumes 2D texture arrays represent textures
with three channels (RGB).

### Tests & Checks

- I verified that all examples still work as expected and that the image series example in particular renders the texture with RGB channels. See video below:

https://github.com/user-attachments/assets/4f81ad20-cdc1-41be-9555-e093c124b7c8


