### PR TITLE
Use a string literal union Answer instead of an enum

### DIFF
--- a/ultrack-prototype/frontend/components/App.tsx
+++ b/ultrack-prototype/frontend/components/App.tsx
@@ -1,7 +1,7 @@
 import { Box } from "@mui/material";
 import Renderer from "./Renderer";
 import PlaybackControls from "./PlaybackControls";
-import { useCallback, useState } from "react";
+import { useState } from "react";
 import { imageSeriesTimeInterval } from "../image_series_props";
 import TaskList from "./TaskList";
 import Question from "./Question";
@@ -22,19 +22,16 @@ export default function App() {
   const [taskIndex, setTaskIndex] = useState(0);
   const [tasks, setTasks] = useState(defaultTasks);
 
-  const setTaskAnswer = useCallback(
-    (answer: Answer) => {
-      const updatedTask = structuredClone(tasks[taskIndex]);
-      updatedTask.answer = answer;
-      const updatedTasks = Array(...tasks);
-      updatedTasks[taskIndex] = updatedTask;
-      setTasks(updatedTasks);
-      setTaskIndex((prevIndex) =>
-        prevIndex < tasks.length - 1 ? prevIndex + 1 : prevIndex
-      );
-    },
-    [tasks, setTasks, taskIndex, setTaskIndex]
-  );
+  const setTaskAnswer = (answer: Answer) => {
+    const updatedTask = structuredClone(tasks[taskIndex]);
+    updatedTask.answer = answer;
+    const updatedTasks = Array(...tasks);
+    updatedTasks[taskIndex] = updatedTask;
+    setTasks(updatedTasks);
+    setTaskIndex((prevIndex) =>
+      prevIndex < tasks.length - 1 ? prevIndex + 1 : prevIndex
+    );
+  };
 
   return (
     <Box

--- a/ultrack-prototype/frontend/components/App.tsx
+++ b/ultrack-prototype/frontend/components/App.tsx
@@ -12,6 +12,7 @@ for (let i = 0; i < 30; ++i) {
   defaultTasks.push({
     index: i,
     question: `Is this Cell Division ${i + 1}?`,
+    answer: Answer.UNANSWERED,
   });
 }
 

--- a/ultrack-prototype/frontend/components/App.tsx
+++ b/ultrack-prototype/frontend/components/App.tsx
@@ -12,7 +12,7 @@ for (let i = 0; i < 30; ++i) {
   defaultTasks.push({
     index: i,
     question: `Is this Cell Division ${i + 1}?`,
-    answer: Answer.UNANSWERED,
+    answer: "Unanswered",
   });
 }
 

--- a/ultrack-prototype/frontend/components/App.tsx
+++ b/ultrack-prototype/frontend/components/App.tsx
@@ -23,13 +23,13 @@ export default function App() {
   const [tasks, setTasks] = useState(defaultTasks);
 
   const setTaskAnswer = (answer: Answer) => {
-    const updatedTask = structuredClone(tasks[taskIndex]);
-    updatedTask.answer = answer;
-    const updatedTasks = Array(...tasks);
-    updatedTasks[taskIndex] = updatedTask;
-    setTasks(updatedTasks);
-    setTaskIndex((prevIndex) =>
-      prevIndex < tasks.length - 1 ? prevIndex + 1 : prevIndex
+    setTasks((prevTasks) =>
+      prevTasks.map((task, index) =>
+        index === taskIndex ? { ...task, answer } : task
+      )
+    );
+    setTaskIndex((prevIdx) =>
+      prevIdx < tasks.length - 1 ? prevIdx + 1 : prevIdx
     );
   };
 

--- a/ultrack-prototype/frontend/components/Question.tsx
+++ b/ultrack-prototype/frontend/components/Question.tsx
@@ -2,6 +2,8 @@ import { Button } from "@czi-sds/components";
 import { Box, Typography } from "@mui/material";
 import { Answer, Task } from "../task";
 
+const answers: Array<Answer> = ["Yes", "No", "Uncertain"];
+
 export type QuestionProps = {
   task: Task;
   setTaskAnswer: (answer: Answer) => void;
@@ -28,21 +30,16 @@ export default function Question(props: QuestionProps) {
           gap: "1em",
         }}
       >
-        {Object.entries(Answer)
-          .slice(1)
-          .map(([answer, label]) => (
-            <Button
-              key={answer}
-              sdsType={task.answer === answer ? "primary" : "secondary"}
-              sdsStyle="square"
-              onClick={() => {
-                const key = answer as keyof typeof Answer;
-                setTaskAnswer(Answer[key]);
-              }}
-            >
-              {label}
-            </Button>
-          ))}
+        {answers.map((answer) => (
+          <Button
+            key={answer}
+            sdsType={task.answer === answer ? "primary" : "secondary"}
+            sdsStyle="square"
+            onClick={() => setTaskAnswer(answer)}
+          >
+            {answer}
+          </Button>
+        ))}
       </Box>
     </Box>
   );

--- a/ultrack-prototype/frontend/components/Question.tsx
+++ b/ultrack-prototype/frontend/components/Question.tsx
@@ -28,19 +28,21 @@ export default function Question(props: QuestionProps) {
           gap: "1em",
         }}
       >
-        {Object.entries(Answer).map(([answer, label]) => (
-          <Button
-            key={answer}
-            sdsType={task.answer === answer ? "primary" : "secondary"}
-            sdsStyle="square"
-            onClick={() => {
-              const key = answer as keyof typeof Answer;
-              setTaskAnswer(Answer[key]);
-            }}
-          >
-            {label}
-          </Button>
-        ))}
+        {Object.entries(Answer)
+          .slice(1)
+          .map(([answer, label]) => (
+            <Button
+              key={answer}
+              sdsType={task.answer === answer ? "primary" : "secondary"}
+              sdsStyle="square"
+              onClick={() => {
+                const key = answer as keyof typeof Answer;
+                setTaskAnswer(Answer[key]);
+              }}
+            >
+              {label}
+            </Button>
+          ))}
       </Box>
     </Box>
   );

--- a/ultrack-prototype/frontend/components/Question.tsx
+++ b/ultrack-prototype/frontend/components/Question.tsx
@@ -2,7 +2,7 @@ import { Button } from "@czi-sds/components";
 import { Box, Typography } from "@mui/material";
 import { Answer, Task } from "../task";
 
-const answers: Array<Answer> = ["Yes", "No", "Uncertain"];
+const answers: Answer[] = ["Yes", "No", "Uncertain"];
 
 export type QuestionProps = {
   task: Task;

--- a/ultrack-prototype/frontend/components/TaskItem.tsx
+++ b/ultrack-prototype/frontend/components/TaskItem.tsx
@@ -11,11 +11,11 @@ export type TaskItemProps = {
 
 function sdsIcon(answer: Answer) {
   switch (answer) {
-    case Answer.YES:
+    case "Yes":
       return "FlagCheck";
-    case Answer.NO:
+    case "No":
       return "FlagXMark";
-    case Answer.UNCERTAIN:
+    case "Uncertain":
       return "FlagQuestionMark";
   }
   return "FlagOutline";

--- a/ultrack-prototype/frontend/components/TaskItem.tsx
+++ b/ultrack-prototype/frontend/components/TaskItem.tsx
@@ -4,13 +4,12 @@ import { Answer } from "../task";
 
 export type TaskItemProps = {
   index: number;
-  answer?: Answer;
+  answer: Answer;
   active: boolean;
   setTaskIndex: Dispatch<SetStateAction<number>>;
 };
 
-function sdsIcon(answer: Answer | undefined) {
-  if (answer === undefined) return "FlagOutline";
+function sdsIcon(answer: Answer) {
   switch (answer) {
     case Answer.YES:
       return "FlagCheck";
@@ -19,6 +18,7 @@ function sdsIcon(answer: Answer | undefined) {
     case Answer.UNCERTAIN:
       return "FlagQuestionMark";
   }
+  return "FlagOutline";
 }
 
 export default function TaskItem(props: TaskItemProps) {

--- a/ultrack-prototype/frontend/components/TaskList.tsx
+++ b/ultrack-prototype/frontend/components/TaskList.tsx
@@ -2,7 +2,7 @@ import { Box, Typography } from "@mui/material";
 import TaskItem from "./TaskItem";
 import { Button } from "@czi-sds/components";
 import { Dispatch, SetStateAction } from "react";
-import { Answer, Task } from "../task";
+import { Task } from "../task";
 
 type TaskListProps = {
   tasks: Task[];
@@ -13,7 +13,7 @@ type TaskListProps = {
 export default function TaskList(props: TaskListProps) {
   const { tasks, taskIndex, setTaskIndex } = props;
   const numReviewed = tasks.reduce(
-    (num, t) => num + (t.answer === Answer.UNANSWERED ? 0 : 1),
+    (num, t) => num + (t.answer === "Unanswered" ? 0 : 1),
     0
   );
   return (

--- a/ultrack-prototype/frontend/components/TaskList.tsx
+++ b/ultrack-prototype/frontend/components/TaskList.tsx
@@ -2,7 +2,7 @@ import { Box, Typography } from "@mui/material";
 import TaskItem from "./TaskItem";
 import { Button } from "@czi-sds/components";
 import { Dispatch, SetStateAction } from "react";
-import { Task } from "../task";
+import { Answer, Task } from "../task";
 
 type TaskListProps = {
   tasks: Task[];
@@ -13,7 +13,7 @@ type TaskListProps = {
 export default function TaskList(props: TaskListProps) {
   const { tasks, taskIndex, setTaskIndex } = props;
   const numReviewed = tasks.reduce(
-    (num, t) => num + (t.answer === undefined ? 0 : 1),
+    (num, t) => num + (t.answer === Answer.UNANSWERED ? 0 : 1),
     0
   );
   return (

--- a/ultrack-prototype/frontend/task.ts
+++ b/ultrack-prototype/frontend/task.ts
@@ -1,4 +1,5 @@
 export enum Answer {
+  UNANSWERED = "Unanswered",
   YES = "Yes",
   NO = "No",
   UNCERTAIN = "Uncertain",
@@ -7,5 +8,5 @@ export enum Answer {
 export type Task = {
   index: number;
   question: string;
-  answer?: Answer;
+  answer: Answer;
 };

--- a/ultrack-prototype/frontend/task.ts
+++ b/ultrack-prototype/frontend/task.ts
@@ -1,9 +1,4 @@
-export enum Answer {
-  UNANSWERED = "Unanswered",
-  YES = "Yes",
-  NO = "No",
-  UNCERTAIN = "Uncertain",
-}
+export type Answer = "Unanswered" | "Yes" | "No" | "Uncertain";
 
 export type Task = {
   index: number;


### PR DESCRIPTION
### Summary
This addresses some post-merge feedback in #93.

Most importantly, it uses a string literal union for the `Answer` type instead of an enum, which makes the related code simpler and more readable. That change also helped fix a bug where a previously answered question did not show the answer as a highlighted button.

### Related Issue
Related to #74

### Tests & Checks
I manually tested the prototype workflow.
