### PR TITLE
[WIP] Image layer that loads only what's in view

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -37,6 +37,7 @@
           >2D Image from 5D OMEZarr with uint16 data</a
         >
       </li>
+      <li><a href="/responsive_loading_2d/index.html">Responsive Loading 2D</a></li>
       <li><a href="/single_mesh_layer/index.html">Single Mesh Layer</a></li>
       <li><a href="/projected_lines/index.html">Projected Lines</a></li>
       <li><a href="/tracks/index.html">Tracks on Image</a></li>

--- a/examples/index.html
+++ b/examples/index.html
@@ -37,7 +37,9 @@
           >2D Image from 5D OMEZarr with uint16 data</a
         >
       </li>
-      <li><a href="/responsive_loading_2d/index.html">Responsive Loading 2D</a></li>
+      <li>
+        <a href="/responsive_loading_2d/index.html">Responsive Loading 2D</a>
+      </li>
       <li><a href="/single_mesh_layer/index.html">Single Mesh Layer</a></li>
       <li><a href="/projected_lines/index.html">Projected Lines</a></li>
       <li><a href="/tracks/index.html">Tracks on Image</a></li>

--- a/examples/responsive_loading_2d/index.html
+++ b/examples/responsive_loading_2d/index.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Web Viewer</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        display: flex;
+        width: 100%;
+        height: 100%;
+      }
+      canvas {
+        width: 100%;
+        height: 100%;
+      }
+    </style>
+  </head>
+  <body>
+    <canvas id="canvas"></canvas>
+    <script type="module" src="./main.ts"></script>
+  </body>
+</html>

--- a/examples/responsive_loading_2d/main.ts
+++ b/examples/responsive_loading_2d/main.ts
@@ -24,7 +24,7 @@ const region = [
   { dimension: "C", index: 0 },
   { dimension: "Z", index: 640 },
 ];
-const layer = new ResponsiveImageLayer(source, region, camera);
+const layer = new ResponsiveImageLayer(source, region, camera, renderer);
 const axes = new AxesLayer({ length: 2048, width: 0.01 });
 layerManager.add(layer);
 layerManager.add(axes);

--- a/examples/responsive_loading_2d/main.ts
+++ b/examples/responsive_loading_2d/main.ts
@@ -1,0 +1,44 @@
+import {
+  LayerManager,
+  ResponsiveImageLayer,
+  WebGLRenderer,
+  OmeZarrImageSource,
+  OrthographicCamera,
+} from "@";
+import { AxesLayer } from "@/layers/axes_layer";
+import { PanZoomControls } from "@/objects/cameras/controls";
+
+// loading from zarr-testcard server
+const url = "http://127.0.0.1:8000/default/";
+const layerManager = new LayerManager();
+const renderer = new WebGLRenderer("#canvas");
+const camera = new OrthographicCamera(-128, 128, -128, 128);
+const panZoomControls = new PanZoomControls(camera);
+renderer.setControls(panZoomControls);
+
+// Source is technically 5D (even though Z is unitary),
+// so provide indices at 3 dimensions to project to 2D.
+const source = new OmeZarrImageSource(url);
+const region = [
+  { dimension: "T", index: 32 },
+  { dimension: "C", index: 0 },
+  { dimension: "Z", index: 0 },
+];
+const layer = new ResponsiveImageLayer(source, region, camera);
+const axes = new AxesLayer({ length: 1920, width: 0.01 });
+layerManager.add(layer);
+layerManager.add(axes);
+
+document.addEventListener("keydown", (event) => {
+  // TODO: add a callback to update on camera change
+  if (event.key === " ") {
+    layer.onCameraFrameChange();
+  }
+});
+
+function animate() {
+  renderer.render(layerManager, camera);
+  requestAnimationFrame(animate);
+}
+
+animate();

--- a/examples/responsive_loading_2d/main.ts
+++ b/examples/responsive_loading_2d/main.ts
@@ -22,10 +22,10 @@ const source = new OmeZarrImageSource(url);
 const region = [
   { dimension: "T", index: 32 },
   { dimension: "C", index: 0 },
-  { dimension: "Z", index: 0 },
+  { dimension: "Z", index: 640 },
 ];
 const layer = new ResponsiveImageLayer(source, region, camera);
-const axes = new AxesLayer({ length: 1920, width: 0.01 });
+const axes = new AxesLayer({ length: 2048, width: 0.01 });
 layerManager.add(layer);
 layerManager.add(axes);
 

--- a/examples/responsive_loading_2d/main.ts
+++ b/examples/responsive_loading_2d/main.ts
@@ -12,8 +12,9 @@ import { PanZoomControls } from "@/objects/cameras/controls";
 const url = "http://127.0.0.1:8000/default/";
 const layerManager = new LayerManager();
 const renderer = new WebGLRenderer("#canvas");
-const camera = new OrthographicCamera(-128, 128, -128, 128);
-const panZoomControls = new PanZoomControls(camera);
+const camera = new OrthographicCamera(0, 2048, 0, 2048);
+camera.zoom = 0.5;
+const panZoomControls = new PanZoomControls(camera, camera.position);
 renderer.setControls(panZoomControls);
 
 // Source is technically 5D (even though Z is unitary),
