### PR TITLE
Improve track visualization in prototype application

### DIFF
--- a/ultrack-prototype/frontend/components/PlaybackControls.tsx
+++ b/ultrack-prototype/frontend/components/PlaybackControls.tsx
@@ -65,7 +65,7 @@ export default function PlaybackControls(props: PlaybackControlsProps) {
         // the slider component is closed on the right, so we need to subtract 1
         max={maxTime - 1}
         disabled={!enabled}
-        valueLabelDisplay="on"
+        valueLabelDisplay={playing ? "off" : "on"}
         onChange={(_, value) => setCurTime(value as number)}
         value={curTime}
       />

--- a/ultrack-prototype/frontend/components/PlaybackControls.tsx
+++ b/ultrack-prototype/frontend/components/PlaybackControls.tsx
@@ -3,7 +3,7 @@ import { Button, InputSlider } from "@czi-sds/components";
 import { Dispatch, SetStateAction, useEffect, useState } from "react";
 import { Task } from "../lib/tasks";
 
-const playbackFPS = 16;
+const playbackFPS = 8;
 const playbackIntervalMs = 1000 / playbackFPS;
 
 type PlaybackControlsProps = {

--- a/ultrack-prototype/frontend/components/Renderer.tsx
+++ b/ultrack-prototype/frontend/components/Renderer.tsx
@@ -36,16 +36,16 @@ export default function Renderer(props: RendererProps) {
 
   useEffect(() => {
     console.debug("Renderer::useEffect::curTime: ", curTime);
-    if (imageSeriesLayer === null) return;
+    if (imageSeriesLayer === null || tracksLayer === null) return;
     if (imageSeriesLayer.state === "ready") {
       imageSeriesLayer.setTimeIndex(curTime);
-      tracksLayer?.setTimeIndex(curTime);
+      tracksLayer.setTimeIndex(curTime);
       return;
     }
     const onStateChange = (newState: LayerState) => {
       if (newState === "ready") {
         imageSeriesLayer.setTimeIndex(curTime);
-        tracksLayer?.setTimeIndex(curTime);
+        tracksLayer.setTimeIndex(curTime);
       }
     };
     imageSeriesLayer.addStateChangeCallback(onStateChange);

--- a/ultrack-prototype/frontend/components/Renderer.tsx
+++ b/ultrack-prototype/frontend/components/Renderer.tsx
@@ -5,6 +5,7 @@ import {
   LayerState,
   OmeZarrImageSource,
   OrthographicCamera,
+  TracksLayer,
   WebGLRenderer,
 } from "@";
 
@@ -31,22 +32,25 @@ export default function Renderer(props: RendererProps) {
   const { curTime, playbackEnabled, setPlaybackEnabled, task } = props;
   const [imageSeriesLayer, setImageSeriesLayer] =
     useState<ImageSeriesLayer | null>(null);
+  const [tracksLayer, setTracksLayer] = useState<TracksLayer | null>(null);
 
   useEffect(() => {
     console.debug("Renderer::useEffect::curTime: ", curTime);
     if (imageSeriesLayer === null) return;
     if (imageSeriesLayer.state === "ready") {
       imageSeriesLayer.setTimeIndex(curTime);
+      tracksLayer?.setTimeIndex(curTime);
       return;
     }
     const onStateChange = (newState: LayerState) => {
       if (newState === "ready") {
         imageSeriesLayer.setTimeIndex(curTime);
+        tracksLayer?.setTimeIndex(curTime);
       }
     };
     imageSeriesLayer.addStateChangeCallback(onStateChange);
     return () => imageSeriesLayer.removeStateChangeCallback(onStateChange);
-  }, [curTime, imageSeriesLayer]);
+  }, [curTime, imageSeriesLayer, tracksLayer]);
 
   useEffect(() => {
     console.debug("Renderer::useEffect::task: ", task);
@@ -57,6 +61,7 @@ export default function Renderer(props: RendererProps) {
     const { tracksLayer, imageSeriesLayer } = task.layers(imageSource);
     imageSeriesLayer.update();
     setImageSeriesLayer(imageSeriesLayer);
+    setTracksLayer(tracksLayer);
     const onStateChange = (newState: LayerState) => {
       if (newState === "ready") {
         setPlaybackEnabled(true);

--- a/ultrack-prototype/frontend/lib/tasks.ts
+++ b/ultrack-prototype/frontend/lib/tasks.ts
@@ -206,6 +206,7 @@ export class Task {
           time: track.time,
           color: COLOR_CYCLE[i % COLOR_CYCLE.length],
           width: 0.01,
+          interpolation: { pointsPerSegment: 10, tangentFactor: 0.3 },
         };
       });
       this.tracksLayer_ = new TracksLayer(tracks);

--- a/ultrack-prototype/frontend/lib/tasks.ts
+++ b/ultrack-prototype/frontend/lib/tasks.ts
@@ -4,7 +4,7 @@ import {
   ImageSeriesLayer,
   OmeZarrImageSource,
   OrthographicCamera,
-  ProjectedLineLayer,
+  TracksLayer,
 } from "@";
 
 type Track = {
@@ -96,7 +96,7 @@ export class Task {
   answer: Answer = "Unanswered";
 
   private timeInterval_: { start: number; stop: number } | null = null;
-  private tracksLayer_: ProjectedLineLayer | null = null;
+  private tracksLayer_: TracksLayer | null = null;
 
   private constructor(taskId: string, taskType: TaskType, taskData: TaskData) {
     this.taskId = taskId;
@@ -158,16 +158,6 @@ export class Task {
     }
   }
 
-  private tracksAs3DPaths(): vec3[][] {
-    const tracksData = this.taskData.tracksData;
-    return tracksData.map((track) => {
-      return track.position.map((pos) => {
-        const z = pos.length === 3 ? pos[2] : 0;
-        return [pos[0], pos[1], z];
-      });
-    });
-  }
-
   private get timeInterval(): { start: number; stop: number } {
     if (!this.timeInterval_) {
       const tracksData = this.taskData.tracksData;
@@ -204,22 +194,28 @@ export class Task {
     return layer;
   }
 
-  tracksLayer(): ProjectedLineLayer {
+  tracksLayer(): TracksLayer {
     if (this.tracksLayer_ === null) {
-      this.tracksLayer_ = new ProjectedLineLayer(
-        this.tracksAs3DPaths().map((path, i) => ({
-          path,
+      const tracksData = this.taskData.tracksData;
+      const tracks = tracksData.map((track, i) => {
+        return {
+          path: track.position.map((pos) => {
+            const z = pos.length === 3 ? pos[2] : 0;
+            return vec3.fromValues(pos[0], pos[1], z);
+          }),
+          time: track.time,
           color: COLOR_CYCLE[i % COLOR_CYCLE.length],
           width: 0.01,
-        }))
-      );
+        };
+      });
+      this.tracksLayer_ = new TracksLayer(tracks);
     }
     return this.tracksLayer_;
   }
 
   public layers(imageSource: OmeZarrImageSource): {
     imageSeriesLayer: ImageSeriesLayer;
-    tracksLayer: ProjectedLineLayer;
+    tracksLayer: TracksLayer;
   } {
     const layers = {
       imageSeriesLayer: this.imageSeriesLayer(imageSource),


### PR DESCRIPTION
### Summary
This improves the tracks visualization in the prototype app, by using the `TracksLayer` defined in #107 in a very similar way to the related dev example. It also reduces the playback speed to make it a little easier to follow the tracks and imaging content.

### Related Issue
#95

### Tests & Checks
I manually tested the prototype application.