### PR TITLE
Change draw order to prevent border artifacts on tracks

### DIFF
--- a/examples/tracks/main.ts
+++ b/examples/tracks/main.ts
@@ -78,8 +78,8 @@ const imageSeriesLayer = new ImageSeriesLayer(source, region, "T");
 const renderer = new WebGLRenderer("#canvas");
 
 const layerManager = new LayerManager();
-layerManager.add(lineLayer);
 layerManager.add(imageSeriesLayer);
+layerManager.add(lineLayer);
 
 const { xMin: left, xMax: right, yMin: top, yMax: bottom } = lineLayer.extent;
 const camera = new OrthographicCamera(left, right, top, bottom);

--- a/src/renderers/webgl_renderer.ts
+++ b/src/renderers/webgl_renderer.ts
@@ -99,6 +99,7 @@ export class WebGLRenderer extends Renderer {
     this.gl.clearColor(1, 1, 1, 1);
     this.gl.clear(this.gl.COLOR_BUFFER_BIT | this.gl.DEPTH_BUFFER_BIT);
     this.gl.enable(this.gl.DEPTH_TEST);
+    this.gl.depthFunc(this.gl.LEQUAL);
   }
 
   // This is a temporary computed property. In the future, we want to assign the

--- a/ultrack-prototype/frontend/components/Renderer.tsx
+++ b/ultrack-prototype/frontend/components/Renderer.tsx
@@ -70,8 +70,8 @@ export default function Renderer(props: RendererProps) {
         setPlaybackEnabled(true);
         // TODO: update the data on the layers instead of creating new ones
         layerManager.layers.length = 0;
-        layerManager.add(tracksLayer);
         layerManager.add(imageSeriesLayer);
+        layerManager.add(tracksLayer);
         const extent = tracksLayer.extent;
         camera.setFrame(extent.xMin, extent.xMax, extent.yMax, extent.yMin);
         camera.zoom = 0.25;


### PR DESCRIPTION
### Summary
This fixes the appearance of flickering white/light pixels near the edges of the tracks in the example and prototype, but it represents a change in the global GL state and draw strategy. I'm not totally sure this the correct long-term fix, but it feels reasonable to me. I think this will require more work when we get to 3D layers and transparency (blending). See [the pygfx docs on blend_mode](https://docs.pygfx.org/stable/_autosummary/renderers/wgpu/pygfx.renderers.wgpu.WgpuRenderer.html#pygfx.renderers.wgpu.WgpuRenderer.blend_mode) for some things to consider.

When drawing, there are three concepts relevant here: layer order, draw order (early -> later), and depth. I think what we want (and what this PR implements) is:
* objects draw in front of other objects according to depth
* in the case of a depth-tie, objects drawn _later_ will be drawn in front of objects drawn _earlier_

Layers are currently drawn first to last in the layer manager. I think it's reasonable to consider this intended behavior.

Depth is also intuitive based on our current coordinate system (with `(0, 0, -1)` pointing out of the screen). Generally our renderable objects for 2D layers are placed at a depth of Z = 0.

The default GL `depthFunc` is `gl.LESS`. So as we draw each layer, only fragments with a depth value _less than_ what has already been drawn will be visible. That means (on main) the tracks are first drawn on a white background, then the image is drawn wherever its depth is less than that of the track fragments. This works okay for most fragments, but some of the edges (due to anti-aliasing?) will end up with light pixels not overwritten by the image draw.

If we only change the order of layers, the tracks do not get drawn at all. The image is drawn and the depth buffer filled (0), then the tracks (also depth 0) do not pass the depth test and are discarded.

This PR changes the order of layers to draw the image first, then the tracks. In addition it sets `depthFunc` to `gl.LEQUAL`. This means later fragments will draw if their depth is less than _or equal to_ the depth of a previously drawn fragment.

### Related Issue
Closes #97 

### Tests & Checks
Manually tested and visually inspected
