### PR TITLE
Add keyboard shortcuts for answering questions

### DIFF
--- a/ultrack-prototype/frontend/components/Question.tsx
+++ b/ultrack-prototype/frontend/components/Question.tsx
@@ -8,6 +8,9 @@ type Answer = {
   shortcut: string;
 };
 
+// Shortcuts "1", "2", and "3" are used to be ergonomic on most
+// keyboard layouts and to be consistent with Ultrack's napari plugin:
+// https://github.com/royerlab/ultrack/blob/ff3bf242e395bde3236153317802b5aff8dbb6a6/ultrack/validation/link_validation.py#L159
 const answers: Answer[] = [
   { type: "Yes", shortcut: "1" },
   { type: "No", shortcut: "2" },

--- a/ultrack-prototype/frontend/components/Question.tsx
+++ b/ultrack-prototype/frontend/components/Question.tsx
@@ -1,8 +1,18 @@
 import { Button } from "@czi-sds/components";
 import { Box, Typography } from "@mui/material";
 import { AnswerType, Task } from "../lib/tasks";
+import { useEffect } from "react";
 
-const answers: AnswerType[] = ["Yes", "No", "Uncertain"];
+type Answer = {
+  type: AnswerType;
+  shortcut: string;
+};
+
+const answers: Answer[] = [
+  { type: "Yes", shortcut: "1" },
+  { type: "No", shortcut: "2" },
+  { type: "Uncertain", shortcut: "3" },
+];
 
 export type QuestionProps = {
   disabled: boolean;
@@ -12,6 +22,21 @@ export type QuestionProps = {
 
 export default function Question(props: QuestionProps) {
   const { disabled, task, setTaskAnswer } = props;
+
+  useEffect(() => {
+    const selectAnswer = (event: KeyboardEvent) => {
+      const answer = answers.find(
+        (answer: Answer) => answer.shortcut === event.key
+      );
+      if (answer !== undefined) {
+        setTaskAnswer(answer.type);
+      }
+    };
+    document.addEventListener("keydown", selectAnswer);
+    return () => {
+      document.removeEventListener("keydown", selectAnswer);
+    };
+  }, [setTaskAnswer]);
 
   return (
     <Box
@@ -33,13 +58,15 @@ export default function Question(props: QuestionProps) {
       >
         {answers.map((answer) => (
           <Button
-            key={answer}
-            sdsType={task?.answer.value === answer ? "primary" : "secondary"}
+            key={answer.type}
+            sdsType={
+              task?.answer.value === answer.type ? "primary" : "secondary"
+            }
             sdsStyle="square"
-            onClick={() => setTaskAnswer(answer)}
+            onClick={() => setTaskAnswer(answer.type)}
             disabled={disabled}
           >
-            {answer}
+            {answer.type} ({answer.shortcut})
           </Button>
         ))}
       </Box>

--- a/ultrack-prototype/frontend/components/Question.tsx
+++ b/ultrack-prototype/frontend/components/Question.tsx
@@ -28,6 +28,7 @@ export default function Question(props: QuestionProps) {
 
   useEffect(() => {
     const selectAnswer = (event: KeyboardEvent) => {
+      if (disabled) return;
       const answer = answers.find(
         (answer: AnswerOption) => answer.shortcut === event.key
       );
@@ -39,7 +40,7 @@ export default function Question(props: QuestionProps) {
     return () => {
       document.removeEventListener("keydown", selectAnswer);
     };
-  }, [setTaskAnswer]);
+  }, [disabled, setTaskAnswer]);
 
   return (
     <Box

--- a/ultrack-prototype/frontend/components/Question.tsx
+++ b/ultrack-prototype/frontend/components/Question.tsx
@@ -3,7 +3,7 @@ import { Box, Typography } from "@mui/material";
 import { AnswerType, Task } from "../lib/tasks";
 import { useEffect } from "react";
 
-type Answer = {
+type AnswerOption = {
   type: AnswerType;
   shortcut: string;
 };
@@ -11,7 +11,7 @@ type Answer = {
 // Shortcuts "1", "2", and "3" are used to be ergonomic on most
 // keyboard layouts and to be consistent with Ultrack's napari plugin:
 // https://github.com/royerlab/ultrack/blob/ff3bf242e395bde3236153317802b5aff8dbb6a6/ultrack/validation/link_validation.py#L159
-const answers: Answer[] = [
+const answers: AnswerOption[] = [
   { type: "Yes", shortcut: "1" },
   { type: "No", shortcut: "2" },
   { type: "Uncertain", shortcut: "3" },
@@ -29,7 +29,7 @@ export default function Question(props: QuestionProps) {
   useEffect(() => {
     const selectAnswer = (event: KeyboardEvent) => {
       const answer = answers.find(
-        (answer: Answer) => answer.shortcut === event.key
+        (answer: AnswerOption) => answer.shortcut === event.key
       );
       if (answer !== undefined) {
         setTaskAnswer(answer.type);


### PR DESCRIPTION
### Summary
This adds hard-coded keyboard shortcuts for selecting an answer to the current question. The shortcut keys are consistent with Ultrack's napari plugin, and should be ergonomic for most keyboard layouts.

### Related Issue
Closes #118

### Tests & Checks
I manually tested my changes by running through the standard workflow on the prototype.
