### PR TITLE
Add support for loading and rendering float32 data

### DIFF
--- a/examples/image2d_from_omezarr3d_f32/index.html
+++ b/examples/image2d_from_omezarr3d_f32/index.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Web Viewer</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        display: flex;
+        width: 100%;
+        height: 100%;
+      }
+      #canvas {
+        width: 100%;
+        height: 100%;
+      }
+    </style>
+  </head>
+  <body>
+    <canvas id="canvas"></canvas>
+    <script type="module" src="./main.ts"></script>
+  </body>
+</html>

--- a/examples/image2d_from_omezarr3d_f32/main.ts
+++ b/examples/image2d_from_omezarr3d_f32/main.ts
@@ -12,10 +12,15 @@ const url =
 const pixelScale = 4.99;
 const layerManager = new LayerManager();
 const renderer = new WebGLRenderer("#canvas");
-const camera = new OrthographicCamera(0, pixelScale * 1264, 0, pixelScale * 1264);
+const camera = new OrthographicCamera(
+  0,
+  pixelScale * 1264,
+  0,
+  pixelScale * 1264
+);
 const controls = new PanZoomControls(camera, camera.position);
 renderer.setControls(controls);
-const region = [{ dimension: "z", index: pixelScale * 120}];
+const region = [{ dimension: "z", index: pixelScale * 120 }];
 
 const source = new OmeZarrImageSource(url);
 const layer = new ImageLayer(source, region);

--- a/examples/image2d_from_omezarr3d_f32/main.ts
+++ b/examples/image2d_from_omezarr3d_f32/main.ts
@@ -1,0 +1,28 @@
+import {
+  LayerManager,
+  ImageLayer,
+  OrthographicCamera,
+  WebGLRenderer,
+  OmeZarrImageSource,
+} from "@";
+import { PanZoomControls } from "@/objects/cameras/controls";
+
+const url =
+  "https://files.cryoetdataportal.cziscience.com/10444/24apr23a_Position_12/Reconstructions/VoxelSpacing4.990/Tomograms/100/24apr23a_Position_12.zarr";
+const layerManager = new LayerManager();
+const renderer = new WebGLRenderer("#canvas");
+const camera = new OrthographicCamera(0, 19.96 * 316, 0, 19.96 * 316);
+const controls = new PanZoomControls(camera, camera.position);
+renderer.setControls(controls);
+const region = [{ dimension: "z", index: 0.5 * 19.96 * 93 }];
+
+const source = new OmeZarrImageSource(url);
+const layer = new ImageLayer(source, region);
+layerManager.add(layer);
+
+function animate() {
+  renderer.render(layerManager, camera);
+  requestAnimationFrame(animate);
+}
+
+animate();

--- a/examples/image2d_from_omezarr3d_f32/main.ts
+++ b/examples/image2d_from_omezarr3d_f32/main.ts
@@ -9,12 +9,13 @@ import { PanZoomControls } from "@/objects/cameras/controls";
 
 const url =
   "https://files.cryoetdataportal.cziscience.com/10444/24apr23a_Position_12/Reconstructions/VoxelSpacing4.990/Tomograms/100/24apr23a_Position_12.zarr";
+const pixelScale = 4.99;
 const layerManager = new LayerManager();
 const renderer = new WebGLRenderer("#canvas");
-const camera = new OrthographicCamera(0, 19.96 * 316, 0, 19.96 * 316);
+const camera = new OrthographicCamera(0, pixelScale * 1264, 0, pixelScale * 1264);
 const controls = new PanZoomControls(camera, camera.position);
 renderer.setControls(controls);
-const region = [{ dimension: "z", index: 0.5 * 19.96 * 93 }];
+const region = [{ dimension: "z", index: pixelScale * 0.5 * 370}];
 
 const source = new OmeZarrImageSource(url);
 const layer = new ImageLayer(source, region);

--- a/examples/image2d_from_omezarr3d_f32/main.ts
+++ b/examples/image2d_from_omezarr3d_f32/main.ts
@@ -15,7 +15,7 @@ const renderer = new WebGLRenderer("#canvas");
 const camera = new OrthographicCamera(0, pixelScale * 1264, 0, pixelScale * 1264);
 const controls = new PanZoomControls(camera, camera.position);
 renderer.setControls(controls);
-const region = [{ dimension: "z", index: pixelScale * 0.5 * 370}];
+const region = [{ dimension: "z", index: pixelScale * 120}];
 
 const source = new OmeZarrImageSource(url);
 const layer = new ImageLayer(source, region);

--- a/examples/index.html
+++ b/examples/index.html
@@ -37,6 +37,11 @@
           >2D Image from 5D OMEZarr with uint16 data</a
         >
       </li>
