### PR TITLE
Make region coordinates and geometry vertices consistent

### DIFF
--- a/examples/image2d_from_omezarr5d_u16/main.ts
+++ b/examples/image2d_from_omezarr5d_u16/main.ts
@@ -5,12 +5,20 @@ import {
   OmeZarrImageSource,
   OrthographicCamera,
 } from "@";
+import { AxesLayer } from "@/layers/axes_layer";
+import { PanZoomControls } from "@/objects/cameras/controls";
 
 const url =
   "https://public.czbiohub.org/royerlab/zebrahub/imaging/single-objective/ZSNS001.ome.zarr/";
 const layerManager = new LayerManager();
 const renderer = new WebGLRenderer("#canvas");
-const camera = new OrthographicCamera(0, 457, 0, 457);
+const left = 150;
+const right = 950;
+const top = 100;
+const bottom = 900;
+const camera = new OrthographicCamera(left, right, top, bottom);
+const controls = new PanZoomControls(camera, camera.position);
+renderer.setControls(controls);
 
 // Source is 5D, so provide indices at 3 dimensions to project to 2D.
 // Also specify a subregion in x and y to exercise that part of the API.
@@ -19,11 +27,13 @@ const region = [
   { dimension: "t", index: 400 },
   { dimension: "c", index: 0 },
   { dimension: "z", index: 300 },
-  { dimension: "y", index: { start: 100, stop: 900 } },
-  { dimension: "x", index: { start: 150, stop: 950 } },
+  { dimension: "y", index: { start: top, stop: bottom } },
+  { dimension: "x", index: { start: left, stop: right } },
 ];
 const layer = new ImageLayer(source, region);
+const axes = new AxesLayer({ length: 2000, width: 0.01 });
 layerManager.add(layer);
+layerManager.add(axes);
 
 function animate() {
   renderer.render(layerManager, camera);

--- a/src/data/image_chunk.ts
+++ b/src/data/image_chunk.ts
@@ -15,13 +15,13 @@ export type ImageChunk = {
   rowStride: number;
   rowAlignmentBytes: TextureUnpackRowAlignment;
   scale: {
-    x: number,
-    y: number,
-  },
+    x: number;
+    y: number;
+  };
   offset: {
-    x: number,
-    y: number,
-  },
+    x: number;
+    y: number;
+  };
 };
 
 export type ImageChunkSource = {

--- a/src/data/image_chunk.ts
+++ b/src/data/image_chunk.ts
@@ -14,6 +14,8 @@ export type ImageChunk = {
   };
   rowStride: number;
   rowAlignmentBytes: TextureUnpackRowAlignment;
+  scale: [number, number];
+  offset: [number, number];
 };
 
 export type ImageChunkSource = {

--- a/src/data/image_chunk.ts
+++ b/src/data/image_chunk.ts
@@ -14,8 +14,14 @@ export type ImageChunk = {
   };
   rowStride: number;
   rowAlignmentBytes: TextureUnpackRowAlignment;
-  scale: [number, number];
-  offset: [number, number];
+  scale: {
+    x: number,
+    y: number,
+  },
+  offset: {
+    x: number,
+    y: number,
+  },
 };
 
 export type ImageChunkSource = {

--- a/src/data/image_chunk.ts
+++ b/src/data/image_chunk.ts
@@ -8,9 +8,9 @@ import { PromiseScheduler } from "./promise_scheduler";
 export type ImageChunk = {
   data: Uint8Array | Uint16Array;
   shape: {
-    width: number;
-    height: number;
-    channels: number;
+    x: number;
+    y: number;
+    c: number;
   };
   rowStride: number;
   rowAlignmentBytes: TextureUnpackRowAlignment;

--- a/src/data/ome_zarr_image_loader.ts
+++ b/src/data/ome_zarr_image_loader.ts
@@ -159,8 +159,8 @@ export class OmeZarrImageLoader {
       },
       rowStride: subarray.stride[subarray.stride.length - 2],
       rowAlignmentBytes: rowAlignment,
-      scale: scales,
-      offset: offsets,
+      scale: {x: scales[1], y: scales[0]},
+      offset: {x: offsets[1], y: offsets[0]},
     };
     console.debug("loaded chunk ", chunk);
     return chunk;

--- a/src/data/ome_zarr_image_loader.ts
+++ b/src/data/ome_zarr_image_loader.ts
@@ -132,6 +132,24 @@ export class OmeZarrImageLoader {
       );
     }
 
