### PR TITLE
Skip tapering if TaperPower <= 0.0

### DIFF
--- a/src/renderers/shaders/projected_line_vert.glsl
+++ b/src/renderers/shaders/projected_line_vert.glsl
@@ -47,10 +47,13 @@ void main() {
     // direction is + or -; which way to project the vertex away from the path
     // path_proportion is the distance along the path, from 0 to 1
     float d = sign(direction);
-    float t = clamp(path_proportion - TaperOffset, -0.5, 0.5);
-    float angle = PI * t;
-    float taper = pow(cos(angle), TaperPower);
-
+    float taper = 1.0;
+    if (TaperPower > 0.0) {
+      // glsl `pow(x, y)` is undefined if x < 0 or x = 0 and y <= 0
+      float t = clamp(path_proportion - TaperOffset, -0.5, 0.5);
+      float angle = PI * t;
+      taper = pow(cos(angle), TaperPower);
+    }
     vec2 normal = normalize(vec2(-diff.y, diff.x));
 
     vec4 offset = vec4(


### PR DESCRIPTION
### Summary
The way I implemented line tapering in #107 causes problems with _non-tapered_ lines. I believe this is because glsl has some unexpected (to me) undefined behavior in the `pow` function, which I use to taper the line. Lines are tapered by a cosine envelope from [-pi/2, pi/2], raised to the `TaperPower`. However, `pow(x, y)` [is undefined if x = 0 and y <= 0](https://registry.khronos.org/OpenGL-Refpages/gl4/html/pow.xhtml), which would be the case at both ends of a line with `TaperPower` set to 0.

### Related Issue
Closes #134 

### Tests & Checks
Tested manually with prototype and examples.