+      <li>
+        <a href="/image2d_from_omezarr3d_f32/index.html"
+          >2D Image from 3D OMEZarr with float32 data</a
+        >
+      </li>
       <li><a href="/single_mesh_layer/index.html">Single Mesh Layer</a></li>
       <li><a href="/projected_lines/index.html">Projected Lines</a></li>
       <li><a href="/tracks/index.html">Tracks on Image</a></li>

--- a/src/data/image_chunk.ts
+++ b/src/data/image_chunk.ts
@@ -6,7 +6,7 @@ import { PromiseScheduler } from "./promise_scheduler";
 // TODO: include the region of this chunk.
 // https://github.com/chanzuckerberg/imaging-active-learning/issues/34
 export type ImageChunk = {
-  data: Uint8Array | Uint16Array;
+  data: Uint8Array | Uint16Array | Float32Array;
   shape: {
     x: number;
     y: number;

--- a/src/data/ome_zarr_image_loader.ts
+++ b/src/data/ome_zarr_image_loader.ts
@@ -33,7 +33,7 @@ type Multiscale = {
   datasets: Array<Dataset>;
 };
 
-const dataTypes = [Uint8Array, Uint16Array] as const;
+const dataTypes = [Uint8Array, Uint16Array, Float32Array] as const;
 const dataTypeNames = dataTypes.map((DataType) => DataType.name);
 type DataType = InstanceType<(typeof dataTypes)[number]>;
 

--- a/src/layers/image_utils.ts
+++ b/src/layers/image_utils.ts
@@ -21,6 +21,9 @@ function updateImageTexture(texture: Texture, chunk: ImageChunk) {
   texture.dataFormat = "red_integer";
   if (chunk.data instanceof Uint16Array) {
     texture.dataType = "unsigned_short";
+  } else if (chunk.data instanceof Float32Array) {
+    texture.dataType = "float";
+    texture.dataFormat = "red";
   }
   texture.unpackRowLength = chunk.rowStride;
   texture.unpackAlignment = chunk.rowAlignmentBytes;

--- a/src/layers/image_utils.ts
+++ b/src/layers/image_utils.ts
@@ -1,6 +1,6 @@
-import { DataTexture2D } from "@/objects/textures/data_texture_2d";
+import { DataTexture2D } from "objects/textures/data_texture_2d";
 import { Texture } from "objects/textures/texture";
-import { Texture2DArray } from "@/objects/textures/texture_2d_array";
+import { Texture2DArray } from "objects/textures/texture_2d_array";
 import { ImageChunk } from "data/image_chunk";
 import { PlaneGeometry } from "objects/geometry/plane_geometry";
 import { Mesh } from "objects/renderable/mesh";
@@ -18,16 +18,16 @@ export function makeImageTextureArray(chunk: ImageChunk) {
 }
 
 function updateImageTexture(texture: Texture, chunk: ImageChunk) {
-  texture.dataFormat = "red_integer";
-  if (chunk.data instanceof Uint16Array) {
+  texture.dataFormat = "scalar";
+  if (chunk.data instanceof Uint8Array) {
+    texture.dataType = "unsigned_byte";
+  } else if (chunk.data instanceof Uint16Array) {
     texture.dataType = "unsigned_short";
   } else if (chunk.data instanceof Float32Array) {
     texture.dataType = "float";
-    texture.dataFormat = "red";
   }
   texture.unpackRowLength = chunk.rowStride;
   texture.unpackAlignment = chunk.rowAlignmentBytes;
-  return texture;
 }
 
 export function makeImageMesh(chunk: ImageChunk, texture: Texture) {

--- a/src/objects/textures/texture.ts
+++ b/src/objects/textures/texture.ts
@@ -4,9 +4,9 @@ export type TextureFilter = "nearest" | "linear";
 
 export type TextureWrapMode = "repeat" | "clamp_to_edge";
 
-export type TextureDataFormat = "rgb" | "rgba" | "red_integer";
+export type TextureDataFormat = "rgb" | "rgba" | "red" | "red_integer";
 
-export type TextureDataType = "unsigned_byte" | "unsigned_short";
+export type TextureDataType = "unsigned_byte" | "unsigned_short" | "float";
 
 export type TextureUnpackRowAlignment = 1 | 2 | 4 | 8;
 

--- a/src/objects/textures/texture.ts
+++ b/src/objects/textures/texture.ts
@@ -4,7 +4,7 @@ export type TextureFilter = "nearest" | "linear";
 
 export type TextureWrapMode = "repeat" | "clamp_to_edge";
 
-export type TextureDataFormat = "rgb" | "rgba" | "red" | "red_integer";
+export type TextureDataFormat = "scalar" | "rgb" | "rgba";
 
 export type TextureDataType = "unsigned_byte" | "unsigned_short" | "float";
 

--- a/src/renderers/shaders/float_image_frag.glsl
+++ b/src/renderers/shaders/float_image_frag.glsl
@@ -14,6 +14,6 @@ void main() {
     // TODO: instead normalization of the value should be controlled by
     // variable parameters (e.g. contrast limits).
     // https://github.com/chanzuckerberg/imaging-active-learning/issues/32
-    float value = 1e5 * texture(texture0, TexCoords).r;
+    float value = 2e5 * texture(texture0, TexCoords).r;
     fragColor = vec4(value, value, value, 1);
 }

--- a/src/renderers/shaders/float_image_frag.glsl
+++ b/src/renderers/shaders/float_image_frag.glsl
@@ -9,8 +9,10 @@ uniform mediump sampler2D texture0;
 in vec2 TexCoords;
 
 void main() {
-    // TODO: normalization of the value should be controlled by variable
-    // parameters (e.g. contrast limits).
+    // The scaling factor gives the float32 CryoET example data some
+    // contrast when rendered.
+    // TODO: instead normalization of the value should be controlled by
+    // variable parameters (e.g. contrast limits).
     // https://github.com/chanzuckerberg/imaging-active-learning/issues/32
     float value = 1e5 * texture(texture0, TexCoords).r;
     fragColor = vec4(value, value, value, 1);

--- a/src/renderers/shaders/float_image_frag.glsl
+++ b/src/renderers/shaders/float_image_frag.glsl
@@ -1,0 +1,17 @@
+#version 300 es
+
+precision mediump float;
+
+layout (location = 0) out vec4 fragColor;
+
+uniform mediump sampler2D texture0;
+
+in vec2 TexCoords;
+
+void main() {
+    // TODO: normalization of the value should be controlled by variable
+    // parameters (e.g. contrast limits).
+    // https://github.com/chanzuckerberg/imaging-active-learning/issues/32
+    float value = 1e5 * texture(texture0, TexCoords).r;
+    fragColor = vec4(value, value, value, 1);
+}

--- a/src/renderers/shaders/index.ts
+++ b/src/renderers/shaders/index.ts
@@ -2,10 +2,16 @@ import projectedLineVertexShader from "./projected_line_vert.glsl";
 import projectedLineFragmentShader from "./projected_line_frag.glsl";
 import meshVertexShader from "./mesh_vert.glsl";
 import meshFragmentShader from "./mesh_frag.glsl";
+import floatImageFragmentShader from "./float_image_frag.glsl";
 import uintImageFragmentShader from "./uint_image_frag.glsl";
 import uintImageArrayFragmentShader from "./uint_image_array_frag.glsl";
 
-export type Shader = "projectedLine" | "mesh" | "uintImage" | "uintImageArray";
+export type Shader =
+  | "projectedLine"
+  | "mesh"
+  | "uintImage"
+  | "uintImageArray"
+  | "floatImage";
 
 export const shaderCode: Record<Shader, { vertex: string; fragment: string }> =
   {
@@ -24,5 +30,9 @@ export const shaderCode: Record<Shader, { vertex: string; fragment: string }> =
     uintImageArray: {
       vertex: meshVertexShader,
       fragment: uintImageArrayFragmentShader,
+    },
+    floatImage: {
+      vertex: meshVertexShader,
+      fragment: floatImageFragmentShader,
     },
   };

--- a/src/renderers/webgl_renderer.ts
+++ b/src/renderers/webgl_renderer.ts
@@ -108,7 +108,10 @@ export class WebGLRenderer extends Renderer {
   private getProgramName(object: RenderableObject) {
     if (object.type === "ProjectedLine") return "projectedLine";
     if (object.textures.length > 0) {
-      if (object.textures[0].type === "DataTexture2D") return "uintImage";
+      if (object.textures[0].type === "DataTexture2D") {
+        if (object.textures[0].dataFormat == "red_integer") return "uintImage";
+        return "floatImage";
+      }
       if (object.textures[0].type === "Texture2DArray") return "uintImageArray";
     }
     return "mesh";

--- a/src/renderers/webgl_renderer.ts
+++ b/src/renderers/webgl_renderer.ts
@@ -109,8 +109,8 @@ export class WebGLRenderer extends Renderer {
     if (object.type === "ProjectedLine") return "projectedLine";
     if (object.textures.length > 0) {
       if (object.textures[0].type === "DataTexture2D") {
-        if (object.textures[0].dataFormat == "red_integer") return "uintImage";
-        return "floatImage";
+        if (object.textures[0].dataType == "float") return "floatImage";
+        return "uintImage";
       }
       if (object.textures[0].type === "Texture2DArray") return "uintImageArray";
     }

--- a/src/renderers/webgl_textures.ts
+++ b/src/renderers/webgl_textures.ts
@@ -76,13 +76,13 @@ export class WebGLTextures {
     gl.texParameteri(
       this.getGLTextureType(texture),
       gl.TEXTURE_MIN_FILTER,
-      this.getGLFilter(texture.minFilter, texture.dataFormat)
+      this.getGLFilter(texture.minFilter, texture.dataFormat, texture.dataType)
     );
 
     gl.texParameteri(
       this.getGLTextureType(texture),
       gl.TEXTURE_MAG_FILTER,
-      this.getGLFilter(texture.maxFilter, texture.dataFormat)
+      this.getGLFilter(texture.maxFilter, texture.dataFormat, texture.dataType)
     );
 
     gl.texParameteri(
@@ -142,7 +142,7 @@ export class WebGLTextures {
         offset.y,
         texture.width,
         texture.height,
-        this.getGLFormat(texture.dataFormat),
+        this.getGLFormat(texture.dataFormat, texture.dataType),
         this.getGLType(texture.dataType),
         // This function has multiple overloads. We are temporarily casting it to
         // ArrayBufferView to ensure the correct overload is called. Once we
@@ -160,7 +160,7 @@ export class WebGLTextures {
         texture.width,
         texture.height,
         texture.depth,
-        this.getGLFormat(texture.dataFormat),
+        this.getGLFormat(texture.dataFormat, texture.dataType),
         this.getGLType(texture.dataType),
         texture.data as ArrayBufferView
       );
@@ -181,8 +181,12 @@ export class WebGLTextures {
     }
   }
 
-  private getGLFilter(filter: TextureFilter, format: TextureDataFormat) {
-    if (format == "red_integer" && filter != "nearest") {
+  private getGLFilter(
+    filter: TextureFilter,
+    format: TextureDataFormat,
+    type: TextureDataType
+  ) {
+    if (format == "scalar" && type != "float" && filter != "nearest") {
       console.warn(
         "Integer values are not filterable. Using gl.NEAREST instead."
       );
@@ -217,15 +221,14 @@ export class WebGLTextures {
     }
   }
 
-  private getGLFormat(type: TextureDataFormat) {
-    switch (type) {
+  private getGLFormat(format: TextureDataFormat, type: TextureDataType) {
+    switch (format) {
       case "rgb":
         return this.gl_.RGB;
       case "rgba":
         return this.gl_.RGBA;
-      case "red":
-        return this.gl_.RED;
-      case "red_integer":
+      case "scalar":
+        if (type === "float") return this.gl_.RED;
         return this.gl_.RED_INTEGER;
     }
   }
@@ -238,11 +241,11 @@ export class WebGLTextures {
       return this.gl_.RGBA8;
     } else if (format === "rgb" && type === "unsigned_byte") {
       return this.gl_.RGB8;
-    } else if (format === "red_integer" && type === "unsigned_byte") {
+    } else if (format === "scalar" && type === "unsigned_byte") {
       return this.gl_.R8UI;
-    } else if (format === "red_integer" && type === "unsigned_short") {
+    } else if (format === "scalar" && type === "unsigned_short") {
       return this.gl_.R16UI;
-    } else if (format === "red" && type === "float") {
+    } else if (format === "scalar" && type === "float") {
       return this.gl_.R32F;
     }
     throw Error(

--- a/src/renderers/webgl_textures.ts
+++ b/src/renderers/webgl_textures.ts
@@ -212,6 +212,8 @@ export class WebGLTextures {
         return this.gl_.UNSIGNED_BYTE;
       case "unsigned_short":
         return this.gl_.UNSIGNED_SHORT;
+      case "float":
+        return this.gl_.FLOAT;
     }
   }
 
@@ -221,6 +223,8 @@ export class WebGLTextures {
         return this.gl_.RGB;
       case "rgba":
         return this.gl_.RGBA;
+      case "red":
+        return this.gl_.RED;
       case "red_integer":
         return this.gl_.RED_INTEGER;
     }
@@ -238,6 +242,8 @@ export class WebGLTextures {
       return this.gl_.R8UI;
     } else if (format === "red_integer" && type === "unsigned_short") {
       return this.gl_.R16UI;
+    } else if (format === "red" && type === "float") {
+      return this.gl_.R32F;
     }
     throw Error(
       `Unsupported data format and type combination ${format}/${type}`


### PR DESCRIPTION
### Summary
This adds support for loading a 32-bit floating point image chunk and using it as a texture. The definitions and logic follow the existing style and make no attempt to abstract the repetition and redundancy. It also adds an example that uses a CryoET OME-Zarr tomogram as a data source.

This PR does does not add support for the equivalent texture array, mostly because that would need another example and/or other tests.

### Related Issue
Closes #146

### Tests & Checks
I manually tested the new example to check consistency with napari (up to contrast limits/scaling), and also checked the existing examples continue to work as expected.
