### PR TITLE
Add pan + zoom for orthographic and perspective cameras

### DIFF
--- a/examples/image2d_from_omezarr5d_u8/main.ts
+++ b/examples/image2d_from_omezarr5d_u8/main.ts
@@ -1,9 +1,11 @@
+import { vec2, vec3 } from "gl-matrix";
 import {
   LayerManager,
   ImageLayer,
   WebGLRenderer,
   OmeZarrImageSource,
   OrthographicCamera,
+  PerspectiveCamera,
 } from "@";
 import { AxesLayer } from "@/layers/axes_layer";
 
@@ -11,7 +13,18 @@ const url =
   "https://public.czbiohub.org/royerlab/ultrack/multi-color/image.zarr/";
 const layerManager = new LayerManager();
 const renderer = new WebGLRenderer("#canvas");
-const camera = new OrthographicCamera(-2000, 2000, -2000, 2000);
+const orthoCam = new OrthographicCamera(-2000, 2000, -2000, 2000);
+const perspectiveCam = new PerspectiveCamera(60, 1, 0.1, 10000);
+const cameraPos = vec3.fromValues(0, 0, 5000);
+perspectiveCam.transform.translate(cameraPos);
+// project the (negative) camera position to clip space
+// to get the distance to the image plane (z = 0)
+const projectedCameraPos = vec3.transformMat4(
+  vec3.create(),
+  vec3.scale(vec3.create(), cameraPos, -1),
+  perspectiveCam.projectionMatrix
+);
+const clipDistance = projectedCameraPos[2];
 
 // Source is technically 5D (even though Z is unitary),
 // so provide indices at 3 dimensions to project to 2D.
@@ -22,13 +35,72 @@ const region = [
   { dimension: "Z", index: 0 },
 ];
 const layer = new ImageLayer(source, region);
-const axes = new AxesLayer({ length: 1920, width: 0.01 });
-layerManager.add(layer);
-layerManager.add(axes);
+
+let camera: PerspectiveCamera | OrthographicCamera;
+toggleCamera();
+
+// TODO: would be nice to provide these functions in the library
+const clientToWorld = (clientPos: vec2) => {
+  const clipPos = renderer.clientToClip(clientPos);
+  const d = camera == perspectiveCam ? clipDistance : 0;
+  return camera.clipToWorld(clipPos, d);
+};
+
+document.addEventListener("wheel", (event) => {
+  const clientPos = vec2.fromValues(event.clientX, event.clientY);
+  const preZoomPos = clientToWorld(clientPos);
+  if (event.deltaY < 0) {
+    camera.zoom *= 1.05;
+  } else {
+    camera.zoom /= 1.05;
+  }
+  // pan to zoom in on the mouse position
+  const postZoomPos = clientToWorld(clientPos);
+  const dWorld = vec2.sub(vec2.create(), postZoomPos, preZoomPos);
+  camera.pan(vec2.scale(vec2.create(), dWorld, -1));
+  console.log(camera);
+});
+
+document.addEventListener("mousedown", (event) => {
+  const clientStart = vec2.fromValues(event.clientX, event.clientY);
+  let worldStart = clientToWorld(clientStart);
+  console.log(clientStart, worldStart);
+
+  const onMouseMove = (event: MouseEvent) => {
+    const clientPos = vec2.fromValues(event.clientX, event.clientY);
+    const worldPos = clientToWorld(clientPos);
+    const dWorld = vec2.sub(vec2.create(), worldPos, worldStart);
+    camera.pan(vec2.scale(vec2.create(), dWorld, -1));
+    worldStart = worldPos;
+  };
+
+  const onMouseUp = () => {
+    document.removeEventListener("mousemove", onMouseMove);
+    document.removeEventListener("mouseup", onMouseUp);
+  };
+
+  document.addEventListener("mousemove", onMouseMove);
+  document.addEventListener("mouseup", onMouseUp);
+});
 
 function animate() {
   renderer.render(layerManager, camera);
   requestAnimationFrame(animate);
+}
+
+document.addEventListener("keydown", (event) => {
+  if (event.key === " ") {
+    toggleCamera();
+  }
+});
+
+function toggleCamera() {
+  camera = camera === orthoCam ? perspectiveCam : orthoCam;
+  const width = camera.type == "PerspectiveCamera" ? 20 : 0.01;
+  const axes = new AxesLayer({ length: 1920, width });
+  layerManager.layers.length = 0;
+  layerManager.add(layer);
+  layerManager.add(axes);
 }
 
 animate();

