### PR TITLE
Skip reload when task ID is unchanged

### DIFF
--- a/ultrack-prototype/frontend/components/Renderer.tsx
+++ b/ultrack-prototype/frontend/components/Renderer.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, SetStateAction, useEffect, useState } from "react";
+import { Dispatch, SetStateAction, useEffect, useRef, useState } from "react";
 import {
   ImageSeriesLayer,
   LayerManager,
@@ -20,7 +20,6 @@ const canvasId = "canvas";
 const camera = new OrthographicCamera(0, 1920, 0, 1440);
 const controls = new PanZoomControls(camera, camera.position);
 const layerManager = new LayerManager();
-let lastTaskId = "";
 
 type RendererProps = {
   curTime: number;
@@ -34,6 +33,7 @@ export default function Renderer(props: RendererProps) {
   const [imageSeriesLayer, setImageSeriesLayer] =
     useState<ImageSeriesLayer | null>(null);
   const [tracksLayer, setTracksLayer] = useState<TracksLayer | null>(null);
+  const lastTaskId = useRef("");
 
   useEffect(() => {
     console.debug("Renderer::useEffect::curTime: ", curTime);
@@ -55,10 +55,10 @@ export default function Renderer(props: RendererProps) {
 
   useEffect(() => {
     console.debug("Renderer::useEffect::task: ", task);
-    if (task?.taskId === lastTaskId) return;
+    if (task?.taskId === lastTaskId.current) return;
     setPlaybackEnabled(false);
     if (!task) return;
-    lastTaskId = task.taskId;
+    lastTaskId.current = task.taskId;
     const { tracksLayer, imageSeriesLayer } = task.layers();
     imageSeriesLayer.update();
     setImageSeriesLayer(imageSeriesLayer);

--- a/ultrack-prototype/frontend/components/Renderer.tsx
+++ b/ultrack-prototype/frontend/components/Renderer.tsx
@@ -74,7 +74,7 @@ export default function Renderer(props: RendererProps) {
       camera.zoom = 0.25;
       controls.panTarget = camera.position;
     };
-    if (imageSeriesLayer.state == "ready") {
+    if (imageSeriesLayer.state === "ready") {
       onReady();
     }
     const onStateChange = (newState: LayerState) => {

--- a/ultrack-prototype/frontend/components/Renderer.tsx
+++ b/ultrack-prototype/frontend/components/Renderer.tsx
@@ -20,6 +20,7 @@ const canvasId = "canvas";
 const camera = new OrthographicCamera(0, 1920, 0, 1440);
 const controls = new PanZoomControls(camera, camera.position);
 const layerManager = new LayerManager();
+let lastTaskId = "";
 
 type RendererProps = {
   curTime: number;
@@ -53,26 +54,32 @@ export default function Renderer(props: RendererProps) {
   }, [curTime, imageSeriesLayer, tracksLayer]);
 
   useEffect(() => {
-    console.debug("Renderer::useEffect::task: ", task);
+    console.debug("Renderer::useEffect::task: ", lastTaskId, task);
+    if (task?.taskId === lastTaskId) return;
     setPlaybackEnabled(false);
-    if (!task) {
-      return;
-    }
+    if (!task) return;
+    lastTaskId = task.taskId;
     const { tracksLayer, imageSeriesLayer } = task.layers();
     imageSeriesLayer.update();
     setImageSeriesLayer(imageSeriesLayer);
     setTracksLayer(tracksLayer);
+    const onReady = () => {
+      setPlaybackEnabled(true);
+      // TODO: update the data on the layers instead of creating new ones
+      layerManager.layers.length = 0;
+      layerManager.add(imageSeriesLayer);
+      layerManager.add(tracksLayer);
+      const extent = tracksLayer.extent;
+      camera.setFrame(extent.xMin, extent.xMax, extent.yMax, extent.yMin);
+      camera.zoom = 0.25;
+      controls.panTarget = camera.position;
+    };
+    if (imageSeriesLayer.state == "ready") {
+      onReady();
+    }
     const onStateChange = (newState: LayerState) => {
       if (newState === "ready") {
-        setPlaybackEnabled(true);
-        // TODO: update the data on the layers instead of creating new ones
-        layerManager.layers.length = 0;
-        layerManager.add(imageSeriesLayer);
-        layerManager.add(tracksLayer);
-        const extent = tracksLayer.extent;
-        camera.setFrame(extent.xMin, extent.xMax, extent.yMax, extent.yMin);
-        camera.zoom = 0.25;
-        controls.panTarget = camera.position;
+        onReady();
       }
     };
     imageSeriesLayer.addStateChangeCallback(onStateChange);

--- a/ultrack-prototype/frontend/components/Renderer.tsx
+++ b/ultrack-prototype/frontend/components/Renderer.tsx
@@ -54,7 +54,7 @@ export default function Renderer(props: RendererProps) {
   }, [curTime, imageSeriesLayer, tracksLayer]);
 
   useEffect(() => {
-    console.debug("Renderer::useEffect::task: ", lastTaskId, task);
+    console.debug("Renderer::useEffect::task: ", task);
     if (task?.taskId === lastTaskId) return;
     setPlaybackEnabled(false);
     if (!task) return;


### PR DESCRIPTION
### Summary
This skips reloading the layers when the task ID does not change, which prevents unnecessary reloads, renders, and loading state indicators. It also addresses the possible case when the image series layer loads and transitions to the ready state before effect finishes, which is another possible cause of the bug described in #121.

### Related Issue
Closes #121

### Tests & Checks
I manually tested the prototype in a workflow that reproduces the bug in #121.