### PR TITLE
Use bounding rect offset of canvas in client-to-clip transform

### DIFF
--- a/src/core/renderer.ts
+++ b/src/core/renderer.ts
@@ -116,9 +116,10 @@ export abstract class Renderer {
 
   public clientToClip(position: vec2, depth: number = 0): vec3 {
     const [x, y] = position;
+    const rect = this.canvas.getBoundingClientRect();
     return vec3.fromValues(
-      (2 * x) / this.canvas.clientWidth - 1,
-      (2 * y) / this.canvas.clientHeight - 1,
+      (2 * (x - rect.x)) / this.canvas.clientWidth - 1,
+      (2 * (y - rect.y)) / this.canvas.clientHeight - 1,
       depth
     );
   }

--- a/src/objects/cameras/controls.ts
+++ b/src/objects/cameras/controls.ts
@@ -51,15 +51,15 @@ export class PanZoomControls implements CameraControls {
   }
 
   private wheel(event: WheelEvent, clientToWorld: ClientToWorld): void {
-    const clientPos = vec2.fromValues(event.clientX, event.clientY);
-    const preZoomPos = clientToWorld(clientPos, this.clipDepth);
+    const eventPos = vec2.fromValues(event.offsetX, event.offsetY);
+    const preZoomPos = clientToWorld(eventPos, this.clipDepth);
     if (event.deltaY < 0) {
       this.camera_.zoom *= 1.05;
     } else {
       this.camera_.zoom /= 1.05;
     }
     // pan to zoom in on the mouse position
-    const postZoomPos = clientToWorld(clientPos, this.clipDepth);
+    const postZoomPos = clientToWorld(eventPos, this.clipDepth);
     const deltaWorld = vec3.sub(vec3.create(), preZoomPos, postZoomPos);
     this.pan(deltaWorld);
   }

--- a/src/objects/cameras/controls.ts
+++ b/src/objects/cameras/controls.ts
@@ -51,15 +51,15 @@ export class PanZoomControls implements CameraControls {
   }
 
   private wheel(event: WheelEvent, clientToWorld: ClientToWorld): void {
-    const eventPos = vec2.fromValues(event.offsetX, event.offsetY);
-    const preZoomPos = clientToWorld(eventPos, this.clipDepth);
+    const clientPos = vec2.fromValues(event.clientX, event.clientY);
+    const preZoomPos = clientToWorld(clientPos, this.clipDepth);
     if (event.deltaY < 0) {
       this.camera_.zoom *= 1.05;
     } else {
       this.camera_.zoom /= 1.05;
     }
     // pan to zoom in on the mouse position
-    const postZoomPos = clientToWorld(eventPos, this.clipDepth);
+    const postZoomPos = clientToWorld(clientPos, this.clipDepth);
     const deltaWorld = vec3.sub(vec3.create(), preZoomPos, postZoomPos);
     this.pan(deltaWorld);
   }

--- a/ultrack-prototype/frontend/components/Renderer.tsx
+++ b/ultrack-prototype/frontend/components/Renderer.tsx
@@ -12,7 +12,7 @@ import {
 import { Task } from "../lib/tasks";
 import { Box } from "@mui/material";
 import { LoadingIndicator } from "@czi-sds/components";
-import { PanZoomControls } from "@/objects/cameras/controls";
+import { NullControls, PanZoomControls } from "@/objects/cameras/controls";
 
 const canvasId = "canvas";
 
@@ -100,6 +100,7 @@ export default function Renderer(props: RendererProps) {
     animate();
     return () => {
       // TODO: cleanup by disposing objects owned by the renderer and camera.
+      renderer.setControls(new NullControls());
       if (lastRequestId > 0) {
         console.debug(`Cancelling animation frame ${lastRequestId}`);
         cancelAnimationFrame(lastRequestId);


### PR DESCRIPTION
### Summary
This fixes the zoom centering bug described in #124 by using the canvas element's [`getClientBoundingRect`](https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect) in the `Renderer.clientToClip` transform. This accounts for the more complex layout in the prototype app, which has components to the left of the canvas.

It also fixes a pan bug in the prototype app by removing controls on the dismount of the renderer component.

### Related Issue
Closes #124

### Tests & Checks
I manually tested my changes with the tracks example and the prototype.
