### PR TITLE
Use pan-zoom controls in tracks example and prototype

### DIFF
--- a/examples/tracks/main.ts
+++ b/examples/tracks/main.ts
@@ -8,6 +8,7 @@ import {
   TracksLayer,
   WebGLRenderer,
 } from "@";
+import { PanZoomControls } from "@/objects/cameras/controls";
 
 // payload roughly equivalent to task 0 from
 // https://public.czbiohub.org/royerlab/ultrack/multi-color/mock_data.json
@@ -84,6 +85,9 @@ const { xMin: left, xMax: right, yMin: top, yMax: bottom } = lineLayer.extent;
 const camera = new OrthographicCamera(left, right, top, bottom);
 camera.zoom = 0.5;
 camera.transform.translate([0, 0, 1]);
+
+const controls = new PanZoomControls(camera, camera.position);
+renderer.setControls(controls);
 
 const slider = document.querySelector<HTMLInputElement>("#slider");
 if (slider === null) throw new Error("Time slider not found.");

--- a/ultrack-prototype/frontend/components/Renderer.tsx
+++ b/ultrack-prototype/frontend/components/Renderer.tsx
@@ -71,9 +71,9 @@ export default function Renderer(props: RendererProps) {
         layerManager.layers.length = 0;
         layerManager.add(tracksLayer);
         layerManager.add(imageSeriesLayer);
-        const { xMin, xMax, yMin, yMax } = task.camera(2.0);
-        camera.setFrame(xMin, xMax, yMax, yMin);
-        camera.update();
+        const extent = tracksLayer.extent;
+        camera.setFrame(extent.xMin, extent.xMax, extent.yMax, extent.yMin);
+        camera.zoom = 0.25;
         controls.panTarget = camera.position;
       }
     };

--- a/ultrack-prototype/frontend/components/Renderer.tsx
+++ b/ultrack-prototype/frontend/components/Renderer.tsx
@@ -12,12 +12,14 @@ import { imageUrl } from "../lib/mock_data";
 import { Task } from "../lib/tasks";
 import { Box } from "@mui/material";
 import { LoadingIndicator } from "@czi-sds/components";
+import { PanZoomControls } from "@/objects/cameras/controls";
 
 const canvasId = "canvas";
 
 // TODO: consider useRef for these objects
 const imageSource = new OmeZarrImageSource(imageUrl);
-let camera = new OrthographicCamera(0, 1920, 0, 1440);
+const camera = new OrthographicCamera(0, 1920, 0, 1440);
+const controls = new PanZoomControls(camera, camera.position);
 const layerManager = new LayerManager();
 
 type RendererProps = {
@@ -64,9 +66,10 @@ export default function Renderer(props: RendererProps) {
         layerManager.layers.length = 0;
         layerManager.add(tracksLayer);
         layerManager.add(imageSeriesLayer);
-        // TODO: update the camera in-place instead of creating a new one
-        // (this will make zoom/pan callbacks easier to manage)
-        camera = task.camera(2.0);
+        const {xMin, xMax, yMin, yMax} = task.camera(2.0);
+        camera.setFrame(xMin, xMax, yMax, yMin);
+        camera.update();
+        controls.panTarget = camera.position;
       }
     };
     imageSeriesLayer.addStateChangeCallback(onStateChange);
@@ -79,6 +82,7 @@ export default function Renderer(props: RendererProps) {
     console.debug("Renderer::mount");
     let lastRequestId = 0;
     const renderer = new WebGLRenderer(`#${canvasId}`);
+    renderer.setControls(controls);
     function animate() {
       renderer.render(layerManager, camera);
       lastRequestId = requestAnimationFrame(animate);

--- a/ultrack-prototype/frontend/components/Renderer.tsx
+++ b/ultrack-prototype/frontend/components/Renderer.tsx
@@ -66,7 +66,7 @@ export default function Renderer(props: RendererProps) {
         layerManager.layers.length = 0;
         layerManager.add(tracksLayer);
         layerManager.add(imageSeriesLayer);
-        const {xMin, xMax, yMin, yMax} = task.camera(2.0);
+        const { xMin, xMax, yMin, yMax } = task.camera(2.0);
         camera.setFrame(xMin, xMax, yMax, yMin);
         camera.update();
         controls.panTarget = camera.position;

--- a/ultrack-prototype/frontend/lib/tasks.ts
+++ b/ultrack-prototype/frontend/lib/tasks.ts
@@ -1,10 +1,6 @@
 import { vec2, vec3 } from "gl-matrix";
 
-import {
-  ImageSeriesLayer,
-  OmeZarrImageSource,
-  TracksLayer,
-} from "@";
+import { ImageSeriesLayer, OmeZarrImageSource, TracksLayer } from "@";
 
 type Track = {
   trackId: number;

--- a/ultrack-prototype/frontend/lib/tasks.ts
+++ b/ultrack-prototype/frontend/lib/tasks.ts
@@ -1,10 +1,6 @@
 import { vec2, vec3 } from "gl-matrix";
 
-import {
-  ImageSeriesLayer,
-  OmeZarrImageSource,
-  ProjectedLineLayer,
-} from "@";
+import { ImageSeriesLayer, OmeZarrImageSource, ProjectedLineLayer } from "@";
 
 type Track = {
   trackId: number;

--- a/ultrack-prototype/frontend/lib/tasks.ts
+++ b/ultrack-prototype/frontend/lib/tasks.ts
@@ -3,7 +3,6 @@ import { vec2, vec3 } from "gl-matrix";
 import {
   ImageSeriesLayer,
   OmeZarrImageSource,
-  OrthographicCamera,
   ProjectedLineLayer,
 } from "@";
 
@@ -229,15 +228,15 @@ export class Task {
     return layers;
   }
 
-  public camera(paddingFactor: number = 1.0): OrthographicCamera {
+  public camera(paddingFactor: number = 1.0) {
     const { xMin, xMax, yMin, yMax } = this.tracksLayer().extent;
     const padding = paddingFactor * Math.max(xMax - xMin, yMax - yMin);
-    return new OrthographicCamera(
-      xMin - padding,
-      xMax + padding,
-      yMin - padding,
-      yMax + padding
-    );
+    return {
+      xMin: xMin - padding,
+      xMax: xMax + padding,
+      yMin: yMin - padding,
+      yMax: yMax + padding,
+    };
   }
 }
 

--- a/ultrack-prototype/frontend/lib/tasks.ts
+++ b/ultrack-prototype/frontend/lib/tasks.ts
@@ -220,17 +220,6 @@ export class Task {
     this.tracksLayer_ = layers.tracksLayer;
     return layers;
   }
-
-  public camera(paddingFactor: number = 1.0) {
-    const { xMin, xMax, yMin, yMax } = this.tracksLayer().extent;
-    const padding = paddingFactor * Math.max(xMax - xMin, yMax - yMin);
-    return {
-      xMin: xMin - padding,
-      xMax: xMax + padding,
-      yMin: yMin - padding,
-      yMax: yMax + padding,
-    };
-  }
 }
 
 // https://colorbrewer2.org/?type=qualitative&scheme=Set1&n=6


### PR DESCRIPTION
### Summary
This uses the recently added `PanZoomControls` in the tracks layer example and in the HITL prototype app.

### Tests & Checks
I manually tested this by using the tracks layer example and the HITL prototype in its standard workflow.
