### PR TITLE
Add instructions and helper script for running the prototype on Bruno

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@ test/__screenshots__
 # ignore Python venv in the backend
 # this is ignored by default, but putting it here allows prettier to also ignore it
 ultrack-prototype/backend/.venv
+
+# slurm job output files
+*.out
+*.err

--- a/README.md
+++ b/README.md
@@ -86,9 +86,9 @@ directly with the backend from your computer.
 
 Now you should be able to access the prototype application on
 `http://localhost:5173`. Likewise the backend server is accessible on
-`http://localhost:8000` as if you were running it locally. Other uses can
+`http://localhost:8000` as if you were running it locally. Other users can
 access the same running instance by just opening the tunneling SSH session.
 
-`run-full-stack.slurm` is also just a bash script, so you can also use it to
+`run-full-stack.slurm` is just a bash script, so you can also use it to
 run both front- and back-end servers locally.
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ VITE_MOCK_ULTRACK=true npm run dev -- --mode prototype
 
 The backend server for the prototype is in the `ultrack-prototype/backend` directory. This is a
 Python FastAPI server that serves the data and provides an API for the frontend to interact with.
-See the README in that directory for more information on installing and running the server.
+See `ultrack-prototype/backend/README.md` for more information on installing and running the server.
 
 ### Running on Bruno
 
@@ -70,7 +70,7 @@ provided script in `ultrack-prototype/run-full-stack.slurm`:
 Submitted batch job 1234567  # job ID will be unique
 ❯ squeue --user $USER
 JOBID PARTITION     NAME     USER ST       TIME  NODES NODELIST(REASON)
-17117490       cpu ultrack- ashley.a  R      28:23      1 cpu-c-1
+1234567       cpu ultrack- your.name  R      28:23      1 cpu-c-1
 ```
 
 Take the node ID from the output of `squeue` (`cpu-c-1` in this case) and open

--- a/README.md
+++ b/README.md
@@ -54,3 +54,41 @@ VITE_MOCK_ULTRACK=true npm run dev -- --mode prototype
 The backend server for the prototype is in the `ultrack-prototype/backend` directory. This is a
 Python FastAPI server that serves the data and provides an API for the frontend to interact with.
 See the README in that directory for more information on installing and running the server.
+
+### Running on Bruno
+
+First, clone the repo into your home directory on Bruno.
+
+The full-stack prototype can be run as a slurm batch job on Bruno with the
+provided script in `ultrack-prototype/run-full-stack.slurm`:
+
+```shell
+❯ ssh $USER@login01.czbiohub.org
+❯ # ...you will need to confirm login using Duo 2FA
+❯ cd src/imaging-active-learning  # or whatever your local path to the repo
+❯ sbatch ./ultrack-prototype/run-full-stack.slurm
+Submitted batch job 1234567  # job ID will be unique
+❯ squeue --user $USER
+JOBID PARTITION     NAME     USER ST       TIME  NODES NODELIST(REASON)
+17117490       cpu ultrack- ashley.a  R      28:23      1 cpu-c-1
+```
+
+Take the node ID from the output of `squeue` (`cpu-c-1` in this case) and open
+a second SSH connection (for example in a new terminal) to set up local tunnels
+to the FE and BE servers. Both servers need to be mapped because the frontend
+is a purely client-side application, and it needs to be able to communicate
+directly with the backend from your computer.
+
+```shell
+❯ ssh -L 5173:localhost:5173 -L 8000:localhost:8000 -J $USER@login01.czbiohub.org $USER@cpu-c-1
+❯ # ...again you will need to confirm login using Duo 2FA
+```
+
+Now you should be able to access the prototype application on
+`http://localhost:5173`. Likewise the backend server is accessible on
+`http://localhost:8000` as if you were running it locally. Other uses can
+access the same running instance by just opening the tunneling SSH session.
+
+`run-full-stack.slurm` is also just a bash script, so you can also use it to
+run both front- and back-end servers locally.
+

--- a/ultrack-prototype/backend/README.md
+++ b/ultrack-prototype/backend/README.md
@@ -49,7 +49,7 @@ options:
 
 ```
 
-Otherwise, mock data is avaialable via the development server at `http://localhost:8000/mock_data`.
+Otherwise, mock data is available via the development server at `http://localhost:8000/mock_data`.
 Mock data endpoints are:
 * `/task` - GET all tasks. This route accepts query parameters `rng_seed` and `num_tasks` to control
   how many tasks are returned and the seed used to generate them.