@@ -34,6 +35,18 @@ document.addEventListener("keydown", (event) => {
   if (event.key === " ") {
     layer.onCameraFrameChange();
   }
+  if (event.key === "=") {
+    const z = region[2].index;
+    region[2].index = Math.min(1280, z + 10);
+    layer.update(true);
+  }
+  if (event.key === "-") {
+    const z = region[2].index;
+    region[2].index = Math.max(0, z - 10);
+    layer.update(true);
+  }
+  console.log(region[2].index);
+  console.log(camera.zoom);
 });
 
 function animate() {

--- a/src/data/image_chunk.ts
+++ b/src/data/image_chunk.ts
@@ -7,13 +7,16 @@ import { PromiseScheduler } from "./promise_scheduler";
 // https://github.com/chanzuckerberg/imaging-active-learning/issues/34
 export type ImageChunk = {
   data: Uint8Array | Uint16Array;
+  rowStride: number;
+  rowAlignmentBytes: TextureUnpackRowAlignment;
+} & ImageChunkSize;
+
+export type ImageChunkSize = {
   shape: {
     x: number;
     y: number;
     c: number;
   };
-  rowStride: number;
-  rowAlignmentBytes: TextureUnpackRowAlignment;
   scale: {
     x: number;
     y: number;
@@ -29,5 +32,7 @@ export type ImageChunkSource = {
 };
 
 export type ImageChunkLoader = {
-  loadChunk(input: Region, scheduler?: PromiseScheduler): Promise<ImageChunk>;
+  // get shape of the texture in world coordinates
+  getShape(input: Region, scaleIndex?: number): Promise<{axis: string, length: number}[]>;
+  loadChunk(input: Region, scheduler?: PromiseScheduler, scaleIndex?: number): Promise<ImageChunk>;
 };

--- a/src/data/image_chunk.ts
+++ b/src/data/image_chunk.ts
@@ -9,9 +9,9 @@ export type ImageChunk = {
   data: Uint8Array | Uint16Array;
   rowStride: number;
   rowAlignmentBytes: TextureUnpackRowAlignment;
-} & ImageChunkSize;
+} & ImageChunkAttributes;
 
-export type ImageChunkSize = {
+export type ImageChunkAttributes = {
   shape: {
     x: number;
     y: number;
@@ -25,6 +25,10 @@ export type ImageChunkSize = {
     x: number;
     y: number;
   };
+  name: {
+    x: string;
+    y: string;
+  };
 };
 
 export type ImageChunkSource = {
@@ -33,10 +37,10 @@ export type ImageChunkSource = {
 
 export type ImageChunkLoader = {
   // get shape of the texture in world coordinates
-  getShape(
+  getChunkAttributes(
     input: Region,
     scaleIndex?: number
-  ): Promise<{ axis: string; length: number }[]>;
+  ): Promise<ImageChunkAttributes>;
   loadChunk(
     input: Region,
     scheduler?: PromiseScheduler,

--- a/src/data/image_chunk.ts
+++ b/src/data/image_chunk.ts
@@ -36,7 +36,6 @@ export type ImageChunkSource = {
 };
 
 export type ImageChunkLoader = {
-  // get shape of the texture in world coordinates
   getChunkAttributes(
     input: Region,
     scaleIndex?: number

--- a/src/data/image_chunk.ts
+++ b/src/data/image_chunk.ts
@@ -36,6 +36,7 @@ export type ImageChunkSource = {
 };
 
 export type ImageChunkLoader = {
+  numScales: number;
   getChunkAttributes(
     input: Region,
     scaleIndex?: number

--- a/src/data/image_chunk.ts
+++ b/src/data/image_chunk.ts
@@ -33,6 +33,13 @@ export type ImageChunkSource = {
 
 export type ImageChunkLoader = {
   // get shape of the texture in world coordinates
-  getShape(input: Region, scaleIndex?: number): Promise<{axis: string, length: number}[]>;
-  loadChunk(input: Region, scheduler?: PromiseScheduler, scaleIndex?: number): Promise<ImageChunk>;
+  getShape(
+    input: Region,
+    scaleIndex?: number
+  ): Promise<{ axis: string; length: number }[]>;
+  loadChunk(
+    input: Region,
+    scheduler?: PromiseScheduler,
+    scaleIndex?: number
+  ): Promise<ImageChunk>;
 };

--- a/src/data/ome_zarr_image_loader.ts
+++ b/src/data/ome_zarr_image_loader.ts
@@ -87,7 +87,10 @@ export class OmeZarrImageLoader {
     return this.datasets_.length - 1;
   }
 
-  public async getShape(input: Region, scaleIndex?: number): Promise<{axis: string, length: number}[]> {
+  public async getShape(
+    input: Region,
+    scaleIndex?: number
+  ): Promise<{ axis: string; length: number }[]> {
     const dataset = this.datasets_[scaleIndex ?? this.lowestResolutionIndex];
     const array = await zarr.open.v2(this.root_.resolve(dataset.path), {
       kind: "array",
@@ -119,7 +122,12 @@ export class OmeZarrImageLoader {
   ): Promise<ImageChunk> {
     // TODO: use the input to determine what level to load.
     // https://github.com/chanzuckerberg/imaging-active-learning/issues/37
-    console.log("loading chunk with region", region, "and scale index", scaleIndex);
+    console.log(
+      "loading chunk with region",
+      region,
+      "and scale index",
+      scaleIndex
+    );
     const dataset = this.datasets_[scaleIndex ?? this.lowestResolutionIndex];
     const scale = dataset.coordinateTransformations[0].scale;
     const translation =

--- a/src/data/ome_zarr_image_loader.ts
+++ b/src/data/ome_zarr_image_loader.ts
@@ -2,7 +2,7 @@ import * as zarr from "zarrita";
 import { Slice } from "@zarrita/indexing";
 
 import { Region } from "data/region";
-import { ImageChunk } from "data/image_chunk";
+import { ImageChunk, ImageChunkAttributes } from "data/image_chunk";
 import { isTextureUnpackRowAlignment } from "objects/textures/texture";
 import { PromiseScheduler } from "./promise_scheduler";
 
@@ -87,32 +87,74 @@ export class OmeZarrImageLoader {
     return this.datasets_.length - 1;
   }
 
-  public async getShape(
+  public async getChunkAttributes(
     input: Region,
     scaleIndex?: number
-  ): Promise<{ axis: string; length: number }[]> {
+  ): Promise<ImageChunkAttributes> {
     const dataset = this.datasets_[scaleIndex ?? this.lowestResolutionIndex];
     const array = await zarr.open.v2(this.root_.resolve(dataset.path), {
       kind: "array",
       attrs: false,
     });
-    const scale = dataset.coordinateTransformations[0].scale;
-    const translation =
+    const datasetScale = dataset.coordinateTransformations[0].scale;
+    const datasetTranslation =
       dataset.coordinateTransformations.length === 2
         ? dataset.coordinateTransformations[1].translation
         : new Array(this.axes_.length).fill(0);
-    const indices = regionToIndices(input, this.axes_, scale, translation);
+    const indices = regionToIndices(
+      input,
+      this.axes_,
+      datasetScale,
+      datasetTranslation
+    );
     console.debug("getting shape with indices", indices);
 
-    return indices.map((index, i) => {
-      if (typeof index === "number") {
-        return { axis: this.axes_[i].name, length: 1 };
-      }
-      index = index as Slice;
-      const start = index.start ?? 0;
-      const stop = index.stop ?? array.shape[i];
-      return { axis: this.axes_[i].name, length: stop - start };
-    });
+    // TODO: is this always the order?
+    const xIndex = indices.length - 1;
+    const yIndex = indices.length - 2;
+
+    const xSlice = indices[xIndex] as Slice;
+    const xStart = xSlice.start ?? 0;
+    const xStop = xSlice.stop ?? array.shape[xIndex];
+
+    const ySlice = indices[yIndex] as Slice;
+    const yStart = ySlice.start ?? 0;
+    const yStop = ySlice.stop ?? array.shape[yIndex];
+
+    const shape = {
+      x: xStop - xStart,
+      y: yStop - yStart,
+      c: 1, // TODO: add support for channels
+    };
+
+    const scale = {
+      x: datasetScale[xIndex],
+      y: datasetScale[yIndex],
+    };
+
+    const offset = {
+      x: datasetTranslation[xIndex],
+      y: datasetTranslation[yIndex],
+    };
+
+    const name = {
+      x: this.axes_[xIndex].name,
+      y: this.axes_[yIndex].name,
+    };
+
+    // next axis (if any) is c (channels)
+
+    // return indices.map((index, i) => {
+    //   if (typeof index === "number") {
+    //     return { axis: this.axes_[i].name, length: 1 };
+    //   }
+    //   index = index as Slice;
+    //   const start = index.start ?? 0;
+    //   const stop = index.stop ?? array.shape[i];
+    //   return { axis: this.axes_[i].name, length: stop - start };
+    // });
+    //
+    return { shape, scale, offset, name };
   }
 
   async loadChunk(
@@ -191,6 +233,10 @@ export class OmeZarrImageLoader {
       rowAlignmentBytes: rowAlignment,
       scale: { x: scale[indices.length - 1], y: scale[indices.length - 2] },
       offset: { x: xOffset, y: yOffset },
+      name: {
+        x: this.axes_[indices.length - 1].name,
+        y: this.axes_[indices.length - 2].name,
+      },
     };
     console.debug("loaded chunk ", chunk);
     return chunk;

--- a/src/data/ome_zarr_image_loader.ts
+++ b/src/data/ome_zarr_image_loader.ts
@@ -83,21 +83,51 @@ export class OmeZarrImageLoader {
     this.datasets_ = image.datasets;
   }
 
-  async loadChunk(
-    region: Region,
-    scheduler?: PromiseScheduler
-  ): Promise<ImageChunk> {
-    // TODO: use the input to determine what level to load.
-    // https://github.com/chanzuckerberg/imaging-active-learning/issues/37
-    const lowestResolutionIndex = this.datasets_.length - 1;
-    const dataset = this.datasets_[lowestResolutionIndex];
+  get lowestResolutionIndex(): number {
+    return this.datasets_.length - 1;
+  }
+
+  public async getShape(input: Region, scaleIndex?: number): Promise<{axis: string, length: number}[]> {
+    const dataset = this.datasets_[scaleIndex ?? this.lowestResolutionIndex];
+    const array = await zarr.open.v2(this.root_.resolve(dataset.path), {
+      kind: "array",
+      attrs: false,
+    });
     const scale = dataset.coordinateTransformations[0].scale;
     const translation =
       dataset.coordinateTransformations.length === 2
         ? dataset.coordinateTransformations[1].translation
         : new Array(this.axes_.length).fill(0);
+    const indices = regionToIndices(input, this.axes_, scale, translation);
+    console.debug("getting shape with indices", indices);
 
+    return indices.map((index, i) => {
+      if (typeof index === "number") {
+        return { axis: this.axes_[i].name, length: 1 };
+      }
+      index = index as Slice;
+      const start = index.start ?? 0;
+      const stop = index.stop ?? array.shape[i];
+      return { axis: this.axes_[i].name, length: stop - start };
+    });
+  }
+
+  async loadChunk(
+    region: Region,
+    scheduler?: PromiseScheduler,
+    scaleIndex?: number
+  ): Promise<ImageChunk> {
+    // TODO: use the input to determine what level to load.
+    // https://github.com/chanzuckerberg/imaging-active-learning/issues/37
+    console.log("loading chunk with region", region, "and scale index", scaleIndex);
+    const dataset = this.datasets_[scaleIndex ?? this.lowestResolutionIndex];
+    const scale = dataset.coordinateTransformations[0].scale;
+    const translation =
+      dataset.coordinateTransformations.length === 2
+        ? dataset.coordinateTransformations[1].translation
+        : new Array(this.axes_.length).fill(0);
     const indices = regionToIndices(region, this.axes_, scale, translation);
+
     console.debug("loading dataset with indices", dataset, indices);
 
     const array = await zarr.open.v2(this.root_.resolve(dataset.path), {

--- a/src/data/ome_zarr_image_loader.ts
+++ b/src/data/ome_zarr_image_loader.ts
@@ -113,9 +113,16 @@ export class OmeZarrImageLoader {
     );
     console.debug("getting shape with indices", indices);
 
+    const xIndex = indices.findLastIndex((index) => typeof index !== "number");
+    const yIndex = indices.findLastIndex(
+      (index, i) => typeof index !== "number" && i !== xIndex
+    );
+    const cIndex = indices.findLastIndex(
+      (index, i) => typeof index !== "number" && i !== xIndex && i !== yIndex
+    );
     // TODO: is this always the order?
-    const xIndex = indices.length - 1;
-    const yIndex = indices.length - 2;
+    // const xIndex = indices.length - 1;
+    // const yIndex = indices.length - 2;
 
     const xSlice = indices[xIndex] as Slice;
     const xStart = xSlice.start ?? 0;
@@ -125,10 +132,18 @@ export class OmeZarrImageLoader {
     const yStart = ySlice.start ?? 0;
     const yStop = ySlice.stop ?? array.shape[yIndex];
 
+    let cShape = 1;
+    if (cIndex != -1) {
+      const cSlice = indices[cIndex] as Slice;
+      const cStart = cSlice.start ?? 0;
+      const cStop = cSlice.stop ?? array.shape[cIndex];
+      cShape = cStop - cStart;
+    }
+
     const shape = {
       x: xStop - xStart,
       y: yStop - yStart,
-      c: 1, // TODO: add support for channels
+      c: cShape,
     };
 
     const scale = {

--- a/src/data/ome_zarr_image_loader.ts
+++ b/src/data/ome_zarr_image_loader.ts
@@ -87,6 +87,10 @@ export class OmeZarrImageLoader {
     return this.datasets_.length - 1;
   }
 
+  public get numScales(): number {
+    return this.datasets_.length;
+  }
+
   public async getChunkAttributes(
     input: Region,
     scaleIndex?: number

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,8 @@ export { ImageLayer } from "layers/image_layer";
 
 export { ImageSeriesLayer } from "layers/image_series_layer";
 
+export { ResponsiveImageLayer } from "layers/responsive_image_layer";
+
 export { OmeZarrImageSource } from "data/ome_zarr_image_source";
 
 export { WebGLRenderer } from "renderers/webgl_renderer";

--- a/src/layers/responsive_image_layer.ts
+++ b/src/layers/responsive_image_layer.ts
@@ -16,7 +16,11 @@ export class ResponsiveImageLayer extends Layer {
   private readonly region_: Region;
   private readonly camera_: OrthographicCamera;
 
-  constructor(source: ImageChunkSource, region: Region, camera: OrthographicCamera) {
+  constructor(
+    source: ImageChunkSource,
+    region: Region,
+    camera: OrthographicCamera
+  ) {
     super();
     this.setState("initialized");
     this.source_ = source;
@@ -39,14 +43,19 @@ export class ResponsiveImageLayer extends Layer {
     }
   }
 
-  private async getXYDimensionNames(): Promise<{ xName: string, yName: string }> {
+  private async getXYDimensionNames(): Promise<{
+    xName: string;
+    yName: string;
+  }> {
     const loader = await this.source_.open();
     const shape = await loader.getShape(this.region_);
     // y (height) is the first non-unit axis
     // x (width) is the second non-unit axis
     const yIndex = shape.findIndex((axis) => axis.length > 1);
     const yName = shape[yIndex].axis;
-    const xIndex = shape.findIndex((axis, i) => i !== yIndex && axis.length > 1);
+    const xIndex = shape.findIndex(
+      (axis, i) => i !== yIndex && axis.length > 1
+    );
     const xName = shape[xIndex].axis;
     return { xName, yName };
   }
@@ -105,7 +114,12 @@ export class ResponsiveImageLayer extends Layer {
     const xIndex = shape.findIndex((axis) => axis.axis === xName);
     const yIndex = shape.findIndex((axis) => axis.axis === yName);
     console.debug("got shape", shape);
-    const plane = new PlaneGeometry(shape[xIndex].length, shape[yIndex].length, 1, 1);
+    const plane = new PlaneGeometry(
+      shape[xIndex].length,
+      shape[yIndex].length,
+      1,
+      1
+    );
 
     const cameraRegion = await this.getCameraRegion();
     console.debug("loading chunk with region", cameraRegion);
@@ -113,7 +127,6 @@ export class ResponsiveImageLayer extends Layer {
     console.debug("got chunk", chunk);
     const texture = new DataTexture2D(chunk.data, chunk.shape.x, chunk.shape.y);
     texture.scaleRST = vec3.fromValues(1.0, 1.0, 1.0);
-
 
     texture.dataFormat = "red_integer";
     if (chunk.data instanceof Uint16Array) {

--- a/src/layers/responsive_image_layer.ts
+++ b/src/layers/responsive_image_layer.ts
@@ -1,0 +1,134 @@
+import { vec3 } from "gl-matrix";
+
+import { Layer } from "core/layer";
+import { Mesh } from "objects/renderable/mesh";
+import { PlaneGeometry } from "objects/geometry/plane_geometry";
+import { Region } from "data/region";
+import { ImageChunkSource } from "data/image_chunk";
+import { DataTexture2D } from "objects/textures/data_texture_2d";
+import { OrthographicCamera } from "objects/cameras/orthographic_camera";
+
+// Loads data from an image source into renderable objects.
+export class ResponsiveImageLayer extends Layer {
+  private readonly source_: ImageChunkSource;
+  // TODO: remove this when region is passed through to update.
+  // https://github.com/chanzuckerberg/imaging-active-learning/issues/33
+  private readonly region_: Region;
+  private readonly camera_: OrthographicCamera;
+
+  constructor(source: ImageChunkSource, region: Region, camera: OrthographicCamera) {
+    super();
+    this.setState("initialized");
+    this.source_ = source;
+    this.region_ = region;
+    this.camera_ = camera;
+  }
+
+  public update(): void {
+    switch (this.state) {
+      case "initialized":
+        this.load(this.region_);
+        break;
+      case "loading":
+      case "ready":
+        break;
+      default: {
+        const exhaustiveCheck: never = this.state;
+        throw new Error(`Unhandled LayerState case: ${exhaustiveCheck}`);
+      }
+    }
+  }
+
+  private async getXYDimensionNames(): Promise<{ xName: string, yName: string }> {
+    const loader = await this.source_.open();
+    const shape = await loader.getShape(this.region_);
+    // y (height) is the first non-unit axis
+    // x (width) is the second non-unit axis
+    const yIndex = shape.findIndex((axis) => axis.length > 1);
+    const yName = shape[yIndex].axis;
+    const xIndex = shape.findIndex((axis, i) => i !== yIndex && axis.length > 1);
+    const xName = shape[xIndex].axis;
+    return { xName, yName };
+  }
+
+  private async getCameraRegion(): Promise<Region> {
+    const loader = await this.source_.open();
+    const shape = await loader.getShape(this.region_, 0);
+
+    const cameraRegion = [...this.region_];
+    const { left, right, bottom, top } = this.camera_.viewportFrame;
+    const { xName, yName } = await this.getXYDimensionNames();
+
+    const yShape = shape.find((axis) => axis.axis === yName);
+    if (!yShape) {
+      throw new Error(`Axis ${yName} not found in shape ${shape}`);
+    }
+    const yStart = Math.max(top, 0);
+    const yStop = Math.min(bottom, yShape.length);
+
+    const yInterval = { start: yStart, stop: yStop };
+
+    const xShape = shape.find((axis) => axis.axis === xName);
+    if (!xShape) {
+      throw new Error(`Axis ${xName} not found in shape ${shape}`);
+    }
+    const xStart = Math.max(left, 0);
+    const xStop = Math.min(right, xShape.length);
+    const xInterval = { start: xStart, stop: xStop };
+
+    const yIndex = this.region_.findIndex((index) => index.dimension === yName);
+    if (yIndex != -1) {
+      cameraRegion[yIndex].index = yInterval;
+    } else {
+      cameraRegion.push({ dimension: yName, index: yInterval });
+    }
+
+    const xIndex = this.region_.findIndex((index) => index.dimension === xName);
+    if (xIndex != -1) {
+      cameraRegion[xIndex].index = xInterval;
+    } else {
+      cameraRegion.push({ dimension: xName, index: xInterval });
+    }
+
+    return cameraRegion;
+  }
+
+  private async load(region: Region) {
+    this.clearObjects();
+    if (this.state !== "initialized") {
+      throw new Error(`Trying to load chunks more than once.`);
+    }
+    this.setState("loading");
+    const loader = await this.source_.open();
+    const shape = await loader.getShape(region);
+    const { xName, yName } = await this.getXYDimensionNames();
+    const xIndex = shape.findIndex((axis) => axis.axis === xName);
+    const yIndex = shape.findIndex((axis) => axis.axis === yName);
+    console.debug("got shape", shape);
+    const plane = new PlaneGeometry(shape[xIndex].length, shape[yIndex].length, 1, 1);
+
+    const cameraRegion = await this.getCameraRegion();
+    console.debug("loading chunk with region", cameraRegion);
+    const chunk = await loader.loadChunk(cameraRegion, undefined, 0);
+    console.debug("got chunk", chunk);
+    const texture = new DataTexture2D(chunk.data, chunk.shape.x, chunk.shape.y);
+    texture.scaleRST = vec3.fromValues(1.0, 1.0, 1.0);
+
+
+    texture.dataFormat = "red_integer";
+    if (chunk.data instanceof Uint16Array) {
+      texture.dataType = "unsigned_short";
+    }
+
+    texture.unpackRowLength = chunk.rowStride;
+    texture.unpackAlignment = chunk.rowAlignmentBytes;
+
+    this.addObject(new Mesh(plane, texture));
+    this.setState("ready");
+  }
+
+  public onCameraFrameChange() {
+    this.setState("initialized");
+    this.update();
+  }
+}

--- a/src/layers/responsive_image_layer.ts
+++ b/src/layers/responsive_image_layer.ts
@@ -3,10 +3,11 @@ import { vec3 } from "gl-matrix";
 import { Layer } from "core/layer";
 import { Mesh } from "objects/renderable/mesh";
 import { PlaneGeometry } from "objects/geometry/plane_geometry";
-import { Region } from "data/region";
+import { Interval, Region } from "data/region";
 import { ImageChunkSource } from "data/image_chunk";
 import { DataTexture2D } from "objects/textures/data_texture_2d";
 import { OrthographicCamera } from "objects/cameras/orthographic_camera";
+import { Renderer } from "core/renderer";
 
 // Loads data from an image source into renderable objects.
 export class ResponsiveImageLayer extends Layer {
@@ -15,20 +16,29 @@ export class ResponsiveImageLayer extends Layer {
   // https://github.com/chanzuckerberg/imaging-active-learning/issues/33
   private readonly region_: Region;
   private readonly camera_: OrthographicCamera;
+  private readonly renderer_: Renderer;
+
+  private mesh_: Mesh | null = null;
 
   constructor(
     source: ImageChunkSource,
     region: Region,
-    camera: OrthographicCamera
+    camera: OrthographicCamera,
+    renderer: Renderer
   ) {
     super();
     this.setState("initialized");
     this.source_ = source;
     this.region_ = region;
     this.camera_ = camera;
+    this.renderer_ = renderer;
   }
 
-  public update(): void {
+  public update(force: boolean = false): void {
+    if (force) {
+      this.load(this.region_);
+      return;
+    }
     switch (this.state) {
       case "initialized":
         this.load(this.region_);
@@ -81,22 +91,46 @@ export class ResponsiveImageLayer extends Layer {
   }
 
   private async load(region: Region) {
-    this.clearObjects();
-    if (this.state !== "initialized") {
-      throw new Error(`Trying to load chunks more than once.`);
+    // if (this.state !== "initialized") {
+    //   throw new Error(`Trying to load chunks more than once.`);
+    // }
+    if (!this.mesh_) {
+      this.setState("loading");
     }
-    this.setState("loading");
     const loader = await this.source_.open();
     const { shape } = await loader.getChunkAttributes(region, 0);
     const plane = new PlaneGeometry(shape.x, shape.y, 1, 1);
 
     const cameraRegion = await this.getCameraRegion();
-    const chunk = await loader.loadChunk(cameraRegion, undefined, 0);
+    const cameraYInterval = cameraRegion[cameraRegion.length - 2]
+      .index as Interval;
+    const cameraYLength = cameraYInterval.stop - cameraYInterval.start;
+    const cameraXInterval = cameraRegion[cameraRegion.length - 1]
+      .index as Interval;
+    const cameraXLength = cameraXInterval.stop - cameraXInterval.start;
+
+    const { left, right, bottom, top } = this.camera_.viewportFrame;
+    const screenWidth = (this.renderer_.width * cameraXLength) / (right - left);
+    const screenHeight =
+      (this.renderer_.height * cameraYLength) / (bottom - top);
+
+    let scaleToFetch = loader.numScales - 1;
+    for (let i = scaleToFetch; i >= 0; i--) {
+      const { shape } = await loader.getChunkAttributes(cameraRegion, i);
+      scaleToFetch = i;
+      if (shape.x > screenWidth && shape.y > screenHeight) {
+        break;
+      }
+    }
+    console.log("SCALE TO FETCH", scaleToFetch);
+    const chunk = await loader.loadChunk(cameraRegion, undefined, scaleToFetch);
+    console.log("LOADED CHUNK", chunk);
+
     const texture = new DataTexture2D(chunk.data, chunk.shape.x, chunk.shape.y);
 
     texture.scaleRST = vec3.fromValues(
-      shape.x / chunk.shape.x,
-      shape.y / chunk.shape.y,
+      shape.x / chunk.shape.x / chunk.scale.x,
+      shape.y / chunk.shape.y / chunk.scale.y,
       1.0
     );
     texture.offsetRST = vec3.fromValues(
@@ -116,12 +150,19 @@ export class ResponsiveImageLayer extends Layer {
     texture.unpackRowLength = chunk.rowStride;
     texture.unpackAlignment = chunk.rowAlignmentBytes;
 
-    this.addObject(new Mesh(plane, texture));
+    if (!this.mesh_) {
+      this.mesh_ = new Mesh(plane, texture);
+      this.addObject(this.mesh_);
+    } else {
+      console.log("UPDATING TEXTURE");
+      this.mesh_.textures.pop();
+      this.mesh_.textures.push(texture);
+    }
+
     this.setState("ready");
   }
 
   public onCameraFrameChange() {
-    this.setState("initialized");
-    this.update();
+    this.update(true);
   }
 }

--- a/src/layers/responsive_image_layer.ts
+++ b/src/layers/responsive_image_layer.ts
@@ -43,60 +43,38 @@ export class ResponsiveImageLayer extends Layer {
     }
   }
 
-  private async getXYDimensionNames(): Promise<{
-    xName: string;
-    yName: string;
-  }> {
-    const loader = await this.source_.open();
-    const shape = await loader.getShape(this.region_);
-    // y (height) is the first non-unit axis
-    // x (width) is the second non-unit axis
-    const yIndex = shape.findIndex((axis) => axis.length > 1);
-    const yName = shape[yIndex].axis;
-    const xIndex = shape.findIndex(
-      (axis, i) => i !== yIndex && axis.length > 1
-    );
-    const xName = shape[xIndex].axis;
-    return { xName, yName };
-  }
-
   private async getCameraRegion(): Promise<Region> {
     const loader = await this.source_.open();
-    const shape = await loader.getShape(this.region_, 0);
+    const { shape, name } = await loader.getChunkAttributes(this.region_, 0);
+    console.debug("got shape", shape, name);
 
     const cameraRegion = [...this.region_];
     const { left, right, bottom, top } = this.camera_.viewportFrame;
-    const { xName, yName } = await this.getXYDimensionNames();
-
-    const yShape = shape.find((axis) => axis.axis === yName);
-    if (!yShape) {
-      throw new Error(`Axis ${yName} not found in shape ${shape}`);
-    }
     const yStart = Math.max(top, 0);
-    const yStop = Math.min(bottom, yShape.length);
+    const yStop = Math.min(bottom, shape.y);
 
     const yInterval = { start: yStart, stop: yStop };
 
-    const xShape = shape.find((axis) => axis.axis === xName);
-    if (!xShape) {
-      throw new Error(`Axis ${xName} not found in shape ${shape}`);
-    }
     const xStart = Math.max(left, 0);
-    const xStop = Math.min(right, xShape.length);
+    const xStop = Math.min(right, shape.x);
     const xInterval = { start: xStart, stop: xStop };
 
-    const yIndex = this.region_.findIndex((index) => index.dimension === yName);
+    const yIndex = this.region_.findIndex(
+      (index) => index.dimension === name.y
+    );
     if (yIndex != -1) {
       cameraRegion[yIndex].index = yInterval;
     } else {
-      cameraRegion.push({ dimension: yName, index: yInterval });
+      cameraRegion.push({ dimension: name.y, index: yInterval });
     }
 
-    const xIndex = this.region_.findIndex((index) => index.dimension === xName);
+    const xIndex = this.region_.findIndex(
+      (index) => index.dimension === name.x
+    );
     if (xIndex != -1) {
       cameraRegion[xIndex].index = xInterval;
     } else {
-      cameraRegion.push({ dimension: xName, index: xInterval });
+      cameraRegion.push({ dimension: name.x, index: xInterval });
     }
 
     return cameraRegion;
@@ -109,24 +87,26 @@ export class ResponsiveImageLayer extends Layer {
     }
     this.setState("loading");
     const loader = await this.source_.open();
-    const shape = await loader.getShape(region);
-    const { xName, yName } = await this.getXYDimensionNames();
-    const xIndex = shape.findIndex((axis) => axis.axis === xName);
-    const yIndex = shape.findIndex((axis) => axis.axis === yName);
-    console.debug("got shape", shape);
-    const plane = new PlaneGeometry(
-      shape[xIndex].length,
-      shape[yIndex].length,
-      1,
-      1
-    );
+    const { shape } = await loader.getChunkAttributes(region, 0);
+    const plane = new PlaneGeometry(shape.x, shape.y, 1, 1);
 
     const cameraRegion = await this.getCameraRegion();
-    console.debug("loading chunk with region", cameraRegion);
     const chunk = await loader.loadChunk(cameraRegion, undefined, 0);
-    console.debug("got chunk", chunk);
     const texture = new DataTexture2D(chunk.data, chunk.shape.x, chunk.shape.y);
-    texture.scaleRST = vec3.fromValues(1.0, 1.0, 1.0);
+
+    texture.scaleRST = vec3.fromValues(
+      shape.x / chunk.shape.x,
+      shape.y / chunk.shape.y,
+      1.0
+    );
+    texture.offsetRST = vec3.fromValues(
+      chunk.offset.x / shape.x,
+      chunk.offset.y / shape.y,
+      0.0
+    );
+    // easier to see unloaded regions for debugging
+    texture.wrapS = "clamp_to_edge";
+    texture.wrapT = "clamp_to_edge";
 
     texture.dataFormat = "red_integer";
     if (chunk.data instanceof Uint16Array) {

--- a/src/layers/responsive_image_layer.ts
+++ b/src/layers/responsive_image_layer.ts
@@ -1,4 +1,4 @@
-import { vec3 } from "gl-matrix";
+import { vec2 } from "gl-matrix";
 
 import { Layer } from "core/layer";
 import { Mesh } from "objects/renderable/mesh";
@@ -99,6 +99,7 @@ export class ResponsiveImageLayer extends Layer {
     }
     const loader = await this.source_.open();
     const { shape } = await loader.getChunkAttributes(region, 0);
+    // TODO: account for scale here as well
     const plane = new PlaneGeometry(shape.x, shape.y, 1, 1);
 
     const cameraRegion = await this.getCameraRegion();
@@ -128,15 +129,14 @@ export class ResponsiveImageLayer extends Layer {
 
     const texture = new DataTexture2D(chunk.data, chunk.shape.x, chunk.shape.y);
 
-    texture.scaleRST = vec3.fromValues(
+    // TODO: account for plane scale here as well
+    texture.scaleST = vec2.fromValues(
       shape.x / chunk.shape.x / chunk.scale.x,
-      shape.y / chunk.shape.y / chunk.scale.y,
-      1.0
+      shape.y / chunk.shape.y / chunk.scale.y
     );
-    texture.offsetRST = vec3.fromValues(
+    texture.offsetST = vec2.fromValues(
       chunk.offset.x / shape.x,
-      chunk.offset.y / shape.y,
-      0.0
+      chunk.offset.y / shape.y
     );
     // easier to see unloaded regions for debugging
     texture.wrapS = "clamp_to_edge";

--- a/src/objects/cameras/orthographic_camera.ts
+++ b/src/objects/cameras/orthographic_camera.ts
@@ -8,8 +8,7 @@ export class OrthographicCamera extends Camera {
 
   constructor(
     left: number,
-    right: number,
-    top: number,
+    right: number, top: number,
     bottom: number,
     near = 0,
     far = 100.0
@@ -49,6 +48,22 @@ export class OrthographicCamera extends Camera {
   }
 
   protected updateProjectionMatrix() {
+    const { left, right, bottom, top } = this.viewportFrame;
+    const viewportHalfWidth = 0.5 * (right - left);
+    const viewportHalfHeight = 0.5 * (bottom - top);
+    // Center the camera frame in the padded viewport frame.
+    mat4.ortho(
+      this.projectionMatrix_,
+      -viewportHalfWidth,
+      viewportHalfWidth,
+      -viewportHalfHeight,
+      viewportHalfHeight,
+      this.near_,
+      this.far_
+    );
+  }
+
+  public get viewportFrame(): { left: number; right: number; bottom: number; top: number } {
     // The following code ensures that the orthographic projection matrix
     // is updated so that the aspect ratio of renderable objects is respected
     // (e.g. image pixels are isotropic) by padding the camera frame to form
@@ -66,15 +81,12 @@ export class OrthographicCamera extends Camera {
     } else {
       viewportHalfHeight *= frameAspectRatio / this.viewportAspectRatio_;
     }
-    // Center the camera frame in the padded viewport frame.
-    mat4.ortho(
-      this.projectionMatrix_,
-      -viewportHalfWidth,
-      viewportHalfWidth,
-      -viewportHalfHeight,
-      viewportHalfHeight,
-      this.near_,
-      this.far_
-    );
+    const center = this.transform.translation;
+    return {
+      left: center[0] - viewportHalfWidth,
+      right: center[0] + viewportHalfWidth,
+      bottom: center[1] + viewportHalfHeight,
+      top: center[1] - viewportHalfHeight,
+    };
   }
 }

--- a/src/objects/cameras/orthographic_camera.ts
+++ b/src/objects/cameras/orthographic_camera.ts
@@ -8,7 +8,8 @@ export class OrthographicCamera extends Camera {
 
   constructor(
     left: number,
-    right: number, top: number,
+    right: number,
+    top: number,
     bottom: number,
     near = 0,
     far = 100.0
@@ -63,7 +64,12 @@ export class OrthographicCamera extends Camera {
     );
   }
 
-  public get viewportFrame(): { left: number; right: number; bottom: number; top: number } {
+  public get viewportFrame(): {
+    left: number;
+    right: number;
+    bottom: number;
+    top: number;
+  } {
     // The following code ensures that the orthographic projection matrix
     // is updated so that the aspect ratio of renderable objects is respected
     // (e.g. image pixels are isotropic) by padding the camera frame to form

--- a/src/objects/textures/data_texture_2d.ts
+++ b/src/objects/textures/data_texture_2d.ts
@@ -1,9 +1,13 @@
 import { Texture } from "objects/textures/texture";
+import { vec2 } from "gl-matrix";
 
 export class DataTexture2D extends Texture {
   private data_: ArrayBufferView;
   private readonly width_: number;
   private readonly height_: number;
+
+  public offsetST = vec2.fromValues(0, 0);
+  public scaleST = vec2.fromValues(1, 1);
 
   constructor(data: ArrayBufferView, width: number, height: number) {
     super();

--- a/src/objects/textures/texture.ts
+++ b/src/objects/textures/texture.ts
@@ -1,4 +1,5 @@
 import { Node } from "core/node";
+import { vec3 } from "gl-matrix";
 
 export type TextureFilter = "nearest" | "linear";
 
@@ -28,6 +29,9 @@ export abstract class Texture extends Node {
   public wrapS: TextureWrapMode = "repeat";
   public wrapT: TextureWrapMode = "repeat";
   public needsUpdate = true;
+
+  public offsetRST = vec3.fromValues(0, 0, 0);
+  public scaleRST = vec3.fromValues(1, 1, 1);
 
   public abstract get width(): number;
   public abstract get height(): number;

--- a/src/objects/textures/texture.ts
+++ b/src/objects/textures/texture.ts
@@ -1,5 +1,4 @@
 import { Node } from "core/node";
-import { vec3 } from "gl-matrix";
 
 export type TextureFilter = "nearest" | "linear";
 
@@ -29,9 +28,6 @@ export abstract class Texture extends Node {
   public wrapS: TextureWrapMode = "repeat";
   public wrapT: TextureWrapMode = "repeat";
   public needsUpdate = true;
-
-  public offsetRST = vec3.fromValues(0, 0, 0);
-  public scaleRST = vec3.fromValues(1, 1, 1);
 
   public abstract get width(): number;
   public abstract get height(): number;

--- a/src/renderers/shaders/uint_image_frag.glsl
+++ b/src/renderers/shaders/uint_image_frag.glsl
@@ -14,7 +14,8 @@ void main() {
     // TODO: normalization of the value should be controlled by variable
     // parameters (e.g. contrast limits).
     // https://github.com/chanzuckerberg/imaging-active-learning/issues/32
-    vec2 texCoords = TexCoords * scaleRST.xy + offsetRST.xy;
+    // vec2 texCoords = TexCoords * scaleRST.xy + offsetRST.xy;
+    vec2 texCoords = (TexCoords - offsetRST.xy) * scaleRST.xy;
     float value = float(texture(texture0, texCoords).r) / 256.0;
     fragColor = vec4(value, value, value, 1);
 }

--- a/src/renderers/shaders/uint_image_frag.glsl
+++ b/src/renderers/shaders/uint_image_frag.glsl
@@ -18,4 +18,9 @@ void main() {
     vec2 texCoords = (TexCoords - offsetRST.xy) * scaleRST.xy;
     float value = float(texture(texture0, texCoords).r) / 256.0;
     fragColor = vec4(value, value, value, 1);
+    if (texCoords.x < 0.0 || texCoords.x > 1.0 || texCoords.y < 0.0 || texCoords.y > 1.0) {
+        fragColor = vec4(0.25, 0.0, 0.25, 1.0);
+    } else {
+        fragColor = vec4(value, value, value, 1.0);
+    }
 }

--- a/src/renderers/shaders/uint_image_frag.glsl
+++ b/src/renderers/shaders/uint_image_frag.glsl
@@ -5,8 +5,8 @@ precision mediump float;
 layout (location = 0) out vec4 fragColor;
 
 uniform mediump usampler2D texture0;
-uniform vec3 offsetRST;
-uniform vec3 scaleRST;
+uniform vec2 offsetST;
+uniform vec2 scaleST;
 
 in vec2 TexCoords;
 
@@ -14,8 +14,8 @@ void main() {
     // TODO: normalization of the value should be controlled by variable
     // parameters (e.g. contrast limits).
     // https://github.com/chanzuckerberg/imaging-active-learning/issues/32
-    // vec2 texCoords = TexCoords * scaleRST.xy + offsetRST.xy;
-    vec2 texCoords = (TexCoords - offsetRST.xy) * scaleRST.xy;
+    // offset and scale for partial/multiscale texture
+    vec2 texCoords = (TexCoords - offsetST.st) * scaleST.st;
     float value = float(texture(texture0, texCoords).r) / 256.0;
     fragColor = vec4(value, value, value, 1);
     if (texCoords.x < 0.0 || texCoords.x > 1.0 || texCoords.y < 0.0 || texCoords.y > 1.0) {

--- a/src/renderers/shaders/uint_image_frag.glsl
+++ b/src/renderers/shaders/uint_image_frag.glsl
@@ -5,6 +5,8 @@ precision mediump float;
 layout (location = 0) out vec4 fragColor;
 
 uniform mediump usampler2D texture0;
+uniform vec3 offsetRST;
+uniform vec3 scaleRST;
 
 in vec2 TexCoords;
 
@@ -12,6 +14,7 @@ void main() {
     // TODO: normalization of the value should be controlled by variable
     // parameters (e.g. contrast limits).
     // https://github.com/chanzuckerberg/imaging-active-learning/issues/32
-    float value = float(texture(texture0, TexCoords).r) / 256.0;
+    vec2 texCoords = TexCoords * scaleRST.xy + offsetRST.xy;
+    float value = float(texture(texture0, texCoords).r) / 256.0;
     fragColor = vec4(value, value, value, 1);
 }

--- a/src/renderers/webgl_renderer.ts
+++ b/src/renderers/webgl_renderer.ts
@@ -5,6 +5,7 @@ import { WebGLShaderProgram } from "./webgl_shader_program";
 import { Shader, shaderCode } from "./shaders";
 import { WebGLBuffers } from "./webgl_buffers";
 import { WebGLTextures } from "./webgl_textures";
+import { DataTexture2D } from "objects/textures/data_texture_2d";
 import { ProjectedLine } from "objects/renderable/projected_line";
 
 import { mat4 } from "gl-matrix";
@@ -79,9 +80,12 @@ export class WebGLRenderer extends Renderer {
       // We temporarily assume this array holds a single texture. We'll need to
       // modify this logic to support multiple textures in the future.
       this.textures_.bind(object.textures[0]);
-      // TODO: shaders do not all support partial/multiscale textures
-      program.setUniform("offsetST", object.textures[0].offsetST);
-      program.setUniform("scaleST", object.textures[0].scaleST);
+      if (object.textures[0].type === "DataTexture2D") {
+        // TODO: ideally don't branch on texture type here!
+        const texture = object.textures[0] as DataTexture2D;
+        program.setUniform("offsetST", texture.offsetST);
+        program.setUniform("scaleST", texture.scaleST);
+      }
     }
 
     // TODO: Move 'type' property to RenderableObject

--- a/src/renderers/webgl_renderer.ts
+++ b/src/renderers/webgl_renderer.ts
@@ -79,8 +79,9 @@ export class WebGLRenderer extends Renderer {
       // We temporarily assume this array holds a single texture. We'll need to
       // modify this logic to support multiple textures in the future.
       this.textures_.bind(object.textures[0]);
-      program.setUniform("offsetRST", object.textures[0].offsetRST);
-      program.setUniform("scaleRST", object.textures[0].scaleRST);
+      // TODO: shaders do not all support partial/multiscale textures
+      program.setUniform("offsetST", object.textures[0].offsetST);
+      program.setUniform("scaleST", object.textures[0].scaleST);
     }
 
     // TODO: Move 'type' property to RenderableObject

--- a/src/renderers/webgl_renderer.ts
+++ b/src/renderers/webgl_renderer.ts
@@ -79,6 +79,8 @@ export class WebGLRenderer extends Renderer {
       // We temporarily assume this array holds a single texture. We'll need to
       // modify this logic to support multiple textures in the future.
       this.textures_.bind(object.textures[0]);
+      program.setUniform("offsetRST", object.textures[0].offsetRST);
+      program.setUniform("scaleRST", object.textures[0].scaleRST);
     }
 
     // TODO: Move 'type' property to RenderableObject

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ES2023",
     "useDefineForClassFields": true,
     "module": "ESNext",
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
     "skipLibCheck": true,
     "baseUrl": "./src",
     "paths": {


### PR DESCRIPTION
### Summary
This is still pretty experimental and very messy, but seems to work as a POC for the specific case at least.

Right now this:
* connect the layer and camera, so the layer can know what the size/extent of the viewport is ( currently requires a keypress, more for debugging purposes)
* decouples the size of the geometry and texture for `Mesh` visual
* adds offset and scale uniforms for the 2D image texture (DataTexture2D) to describe its coverage of the geometry
* chooses the scale to load based on the size of the rendered object in screen space (pixels)