### PR TITLE
Run limited number of concurrent promises to load image series chunks

### DIFF
--- a/src/data/image_chunk.ts
+++ b/src/data/image_chunk.ts
@@ -1,5 +1,6 @@
 import { Region } from "data/region";
 import { TextureUnpackRowAlignment } from "objects/textures/texture";
+import { PromiseScheduler } from "./promise_scheduler";
 
 // One 2D chunk of n-dimensional image data.
 // TODO: include the region of this chunk.
@@ -20,5 +21,5 @@ export type ImageChunkSource = {
 };
 
 export type ImageChunkLoader = {
-  loadChunk(input: Region): Promise<ImageChunk>;
+  loadChunk(input: Region, scheduler?: PromiseScheduler): Promise<ImageChunk>;
 };

--- a/src/data/ome_zarr_image_loader.ts
+++ b/src/data/ome_zarr_image_loader.ts
@@ -4,6 +4,7 @@ import { Slice } from "@zarrita/indexing";
 import { Region } from "data/region";
 import { ImageChunk } from "data/image_chunk";
 import { isTextureUnpackRowAlignment } from "objects/textures/texture";
+import { PromiseScheduler } from "./promise_scheduler";
 
 type IdentityTransform = {
   type: "identity";
@@ -44,6 +45,25 @@ function isDataType(value: unknown): value is DataType {
   return dataTypes.some((DataType) => value instanceof DataType);
 }
 
+// Implements the interface required for getting array chunks in zarrita:
+// https://github.com/manzt/zarrita.js/blob/c15c1a14e42a83516972368ac962ebdf56a6dcdb/packages/indexing/src/types.ts#L52
+export class PromiseQueue<T> {
+  private promises_: Array<() => Promise<T>> = [];
+  private scheduler_: PromiseScheduler;
+
+  constructor(scheduler: PromiseScheduler) {
+    this.scheduler_ = scheduler;
+  }
+
+  add(promise: () => Promise<T>): void {
+    this.promises_.push(promise);
+  }
+
+  onIdle(): Promise<Array<T>> {
+    return Promise.all(this.promises_.map((p) => this.scheduler_.submit(p)));
+  }
+}
+
 // Loads chunks from a multiscale zarr image implementing OME-NGFF v0.4:
 // https://ngff.openmicroscopy.org/0.4/#image-layout
 export class OmeZarrImageLoader {
@@ -67,7 +87,10 @@ export class OmeZarrImageLoader {
     this.datasets_ = image.datasets;
   }
 
-  async loadChunk(region: Region): Promise<ImageChunk> {
+  async loadChunk(
+    region: Region,
+    scheduler?: PromiseScheduler
+  ): Promise<ImageChunk> {
     // TODO: use the input to determine what level to load.
     // https://github.com/chanzuckerberg/imaging-active-learning/issues/37
     const lowestResolutionIndex = this.datasets_.length - 1;
@@ -81,7 +104,14 @@ export class OmeZarrImageLoader {
     });
     console.debug("opened array ", array);
 
-    const subarray = await zarr.get(array, indices);
+    let options = {};
+    if (scheduler !== undefined) {
+      options = {
+        create_queue: () => new PromiseQueue(scheduler),
+        opts: { signal: scheduler.abortSignal },
+      };
+    }
+    const subarray = await zarr.get(array, indices, options);
 
     if (!isDataType(subarray.data)) {
       throw new Error(

--- a/src/data/promise_scheduler.ts
+++ b/src/data/promise_scheduler.ts
@@ -1,3 +1,13 @@
+export class AbortError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AbortError";
+    // Manually adjust the prototype to handle sub-classing Error
+    // https://github.com/microsoft/TypeScript/wiki/FAQ#why-doesnt-extending-built-ins-like-error-array-and-map-work
+    Object.setPrototypeOf(this, AbortError.prototype);
+  }
+}
+
 // Executes a limited number of promises concurrently.
 export class PromiseScheduler {
   private readonly maxConcurrent_: number;
@@ -46,7 +56,7 @@ export class PromiseScheduler {
 
   shutdown() {
     console.debug(`Cancelling ${this.pending_.length} tasks.`);
-    this.abortController_.abort("shutdown");
+    this.abortController_.abort(new AbortError("shutdown"));
   }
 
   get numRunning() {

--- a/src/data/promise_scheduler.ts
+++ b/src/data/promise_scheduler.ts
@@ -1,5 +1,5 @@
 // Executes a limited number of promises concurrently.
-export class PromiseScheduler<T> {
+export class PromiseScheduler {
   private readonly maxConcurrent_: number;
   private readonly pending_: Array<() => Promise<void>> = [];
   private readonly abortController_ = new AbortController();
@@ -12,7 +12,7 @@ export class PromiseScheduler<T> {
     this.maxConcurrent_ = maxConcurrent;
   }
 
-  async submit(task: () => Promise<T>): Promise<T> {
+  async submit<T>(task: () => Promise<T>): Promise<T> {
     this.abortController_.signal.throwIfAborted();
     return new Promise((resolve, reject) => {
       const promise = async () => {

--- a/src/data/promise_scheduler.ts
+++ b/src/data/promise_scheduler.ts
@@ -1,0 +1,59 @@
+// Executes a limited number of promises concurrently.
+export class PromiseScheduler<T> {
+  private readonly maxConcurrent_: number;
+  private readonly pending_: Array<() => Promise<void>> = [];
+  private readonly abortController_ = new AbortController();
+  private numRunning_ = 0;
+
+  constructor(maxConcurrent: number) {
+    if (maxConcurrent <= 0) {
+      throw Error(`maxConcurrent (${maxConcurrent}) must be positive`);
+    }
+    this.maxConcurrent_ = maxConcurrent;
+  }
+
+  async submit(task: () => Promise<T>): Promise<T> {
+    this.abortController_.signal.throwIfAborted();
+    return new Promise((resolve, reject) => {
+      const promise = async () => {
+        try {
+          this.abortController_.signal.throwIfAborted();
+          const result = await task();
+          resolve(result);
+        } catch (error) {
+          reject(error);
+        } finally {
+          this.numRunning_--;
+          this.maybeRunNext();
+        }
+      };
+      this.pending_.push(promise);
+      this.maybeRunNext();
+    });
+  }
+
+  private maybeRunNext(): void {
+    if (this.numRunning_ >= this.maxConcurrent_) return;
+    const promise = this.pending_.shift();
+    if (promise === undefined) return;
+    this.numRunning_++;
+    promise();
+  }
+
+  get abortSignal() {
+    return this.abortController_.signal;
+  }
+
+  shutdown() {
+    console.debug(`Cancelling ${this.pending_.length} tasks.`);
+    this.abortController_.abort("shutdown");
+  }
+
+  get numRunning() {
+    return this.numRunning_;
+  }
+
+  get numPending() {
+    return this.pending_.length;
+  }
+}

--- a/src/layers/image_series_layer.ts
+++ b/src/layers/image_series_layer.ts
@@ -4,6 +4,7 @@ import { PlaneGeometry } from "objects/geometry/plane_geometry";
 import { Interval, Region } from "data/region";
 import { ImageChunk, ImageChunkSource } from "data/image_chunk";
 import { Texture2DArray } from "objects/textures/texture_2d_array";
+import { PromiseScheduler } from "@/data/promise_scheduler";
 
 // Loads 2D+t image data from an image source into renderable objects.
 export class ImageSeriesLayer extends Layer {
@@ -13,6 +14,7 @@ export class ImageSeriesLayer extends Layer {
   private readonly timeDimensionIndex_: number;
   private texture_: Texture2DArray | null = null;
   private dataChunks_: ImageChunk[] = [];
+  private scheduler_: PromiseScheduler = new PromiseScheduler(16);
 
   constructor(source: ImageChunkSource, region: Region, timeDimension: string) {
     super();
@@ -93,7 +95,7 @@ export class ImageSeriesLayer extends Layer {
       region[this.timeDimensionIndex_].index = t;
       loadPromises.push(
         loader
-          .loadChunk(region)
+          .loadChunk(region, this.scheduler_)
           .then((chunk) => (this.dataChunks_[t - start] = chunk))
       );
     }

--- a/src/layers/image_series_layer.ts
+++ b/src/layers/image_series_layer.ts
@@ -4,7 +4,7 @@ import { PlaneGeometry } from "objects/geometry/plane_geometry";
 import { Interval, Region } from "data/region";
 import { ImageChunk, ImageChunkSource } from "data/image_chunk";
 import { Texture2DArray } from "objects/textures/texture_2d_array";
-import { PromiseScheduler } from "@/data/promise_scheduler";
+import { AbortError, PromiseScheduler } from "@/data/promise_scheduler";
 
 // Loads 2D+t image data from an image source into renderable objects.
 export class ImageSeriesLayer extends Layer {
@@ -76,6 +76,10 @@ export class ImageSeriesLayer extends Layer {
     }
   }
 
+  public close(): void {
+    this.scheduler_.shutdown();
+  }
+
   private async load() {
     if (this.state !== "initialized") {
       throw new Error(`Trying to open chunk loader more than once.`);
@@ -99,7 +103,12 @@ export class ImageSeriesLayer extends Layer {
           .then((chunk) => (this.dataChunks_[t - start] = chunk))
       );
     }
-    await Promise.all(loadPromises);
+    await Promise.all(loadPromises).catch((error) => {
+      if (error instanceof AbortError) {
+        console.debug("Loading aborted.");
+        return;
+      }
+    });
 
     this.setState("ready");
   }

--- a/test/promise_scheduler.test.ts
+++ b/test/promise_scheduler.test.ts
@@ -1,0 +1,111 @@
+import { PromiseScheduler } from "@/data/promise_scheduler";
+import { expect, test } from "vitest";
+
+test("submit one promise", async () => {
+  const executor = new PromiseScheduler(1);
+  let blocked = true;
+  const promise = executor.submit(async () => {
+    while (blocked) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    return 0;
+  });
+  expect(executor.numPending).toEqual(0);
+  expect(executor.numRunning).toEqual(1);
+  blocked = false;
+  await expect(promise).resolves.toEqual(0);
+  expect(executor.numRunning).toEqual(0);
+  expect(executor.numPending).toEqual(0);
+});
+
+test("submit two concurrent promises", async () => {
+  const executor = new PromiseScheduler(2);
+  let blocked = true;
+  const promise0 = executor.submit(async () => {
+    while (blocked) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    return 0;
+  });
+  const promise1 = executor.submit(async () => {
+    while (blocked) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    return 1;
+  });
+  expect(executor.numPending).toEqual(0);
+  expect(executor.numRunning).toEqual(2);
+  blocked = false;
+  await expect(promise0).resolves.toEqual(0);
+  await expect(promise1).resolves.toEqual(1);
+  expect(executor.numRunning).toEqual(0);
+  expect(executor.numPending).toEqual(0);
+});
+
+test("submit one pending promise", async () => {
+  const executor = new PromiseScheduler(1);
+  let blocked = true;
+  const promise0 = executor.submit(async () => {
+    while (blocked) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    return 0;
+  });
+  const promise1 = executor.submit(async () => {
+    return 1;
+  });
+  expect(executor.numPending).toEqual(1);
+  expect(executor.numRunning).toEqual(1);
+  blocked = false;
+  await expect(promise0).resolves.toEqual(0);
+  await expect(promise1).resolves.toEqual(1);
+  expect(executor.numRunning).toEqual(0);
+  expect(executor.numPending).toEqual(0);
+});
+
+test("cancel one pending promise", async () => {
+  const executor = new PromiseScheduler(1);
+  let blocked = true;
+  const promise0 = executor.submit(async () => {
+    while (blocked) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    return 0;
+  });
+  const promise1 = executor.submit(async () => {
+    return 1;
+  });
+  expect(executor.numPending).toEqual(1);
+  expect(executor.numRunning).toEqual(1);
+  executor.shutdown();
+  blocked = false;
+  await expect(promise0).resolves.toEqual(0);
+  await expect(promise1).rejects.toThrow("shutdown");
+  expect(executor.numRunning).toEqual(0);
+  expect(executor.numPending).toEqual(0);
+});
+
+test("submit one promise after shutdown", async () => {
+  const executor = new PromiseScheduler(1);
+  executor.shutdown();
+  expect(executor.submit(async () => 1)).rejects.toThrow("shutdown");
+  expect(executor.numPending).toEqual(0);
+  expect(executor.numRunning).toEqual(0);
+});
+
+test("submit promise that throws", async () => {
+  const executor = new PromiseScheduler(1);
+  let blocked = true;
+  const promise = executor.submit(async () => {
+    while (blocked) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    throw "test";
+  });
+  expect(executor.numRunning).toEqual(1);
+  expect(executor.numPending).toEqual(0);
+  blocked = false;
+  await expect(promise).rejects.toThrow("test");
+  expect(executor.numRunning).toEqual(0);
+  expect(executor.numPending).toEqual(0);
+});

--- a/test/promise_scheduler.test.ts
+++ b/test/promise_scheduler.test.ts
@@ -1,4 +1,4 @@
-import { PromiseScheduler } from "@/data/promise_scheduler";
+import { AbortError, PromiseScheduler } from "@/data/promise_scheduler";
 import { expect, test } from "vitest";
 
 test("submit one promise", async () => {
@@ -80,7 +80,7 @@ test("cancel one pending promise", async () => {
   executor.shutdown();
   blocked = false;
   await expect(promise0).resolves.toEqual(0);
-  await expect(promise1).rejects.toThrow("shutdown");
+  await expect(promise1).rejects.toThrow(new AbortError("shutdown"));
   expect(executor.numRunning).toEqual(0);
   expect(executor.numPending).toEqual(0);
 });
@@ -88,7 +88,9 @@ test("cancel one pending promise", async () => {
 test("submit one promise after shutdown", async () => {
   const executor = new PromiseScheduler(1);
   executor.shutdown();
-  expect(executor.submit(async () => 1)).rejects.toThrow("shutdown");
+  expect(executor.submit(async () => 1)).rejects.toThrow(
+    new AbortError("shutdown")
+  );
   expect(executor.numPending).toEqual(0);
   expect(executor.numRunning).toEqual(0);
 });

--- a/test/promise_scheduler.test.ts
+++ b/test/promise_scheduler.test.ts
@@ -93,7 +93,7 @@ test("submit one promise after shutdown", async () => {
   expect(executor.numRunning).toEqual(0);
 });
 
-test("submit promise that throws", async () => {
+test("submit one promise that throws", async () => {
   const executor = new PromiseScheduler(1);
   let blocked = true;
   const promise = executor.submit(async () => {

--- a/ultrack-prototype/frontend/components/Renderer.tsx
+++ b/ultrack-prototype/frontend/components/Renderer.tsx
@@ -63,7 +63,10 @@ export default function Renderer({
     lastTaskId.current = task.taskId;
     const { tracksLayer, imageSeriesLayer } = task.layers();
     imageSeriesLayer.update();
-    setImageSeriesLayer(imageSeriesLayer);
+    setImageSeriesLayer((prevLayer) => {
+      if (prevLayer !== null) prevLayer.close();
+      return imageSeriesLayer;
+    });
     setTracksLayer(tracksLayer);
     const onReady = () => {
       setPlaybackEnabled(true);


### PR DESCRIPTION
### Summary
This allows an optional promise scheduler to be passed to `loadChunks`, so that the number of concurrent promises can be limited. This scheduler is used to implement a queue that can be passed through to zarrita's `Array.get` function, so that the number of underlying concurrent requests can be limited.

Allowing too many concurrent requests has been observed to cause unhandled errors for some datasets using Chrome. Since most browsers can actually handle a limited number of requests anyway, limiting the number to something like 16 should have no adverse performance effects, and also allows us to cancel pending tasks. Using an `AbortController` and passing its `AbortSignal` down to `Array.get` should also allow us to cancel requests that have already started.

### Tests & Checks
I manually tested my changes in the prototype and I added some automated tests for the scheduler.