+    const scales: [number, number] = [1, 1];
+    const offsets: [number, number] = [0, 0];
+    for (let i = 0, j = 0; i < indices.length; ++i) {
+      const index = indices[i];
+      if (typeof index === "number") continue;
+      if (index.start === null || index.stop === null) continue;
+      const scale = dataset.coordinateTransformations
+        .map((transform) => transformScale(transform, i))
+        .reduce((totalScale, scale) => scale * totalScale, 1);
+      const translate = dataset.coordinateTransformations
+        .map((transform) => transformTranslation(transform, i))
+        .reduce((totalTranslate, translate) => translate + totalTranslate, 0);
+      const offset = translate + index.start * scale;
+      offsets[j] = offset;
+      scales[j] = scale;
+      j++;
+    }
+
     const chunk = {
       data: subarray.data,
       shape: {
@@ -141,6 +159,8 @@ export class OmeZarrImageLoader {
       },
       rowStride: subarray.stride[subarray.stride.length - 2],
       rowAlignmentBytes: rowAlignment,
+      scale: scales,
+      offset: offsets,
     };
     console.debug("loaded chunk ", chunk);
     return chunk;
@@ -185,4 +205,11 @@ function transformScale(transform: Transform, index: number): number {
   if (transform.type !== "scale") return 1;
   if (!(transform.scale instanceof Array)) return 1;
   return transform.scale[index];
+}
+
+// Returns a translation from a transform at some axis index or 0 if a translation cannot be found.
+function transformTranslation(transform: Transform, index: number): number {
+  if (transform.type !== "translation") return 0;
+  if (!(transform.translation instanceof Array)) return 0;
+  return transform.translation[index];
 }

--- a/src/data/ome_zarr_image_loader.ts
+++ b/src/data/ome_zarr_image_loader.ts
@@ -145,9 +145,9 @@ export class OmeZarrImageLoader {
     const chunk = {
       data: subarray.data,
       shape: {
-        width: subarray.shape[subarray.shape.length - 1],
-        height: subarray.shape[subarray.shape.length - 2],
-        channels: subarray.shape.length === 3 ? subarray.shape[0] : 1,
+        x: subarray.shape[subarray.shape.length - 1],
+        y: subarray.shape[subarray.shape.length - 2],
+        c: subarray.shape.length === 3 ? subarray.shape[0] : 1,
       },
       rowStride: subarray.stride[subarray.stride.length - 2],
       rowAlignmentBytes: rowAlignment,

--- a/src/data/ome_zarr_image_loader.ts
+++ b/src/data/ome_zarr_image_loader.ts
@@ -6,10 +6,6 @@ import { ImageChunk } from "data/image_chunk";
 import { isTextureUnpackRowAlignment } from "objects/textures/texture";
 import { PromiseScheduler } from "./promise_scheduler";
 
-type IdentityTransform = {
-  type: "identity";
-};
-
 type TranslationTransform = {
   type: "translation";
   translation: Array<number>;
@@ -20,11 +16,11 @@ type ScaleTransform = {
   scale: Array<number>;
 };
 
-type Transform = IdentityTransform | TranslationTransform | ScaleTransform;
-
 type Dataset = {
   path: string;
-  coordinateTransformations: Array<Transform>;
+  coordinateTransformations:
+    | [ScaleTransform]
+    | [ScaleTransform, TranslationTransform];
 };
 
 type Axis = {
@@ -95,7 +91,13 @@ export class OmeZarrImageLoader {
     // https://github.com/chanzuckerberg/imaging-active-learning/issues/37
     const lowestResolutionIndex = this.datasets_.length - 1;
     const dataset = this.datasets_[lowestResolutionIndex];
-    const indices = regionToIndices(region, dataset, this.axes_);
+    const scale = dataset.coordinateTransformations[0].scale;
+    const translation =
+      dataset.coordinateTransformations.length === 2
+        ? dataset.coordinateTransformations[1].translation
+        : new Array(this.axes_.length).fill(0);
+
+    const indices = regionToIndices(region, this.axes_, scale, translation);
     console.debug("loading dataset with indices", dataset, indices);
 
     const array = await zarr.open.v2(this.root_.resolve(dataset.path), {
@@ -132,23 +134,13 @@ export class OmeZarrImageLoader {
       );
     }
 
-    const scales: [number, number] = [1, 1];
-    const offsets: [number, number] = [0, 0];
-    for (let i = 0, j = 0; i < indices.length; ++i) {
+    const calculateOffset = (i: number) => {
       const index = indices[i];
-      if (typeof index === "number") continue;
-      if (index.start === null || index.stop === null) continue;
-      const scale = dataset.coordinateTransformations
-        .map((transform) => transformScale(transform, i))
-        .reduce((totalScale, scale) => scale * totalScale, 1);
-      const translate = dataset.coordinateTransformations
-        .map((transform) => transformTranslation(transform, i))
-        .reduce((totalTranslate, translate) => translate + totalTranslate, 0);
-      const offset = translate + index.start * scale;
-      offsets[j] = offset;
-      scales[j] = scale;
-      j++;
-    }
+      if (typeof index === "number" || index.start === null) return 0;
+      return index.start * scale[i] + translation[i];
+    };
+    const xOffset = calculateOffset(indices.length - 1);
+    const yOffset = calculateOffset(indices.length - 2);
 
     const chunk = {
       data: subarray.data,
@@ -159,8 +151,8 @@ export class OmeZarrImageLoader {
       },
       rowStride: subarray.stride[subarray.stride.length - 2],
       rowAlignmentBytes: rowAlignment,
-      scale: {x: scales[1], y: scales[0]},
-      offset: {x: offsets[1], y: offsets[0]},
+      scale: { x: scale[indices.length - 1], y: scale[indices.length - 2] },
+      offset: { x: xOffset, y: yOffset },
     };
     console.debug("loaded chunk ", chunk);
     return chunk;
@@ -170,8 +162,9 @@ export class OmeZarrImageLoader {
 // Converts a region to indices within an OME-Zarr image array.
 function regionToIndices(
   region: Region,
-  dataset: Dataset,
-  axes: Array<Axis>
+  axes: Array<Axis>,
+  scale: number[],
+  translation: number[]
 ): Array<Slice | number> {
   const indices: Array<Slice | number> = [];
   for (const [i, axis] of axes.entries()) {
@@ -180,36 +173,17 @@ function regionToIndices(
     // the complete extent of a dimension like Python's `slice(None)`.
     let index: Slice | number = zarr.slice(null);
     if (match) {
-      // TODO: handle more than just scale list to transform input region.
-      // https://github.com/chanzuckerberg/imaging-active-learning/issues/38
-      const scale = dataset.coordinateTransformations
-        .map((transform) => transformScale(transform, i))
-        .reduce((totalScale, scale) => scale * totalScale, 1);
       const regionIndex = match.index;
       if (typeof regionIndex === "number") {
-        index = Math.round(regionIndex / scale);
+        index = Math.round(translation[i] + regionIndex / scale[i]);
       } else {
         index = zarr.slice(
-          Math.floor(regionIndex.start / scale),
-          Math.ceil(regionIndex.stop / scale)
+          Math.floor(translation[i] + regionIndex.start / scale[i]),
+          Math.ceil(translation[i] + regionIndex.stop / scale[i])
         );
       }
     }
     indices.push(index);
   }
   return indices;
-}
-
-// Returns a scale from a transform at some axis index or 1 if a scale cannot be found.
-function transformScale(transform: Transform, index: number): number {
-  if (transform.type !== "scale") return 1;
-  if (!(transform.scale instanceof Array)) return 1;
-  return transform.scale[index];
-}
-
-// Returns a translation from a transform at some axis index or 0 if a translation cannot be found.
-function transformTranslation(transform: Transform, index: number): number {
-  if (transform.type !== "translation") return 0;
-  if (!(transform.translation instanceof Array)) return 0;
-  return transform.translation[index];
 }

--- a/src/layers/image_layer.ts
+++ b/src/layers/image_layer.ts
@@ -44,12 +44,12 @@ export class ImageLayer extends Layer {
     const shape = chunk.shape;
     const texture = new DataTexture2D(chunk.data, shape.width, shape.height);
     const plane = new PlaneGeometry(
-      chunk.scale[1] * shape.width,
-      chunk.scale[0] * shape.height,
+      chunk.scale.x * shape.width,
+      chunk.scale.y * shape.height,
       1,
       1,
-      chunk.offset[1],
-      chunk.offset[0]
+      chunk.offset.x,
+      chunk.offset.y
     );
 
     texture.dataFormat = "red_integer";

--- a/src/layers/image_layer.ts
+++ b/src/layers/image_layer.ts
@@ -4,7 +4,6 @@ import { PlaneGeometry } from "objects/geometry/plane_geometry";
 import { Region } from "data/region";
 import { ImageChunkSource } from "data/image_chunk";
 import { DataTexture2D } from "objects/textures/data_texture_2d";
-// import { vec3 } from "gl-matrix";
 
 // Loads data from an image source into renderable objects.
 export class ImageLayer extends Layer {
@@ -44,14 +43,9 @@ export class ImageLayer extends Layer {
     const chunk = await loader.loadChunk(region);
     const shape = chunk.shape;
     const texture = new DataTexture2D(chunk.data, shape.width, shape.height);
-    const size = [shape.width, shape.height];
-    console.debug("chunk.scale", chunk.scale);
-    console.debug("chunk.offset", chunk.offset);
-    size[0] = chunk.scale[1] * shape.width;
-    size[1] = chunk.scale[0] * shape.height;
     const plane = new PlaneGeometry(
-      size[0],
-      size[1],
+      chunk.scale[1] * shape.width,
+      chunk.scale[0] * shape.height,
       1,
       1,
       chunk.offset[1],
@@ -66,13 +60,7 @@ export class ImageLayer extends Layer {
     texture.unpackRowLength = chunk.rowStride;
     texture.unpackAlignment = chunk.rowAlignmentBytes;
 
-    const mesh = new Mesh(plane, texture);
-    // if (chunk.scale !== undefined) {
-    //   console.debug(mesh.transform.translation);
-    //   mesh.transform.scale(vec3.fromValues(...chunk.scale, 1));
-    // }
-
-    this.addObject(mesh);
+    this.addObject(new Mesh(plane, texture));
     this.setState("ready");
   }
 }

--- a/src/layers/image_layer.ts
+++ b/src/layers/image_layer.ts
@@ -42,10 +42,10 @@ export class ImageLayer extends Layer {
     const loader = await this.source_.open();
     const chunk = await loader.loadChunk(region);
     const shape = chunk.shape;
-    const texture = new DataTexture2D(chunk.data, shape.width, shape.height);
+    const texture = new DataTexture2D(chunk.data, shape.x, shape.y);
     const plane = new PlaneGeometry(
-      chunk.scale.x * shape.width,
-      chunk.scale.y * shape.height,
+      chunk.scale.x * shape.x,
+      chunk.scale.y * shape.y,
       1,
       1,
       chunk.offset.x,

--- a/src/layers/image_layer.ts
+++ b/src/layers/image_layer.ts
@@ -4,6 +4,7 @@ import { PlaneGeometry } from "objects/geometry/plane_geometry";
 import { Region } from "data/region";
 import { ImageChunkSource } from "data/image_chunk";
 import { DataTexture2D } from "objects/textures/data_texture_2d";
+// import { vec3 } from "gl-matrix";
 
 // Loads data from an image source into renderable objects.
 export class ImageLayer extends Layer {
@@ -43,7 +44,19 @@ export class ImageLayer extends Layer {
     const chunk = await loader.loadChunk(region);
     const shape = chunk.shape;
     const texture = new DataTexture2D(chunk.data, shape.width, shape.height);
-    const plane = new PlaneGeometry(shape.width, shape.height, 1, 1);
+    const size = [shape.width, shape.height];
+    console.debug("chunk.scale", chunk.scale);
+    console.debug("chunk.offset", chunk.offset);
+    size[0] = chunk.scale[1] * shape.width;
+    size[1] = chunk.scale[0] * shape.height;
+    const plane = new PlaneGeometry(
+      size[0],
+      size[1],
+      1,
+      1,
+      chunk.offset[1],
+      chunk.offset[0]
+    );
 
     texture.dataFormat = "red_integer";
     if (chunk.data instanceof Uint16Array) {
@@ -53,7 +66,13 @@ export class ImageLayer extends Layer {
     texture.unpackRowLength = chunk.rowStride;
     texture.unpackAlignment = chunk.rowAlignmentBytes;
 
-    this.addObject(new Mesh(plane, texture));
+    const mesh = new Mesh(plane, texture);
+    // if (chunk.scale !== undefined) {
+    //   console.debug(mesh.transform.translation);
+    //   mesh.transform.scale(vec3.fromValues(...chunk.scale, 1));
+    // }
+
+    this.addObject(mesh);
     this.setState("ready");
   }
 }

--- a/src/layers/image_layer.ts
+++ b/src/layers/image_layer.ts
@@ -1,9 +1,7 @@
 import { Layer } from "core/layer";
-import { Mesh } from "objects/renderable/mesh";
-import { PlaneGeometry } from "objects/geometry/plane_geometry";
 import { Region } from "data/region";
 import { ImageChunkSource } from "data/image_chunk";
-import { DataTexture2D } from "objects/textures/data_texture_2d";
+import { makeImageMesh, makeImageTexture } from "layers/image_utils";
 
 // Loads data from an image source into renderable objects.
 export class ImageLayer extends Layer {
@@ -41,21 +39,8 @@ export class ImageLayer extends Layer {
     this.setState("loading");
     const loader = await this.source_.open();
     const chunk = await loader.loadChunk(region);
-    const shape = chunk.shape;
-    const texture = new DataTexture2D(chunk.data, shape.x, shape.y);
-    const plane = new PlaneGeometry(shape.x, shape.y, 1, 1);
-
-    texture.dataFormat = "red_integer";
-    if (chunk.data instanceof Uint16Array) {
-      texture.dataType = "unsigned_short";
-    }
-
-    texture.unpackRowLength = chunk.rowStride;
-    texture.unpackAlignment = chunk.rowAlignmentBytes;
-
-    const mesh = new Mesh(plane, texture);
-    mesh.transform.scale([chunk.scale.x, chunk.scale.y, 1]);
-    mesh.transform.translate([chunk.offset.x, chunk.offset.y, 0]);
+    const texture = makeImageTexture(chunk);
+    const mesh = makeImageMesh(chunk, texture);
     this.addObject(mesh);
     this.setState("ready");
   }

--- a/src/layers/image_layer.ts
+++ b/src/layers/image_layer.ts
@@ -43,14 +43,7 @@ export class ImageLayer extends Layer {
     const chunk = await loader.loadChunk(region);
     const shape = chunk.shape;
     const texture = new DataTexture2D(chunk.data, shape.x, shape.y);
-    const plane = new PlaneGeometry(
-      chunk.scale.x * shape.x,
-      chunk.scale.y * shape.y,
-      1,
-      1,
-      chunk.offset.x,
-      chunk.offset.y
-    );
+    const plane = new PlaneGeometry(shape.x, shape.y, 1, 1);
 
     texture.dataFormat = "red_integer";
     if (chunk.data instanceof Uint16Array) {
@@ -60,7 +53,10 @@ export class ImageLayer extends Layer {
     texture.unpackRowLength = chunk.rowStride;
     texture.unpackAlignment = chunk.rowAlignmentBytes;
 
-    this.addObject(new Mesh(plane, texture));
+    const mesh = new Mesh(plane, texture);
+    mesh.transform.scale([chunk.scale.x, chunk.scale.y, 1]);
+    mesh.transform.translate([chunk.offset.x, chunk.offset.y, 0]);
+    this.addObject(mesh);
     this.setState("ready");
   }
 }

--- a/src/layers/image_series_layer.ts
+++ b/src/layers/image_series_layer.ts
@@ -69,7 +69,7 @@ export class ImageSeriesLayer extends Layer {
     if (this.texture_ === null) {
       this.initializeTexture(chunk);
       const shape = chunk.shape;
-      const plane = new PlaneGeometry(shape.width, shape.height, 1, 1);
+      const plane = new PlaneGeometry(shape.x, shape.y, 1, 1);
       this.addObject(new Mesh(plane, this.texture_));
     } else {
       this.texture_.data = chunk.data;
@@ -116,8 +116,8 @@ export class ImageSeriesLayer extends Layer {
   private initializeTexture(chunk: ImageChunk) {
     this.texture_ = new Texture2DArray(
       chunk.data,
-      chunk.shape.width,
-      chunk.shape.height
+      chunk.shape.x,
+      chunk.shape.y
     );
 
     this.texture_.unpackRowLength = chunk.rowStride;

--- a/src/layers/image_series_layer.ts
+++ b/src/layers/image_series_layer.ts
@@ -1,10 +1,9 @@
 import { Layer } from "core/layer";
-import { Mesh } from "objects/renderable/mesh";
-import { PlaneGeometry } from "objects/geometry/plane_geometry";
 import { Interval, Region } from "data/region";
 import { ImageChunk, ImageChunkSource } from "data/image_chunk";
 import { Texture2DArray } from "objects/textures/texture_2d_array";
 import { AbortError, PromiseScheduler } from "@/data/promise_scheduler";
+import { makeImageMesh, makeImageTextureArray } from "layers/image_utils";
 
 // Loads 2D+t image data from an image source into renderable objects.
 export class ImageSeriesLayer extends Layer {
@@ -67,10 +66,9 @@ export class ImageSeriesLayer extends Layer {
     }
     const chunk = this.dataChunks_[chunkIndex];
     if (this.texture_ === null) {
-      this.initializeTexture(chunk);
-      const shape = chunk.shape;
-      const plane = new PlaneGeometry(shape.x, shape.y, 1, 1);
-      this.addObject(new Mesh(plane, this.texture_));
+      this.texture_ = makeImageTextureArray(chunk);
+      const mesh = makeImageMesh(chunk, this.texture_);
+      this.addObject(mesh);
     } else {
       this.texture_.data = chunk.data;
     }
@@ -109,22 +107,6 @@ export class ImageSeriesLayer extends Layer {
         return;
       }
     });
-
     this.setState("ready");
-  }
-
-  private initializeTexture(chunk: ImageChunk) {
-    this.texture_ = new Texture2DArray(
-      chunk.data,
-      chunk.shape.x,
-      chunk.shape.y
-    );
-
-    this.texture_.unpackRowLength = chunk.rowStride;
-    this.texture_.unpackAlignment = chunk.rowAlignmentBytes;
-    this.texture_.dataFormat = "red_integer";
-    if (chunk.data instanceof Uint16Array) {
-      this.texture_.dataType = "unsigned_short";
-    }
   }
 }

--- a/src/layers/image_utils.ts
+++ b/src/layers/image_utils.ts
@@ -1,0 +1,36 @@
+import { DataTexture2D } from "@/objects/textures/data_texture_2d";
+import { Texture } from "objects/textures/texture";
+import { Texture2DArray } from "@/objects/textures/texture_2d_array";
+import { ImageChunk } from "data/image_chunk";
+import { PlaneGeometry } from "objects/geometry/plane_geometry";
+import { Mesh } from "objects/renderable/mesh";
+
+export function makeImageTexture(chunk: ImageChunk) {
+  const texture = new DataTexture2D(chunk.data, chunk.shape.x, chunk.shape.y);
+  updateImageTexture(texture, chunk);
+  return texture;
+}
+
+export function makeImageTextureArray(chunk: ImageChunk) {
+  const texture = new Texture2DArray(chunk.data, chunk.shape.x, chunk.shape.y);
+  updateImageTexture(texture, chunk);
+  return texture;
+}
+
+function updateImageTexture(texture: Texture, chunk: ImageChunk) {
+  texture.dataFormat = "red_integer";
+  if (chunk.data instanceof Uint16Array) {
+    texture.dataType = "unsigned_short";
+  }
+  texture.unpackRowLength = chunk.rowStride;
+  texture.unpackAlignment = chunk.rowAlignmentBytes;
+  return texture;
+}
+
+export function makeImageMesh(chunk: ImageChunk, texture: Texture) {
+  const plane = new PlaneGeometry(chunk.shape.x, chunk.shape.y, 1, 1);
+  const mesh = new Mesh(plane, texture);
+  mesh.transform.scale([chunk.scale.x, chunk.scale.y, 1]);
+  mesh.transform.translate([chunk.offset.x, chunk.offset.y, 0]);
+  return mesh;
+}

--- a/src/objects/geometry/plane_geometry.ts
+++ b/src/objects/geometry/plane_geometry.ts
@@ -5,9 +5,7 @@ export class PlaneGeometry extends Geometry {
     width: number,
     height: number,
     widthSegments: number,
-    heightSegments: number,
-    offsetX: number = 0,
-    offsetY: number = 0
+    heightSegments: number
   ) {
     super();
     const vertex: number[] = [];
@@ -21,9 +19,9 @@ export class PlaneGeometry extends Geometry {
     const segmentH = height / gridY;
 
     for (let iy = 0; iy < gridY1; ++iy) {
-      const y = offsetY + iy * segmentH;
+      const y = iy * segmentH;
       for (let ix = 0; ix < gridX1; ++ix) {
-        const x = offsetX + ix * segmentW;
+        const x = ix * segmentW;
         const u = ix / gridX;
         const v = iy / gridY;
 

--- a/src/objects/geometry/plane_geometry.ts
+++ b/src/objects/geometry/plane_geometry.ts
@@ -5,7 +5,9 @@ export class PlaneGeometry extends Geometry {
     width: number,
     height: number,
     widthSegments: number,
-    heightSegments: number
+    heightSegments: number,
+    offsetX: number = 0,
+    offsetY: number = 0
   ) {
     super();
     const vertex: number[] = [];
@@ -19,9 +21,9 @@ export class PlaneGeometry extends Geometry {
     const segmentH = height / gridY;
 
     for (let iy = 0; iy < gridY1; ++iy) {
-      const y = iy * segmentH;
+      const y = offsetY + iy * segmentH;
       for (let ix = 0; ix < gridX1; ++ix) {
-        const x = ix * segmentW;
+        const x = offsetX + ix * segmentW;
         const u = ix / gridX;
         const v = iy / gridY;
 

--- a/src/renderers/webgl_renderer.ts
+++ b/src/renderers/webgl_renderer.ts
@@ -47,8 +47,8 @@ export class WebGLRenderer extends Renderer {
 
     const modelView = mat4.multiply(
       mat4.create(),
-      object.transform.matrix,
-      this.activeCamera.transform.inverse
+      this.activeCamera.transform.inverse,
+      object.transform.matrix
     );
     program.setUniform("ModelView", modelView);
     const projection = mat4.multiply(


### PR DESCRIPTION
### Summary
This makes the loading input region coordinates and the output geometry vertex coordinates consistent for image layers. This is demonstrated in the u16 example, which defines a sub-region in the x-y plane which is used for both loading and for the orthographic camera.

This also uses OME-Zarr dataset translation values if they are present and generally simplifies reading the dataset transformation values based on the restricted specification described in OME-NGFF.

### Related Issue
Closes #35
Closes #38

### Tests & Checks
I tested the development examples.