--- a/examples/image2d_from_omezarr5d_u8/main.ts
+++ b/examples/image2d_from_omezarr5d_u8/main.ts
@@ -1,4 +1,4 @@
-import { vec2, vec3 } from "gl-matrix";
+import { vec3 } from "gl-matrix";
 import {
   LayerManager,
   ImageLayer,
@@ -8,6 +8,7 @@ import {
   PerspectiveCamera,
 } from "@";
 import { AxesLayer } from "@/layers/axes_layer";
+import { PanZoomControls } from "@/objects/cameras/controls";
 
 const url =
   "https://public.czbiohub.org/royerlab/ultrack/multi-color/image.zarr/";
@@ -42,49 +43,13 @@ layerManager.add(axes);
 
 let camera: PerspectiveCamera | OrthographicCamera = perspectiveCam;
 
-// TODO: would be nice to provide these functions in the library
-const clientToWorld = (clientPos: vec2) => {
-  const clipPos = renderer.clientToClip(clientPos);
-  const d = camera == perspectiveCam ? clipDistance : 0;
-  return camera.clipToWorld(vec3.fromValues(clipPos[0], clipPos[1], d));
-};
+const orthoCamControls = new PanZoomControls(orthoCam);
+const perspectiveCamControls = new PanZoomControls(
+  perspectiveCam,
+  clipDistance
+);
 
-document.addEventListener("wheel", (event) => {
-  const clientPos = vec2.fromValues(event.clientX, event.clientY);
-  const preZoomPos = clientToWorld(clientPos);
-  if (event.deltaY < 0) {
-    camera.zoom *= 1.05;
-  } else {
-    camera.zoom /= 1.05;
-  }
-  // pan to zoom in on the mouse position
-  const postZoomPos = clientToWorld(clientPos);
-  const dWorld = vec3.sub(vec3.create(), postZoomPos, preZoomPos);
-  camera.pan(vec3.scale(vec3.create(), dWorld, -1));
-  console.log(camera);
-});
-
-document.addEventListener("mousedown", (event) => {
-  const clientStart = vec2.fromValues(event.clientX, event.clientY);
-  let worldStart = clientToWorld(clientStart);
-  console.log(clientStart, worldStart);
-
-  const onMouseMove = (event: MouseEvent) => {
-    const clientPos = vec2.fromValues(event.clientX, event.clientY);
-    const worldPos = clientToWorld(clientPos);
-    const dWorld = vec3.sub(vec3.create(), worldPos, worldStart);
-    camera.pan(vec3.scale(vec3.create(), dWorld, -1));
-    worldStart = worldPos;
-  };
-
-  const onMouseUp = () => {
-    document.removeEventListener("mousemove", onMouseMove);
-    document.removeEventListener("mouseup", onMouseUp);
-  };
-
-  document.addEventListener("mousemove", onMouseMove);
-  document.addEventListener("mouseup", onMouseUp);
-});
+renderer.setControls(perspectiveCamControls);
 
 function animate() {
   renderer.render(layerManager, camera);
@@ -99,6 +64,9 @@ document.addEventListener("keydown", (event) => {
 
 function toggleCamera() {
   camera = camera === orthoCam ? perspectiveCam : orthoCam;
+  renderer.setControls(
+    camera === orthoCam ? orthoCamControls : perspectiveCamControls
+  );
 }
 
 animate();

--- a/examples/image2d_from_omezarr5d_u8/main.ts
+++ b/examples/image2d_from_omezarr5d_u8/main.ts
@@ -15,9 +15,8 @@ const url =
 const layerManager = new LayerManager();
 const renderer = new WebGLRenderer("#canvas");
 const orthoCam = new OrthographicCamera(-2000, 2000, -2000, 2000);
-const perspectiveCam = new PerspectiveCamera(60, 1, 0.1, 10000);
 const cameraPos = vec3.fromValues(0, 0, 5000);
-perspectiveCam.transform.translate(cameraPos);
+const perspectiveCam = new PerspectiveCamera({ fov: 60, position: cameraPos });
 // project the (negative) camera position to clip space
 // to get the distance to the image plane (z = 0)
 const projectedCameraPos = vec3.transformMat4(

--- a/examples/image2d_from_omezarr5d_u8/main.ts
+++ b/examples/image2d_from_omezarr5d_u8/main.ts
@@ -17,14 +17,6 @@ const renderer = new WebGLRenderer("#canvas");
 const orthoCam = new OrthographicCamera(-2000, 2000, -2000, 2000);
 const cameraPos = vec3.fromValues(0, 0, 5000);
 const perspectiveCam = new PerspectiveCamera({ fov: 60, position: cameraPos });
-// project the (negative) camera position to clip space
-// to get the distance to the image plane (z = 0)
-const projectedCameraPos = vec3.transformMat4(
-  vec3.create(),
-  vec3.scale(vec3.create(), cameraPos, -1),
-  perspectiveCam.projectionMatrix
-);
-const clipDistance = projectedCameraPos[2];
 
 // Source is technically 5D (even though Z is unitary),
 // so provide indices at 3 dimensions to project to 2D.
@@ -43,10 +35,7 @@ layerManager.add(axes);
 let camera: PerspectiveCamera | OrthographicCamera = perspectiveCam;
 
 const orthoCamControls = new PanZoomControls(orthoCam);
-const perspectiveCamControls = new PanZoomControls(
-  perspectiveCam,
-  clipDistance
-);
+const perspectiveCamControls = new PanZoomControls(perspectiveCam);
 
 renderer.setControls(perspectiveCamControls);
 

--- a/examples/image2d_from_omezarr5d_u8/main.ts
+++ b/examples/image2d_from_omezarr5d_u8/main.ts
@@ -46,7 +46,7 @@ let camera: PerspectiveCamera | OrthographicCamera = perspectiveCam;
 const clientToWorld = (clientPos: vec2) => {
   const clipPos = renderer.clientToClip(clientPos);
   const d = camera == perspectiveCam ? clipDistance : 0;
-  return camera.clipToWorld(clipPos, d);
+  return camera.clipToWorld(vec3.fromValues(clipPos[0], clipPos[1], d));
 };
 
 document.addEventListener("wheel", (event) => {
@@ -59,8 +59,8 @@ document.addEventListener("wheel", (event) => {
   }
   // pan to zoom in on the mouse position
   const postZoomPos = clientToWorld(clientPos);
-  const dWorld = vec2.sub(vec2.create(), postZoomPos, preZoomPos);
-  camera.pan(vec2.scale(vec2.create(), dWorld, -1));
+  const dWorld = vec3.sub(vec3.create(), postZoomPos, preZoomPos);
+  camera.pan(vec3.scale(vec3.create(), dWorld, -1));
   console.log(camera);
 });
 
@@ -72,8 +72,8 @@ document.addEventListener("mousedown", (event) => {
   const onMouseMove = (event: MouseEvent) => {
     const clientPos = vec2.fromValues(event.clientX, event.clientY);
     const worldPos = clientToWorld(clientPos);
-    const dWorld = vec2.sub(vec2.create(), worldPos, worldStart);
-    camera.pan(vec2.scale(vec2.create(), dWorld, -1));
+    const dWorld = vec3.sub(vec3.create(), worldPos, worldStart);
+    camera.pan(vec3.scale(vec3.create(), dWorld, -1));
     worldStart = worldPos;
   };
 

--- a/examples/image2d_from_omezarr5d_u8/main.ts
+++ b/examples/image2d_from_omezarr5d_u8/main.ts
@@ -36,8 +36,11 @@ const region = [
 ];
 const layer = new ImageLayer(source, region);
 
-let camera: PerspectiveCamera | OrthographicCamera;
-toggleCamera();
+const axes = new AxesLayer({ length: 1920, width: 0.01 });
+layerManager.add(layer);
+layerManager.add(axes);
+
+let camera: PerspectiveCamera | OrthographicCamera = perspectiveCam;
 
 // TODO: would be nice to provide these functions in the library
 const clientToWorld = (clientPos: vec2) => {
@@ -96,11 +99,6 @@ document.addEventListener("keydown", (event) => {
 
 function toggleCamera() {
   camera = camera === orthoCam ? perspectiveCam : orthoCam;
-  const width = camera.type == "PerspectiveCamera" ? 20 : 0.01;
-  const axes = new AxesLayer({ length: 1920, width });
-  layerManager.layers.length = 0;
-  layerManager.add(layer);
-  layerManager.add(axes);
 }
 
 animate();

--- a/examples/projected_lines/main.ts
+++ b/examples/projected_lines/main.ts
@@ -22,14 +22,17 @@ const helixB = generateHelix({
   phase: 90.0,
 });
 const layer = new ProjectedLineLayer([
-  { path: helixA, color: [1.0, 0.7, 0.0], width: 0.1 },
-  { path: helixB, color: [0.0, 0.7, 0.0], width: 0.2 },
+  { path: helixA, color: [1.0, 0.7, 0.0], width: 0.01 },
+  { path: helixB, color: [0.0, 0.7, 0.0], width: 0.02 },
 ]);
 
 layersManager.add(layer);
 
 const renderer = new WebGLRenderer("#canvas");
-const camera = new PerspectiveCamera(60, renderer.width / renderer.height);
+const camera = new PerspectiveCamera({
+  fov: 60,
+  aspectRatio: renderer.width / renderer.height,
+});
 
 animate();
 

--- a/src/core/renderer.ts
+++ b/src/core/renderer.ts
@@ -4,14 +4,14 @@ import { Camera } from "objects/cameras/camera";
 import { RenderableObject } from "core/renderable_object";
 import { PerspectiveCamera } from "objects/cameras/perspective_camera";
 import { OrthographicCamera } from "objects/cameras/orthographic_camera";
-import { CameraControls } from "objects/cameras/controls";
+import { CameraControls, NullControls } from "objects/cameras/controls";
 
 export abstract class Renderer {
   private readonly canvas_: HTMLCanvasElement | null;
   private width_ = 0;
   private height_ = 0;
   private activeCamera_: Camera | null = null;
-  private controls_: CameraControls | null = null;
+  private controls_: CameraControls = new NullControls();
   private controlCallbacks_: [string, (event: Event) => void][] = [];
 
   protected abstract resize(width: number, height: number): void;
@@ -56,12 +56,10 @@ export abstract class Renderer {
     this.controlCallbacks_.forEach(([event, listener]) => {
       this.canvas.removeEventListener(event, listener);
     });
+    this.controlCallbacks_ = [];
   }
 
   private bindControls() {
-    if (!this.controls_) {
-      throw new Error("Unable to unbind controls before they are set");
-    }
     const clientToClip = this.clientToClip.bind(this);
     this.controlCallbacks_ = this.controls_.callbacks(
       this.canvas,

--- a/src/core/renderer.ts
+++ b/src/core/renderer.ts
@@ -1,3 +1,4 @@
+import { vec2 } from "gl-matrix";
 import { LayerManager } from "./layer_manager";
 import { Camera } from "objects/cameras/camera";
 import { RenderableObject } from "core/renderable_object";
@@ -84,5 +85,13 @@ export abstract class Renderer {
       );
     }
     return this.activeCamera_;
+  }
+
+  public clientToClip(position: vec2): vec2 {
+    const [x, y] = position;
+    return vec2.fromValues(
+      (2 * x) / this.canvas.clientWidth - 1,
+      1 - (2 * y) / this.canvas.clientHeight
+    );
   }
 }

--- a/src/core/renderer.ts
+++ b/src/core/renderer.ts
@@ -1,15 +1,18 @@
-import { vec2 } from "gl-matrix";
+import { vec2, vec3 } from "gl-matrix";
 import { LayerManager } from "./layer_manager";
 import { Camera } from "objects/cameras/camera";
 import { RenderableObject } from "core/renderable_object";
 import { PerspectiveCamera } from "objects/cameras/perspective_camera";
 import { OrthographicCamera } from "objects/cameras/orthographic_camera";
+import { CameraControls } from "objects/cameras/controls";
 
 export abstract class Renderer {
   private readonly canvas_: HTMLCanvasElement | null;
   private width_ = 0;
   private height_ = 0;
   private activeCamera_: Camera | null = null;
+  private controls_: CameraControls | null = null;
+  private controlCallbacks_: [string, (event: Event) => void][] = [];
 
   protected abstract resize(width: number, height: number): void;
   protected abstract renderObject(object: RenderableObject): void;
@@ -40,6 +43,32 @@ export abstract class Renderer {
           this.renderObject(obj);
         });
       }
+    });
+  }
+
+  public setControls(controls: CameraControls) {
+    this.unbindControls();
+    this.controls_ = controls;
+    this.bindControls();
+  }
+
+  private unbindControls() {
+    this.controlCallbacks_.forEach(([event, listener]) => {
+      this.canvas.removeEventListener(event, listener);
+    });
+  }
+
+  private bindControls() {
+    if (!this.controls_) {
+      throw new Error("Unable to unbind controls before they are set");
+    }
+    const clientToClip = this.clientToClip.bind(this);
+    this.controlCallbacks_ = this.controls_.callbacks(
+      this.canvas,
+      clientToClip
+    );
+    this.controlCallbacks_.forEach(([event, listener]) => {
+      this.canvas.addEventListener(event, listener);
     });
   }
 
@@ -87,11 +116,12 @@ export abstract class Renderer {
     return this.activeCamera_;
   }
 
-  public clientToClip(position: vec2): vec2 {
+  public clientToClip(position: vec2, depth: number = 0): vec3 {
     const [x, y] = position;
-    return vec2.fromValues(
+    return vec3.fromValues(
       (2 * x) / this.canvas.clientWidth - 1,
-      1 - (2 * y) / this.canvas.clientHeight
+      1 - (2 * y) / this.canvas.clientHeight,
+      depth
     );
   }
 }

--- a/src/core/transforms.ts
+++ b/src/core/transforms.ts
@@ -18,6 +18,11 @@ export class AffineTransform {
     this.dirty_ = true;
   }
 
+  public setTranslation(vec: vec3) {
+    vec3.copy(this.translation_, vec);
+    this.dirty_ = true;
+  }
+
   public scale(vec: vec3) {
     vec3.multiply(this.scale_, this.scale_, vec);
     vec3.multiply(this.translation_, this.translation_, vec);

--- a/src/core/transforms.ts
+++ b/src/core/transforms.ts
@@ -18,6 +18,14 @@ export class AffineTransform {
     this.dirty_ = true;
   }
 
+  public lookAt(target: vec3, up: vec3 = vec3.fromValues(0, 1, 0)) {
+    mat4.getRotation(
+      this.rotation_,
+      mat4.lookAt(mat4.create(), this.translation_, target, up)
+    );
+    this.dirty_ = true;
+  }
+
   public setTranslation(vec: vec3) {
     vec3.copy(this.translation_, vec);
     this.dirty_ = true;

--- a/src/core/transforms.ts
+++ b/src/core/transforms.ts
@@ -18,17 +18,13 @@ export class AffineTransform {
     this.dirty_ = true;
   }
 
-  public lookAt(target: vec3, up: vec3 = vec3.fromValues(0, 1, 0)) {
-    mat4.getRotation(
-      this.rotation_,
-      mat4.lookAt(mat4.create(), this.translation_, target, up)
-    );
-    this.dirty_ = true;
-  }
-
   public setTranslation(vec: vec3) {
     vec3.copy(this.translation_, vec);
     this.dirty_ = true;
+  }
+
+  public get translation() {
+    return vec3.clone(this.translation_);
   }
 
   public scale(vec: vec3) {

--- a/src/objects/cameras/camera.ts
+++ b/src/objects/cameras/camera.ts
@@ -35,11 +35,11 @@ export abstract class Camera extends RenderableObject {
   }
 
   public clipToWorld(position: vec3): vec3 {
-    const screenPos = vec4.fromValues(position[0], position[1], position[2], 1);
+    const clipPos = vec4.fromValues(position[0], position[1], position[2], 1);
     const projectionInverse = mat4.invert(mat4.create(), this.projectionMatrix);
     const worldPos = vec4.transformMat4(
       vec4.create(),
-      screenPos,
+      clipPos,
       projectionInverse
     );
     const rotation = mat4.getRotation(quat.create(), this.transform.matrix);

--- a/src/objects/cameras/camera.ts
+++ b/src/objects/cameras/camera.ts
@@ -1,10 +1,11 @@
 import { RenderableObject } from "core/renderable_object";
-import { mat4 } from "gl-matrix";
+import { mat4, quat, vec2, vec3, vec4 } from "gl-matrix";
 
 export abstract class Camera extends RenderableObject {
   protected projectionMatrix_ = mat4.create();
   protected near_ = 0;
   protected far_ = 0;
+  protected zoom_ = 1;
 
   protected abstract updateProjectionMatrix(): void;
 
@@ -18,5 +19,35 @@ export abstract class Camera extends RenderableObject {
 
   get projectionMatrix() {
     return this.projectionMatrix_;
+  }
+
+  public get zoom() {
+    return this.zoom_;
+  }
+
+  public set zoom(zoom: number) {
+    this.zoom_ = zoom;
+    this.updateProjectionMatrix();
+  }
+
+  // TODO: pan in the camera plane, not just xy
+  public pan(vec: vec2) {
+    const vec3d = vec3.fromValues(vec[0], vec[1], 0);
+    this.transform.translate(vec3d);
+  }
+
+  public clipToWorld(position: vec2, depth: number = 0): vec2 {
+    const screenPos = vec4.fromValues(position[0], position[1], depth, 1);
+    const projectionInverse = mat4.invert(mat4.create(), this.projectionMatrix);
+    const worldPos = vec4.transformMat4(
+      vec4.create(),
+      screenPos,
+      projectionInverse
+    );
+    const rotation = mat4.getRotation(quat.create(), this.transform.matrix);
+    vec4.transformQuat(worldPos, worldPos, rotation);
+    vec4.scale(worldPos, worldPos, 1 / worldPos[3]);
+    // TODO: return vec3?
+    return vec2.fromValues(worldPos[0], worldPos[1]);
   }
 }

--- a/src/objects/cameras/camera.ts
+++ b/src/objects/cameras/camera.ts
@@ -1,5 +1,5 @@
 import { RenderableObject } from "core/renderable_object";
-import { mat4, quat, vec2, vec3, vec4 } from "gl-matrix";
+import { mat4, quat, vec3, vec4 } from "gl-matrix";
 
 export abstract class Camera extends RenderableObject {
   protected projectionMatrix_ = mat4.create();
@@ -30,14 +30,12 @@ export abstract class Camera extends RenderableObject {
     this.updateProjectionMatrix();
   }
 
-  // TODO: pan in the camera plane, not just xy
-  public pan(vec: vec2) {
-    const vec3d = vec3.fromValues(vec[0], vec[1], 0);
-    this.transform.translate(vec3d);
+  public pan(vec: vec3) {
+    this.transform.translate(vec);
   }
 
-  public clipToWorld(position: vec2, depth: number = 0): vec2 {
-    const screenPos = vec4.fromValues(position[0], position[1], depth, 1);
+  public clipToWorld(position: vec3): vec3 {
+    const screenPos = vec4.fromValues(position[0], position[1], position[2], 1);
     const projectionInverse = mat4.invert(mat4.create(), this.projectionMatrix);
     const worldPos = vec4.transformMat4(
       vec4.create(),
@@ -47,7 +45,6 @@ export abstract class Camera extends RenderableObject {
     const rotation = mat4.getRotation(quat.create(), this.transform.matrix);
     vec4.transformQuat(worldPos, worldPos, rotation);
     vec4.scale(worldPos, worldPos, 1 / worldPos[3]);
-    // TODO: return vec3?
-    return vec2.fromValues(worldPos[0], worldPos[1]);
+    return vec3.fromValues(worldPos[0], worldPos[1], worldPos[2]);
   }
 }

--- a/src/objects/cameras/camera.ts
+++ b/src/objects/cameras/camera.ts
@@ -34,6 +34,10 @@ export abstract class Camera extends RenderableObject {
     this.transform.translate(vec);
   }
 
+  public get position() {
+    return this.transform.translation;
+  }
+
   public clipToWorld(position: vec3): vec3 {
     const clipPos = vec4.fromValues(position[0], position[1], position[2], 1);
     const projectionInverse = mat4.invert(mat4.create(), this.projectionMatrix);

--- a/src/objects/cameras/controls.ts
+++ b/src/objects/cameras/controls.ts
@@ -1,0 +1,92 @@
+import { vec2, vec3 } from "gl-matrix";
+import { Camera } from "./camera";
+
+type ClientToClip = (clientPos: vec2, depth: number) => vec3;
+type ClientToWorld = (clientPos: vec2, depth: number) => vec3;
+
+export abstract class CameraControls {
+  protected camera_: Camera;
+
+  constructor(camera: Camera) {
+    this.camera_ = camera;
+  }
+
+  public abstract callbacks(
+    target: EventTarget,
+    clientToClip: ClientToClip
+  ): [string, EventListener][];
+}
+
+export class PanZoomControls extends CameraControls {
+  private depth_: number;
+
+  constructor(camera: Camera, panDepth: number = 0) {
+    super(camera);
+    this.depth_ = panDepth;
+  }
+
+  public callbacks(
+    target: EventTarget,
+    clientToClip: ClientToClip
+  ): [string, EventListener][] {
+    const clientToWorld: ClientToWorld = (clientPos, depth) => {
+      const clipPos = clientToClip(clientPos, depth);
+      return this.camera_.clipToWorld(clipPos);
+    };
+    return [
+      [
+        "wheel",
+        (event: Event) => this.wheel(event as WheelEvent, clientToWorld),
+      ],
+      [
+        "mousedown",
+        (event: Event) =>
+          this.mousedown(event as MouseEvent, target, clientToWorld),
+      ],
+    ];
+  }
+
+  private wheel(event: WheelEvent, clientToWorld: ClientToWorld): void {
+    const clientPos = vec2.fromValues(event.clientX, event.clientY);
+    const preZoomPos = clientToWorld(clientPos, this.depth_);
+    if (event.deltaY < 0) {
+      this.camera_.zoom *= 1.05;
+    } else {
+      this.camera_.zoom /= 1.05;
+    }
+    // pan to zoom in on the mouse position
+    const postZoomPos = clientToWorld(clientPos, this.depth_);
+    const dWorld = vec3.sub(vec3.create(), postZoomPos, preZoomPos);
+    this.camera_.pan(vec3.scale(vec3.create(), dWorld, -1));
+  }
+
+  private mousedown(
+    event: MouseEvent,
+    target: EventTarget,
+    clientToWorld: ClientToWorld
+  ): void {
+    console.log("mousedown", this.camera_.type);
+    const clientStart = vec2.fromValues(event.clientX, event.clientY);
+    let worldStart = clientToWorld(clientStart, this.depth_);
+    console.log(clientStart, worldStart);
+
+    const onMouseMove = (event: Event) => {
+      if (!(event instanceof MouseEvent)) {
+        throw new Error("Expected MouseEvent");
+      }
+      const clientPos = vec2.fromValues(event.clientX, event.clientY);
+      const worldPos = clientToWorld(clientPos, this.depth_);
+      const dWorld = vec3.sub(vec3.create(), worldPos, worldStart);
+      this.camera_.pan(vec3.scale(vec3.create(), dWorld, -1));
+      worldStart = worldPos;
+    };
+
+    const onMouseUp = () => {
+      target.removeEventListener("mousemove", onMouseMove);
+      target.removeEventListener("mouseup", onMouseUp);
+    };
+
+    target.addEventListener("mousemove", onMouseMove);
+    target.addEventListener("mouseup", onMouseUp);
+  }
+}

--- a/src/objects/cameras/controls.ts
+++ b/src/objects/cameras/controls.ts
@@ -1,28 +1,31 @@
 import { vec2, vec3 } from "gl-matrix";
 import { Camera } from "./camera";
+import { PerspectiveCamera } from "./perspective_camera";
 
 type ClientToClip = (clientPos: vec2, depth: number) => vec3;
 type ClientToWorld = (clientPos: vec2, depth: number) => vec3;
 
-export abstract class CameraControls {
-  protected camera_: Camera;
-
-  constructor(camera: Camera) {
-    this.camera_ = camera;
-  }
-
-  public abstract callbacks(
+export interface CameraControls {
+  callbacks(
     target: EventTarget,
     clientToClip: ClientToClip
   ): [string, EventListener][];
 }
 
-export class PanZoomControls extends CameraControls {
-  private depth_: number;
+export class NullControls implements CameraControls {
+  public callbacks(
+    _target: EventTarget,
+    _clientToClip: ClientToClip
+  ): [string, EventListener][] {
+    return [];
+  }
+}
 
-  constructor(camera: Camera, panDepth: number = 0) {
-    super(camera);
-    this.depth_ = panDepth;
+export class PanZoomControls implements CameraControls {
+  private camera_: Camera;
+
+  constructor(camera: Camera) {
+    this.camera_ = camera;
   }
 
   public callbacks(
@@ -48,16 +51,16 @@ export class PanZoomControls extends CameraControls {
 
   private wheel(event: WheelEvent, clientToWorld: ClientToWorld): void {
     const clientPos = vec2.fromValues(event.clientX, event.clientY);
-    const preZoomPos = clientToWorld(clientPos, this.depth_);
+    const preZoomPos = clientToWorld(clientPos, this.clipDepth);
     if (event.deltaY < 0) {
       this.camera_.zoom *= 1.05;
     } else {
       this.camera_.zoom /= 1.05;
     }
     // pan to zoom in on the mouse position
-    const postZoomPos = clientToWorld(clientPos, this.depth_);
-    const dWorld = vec3.sub(vec3.create(), postZoomPos, preZoomPos);
-    this.camera_.pan(vec3.scale(vec3.create(), dWorld, -1));
+    const postZoomPos = clientToWorld(clientPos, this.clipDepth);
+    const deltaWorld = vec3.sub(vec3.create(), preZoomPos, postZoomPos);
+    this.camera_.pan(deltaWorld);
   }
 
   private mousedown(
@@ -65,19 +68,17 @@ export class PanZoomControls extends CameraControls {
     target: EventTarget,
     clientToWorld: ClientToWorld
   ): void {
-    console.log("mousedown", this.camera_.type);
     const clientStart = vec2.fromValues(event.clientX, event.clientY);
-    let worldStart = clientToWorld(clientStart, this.depth_);
-    console.log(clientStart, worldStart);
+    let worldStart = clientToWorld(clientStart, this.clipDepth);
 
     const onMouseMove = (event: Event) => {
       if (!(event instanceof MouseEvent)) {
         throw new Error("Expected MouseEvent");
       }
       const clientPos = vec2.fromValues(event.clientX, event.clientY);
-      const worldPos = clientToWorld(clientPos, this.depth_);
-      const dWorld = vec3.sub(vec3.create(), worldPos, worldStart);
-      this.camera_.pan(vec3.scale(vec3.create(), dWorld, -1));
+      const worldPos = clientToWorld(clientPos, this.clipDepth);
+      const deltaWorld = vec3.sub(vec3.create(), worldStart, worldPos);
+      this.camera_.pan(deltaWorld);
       worldStart = worldPos;
     };
 
@@ -88,5 +89,23 @@ export class PanZoomControls extends CameraControls {
 
     target.addEventListener("mousemove", onMouseMove);
     target.addEventListener("mouseup", onMouseUp);
+  }
+
+  private get clipDepth() {
+    let distance = 0;
+    if (this.camera_ instanceof PerspectiveCamera) {
+      const targetToPosition = vec3.sub(
+        vec3.create(),
+        this.camera_.target,
+        this.camera_.position
+      );
+      const projectedViewVector = vec3.transformMat4(
+        vec3.create(),
+        targetToPosition,
+        this.camera_.projectionMatrix
+      );
+      distance = vec3.length(projectedViewVector);
+    }
+    return distance;
   }
 }

--- a/src/objects/cameras/controls.ts
+++ b/src/objects/cameras/controls.ts
@@ -1,6 +1,5 @@
 import { vec2, vec3 } from "gl-matrix";
 import { Camera } from "./camera";
-import { PerspectiveCamera } from "./perspective_camera";
 
 type ClientToClip = (clientPos: vec2, depth: number) => vec3;
 type ClientToWorld = (clientPos: vec2, depth: number) => vec3;
@@ -23,9 +22,11 @@ export class NullControls implements CameraControls {
 
 export class PanZoomControls implements CameraControls {
   private camera_: Camera;
+  private panTarget_: vec3;
 
-  constructor(camera: Camera) {
+  constructor(camera: Camera, panTarget: vec3 = vec3.fromValues(0, 0, 0)) {
     this.camera_ = camera;
+    this.panTarget_ = panTarget;
   }
 
   public callbacks(
@@ -60,7 +61,7 @@ export class PanZoomControls implements CameraControls {
     // pan to zoom in on the mouse position
     const postZoomPos = clientToWorld(clientPos, this.clipDepth);
     const deltaWorld = vec3.sub(vec3.create(), preZoomPos, postZoomPos);
-    this.camera_.pan(deltaWorld);
+    this.pan(deltaWorld);
   }
 
   private mousedown(
@@ -78,7 +79,7 @@ export class PanZoomControls implements CameraControls {
       const clientPos = vec2.fromValues(event.clientX, event.clientY);
       const worldPos = clientToWorld(clientPos, this.clipDepth);
       const deltaWorld = vec3.sub(vec3.create(), worldStart, worldPos);
-      this.camera_.pan(deltaWorld);
+      this.pan(deltaWorld);
       worldStart = worldPos;
     };
 
@@ -91,21 +92,29 @@ export class PanZoomControls implements CameraControls {
     target.addEventListener("mouseup", onMouseUp);
   }
 
+  private pan(deltaWorld: vec3): void {
+    this.camera_.pan(deltaWorld);
+    vec3.add(this.panTarget_, this.panTarget_, deltaWorld);
+  }
+
+  public set panTarget(panTarget: vec3) {
+    this.panTarget_ = panTarget;
+  }
+
   private get clipDepth() {
-    let distance = 0;
-    if (this.camera_ instanceof PerspectiveCamera) {
-      const targetToPosition = vec3.sub(
-        vec3.create(),
-        this.camera_.target,
-        this.camera_.position
-      );
-      const projectedViewVector = vec3.transformMat4(
-        vec3.create(),
-        targetToPosition,
-        this.camera_.projectionMatrix
-      );
-      distance = vec3.length(projectedViewVector);
-    }
+    const targetToPosition = vec3.sub(
+      vec3.create(),
+      this.panTarget_,
+      this.camera_.position
+    );
+    const projectedViewVector = vec3.transformMat4(
+      vec3.create(),
+      targetToPosition,
+      this.camera_.projectionMatrix
+    );
+    // TODO: the distance should be projected onto the camera's view
+    // normal when we start rotating cameras
+    const distance = vec3.length(projectedViewVector);
     return distance;
   }
 }

--- a/src/objects/cameras/orthographic_camera.ts
+++ b/src/objects/cameras/orthographic_camera.ts
@@ -2,6 +2,7 @@ import { Camera } from "./camera";
 import { mat4 } from "gl-matrix";
 
 export class OrthographicCamera extends Camera {
+  // TODO: store width and height instead?
   private left_: number;
   private right_: number;
   private bottom_: number;
@@ -18,10 +19,18 @@ export class OrthographicCamera extends Camera {
   ) {
     super();
 
-    this.left_ = left;
-    this.right_ = right;
-    this.bottom_ = bottom;
-    this.top_ = top;
+    // this keeps the camera frame centered at the origin
+    // use camera.pan or set its *position* (this.transform) to move the center
+    const halfWidth = Math.abs(right - left);
+    const halfHeight = Math.abs(top - bottom);
+    const centerX = 0.5 * (left + right);
+    const centerY = 0.5 * (bottom + top);
+    this.transform.setTranslation([centerX, centerY, 0]);
+    this.left_ = -halfWidth;
+    this.right_ = halfWidth;
+    this.bottom_ = -halfHeight;
+    this.top_ = halfHeight;
+
     this.near_ = near;
     this.far_ = far;
 
@@ -33,10 +42,16 @@ export class OrthographicCamera extends Camera {
   }
 
   public setFrame(left: number, right: number, bottom: number, top: number) {
-    this.left_ = left;
-    this.right_ = right;
-    this.bottom_ = bottom;
-    this.top_ = top;
+    const halfWidth = Math.abs(right - left);
+    const halfHeight = Math.abs(top - bottom);
+    const centerX = 0.5 * (left + right);
+    const centerY = 0.5 * (bottom + top);
+    this.transform.setTranslation([centerX, centerY, 0]);
+    this.left_ = -halfWidth;
+    this.right_ = halfWidth;
+    this.bottom_ = -halfHeight;
+    this.top_ = halfHeight;
+    this.zoom_ = 1.0;
   }
 
   public get type() {
@@ -48,8 +63,8 @@ export class OrthographicCamera extends Camera {
     // is updated so that the aspect ratio of renderable objects is respected
     // (e.g. image pixels are isotropic) by padding the camera frame to form
     // the viewport frame.
-    const width = this.right_ - this.left_;
-    const height = this.top_ - this.bottom_;
+    const width = (this.right_ - this.left_) / this.zoom_;
+    const height = (this.top_ - this.bottom_) / this.zoom_;
     const frameAspectRatio = width / height;
     // When the viewport is wider than the camera frame, add horizontal
     // padding such that the height is unchanged. Otherwise, add vertical

--- a/src/objects/cameras/orthographic_camera.ts
+++ b/src/objects/cameras/orthographic_camera.ts
@@ -2,11 +2,8 @@ import { Camera } from "./camera";
 import { mat4 } from "gl-matrix";
 
 export class OrthographicCamera extends Camera {
-  // TODO: store width and height instead?
-  private left_: number;
-  private right_: number;
-  private bottom_: number;
-  private top_: number;
+  private width_: number;
+  private height_: number;
   private viewportAspectRatio_: number = 1;
 
   constructor(
@@ -21,15 +18,12 @@ export class OrthographicCamera extends Camera {
 
     // this keeps the camera frame centered at the origin
     // use camera.pan or set its *position* (this.transform) to move the center
-    const halfWidth = Math.abs(right - left);
-    const halfHeight = Math.abs(top - bottom);
+    this.width_ = Math.abs(right - left);
+    this.height_ = Math.abs(top - bottom);
     const centerX = 0.5 * (left + right);
     const centerY = 0.5 * (bottom + top);
     this.transform.setTranslation([centerX, centerY, 0]);
-    this.left_ = -halfWidth;
-    this.right_ = halfWidth;
-    this.bottom_ = -halfHeight;
-    this.top_ = halfHeight;
+    this.setFrame(left, right, bottom, top);
 
     this.near_ = near;
     this.far_ = far;
@@ -42,15 +36,11 @@ export class OrthographicCamera extends Camera {
   }
 
   public setFrame(left: number, right: number, bottom: number, top: number) {
-    const halfWidth = Math.abs(right - left);
-    const halfHeight = Math.abs(top - bottom);
+    this.width_ = Math.abs(right - left);
+    this.height_ = Math.abs(top - bottom);
     const centerX = 0.5 * (left + right);
     const centerY = 0.5 * (bottom + top);
     this.transform.setTranslation([centerX, centerY, 0]);
-    this.left_ = -halfWidth;
-    this.right_ = halfWidth;
-    this.bottom_ = -halfHeight;
-    this.top_ = halfHeight;
     this.zoom_ = 1.0;
   }
 
@@ -63,8 +53,8 @@ export class OrthographicCamera extends Camera {
     // is updated so that the aspect ratio of renderable objects is respected
     // (e.g. image pixels are isotropic) by padding the camera frame to form
     // the viewport frame.
-    const width = (this.right_ - this.left_) / this.zoom_;
-    const height = (this.top_ - this.bottom_) / this.zoom_;
+    const width = this.width_ / this.zoom_;
+    const height = this.height_ / this.zoom_;
     const frameAspectRatio = width / height;
     // When the viewport is wider than the camera frame, add horizontal
     // padding such that the height is unchanged. Otherwise, add vertical
@@ -77,14 +67,12 @@ export class OrthographicCamera extends Camera {
       viewportHalfHeight *= frameAspectRatio / this.viewportAspectRatio_;
     }
     // Center the camera frame in the padded viewport frame.
-    const horizontalCenter = 0.5 * (this.left_ + this.right_);
-    const verticalCenter = 0.5 * (this.bottom_ + this.top_);
     mat4.ortho(
       this.projectionMatrix_,
-      horizontalCenter - viewportHalfWidth,
-      horizontalCenter + viewportHalfWidth,
-      verticalCenter - viewportHalfHeight,
-      verticalCenter + viewportHalfHeight,
+      -viewportHalfWidth,
+      viewportHalfWidth,
+      -viewportHalfHeight,
+      viewportHalfHeight,
       this.near_,
       this.far_
     );

--- a/src/objects/cameras/perspective_camera.ts
+++ b/src/objects/cameras/perspective_camera.ts
@@ -1,19 +1,30 @@
 import { Camera } from "./camera";
-import { glMatrix, mat4 } from "gl-matrix";
+import { glMatrix, mat4, vec3 } from "gl-matrix";
 
 const DEFAULT_FOV = 60; // degrees
 const DEFAULT_ASPECT_RATIO = 1.77; // 16:9
+
+type PerspectiveCameraOptions = {
+  fov?: number;
+  aspectRatio?: number;
+  near?: number;
+  far?: number;
+  position?: vec3;
+};
 
 export class PerspectiveCamera extends Camera {
   private fov_: number;
   private aspectRatio_: number;
 
-  constructor(
-    fov: number = DEFAULT_FOV,
-    aspectRatio: number = DEFAULT_ASPECT_RATIO,
-    near = 0.1,
-    far = 1000.0
-  ) {
+  constructor(options: PerspectiveCameraOptions = {}) {
+    const {
+      fov = DEFAULT_FOV,
+      aspectRatio = DEFAULT_ASPECT_RATIO,
+      near = 0.1,
+      far = 10000,
+      position = vec3.create(),
+    } = options;
+
     if (fov <= 0 || fov >= 180) {
       throw new Error(`Invalid field of view: ${fov}`);
     }
@@ -22,6 +33,8 @@ export class PerspectiveCamera extends Camera {
     this.aspectRatio_ = aspectRatio;
     this.near_ = near;
     this.far_ = far;
+
+    this.transform.setTranslation(position);
 
     this.updateProjectionMatrix();
   }

--- a/src/objects/cameras/perspective_camera.ts
+++ b/src/objects/cameras/perspective_camera.ts
@@ -10,14 +10,11 @@ type PerspectiveCameraOptions = {
   near?: number;
   far?: number;
   position?: vec3;
-  target?: vec3;
 };
 
 export class PerspectiveCamera extends Camera {
   private fov_: number;
   private aspectRatio_: number;
-  private position_: vec3;
-  private target_: vec3;
 
   constructor(options: PerspectiveCameraOptions = {}) {
     const {
@@ -25,8 +22,7 @@ export class PerspectiveCamera extends Camera {
       aspectRatio = DEFAULT_ASPECT_RATIO,
       near = 0.1,
       far = 10000,
-      position = vec3.create(),
-      target = vec3.create(),
+      position = vec3.fromValues(0, 0, 0),
     } = options;
 
     if (fov <= 0 || fov >= 180) {
@@ -38,10 +34,7 @@ export class PerspectiveCamera extends Camera {
     this.near_ = near;
     this.far_ = far;
 
-    this.position_ = position;
-    this.target_ = target;
     this.transform.setTranslation(position);
-    this.transform.lookAt(target);
 
     this.updateProjectionMatrix();
   }
@@ -60,24 +53,6 @@ export class PerspectiveCamera extends Camera {
 
   public get effectiveFov() {
     return this.fov_ / this.zoom_;
-  }
-
-  public get position() {
-    return this.position_;
-  }
-
-  public set position(position: vec3) {
-    this.position_ = position;
-    this.transform.setTranslation(position);
-  }
-
-  public get target() {
-    return this.target_;
-  }
-
-  public set target(target: vec3) {
-    this.target_ = target;
-    this.transform.lookAt(target);
   }
 
   protected updateProjectionMatrix() {

--- a/src/objects/cameras/perspective_camera.ts
+++ b/src/objects/cameras/perspective_camera.ts
@@ -10,11 +10,14 @@ type PerspectiveCameraOptions = {
   near?: number;
   far?: number;
   position?: vec3;
+  target?: vec3;
 };
 
 export class PerspectiveCamera extends Camera {
   private fov_: number;
   private aspectRatio_: number;
+  private position_: vec3;
+  private target_: vec3;
 
   constructor(options: PerspectiveCameraOptions = {}) {
     const {
@@ -23,6 +26,7 @@ export class PerspectiveCamera extends Camera {
       near = 0.1,
       far = 10000,
       position = vec3.create(),
+      target = vec3.create(),
     } = options;
 
     if (fov <= 0 || fov >= 180) {
@@ -34,7 +38,10 @@ export class PerspectiveCamera extends Camera {
     this.near_ = near;
     this.far_ = far;
 
+    this.position_ = position;
+    this.target_ = target;
     this.transform.setTranslation(position);
+    this.transform.lookAt(target);
 
     this.updateProjectionMatrix();
   }
@@ -53,6 +60,24 @@ export class PerspectiveCamera extends Camera {
 
   public get effectiveFov() {
     return this.fov_ / this.zoom_;
+  }
+
+  public get position() {
+    return this.position_;
+  }
+
+  public set position(position: vec3) {
+    this.position_ = position;
+    this.transform.setTranslation(position);
+  }
+
+  public get target() {
+    return this.target_;
+  }
+
+  public set target(target: vec3) {
+    this.target_ = target;
+    this.transform.lookAt(target);
   }
 
   protected updateProjectionMatrix() {

--- a/src/objects/cameras/perspective_camera.ts
+++ b/src/objects/cameras/perspective_camera.ts
@@ -32,9 +32,12 @@ export class PerspectiveCamera extends Camera {
   }
 
   protected updateProjectionMatrix() {
+    // clamp the field of view and zoom to prevent degenerate behavior
+    const fov = Math.max(0.1, Math.min(179.9, this.fov_ / this.zoom_));
+    this.zoom_ = this.fov_ / fov;
     mat4.perspective(
       this.projectionMatrix_,
-      glMatrix.toRadian(this.fov_),
+      glMatrix.toRadian(fov),
       this.aspectRatio_,
       this.near_,
       this.far_

--- a/src/objects/cameras/perspective_camera.ts
+++ b/src/objects/cameras/perspective_camera.ts
@@ -14,6 +14,9 @@ export class PerspectiveCamera extends Camera {
     near = 0.1,
     far = 1000.0
   ) {
+    if (fov <= 0 || fov >= 180) {
+      throw new Error(`Invalid field of view: ${fov}`);
+    }
     super();
     this.fov_ = fov;
     this.aspectRatio_ = aspectRatio;
@@ -29,6 +32,14 @@ export class PerspectiveCamera extends Camera {
 
   public get type() {
     return "PerspectiveCamera";
+  }
+
+  public get fov() {
+    return this.fov_;
+  }
+
+  public get effectiveFov() {
+    return this.fov_ / this.zoom_;
   }
 
   protected updateProjectionMatrix() {

--- a/src/renderers/shaders/projected_line_vert.glsl
+++ b/src/renderers/shaders/projected_line_vert.glsl
@@ -46,7 +46,7 @@ void main() {
         0.0,
         0.0
     );
-    gl_Position = currPos + offset;
+    gl_Position = currPos + offset * currPos.w;
 
     // draw as GL_POINTS for debugging
     gl_PointSize = 5.0;


### PR DESCRIPTION
### Summary
As discussed each camera has two transformation matrices that ultimately just get composed. This also stores zoom separately and applies it when updating the projection matrix. For the `OrthographicCamera` it keeps the frame centered (0, 0) and pans by setting translation on the `camera.transform`, so I updated it to store just width and height.

I moved the camera controls to their own class in https://github.com/chanzuckerberg/imaging-active-learning/commit/2f7f7e6a5d579701fed8c4bc00095cdf88136c7d. This has some oddities as we discussed yesterday, mostly due to render.canvas being private and the "active" camera switching. I am open to reverting that (keeping the callbacks in the example for demo purposes) for to keep the PR a bit less intrusive.

It's an open question how to get the clip-space Z value for the object - necessary for natural panning with the `PerspectiveCamera`. Right now I calculate this in the client and just assume the object is at Z = 0 in world space (and that the camera is looking along Z). Ultimately picking or some other parameter (i.e. giving a world-space plane) might be a better solution.

### Related Issue
Related to #89 (but does not close)
Closes #101 

### Tests & Checks
Tested manually by adding pan/zoom mouse controls and a camera toggle to the `image2d_from_omezarr5d_u8` example.


https://github.com/user-attachments/assets/9a21c836-7039-48e9-9948-1e9b7bee4fbc


