### PR TITLE
Connect client to HITL server

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,17 @@ You can run it for development purposes by passing the `prototype` mode to vite:
 npm run dev -- --mode prototype
 ```
 
+The prototype will try to connect to a backend server running on <http://localhost:8000>. You can
+mock this by setting `VITE_MOCK_ULTRACK=true` in your environment. This can be set in a
+`ultrack-prototype/frontent/.env` file, or when running the dev server:
+
+```shell
+VITE_MOCK_ULTRACK=true npm run dev -- --mode prototype
+```
+
+(Note: this is likely to change in the future)
+
+
 ### Backend server
 
 The backend server for the prototype is in the `ultrack-prototype/backend` directory. This is a

--- a/ultrack-prototype/backend/src/ultrack_learns/db.py
+++ b/ultrack-prototype/backend/src/ultrack_learns/db.py
@@ -1,9 +1,19 @@
 import os
 from contextlib import contextmanager
 
-from ultrack_learns.models import TrackData
+from ultrack_learns.models import TaskData, TaskType, TrackData
 
-from sqlalchemy import create_engine, select, Column, Integer, Float
+from sqlalchemy import (
+    create_engine,
+    select,
+    Column,
+    DateTime,
+    Integer,
+    Float,
+    ForeignKey,
+    String,
+    UUID,
+)
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker, Session
 
@@ -18,11 +28,14 @@ SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 
 def get_session():
-    db = SessionLocal()
-    try:
-        yield db
-    finally:
-        db.close()
+    with SessionLocal() as session:
+        try:
+            yield session
+            session.commit()
+        except Exception:
+            # TODO: log the exception, but don't expose it
+            session.rollback()
+            raise
 
 
 session_context = contextmanager(get_session)
@@ -41,6 +54,39 @@ class TrackPoint(Base):
     x = Column(Float)
 
 
+class Task(Base):
+    __tablename__ = "tasks"
+
+    id = Column(Integer, primary_key=True, index=True)
+    task_id = Column(UUID, index=True, unique=True)
+    # these can be used to query track_points to get the task_data
+    # this is much simpler than storing this relationship directly in the DB
+    # and allows more flexibility (e.g. changing the time window)
+    task_type = Column(String, nullable=False)
+    node_id = Column(Integer, ForeignKey("track_points.id"))
+
+    def get_task_data(self, db: Session, time_window: int = 10) -> TaskData:
+        return TaskData(
+            node_id=self.node_id,
+            tracks_data=track_points_around_node(
+                db,
+                self.node_id,
+                time_window=time_window,
+                include_children=self.task_type == TaskType.DIVISION,
+            ),
+        )
+
+
+class Answer(Base):
+    __tablename__ = "answers"
+
+    id = Column(Integer, primary_key=True, index=True)
+    answer_id = Column(UUID, index=True, unique=True)
+    task_id = Column(UUID, ForeignKey("tasks.task_id"))
+    created_at = Column(DateTime(timezone=True))
+    answer = Column(String, nullable=False)
+
+
 def track_points_around_node(
     db: Session,
     node_id: int,
@@ -55,9 +101,11 @@ def track_points_around_node(
 
     track_ids = [node_record.track_id]
     if include_children:
-        get_children = select(TrackPoint.track_id).where(
-            TrackPoint.parent_track_id == node_record.track_id
-        ).distinct()
+        get_children = (
+            select(TrackPoint.track_id)
+            .where(TrackPoint.parent_track_id == node_record.track_id)
+            .distinct()
+        )
         children = db.execute(get_children).scalars().all()
         track_ids.extend(children)
 
@@ -82,7 +130,7 @@ def track_points_around_node(
                 if tp.track_id == track_id
             ],
         )
-        for track_id in track_ids
+        for track_id in sorted(track_ids)
     ]
 
 

--- a/ultrack-prototype/backend/src/ultrack_learns/db.py
+++ b/ultrack-prototype/backend/src/ultrack_learns/db.py
@@ -57,8 +57,7 @@ class TrackPoint(Base):
 class Task(Base):
     __tablename__ = "tasks"
 
-    id = Column(Integer, primary_key=True, index=True)
-    task_id = Column(UUID, index=True, unique=True)
+    task_id = Column(UUID, primary_key=True, index=True)
     # these can be used to query track_points to get the task_data
     # this is much simpler than storing this relationship directly in the DB
     # and allows more flexibility (e.g. changing the time window)
@@ -80,8 +79,7 @@ class Task(Base):
 class Answer(Base):
     __tablename__ = "answers"
 
-    id = Column(Integer, primary_key=True, index=True)
-    answer_id = Column(UUID, index=True, unique=True)
+    answer_id = Column(UUID, primary_key=True, index=True)
     task_id = Column(UUID, ForeignKey("tasks.task_id"))
     created_at = Column(DateTime(timezone=True))
     answer = Column(String, nullable=False)

--- a/ultrack-prototype/backend/src/ultrack_learns/db.py
+++ b/ultrack-prototype/backend/src/ultrack_learns/db.py
@@ -64,7 +64,7 @@ class Task(Base):
     task_type = Column(String, nullable=False)
     node_id = Column(Integer, ForeignKey("track_points.id"))
 
-    def get_task_data(self, db: Session, time_window: int = 10) -> TaskData:
+    def get_task_data(self, db: Session, time_window: int = 16) -> TaskData:
         return TaskData(
             node_id=self.node_id,
             tracks_data=track_points_around_node(

--- a/ultrack-prototype/backend/src/ultrack_learns/mock_data.py
+++ b/ultrack-prototype/backend/src/ultrack_learns/mock_data.py
@@ -15,6 +15,7 @@ from ultrack_learns.db import (
     set_up_db,
     track_points_around_node,
     TrackPoint,
+    Task as TaskRecord,
 )
 
 SAMPLE_DATA_URL = "https://public.czbiohub.org/royerlab/ultrack/multi-color/tracks.csv"
@@ -136,6 +137,7 @@ CACHE = {}
 def all_tasks(
     rng_seed: int = 42,
     num_tasks: int = 10,
+    time_window: int = 16,
     db: Session = Depends(get_session),
 ) -> list[Task]:
     key = (rng_seed, num_tasks)
@@ -144,6 +146,8 @@ def all_tasks(
     seed(rng_seed)
     tasks = []
     task_types = Counter(choices(list(TaskType), k=num_tasks))
+    # TODO: the client does not yet support different task types
+    task_types = {TaskType.DIVISION: num_tasks}
     for task_type, count in task_types.items():
         task_roots = sampling_functions[task_type](db, count)
         task_data = [
@@ -152,7 +156,7 @@ def all_tasks(
                 tracks_data=track_points_around_node(
                     db,
                     root_node.id,
-                    time_window=10,
+                    time_window=time_window,
                     include_children=task_type == TaskType.DIVISION,
                 ),
             )
@@ -168,6 +172,22 @@ def all_tasks(
                 for data in task_data
             ]
         )
+
+    for task in tasks:
+        db.add(
+            TaskRecord(
+                task_id=task.task_id,
+                task_type=task.task_type,
+                node_id=task.task_data.node_id,
+            )
+        )
+    try:
+        db.commit()
+    except Exception as e:
+        db.rollback()
+        print("Error committing tasks to the database")
+        print(e)
+
     CACHE[key] = tasks
     return tasks
 

--- a/ultrack-prototype/backend/src/ultrack_learns/mock_data.py
+++ b/ultrack-prototype/backend/src/ultrack_learns/mock_data.py
@@ -140,7 +140,7 @@ def all_tasks(
     time_window: int = 16,
     db: Session = Depends(get_session),
 ) -> list[Task]:
-    key = (rng_seed, num_tasks)
+    key = (rng_seed, num_tasks, time_window)
     if key in CACHE:
         return CACHE[key]
     seed(rng_seed)

--- a/ultrack-prototype/backend/src/ultrack_learns/models.py
+++ b/ultrack-prototype/backend/src/ultrack_learns/models.py
@@ -1,8 +1,9 @@
+from datetime import datetime, timezone
 from uuid import UUID
 
 from enum import auto, StrEnum
 
-from pydantic import BaseModel
+from pydantic import AwareDatetime, BaseModel, Field
 
 
 Path2D = list[tuple[float, float]]
@@ -30,3 +31,19 @@ class Task(BaseModel):
     task_id: UUID
     task_type: TaskType
     task_data: TaskData
+
+
+class AnswerType(StrEnum):
+    YES = auto()
+    NO = auto()
+    UNCERTAIN = auto()
+
+
+class Answer(BaseModel):
+    answer_id: UUID
+    task_id: UUID
+    created_at: AwareDatetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc),
+        init=False,
+    )
+    answer: AnswerType

--- a/ultrack-prototype/backend/src/ultrack_learns/server.py
+++ b/ultrack-prototype/backend/src/ultrack_learns/server.py
@@ -1,16 +1,29 @@
 from typing import Annotated
 
-from fastapi import FastAPI, APIRouter, Depends, Query
-from sqlalchemy import inspect
+from fastapi import FastAPI, APIRouter, Depends, HTTPException, Query
+from fastapi.middleware.cors import CORSMiddleware
+from sqlalchemy import inspect, select, exc
 from sqlalchemy.orm import Session
 
-from ultrack_learns.db import get_session, track_points_around_node
+from ultrack_learns.db import (
+    get_session,
+    track_points_around_node,
+    Answer as AnswerRecord,
+)
+from ultrack_learns.models import Answer
 
 # TODO: control mock mode with env var
 from ultrack_learns.mock_data import mock_lifespan as lifespan
 from ultrack_learns.mock_data import mock_router
 
 app = FastAPI(lifespan=lifespan)
+
+# TODO: allow some configuration here
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+)
 
 debug_router = APIRouter(prefix="/debug")
 
@@ -34,6 +47,42 @@ def get_track_for_node(
     db: Session = Depends(get_session),
 ):
     return track_points_around_node(db, node_id, time_window, include_children)
+
+
+@app.get("/task/{task_id}/answer")
+def get_task_answers(
+    task_id: str,
+    db: Session = Depends(get_session),
+) -> list[Answer]:
+    query = select(AnswerRecord).where(AnswerRecord.task_id == task_id)
+    return [Answer(**record.__dict__) for record in db.execute(query).all()]
+
+
+# TODO: allow upsert instead of 409
+@app.post("/answer")
+def post_one_or_many_answers(
+    answers: Answer | list[Answer],
+    db: Session = Depends(get_session),
+):
+    if isinstance(answers, Answer):
+        answers = [answers]
+
+    new_records = []
+    for answer in answers:
+        existing = (
+            select(AnswerRecord)
+            .where(AnswerRecord.answer_id == answer.answer_id)
+            .limit(1)
+        )
+        existing = db.execute(existing).scalar()
+        if existing:
+            existing.answer = answer.answer
+            existing.created_at = answer.created_at
+        else:
+            new_records.append(AnswerRecord(**answer.__dict__))
+    db.add_all(new_records)
+
+    return answers
 
 
 app.include_router(mock_router)

--- a/ultrack-prototype/backend/src/ultrack_learns/server.py
+++ b/ultrack-prototype/backend/src/ultrack_learns/server.py
@@ -1,8 +1,8 @@
 from typing import Annotated
 
-from fastapi import FastAPI, APIRouter, Depends, HTTPException, Query
+from fastapi import FastAPI, APIRouter, Depends, Query
 from fastapi.middleware.cors import CORSMiddleware
-from sqlalchemy import inspect, select, exc
+from sqlalchemy import inspect, select
 from sqlalchemy.orm import Session
 
 from ultrack_learns.db import (
@@ -25,10 +25,11 @@ app.add_middleware(
     allow_methods=["*"],
 )
 
+# TODO: debug routes are for anything *not* used in the prototype
 debug_router = APIRouter(prefix="/debug")
 
 
-@app.get("/ping")
+@debug_router.get("/ping")
 def read_root():
     return {"Hello": "World"}
 
@@ -39,7 +40,7 @@ def list_tables(db: Session = Depends(get_session)):
     return {"tables": inspector.get_table_names()}
 
 
-@app.get("/track")
+@debug_router.get("/track")
 def get_track_for_node(
     node_id: int,
     time_window: Annotated[int | None, Query(gt=0)] = None,
@@ -49,7 +50,7 @@ def get_track_for_node(
     return track_points_around_node(db, node_id, time_window, include_children)
 
 
-@app.get("/task/{task_id}/answer")
+@debug_router.get("/task/{task_id}/answer")
 def get_task_answers(
     task_id: str,
     db: Session = Depends(get_session),
@@ -58,7 +59,6 @@ def get_task_answers(
     return [Answer(**record.__dict__) for record in db.execute(query).all()]
 
 
-# TODO: allow upsert instead of 409
 @app.post("/answer")
 def post_one_or_many_answers(
     answers: Answer | list[Answer],
@@ -69,6 +69,7 @@ def post_one_or_many_answers(
 
     new_records = []
     for answer in answers:
+        # upsert answer - answer_id is unique per-session (reload)
         existing = (
             select(AnswerRecord)
             .where(AnswerRecord.answer_id == answer.answer_id)

--- a/ultrack-prototype/frontend/components/App.tsx
+++ b/ultrack-prototype/frontend/components/App.tsx
@@ -4,8 +4,23 @@ import PlaybackControls from "./PlaybackControls";
 import { useEffect, useState } from "react";
 import TaskList from "./TaskList";
 import Question from "./Question";
-import { Answer, Task } from "../lib/tasks";
-import { fetchTasks } from "../lib/mock_data";
+import { AnswerType, Task } from "../lib/tasks";
+import {
+  fetchTasks as fetchMockTasks,
+  postAnswers as postMockAnswers,
+} from "../lib/mock_data";
+import {
+  fetchTasks as fetchRealTasks,
+  postAnswers as postRealAnswers,
+} from "../lib/data";
+
+let fetchTasks = fetchRealTasks;
+let postAnswers = postRealAnswers;
+
+if (import.meta.env.VITE_MOCK_ULTRACK === "true") {
+  fetchTasks = fetchMockTasks;
+  postAnswers = postMockAnswers;
+}
 
 export default function App() {
   const [playbackEnabled, setPlaybackEnabled] = useState(false);
@@ -15,19 +30,26 @@ export default function App() {
 
   // TODO: we want to fetch new tasks more than just on mount
   // TODO: fetching and syncing might be better handled by `TaskList`
+  // TODO: fetch the latest answers as well, or prevent overwriting them when refreshing?
   useEffect(() => {
     const fetchOnMount = async () => {
-      setTasks(await fetchTasks());
+      const tasks = await fetchTasks();
+      console.debug("App::fetched tasks", tasks);
+      setTasks(tasks);
     };
     fetchOnMount();
   }, []);
 
-  const setTaskAnswer = (answer: Answer) => {
+  const task = tasks[taskIndex] ?? null;
+  console.debug(`App::taskIndex: ${taskIndex}/${tasks.length}, task:`, task);
+
+  const setTaskAnswer = (answer: AnswerType) => {
     setTasks((prevTasks) =>
       prevTasks.map((task, index) => {
         if (index === taskIndex) {
           const newTask = task.clone();
-          newTask.answer = answer;
+          newTask.answer.value = answer;
+          newTask.answer.synced = "not_synced";
           return newTask;
         }
         return task;
@@ -38,8 +60,45 @@ export default function App() {
     );
   };
 
-  const task = tasks[taskIndex] ?? null;
-  console.debug(`App::taskIndex: ${taskIndex}/${tasks.length}, task:`, task);
+  useEffect(() => {
+    const answersToSync = tasks
+      .map((task) => task.answer)
+      .filter((answer) => answer.synced === "not_synced");
+
+    if (answersToSync.length === 0) {
+      return;
+    }
+
+    const setPending = () => {
+      setTasks((prevTasks) =>
+        prevTasks.map((task) => {
+          if (task.answer.synced === "not_synced") {
+            const newTask = task.clone();
+            newTask.answer.synced = "pending";
+            return newTask;
+          }
+          return task;
+        })
+      );
+    };
+    setPending();
+
+    const postAnswersToSync = async () => {
+      const synced = await postAnswers(answersToSync);
+      setTasks((prevTasks) =>
+        prevTasks.map((task) => {
+          const syncedAnswer = synced.find((a) => a.taskId === task.taskId);
+          if (syncedAnswer) {
+            const newTask = task.clone();
+            newTask.answer.synced = syncedAnswer.synced;
+            return newTask;
+          }
+          return task;
+        })
+      );
+    };
+    postAnswersToSync();
+  }, [tasks, setTasks]);
 
   return (
     <Box

--- a/ultrack-prototype/frontend/components/App.tsx
+++ b/ultrack-prototype/frontend/components/App.tsx
@@ -30,7 +30,7 @@ export default function App() {
 
   // TODO: we want to fetch new tasks more than just on mount
   // TODO: fetching and syncing might be better handled by `TaskList`
-  // TODO: fetch the latest answers as well, or prevent overwriting them when refreshing?
+  // TODO: fetch the latest answers as well? this would require some session ID
   useEffect(() => {
     const fetchOnMount = async () => {
       const tasks = await fetchTasks();

--- a/ultrack-prototype/frontend/components/Question.tsx
+++ b/ultrack-prototype/frontend/components/Question.tsx
@@ -1,13 +1,13 @@
 import { Button } from "@czi-sds/components";
 import { Box, Typography } from "@mui/material";
-import { Answer, Task } from "../lib/tasks";
+import { AnswerType, Task } from "../lib/tasks";
 
-const answers: Answer[] = ["Yes", "No", "Uncertain"];
+const answers: AnswerType[] = ["Yes", "No", "Uncertain"];
 
 export type QuestionProps = {
   disabled: boolean;
   task: Task | null;
-  setTaskAnswer: (answer: Answer) => void;
+  setTaskAnswer: (answer: AnswerType) => void;
 };
 
 export default function Question(props: QuestionProps) {
@@ -34,7 +34,7 @@ export default function Question(props: QuestionProps) {
         {answers.map((answer) => (
           <Button
             key={answer}
-            sdsType={task?.answer === answer ? "primary" : "secondary"}
+            sdsType={task?.answer.value === answer ? "primary" : "secondary"}
             sdsStyle="square"
             onClick={() => setTaskAnswer(answer)}
             disabled={disabled}

--- a/ultrack-prototype/frontend/components/Renderer.tsx
+++ b/ultrack-prototype/frontend/components/Renderer.tsx
@@ -9,6 +9,7 @@ import {
   WebGLRenderer,
 } from "@";
 
+// TODO: imageURL should come from the server (probably with each task)
 import { imageUrl } from "../lib/mock_data";
 import { Task } from "../lib/tasks";
 import { Box } from "@mui/material";

--- a/ultrack-prototype/frontend/components/TaskItem.tsx
+++ b/ultrack-prototype/frontend/components/TaskItem.tsx
@@ -1,15 +1,17 @@
 import { Button, Icon } from "@czi-sds/components";
 import { Dispatch, SetStateAction } from "react";
-import { Answer } from "../lib/tasks";
+import { AnswerType, SyncStatus, TaskType } from "../lib/tasks";
 
 export type TaskItemProps = {
   index: number;
-  answer: Answer;
+  answer: AnswerType;
+  syncStatus: SyncStatus;
   active: boolean;
+  taskType: TaskType;
   setTaskIndex: Dispatch<SetStateAction<number>>;
 };
 
-function sdsIcon(answer: Answer) {
+function sdsIcon(answer: AnswerType) {
   switch (answer) {
     case "Yes":
       return "FlagCheck";
@@ -21,18 +23,38 @@ function sdsIcon(answer: Answer) {
   return "FlagOutline";
 }
 
+function sdsIconColor(synced: SyncStatus) {
+  switch (synced) {
+    case "synced":
+      return "blue";
+    case "not_synced":
+    case "pending":
+      return "yellow";
+    case "error":
+    default:
+      return "red";
+  }
+}
+
 export default function TaskItem(props: TaskItemProps) {
-  const { index, answer, active, setTaskIndex } = props;
+  const { index, answer, syncStatus, active, taskType, setTaskIndex } = props;
   return (
     <Button
-      endIcon={<Icon sdsIcon={sdsIcon(answer)} sdsType="static" sdsSize="s" />}
+      endIcon={
+        <Icon
+          sdsIcon={sdsIcon(answer)}
+          sdsType="static"
+          sdsSize="s"
+          color={sdsIconColor(syncStatus)}
+        />
+      }
       sdsType={active ? "primary" : "secondary"}
       sdsStyle="minimal"
       isAllCaps={false}
       sx={{ justifyContent: "space-between" }}
       onClick={() => setTaskIndex(index)}
     >
-      {`${index + 1} Track`}
+      {`${index + 1} Cell ${taskType}`}
     </Button>
   );
 }

--- a/ultrack-prototype/frontend/components/TaskList.tsx
+++ b/ultrack-prototype/frontend/components/TaskList.tsx
@@ -13,7 +13,7 @@ type TaskListProps = {
 export default function TaskList(props: TaskListProps) {
   const { tasks, taskIndex, setTaskIndex } = props;
   const numReviewed = tasks.reduce(
-    (num, t) => num + (t.answer === "Unanswered" ? 0 : 1),
+    (num, t) => num + (t.answer.value === "Unanswered" ? 0 : 1),
     0
   );
 
@@ -55,8 +55,10 @@ export default function TaskList(props: TaskListProps) {
           <TaskItem
             key={t.taskId}
             index={index}
-            answer={t.answer}
+            answer={t.answer.value}
+            syncStatus={t.answer.synced}
             active={taskIndex === index}
+            taskType={t.taskType}
             setTaskIndex={setTaskIndex}
           />
         ))}

--- a/ultrack-prototype/frontend/lib/data.ts
+++ b/ultrack-prototype/frontend/lib/data.ts
@@ -1,0 +1,43 @@
+import { Answer, Task } from "./tasks";
+
+const SERVER_URL = "http://localhost:8000";
+
+export async function fetchTasks(): Promise<Task[]> {
+  const response = await fetch(`${SERVER_URL}/mock_data/task`);
+  const tasks = await response.json();
+  return tasks.map((task: unknown) => Task.fromJSON(task));
+}
+
+export async function postAnswers(answers: Answer[]): Promise<Answer[]> {
+  // TODO: support retrying failed syncs?
+  const post = fetch(`${SERVER_URL}/answer`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(
+      answers.map((answer) => ({
+        task_id: answer.taskId,
+        answer_id: answer.answerId,
+        answer: answer.value.toLowerCase(),
+      }))
+    ),
+  });
+
+  let response;
+  try {
+    response = await post;
+  } catch (error) {
+    console.error("SYNC FAILED", error);
+    return answers.map((answer) => ({ ...answer, synced: "error" }));
+  }
+
+  // TODO: set separate status for each answer (requires server changes as well)
+  if (!response.ok) {
+    console.log("SYNC FAILED", await response.json());
+    return answers.map((answer) => ({ ...answer, synced: "error" }));
+  } else {
+    console.log("SYNCED", await response.json());
+    return answers.map((answer) => ({ ...answer, synced: "synced" }));
+  }
+}

--- a/ultrack-prototype/frontend/lib/data.ts
+++ b/ultrack-prototype/frontend/lib/data.ts
@@ -1,6 +1,6 @@
 import { Answer, Task } from "./tasks";
 
-const SERVER_URL = "http://localhost:8000";
+const SERVER_URL = "http://127.0.0.1:8000";
 
 export async function fetchTasks(): Promise<Task[]> {
   const response = await fetch(`${SERVER_URL}/mock_data/task`);

--- a/ultrack-prototype/frontend/lib/data.ts
+++ b/ultrack-prototype/frontend/lib/data.ts
@@ -3,6 +3,8 @@ import { Answer, Task } from "./tasks";
 const SERVER_URL = "http://127.0.0.1:8000";
 
 export async function fetchTasks(): Promise<Task[]> {
+  // TODO: server endpoint will change
+  // this does a real fetch from the server, but the server provides mock data (random tasks)
   const response = await fetch(`${SERVER_URL}/mock_data/task`);
   const tasks = await response.json();
   return tasks.map((task: unknown) => Task.fromJSON(task));

--- a/ultrack-prototype/frontend/lib/mock_data.ts
+++ b/ultrack-prototype/frontend/lib/mock_data.ts
@@ -1,6 +1,6 @@
 // TODO: this is a temporary store for hard-coded data. It will be replaced by
 // a more dynamic data source in the future.
-import { Task } from "./tasks";
+import { Answer, Task } from "./tasks";
 
 export const imageUrl =
   "https://public.czbiohub.org/royerlab/ultrack/multi-color/image.zarr/";
@@ -439,4 +439,8 @@ const tasks = [
 // TODO: perhaps could be an async iterator or something
 export async function fetchTasks(): Promise<Task[]> {
   return tasks.map((task) => Task.fromJSON(task));
+}
+
+export async function postAnswers(answers: Answer[]): Promise<Answer[]> {
+  return answers.map((answer) => ({ ...answer, synced: "synced" }));
 }

--- a/ultrack-prototype/frontend/lib/tasks.ts
+++ b/ultrack-prototype/frontend/lib/tasks.ts
@@ -73,7 +73,7 @@ function taskDataFromJSON(taskDataJSON: unknown): TaskData {
 }
 
 const TASK_TYPES = ["appearance", "disappearance", "division"] as const;
-type TaskType = (typeof TASK_TYPES)[number];
+export type TaskType = (typeof TASK_TYPES)[number];
 
 function isValidTaskType(taskType: unknown): taskType is TaskType {
   return (
@@ -81,22 +81,45 @@ function isValidTaskType(taskType: unknown): taskType is TaskType {
   );
 }
 
-export type Answer = "Unanswered" | "Yes" | "No" | "Uncertain";
+export type AnswerType = "Unanswered" | "Yes" | "No" | "Uncertain";
+export type SyncStatus = "synced" | "not_synced" | "pending" | "error";
+
+export type Answer = {
+  answerId: string;
+  taskId: string;
+  value: AnswerType;
+  synced: SyncStatus;
+};
+
+const defaultAnswer = (taskId: string) => {
+  return {
+    answerId: window.crypto.randomUUID(),
+    taskId: taskId,
+    value: "Unanswered" as AnswerType,
+    synced: "synced" as SyncStatus,
+  };
+};
 
 // TODO: create a function to validate tasks as they come from the server
 export class Task {
   taskId: string;
   taskType: TaskType;
   taskData: TaskData;
-  answer: Answer = "Unanswered";
+  answer: Answer;
 
   private timeInterval_: { start: number; stop: number } | null = null;
   private tracksLayer_: TracksLayer | null = null;
 
-  private constructor(taskId: string, taskType: TaskType, taskData: TaskData) {
+  private constructor(
+    taskId: string,
+    taskType: TaskType,
+    taskData: TaskData,
+    answer: Answer = defaultAnswer(taskId)
+  ) {
     this.taskId = taskId;
     this.taskType = taskType;
     this.taskData = taskData;
+    this.answer = answer;
   }
 
   static fromJSON(json: unknown): Task {
@@ -126,16 +149,21 @@ export class Task {
   }
 
   public clone(): Task {
-    return new Task(this.taskId, this.taskType, {
-      nodeId: this.taskData.nodeId,
-      tracksData: this.taskData.tracksData.map((track) => ({
-        trackId: track.trackId,
-        time: [...track.time],
-        position: track.position.map((pos) => [
-          ...pos,
-        ]) as typeof track.position,
-      })),
-    });
+    return new Task(
+      this.taskId,
+      this.taskType,
+      {
+        nodeId: this.taskData.nodeId,
+        tracksData: this.taskData.tracksData.map((track) => ({
+          trackId: track.trackId,
+          time: [...track.time],
+          position: track.position.map((pos) => [
+            ...pos,
+          ]) as typeof track.position,
+        })),
+      },
+      { ...this.answer }
+    );
   }
 
   public get question(): string {


### PR DESCRIPTION
### Summary
This makes the client (prototype frontend) talk to the HITL server (prototype backend).

This is WIP so feel free to take a look, but I'd like to split it up a bit to make it easier to review and merge.

What's in here now:
* added `tasks` table to the HITL server DB
* added `answers` table to the HITL server DB
* added an `answer` endpoint to the HITL server
* changed `Answer` in FE to a type that contains a UUID, timestamp, and sync status
* added effects to sync answers with the server
* icon color in `TaskList` reflects sync status
* control whether using hard-coded data (and mock `answer` endpoint) via `VITE_MOCK_ULTRACK` env var (allows developing FE without running BE)
* make the HITL server very CORS-permissive (required if FE and BE are hosted on different origin)
* sort the tracks by ID within a task - this makes every division `red -> (blue, green)` but I'm not sure it's completely correct (that is, can a parent have an ID larger than its child?). Maybe we just need to make sure parent is first.

TODO (will make an issue):
Currently you get a new UUID for each `Answer` when the page loads. Answers can then be overwritten if you go back to a given task and re-answer, it will overwrite the previous answer in the DB. If the page is reloaded or refreshed, you will get new UUIDs and can re-submit _new_ answers. It's up to the server to do what it wants with multiple answers to one task. An improvement may be adding a concept of a user or session ID (no need to be secure), such that answers can be changed within the same session, and perhaps sessions could be resumed

### Related Issues
#105
#106

### Tests & Checks
Manual testing
