### PR TITLE
Destructure React component props inline

### DIFF
--- a/ultrack-prototype/frontend/components/PlaybackControls.tsx
+++ b/ultrack-prototype/frontend/components/PlaybackControls.tsx
@@ -6,15 +6,17 @@ import { Task } from "../lib/tasks";
 const playbackFPS = 8;
 const playbackIntervalMs = 1000 / playbackFPS;
 
-type PlaybackControlsProps = {
+export default function PlaybackControls({
+  curTime,
+  enabled,
+  setCurTime,
+  task,
+}: {
   curTime: number;
   enabled: boolean;
   setCurTime: Dispatch<SetStateAction<number>>;
   task: Task | null;
-};
-
-export default function PlaybackControls(props: PlaybackControlsProps) {
-  const { curTime, enabled, setCurTime, task } = props;
+}) {
   const [playing, setPlaying] = useState(false);
 
   const minTime = task?.minTime ?? 0;

--- a/ultrack-prototype/frontend/components/Question.tsx
+++ b/ultrack-prototype/frontend/components/Question.tsx
@@ -17,15 +17,15 @@ const answers: AnswerOption[] = [
   { type: "Uncertain", shortcut: "3" },
 ];
 
-export type QuestionProps = {
+export default function Question({
+  disabled,
+  task,
+  setTaskAnswer,
+}: {
   disabled: boolean;
   task: Task | null;
   setTaskAnswer: (answer: AnswerType) => void;
-};
-
-export default function Question(props: QuestionProps) {
-  const { disabled, task, setTaskAnswer } = props;
-
+}) {
   useEffect(() => {
     const selectAnswer = (event: KeyboardEvent) => {
       if (disabled) return;

--- a/ultrack-prototype/frontend/components/Renderer.tsx
+++ b/ultrack-prototype/frontend/components/Renderer.tsx
@@ -21,15 +21,17 @@ const camera = new OrthographicCamera(0, 1920, 0, 1440);
 const controls = new PanZoomControls(camera, camera.position);
 const layerManager = new LayerManager();
 
-type RendererProps = {
+export default function Renderer({
+  curTime,
+  playbackEnabled,
+  setPlaybackEnabled,
+  task,
+}: {
   curTime: number;
   playbackEnabled: boolean;
   setPlaybackEnabled: Dispatch<SetStateAction<boolean>>;
   task: Task | null;
-};
-
-export default function Renderer(props: RendererProps) {
-  const { curTime, playbackEnabled, setPlaybackEnabled, task } = props;
+}) {
   const [imageSeriesLayer, setImageSeriesLayer] =
     useState<ImageSeriesLayer | null>(null);
   const [tracksLayer, setTracksLayer] = useState<TracksLayer | null>(null);

--- a/ultrack-prototype/frontend/components/TaskItem.tsx
+++ b/ultrack-prototype/frontend/components/TaskItem.tsx
@@ -2,15 +2,6 @@ import { Button, Icon } from "@czi-sds/components";
 import { Dispatch, SetStateAction } from "react";
 import { AnswerType, SyncStatus, TaskType } from "../lib/tasks";
 
-export type TaskItemProps = {
-  index: number;
-  answer: AnswerType;
-  syncStatus: SyncStatus;
-  active: boolean;
-  taskType: TaskType;
-  setTaskIndex: Dispatch<SetStateAction<number>>;
-};
-
 function sdsIcon(answer: AnswerType) {
   switch (answer) {
     case "Yes":
@@ -36,8 +27,21 @@ function sdsIconColor(synced: SyncStatus) {
   }
 }
 
-export default function TaskItem(props: TaskItemProps) {
-  const { index, answer, syncStatus, active, taskType, setTaskIndex } = props;
+export default function TaskItem({
+  index,
+  answer,
+  syncStatus,
+  active,
+  taskType,
+  setTaskIndex,
+}: {
+  index: number;
+  answer: AnswerType;
+  syncStatus: SyncStatus;
+  active: boolean;
+  taskType: TaskType;
+  setTaskIndex: Dispatch<SetStateAction<number>>;
+}) {
   return (
     <Button
       endIcon={

--- a/ultrack-prototype/frontend/components/TaskList.tsx
+++ b/ultrack-prototype/frontend/components/TaskList.tsx
@@ -4,14 +4,15 @@ import { Button } from "@czi-sds/components";
 import { useEffect, Dispatch, SetStateAction } from "react";
 import { Task } from "../lib/tasks";
 
-type TaskListProps = {
+export default function TaskList({
+  tasks,
+  taskIndex,
+  setTaskIndex,
+}: {
   tasks: Task[];
   taskIndex: number;
   setTaskIndex: Dispatch<SetStateAction<number>>;
-};
-
-export default function TaskList(props: TaskListProps) {
-  const { tasks, taskIndex, setTaskIndex } = props;
+}) {
   const numReviewed = tasks.reduce(
     (num, t) => num + (t.answer.value === "Unanswered" ? 0 : 1),
     0


### PR DESCRIPTION
### Summary
This uses inline destructuring for the React component functions in the prototype application, which avoids the need for explicitly defining a props type and destructuring that on the first line of the component functions.

### Related Issue
Closes #99

### Tests & Checks
I manually tested the application using the standard workflow, and also relied on the linter/formatter to confirm these changes.