--- a/ultrack-prototype/backend/README.md
+++ b/ultrack-prototype/backend/README.md
@@ -49,7 +49,7 @@ options:
 
 ```
 
-Otherwise, mock data is avaialable via the development server at `http://localhost:8000/mock-data`.
+Otherwise, mock data is avaialable via the development server at `http://localhost:8000/mock_data`.
 Mock data endpoints are:
 * `/task` - GET all tasks. This route accepts query parameters `rng_seed` and `num_tasks` to control
   how many tasks are returned and the seed used to generate them.

--- a/ultrack-prototype/run-full-stack.slurm
+++ b/ultrack-prototype/run-full-stack.slurm
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+#SBATCH --job-name=ultrack-prototype
+#SBATCH --output=ultrack-prototype-%j.out
+#SBATCH --error=ultrack-prototype-%j.err
+#SBATCH --ntasks=1
+
+set -ueo pipefail
+
+unset XDG_RUNTIME_DIR
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+
+if command -v uv &> /dev/null; then
+    echo "uv already installed..."
+else
+    echo "installing uv..."
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+fi
+
+
+if [-s "NVM_DIR/nvm.sh" ]; then
+    echo "nvm already installed..."
+else
+    echo "installing nvm..."
+    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
+fi
+[ -s "$NVM_DIR/nvm.sh" ] && source "$NVM_DIR/nvm.sh"
+nvm install 20
+npm i
+
+function cleanup {
+    echo "(cleanup) Stopping servers..."
+    kill $FE_PID $BE_PID
+    wait $FE_PID $BE_PID
+    echo "Servers stopped."
+}
+
+trap cleanup SIGTERM SIGINT
+
+npm run dev -- --mode prototype &
+FE_PID=$!
+
+uv --directory "$REPO_ROOT/ultrack-prototype/backend" run fastapi dev src/ultrack_learns/server.py &
+BE_PID=$!
+
+echo "FE_PID=$FE_PID"
+echo "BE_PID=$BE_PID"
+
+wait $FE_PID $BE_PID

--- a/ultrack-prototype/run-full-stack.slurm
+++ b/ultrack-prototype/run-full-stack.slurm
@@ -21,7 +21,12 @@ else
     curl -LsSf https://astral.sh/uv/install.sh | sh
 fi
 
-if [ -s "NVM_DIR/nvm.sh" ]; then
+# DEFAULT_NVM_DIR determined the same way the nvm installer does it
+# https://github.com/nvm-sh/nvm?tab=readme-ov-file#install--update-script
+DEFAULT_NVM_DIR="$([ -z "${XDG_CONFIG_HOME-}" ] && printf %s "${HOME}/.nvm" || printf %s "${XDG_CONFIG_HOME}/nvm")"
+export NVM_DIR=${NVM_DIR:-$DEFAULT_NVM_DIR}
+
+if [ -s "$NVM_DIR/nvm.sh" ]; then
     echo "nvm already installed..."
 else
     echo "installing nvm..."

--- a/ultrack-prototype/run-full-stack.slurm
+++ b/ultrack-prototype/run-full-stack.slurm
@@ -6,8 +6,12 @@
 
 set -ueo pipefail
 
+# XDG_RUNTIME_DIR is used by some tools like uv and just
+# this could be different on the job runner, which causes issues
 unset XDG_RUNTIME_DIR
 
+# REPO_ROOT is more reliable than BASH_SOURCE or SLURM_SUBMIT_DIR
+# it works if `sbatch` is called from anywhere within the repository
 REPO_ROOT=$(git rev-parse --show-toplevel)
 
 if command -v uv &> /dev/null; then
@@ -17,8 +21,7 @@ else
     curl -LsSf https://astral.sh/uv/install.sh | sh
 fi
 
-
-if [-s "NVM_DIR/nvm.sh" ]; then
+if [ -s "NVM_DIR/nvm.sh" ]; then
     echo "nvm already installed..."
 else
     echo "installing nvm..."


### PR DESCRIPTION
### Summary
This adds a helper script and some instructions for running the prototype app on Bruno (BioHub HPC). This was our stated goal deployment state for Q4 2024.

Hopefully most of this is pretty clear. I was happy to see no necessary code changes. I tried to include as much setup as possible in the slurm script, so it sets up node version manager, node, and uv.

Future improvements include:
* First check for node version instead of blindly installing it
* Run production versions of the servers
* Document process for _users_ of the app, and look into simplifying this - right now one person needs to launch the slurm job, and others need to set up the SSH tunnel to connect to the servers.
* Consider splitting jobs for FE + BE servers - FE will be very cheap, but BE might be co-located with compute and shorter lived. Alternatively the BE could kick off its own additional slurm jobs (still probably good to split FE + BE).

### Related Issue
Closes #114 

### Tests & Checks
With this configuration I can interact with the application from my laptop, and later inspect the SQLite file on Bruno to confirm the answers have synced properly.