### PR TITLE
[WIP] Cache image series layer on task

### DIFF
--- a/ultrack-prototype/frontend/components/Renderer.tsx
+++ b/ultrack-prototype/frontend/components/Renderer.tsx
@@ -62,17 +62,23 @@ export default function Renderer(props: RendererProps) {
     imageSeriesLayer.update();
     setImageSeriesLayer(imageSeriesLayer);
     setTracksLayer(tracksLayer);
+    const onReady = () => {
+      setPlaybackEnabled(true);
+      // TODO: update the data on the layers instead of creating new ones
+      layerManager.layers.length = 0;
+      layerManager.add(imageSeriesLayer);
+      layerManager.add(tracksLayer);
+      const extent = tracksLayer.extent;
+      camera.setFrame(extent.xMin, extent.xMax, extent.yMax, extent.yMin);
+      camera.zoom = 0.25;
+      controls.panTarget = camera.position;
+    };
+    if (imageSeriesLayer.state == "ready") {
+      onReady();
+    }
     const onStateChange = (newState: LayerState) => {
       if (newState === "ready") {
-        setPlaybackEnabled(true);
-        // TODO: update the data on the layers instead of creating new ones
-        layerManager.layers.length = 0;
-        layerManager.add(imageSeriesLayer);
-        layerManager.add(tracksLayer);
-        const extent = tracksLayer.extent;
-        camera.setFrame(extent.xMin, extent.xMax, extent.yMax, extent.yMin);
-        camera.zoom = 0.25;
-        controls.panTarget = camera.position;
+        onReady();
       }
     };
     imageSeriesLayer.addStateChangeCallback(onStateChange);

--- a/ultrack-prototype/frontend/lib/tasks.ts
+++ b/ultrack-prototype/frontend/lib/tasks.ts
@@ -161,6 +161,7 @@ export class Task {
 
   private timeInterval_: { start: number; stop: number } | null = null;
   private tracksLayer_: TracksLayer | null = null;
+  private imageSeriesLayer_: ImageSeriesLayer | null = null;
 
   private constructor(
     taskId: string,
@@ -201,7 +202,7 @@ export class Task {
   }
 
   public clone(): Task {
-    return new Task(
+    const task = new Task(
       this.taskId,
       this.taskType,
       {
@@ -217,6 +218,10 @@ export class Task {
       },
       { ...this.answer }
     );
+    task.timeInterval_ = this.timeInterval_;
+    task.tracksLayer_ = this.tracksLayer_;
+    task.imageSeriesLayer_ = this.imageSeriesLayer_;
+    return task;
   }
 
   public get question(): string {
@@ -256,19 +261,25 @@ export class Task {
   }
 
   imageSeriesLayer(preLoad = true): ImageSeriesLayer {
-    const imageData = this.taskData.imageData;
-    const region: Region = [
-      { dimension: imageData.timeDimension, index: this.timeInterval },
-    ];
-    for (const [d, i] of imageData.sliceIndices.entries()) {
-      region.push({ dimension: d, index: i });
+    if (this.imageSeriesLayer_ === null) {
+      const imageData = this.taskData.imageData;
+      const region: Region = [
+        { dimension: imageData.timeDimension, index: this.timeInterval },
+      ];
+      for (const [d, i] of imageData.sliceIndices.entries()) {
+        region.push({ dimension: d, index: i });
+      }
+      const source = new OmeZarrImageSource(imageData.url);
+      this.imageSeriesLayer_ = new ImageSeriesLayer(
+        source,
+        region,
+        imageData.timeDimension
+      );
+      if (preLoad) {
+        this.imageSeriesLayer_.update();
+      }
     }
-    const source = new OmeZarrImageSource(imageData.url);
-    const layer = new ImageSeriesLayer(source, region, imageData.timeDimension);
-    if (preLoad) {
-      layer.update();
-    }
-    return layer;
+    return this.imageSeriesLayer_;
   }
 
   tracksLayer(): TracksLayer {


### PR DESCRIPTION
### Summary
This caches the image series layer on the `Task` object and also passes all cached values to the new instance of the `Task` create in `Task.clone`.

In this case, the layers will still be re-added, but their state will already be `"ready"` so we need to explicitly check for that.

### Related Issue
Closes #121

### Tests & Checks
I manually tested the prototype in a workflow that reproduces the bug in #121.