### PR TITLE
Support system-dependent theme in prototype

### DIFF
--- a/src/core/renderer.ts
+++ b/src/core/renderer.ts
@@ -6,10 +6,13 @@ import { PerspectiveCamera } from "objects/cameras/perspective_camera";
 import { OrthographicCamera } from "objects/cameras/orthographic_camera";
 import { CameraControls, NullControls } from "objects/cameras/controls";
 
+type Color = readonly [number, number, number, number];
+
 export abstract class Renderer {
   private readonly canvas_: HTMLCanvasElement | null;
   private width_ = 0;
   private height_ = 0;
+  private backgroundColor_: Color = [0, 0, 0, 0];
   private activeCamera_: Camera | null = null;
   private controls_: CameraControls = new NullControls();
   private controlCallbacks_: [string, (event: Event) => void][] = [];
@@ -103,6 +106,14 @@ export abstract class Renderer {
 
   public get height() {
     return this.height_;
+  }
+
+  public get backgroundColor() {
+    return this.backgroundColor_;
+  }
+
+  public set backgroundColor(color: Color) {
+    this.backgroundColor_ = color;
   }
 
   protected get activeCamera() {

--- a/src/core/renderer.ts
+++ b/src/core/renderer.ts
@@ -6,7 +6,7 @@ import { PerspectiveCamera } from "objects/cameras/perspective_camera";
 import { OrthographicCamera } from "objects/cameras/orthographic_camera";
 import { CameraControls, NullControls } from "objects/cameras/controls";
 
-type Color = readonly [number, number, number, number];
+type Color = [number, number, number, number];
 
 export abstract class Renderer {
   private readonly canvas_: HTMLCanvasElement | null;

--- a/src/renderers/webgl_renderer.ts
+++ b/src/renderers/webgl_renderer.ts
@@ -96,7 +96,7 @@ export class WebGLRenderer extends Renderer {
   }
 
   protected clear() {
-    this.gl.clearColor(1, 1, 1, 1);
+    this.gl.clearColor(...this.backgroundColor);
     this.gl.clear(this.gl.COLOR_BUFFER_BIT | this.gl.DEPTH_BUFFER_BIT);
     this.gl.enable(this.gl.DEPTH_TEST);
     this.gl.depthFunc(this.gl.LEQUAL);

--- a/ultrack-prototype/frontend/components/Main.tsx
+++ b/ultrack-prototype/frontend/components/Main.tsx
@@ -1,21 +1,13 @@
 import React from "react";
 import { createRoot } from "react-dom/client";
-import { ThemeProvider as EmotionThemeProvider } from "@emotion/react";
-import { StyledEngineProvider, ThemeProvider } from "@mui/material/styles";
-import { defaultTheme } from "@czi-sds/components";
 
-import App from "./App.tsx";
+import ThemedApp from "./ThemedApp.tsx";
 
 const domNode = document.getElementById("app")!;
 const root = createRoot(domNode);
+
 root.render(
   <React.StrictMode>
-    <StyledEngineProvider injectFirst>
-      <ThemeProvider theme={defaultTheme}>
-        <EmotionThemeProvider theme={defaultTheme}>
-          <App />
-        </EmotionThemeProvider>
-      </ThemeProvider>
-    </StyledEngineProvider>
+    <ThemedApp />
   </React.StrictMode>
 );

--- a/ultrack-prototype/frontend/components/Renderer.tsx
+++ b/ultrack-prototype/frontend/components/Renderer.tsx
@@ -94,7 +94,6 @@ export default function Renderer(props: RendererProps) {
     const renderer = new WebGLRenderer(`#${canvasId}`);
     renderer.setControls(controls);
     function animate() {
-      if (renderer === null) return;
       renderer.render(layerManager, camera);
       lastRequestId = requestAnimationFrame(animate);
     }

--- a/ultrack-prototype/frontend/components/Renderer.tsx
+++ b/ultrack-prototype/frontend/components/Renderer.tsx
@@ -94,6 +94,7 @@ export default function Renderer(props: RendererProps) {
     const renderer = new WebGLRenderer(`#${canvasId}`);
     renderer.setControls(controls);
     function animate() {
+      if (renderer === null) return;
       renderer.render(layerManager, camera);
       lastRequestId = requestAnimationFrame(animate);
     }

--- a/ultrack-prototype/frontend/components/ThemedApp.tsx
+++ b/ultrack-prototype/frontend/components/ThemedApp.tsx
@@ -1,0 +1,23 @@
+import { ThemeProvider as EmotionThemeProvider } from "@emotion/react";
+import { StyledEngineProvider, ThemeProvider } from "@mui/material/styles";
+import { Theme } from "@czi-sds/components";
+import CssBaseline from "@mui/material/CssBaseline";
+import useMediaQuery from "@mui/material/useMediaQuery";
+
+import App from "./App.tsx";
+
+// Create a wrapper component to handle theme and useMediaQuery
+export default function ThemedApp() {
+  const prefersDarkMode = useMediaQuery("(prefers-color-scheme: dark)");
+  const theme = prefersDarkMode ? Theme("dark") : Theme("light");
+  return (
+    <StyledEngineProvider injectFirst>
+      <ThemeProvider theme={theme}>
+        <EmotionThemeProvider theme={theme}>
+          <CssBaseline />
+          <App />
+        </EmotionThemeProvider>
+      </ThemeProvider>
+    </StyledEngineProvider>
+  );
+}


### PR DESCRIPTION
### Summary
This adds a wrapper `ThemedApp` component to add a system-dependent dark/light theme. I created a wrapper app based on the [SDS docs](https://sds.czi.design/009eaf17b/v/0/p/169911-theming/b/36245e) and moved that to a separate module to satisfy the default requirements of the [fast refresh React plugin](https://github.com/ArnaudBarre/eslint-plugin-react-refresh).

I also made the background color of the renderer a mutable attribute. That's not necessary for this PR as I just use a default of (0, 0, 0, 0) to make it transparent so that it works well in the application in light and dark mode. But I think it seems generally useful.

I started making changes to the application to use a non-transparent background color that matches the light/dark theme, which might be needed to support certain types of blending. But those set of changes are much more complicated.

https://github.com/user-attachments/assets/3ea18aec-faa0-4cd2-8e74-977a9a6c70ca

### Related Issue
Closes #52
Closes #100 

### Tests & Checks
I manually tested the prototype in both system dark and light mode after these changes. I also tested the examples to ensure there were no regressions there either.
