### PR TITLE
Refactor programName to be provided by the renderable object

### DIFF
--- a/src/core/renderable_object.ts
+++ b/src/core/renderable_object.ts
@@ -3,10 +3,13 @@ import { Geometry } from "core/geometry";
 import { Texture } from "objects/textures/texture";
 import { AffineTransform } from "core/transforms";
 
+import { Shader } from "renderers/shaders";
+
 export abstract class RenderableObject extends Node {
   private geometry_ = new Geometry();
   private textures_: Texture[] = [];
   private transform_ = new AffineTransform();
+  private programName_: Shader | null = null;
 
   public addTexture(texture: Texture) {
     this.textures_.push(texture);
@@ -26,5 +29,16 @@ export abstract class RenderableObject extends Node {
 
   public set geometry(geometry: Geometry) {
     this.geometry_ = geometry;
+  }
+
+  public get programName(): Shader {
+    if (this.programName_ === null) {
+      throw new Error("Program name not set");
+    }
+    return this.programName_;
+  }
+
+  protected set programName(programName: Shader) {
+    this.programName_ = programName;
   }
 }

--- a/src/objects/renderable/mesh.ts
+++ b/src/objects/renderable/mesh.ts
@@ -21,9 +21,11 @@ export class Mesh extends RenderableObject {
   }
 
   private setProgramName() {
-    // TODO: much of this can be consolidated when we have modular shaders
+    // TODO: this can be consolidated when we have modular shaders
     const texture = this.textures[0];
-    if (!texture || texture.type == "Texture2D") {
+    if (!texture) {
+      throw new Error("un-textured mesh not implemented");
+    } else if (texture.type == "Texture2D") {
       this.programName = "mesh";
     } else if (texture.type == "DataTexture2D") {
       this.programName =
@@ -31,7 +33,6 @@ export class Mesh extends RenderableObject {
     } else if (texture.type == "Texture2DArray") {
       if (texture.dataType == "float") {
         throw new Error("floatImageArray not implemented");
-        // this.programName = "floatImageArray";
       } else {
         this.programName = "uintImageArray";
       }

--- a/src/objects/renderable/mesh.ts
+++ b/src/objects/renderable/mesh.ts
@@ -13,9 +13,28 @@ export class Mesh extends RenderableObject {
     if (texture) {
       this.addTexture(texture);
     }
+    this.setProgramName();
   }
 
   public get type() {
     return "Mesh";
+  }
+
+  private setProgramName() {
+    // TODO: much of this can be consolidated when we have modular shaders
+    const texture = this.textures[0];
+    if (!texture || texture.type == "Texture2D") {
+      this.programName = "mesh";
+    } else if (texture.type == "DataTexture2D") {
+      this.programName =
+        texture.dataType == "float" ? "floatImage" : "uintImage";
+    } else if (texture.type == "Texture2DArray") {
+      if (texture.dataType == "float") {
+        throw new Error("floatImageArray not implemented");
+        // this.programName = "floatImageArray";
+      } else {
+        this.programName = "uintImageArray";
+      }
+    }
   }
 }

--- a/src/objects/renderable/projected_line.ts
+++ b/src/objects/renderable/projected_line.ts
@@ -29,6 +29,7 @@ export class ProjectedLine extends RenderableObject {
     this.width_ = width;
     this.taperOffset_ = taperOffset ?? this.taperOffset_;
     this.taperPower_ = taperPower ?? this.taperPower_;
+    this.programName = "projectedLine";
   }
 
   public get type() {

--- a/src/renderers/shaders/index.ts
+++ b/src/renderers/shaders/index.ts
@@ -19,10 +19,12 @@ export const shaderCode: Record<Shader, { vertex: string; fragment: string }> =
       vertex: projectedLineVertexShader,
       fragment: projectedLineFragmentShader,
     },
+    // TODO: a mesh shader without a texture
     mesh: {
       vertex: meshVertexShader,
       fragment: meshFragmentShader,
     },
+    // TODO: consolidate image shaders
     uintImage: {
       vertex: meshVertexShader,
       fragment: uintImageFragmentShader,

--- a/src/renderers/webgl_renderer.ts
+++ b/src/renderers/webgl_renderer.ts
@@ -43,7 +43,7 @@ export class WebGLRenderer extends Renderer {
   }
 
   protected renderObject(object: RenderableObject) {
-    const program = this.getShaderProgram(this.getProgramName(object)).use();
+    const program = this.getShaderProgram(object.programName).use();
 
     const modelView = mat4.multiply(
       mat4.create(),
@@ -100,21 +100,6 @@ export class WebGLRenderer extends Renderer {
     this.gl.clear(this.gl.COLOR_BUFFER_BIT | this.gl.DEPTH_BUFFER_BIT);
     this.gl.enable(this.gl.DEPTH_TEST);
     this.gl.depthFunc(this.gl.LEQUAL);
-  }
-
-  // This is a temporary computed property. In the future, we want to assign the
-  // program name to the class derived from the renderable object but we need to
-  // refactor textures first (consolidating the two programs below.)
-  private getProgramName(object: RenderableObject) {
-    if (object.type === "ProjectedLine") return "projectedLine";
-    if (object.textures.length > 0) {
-      if (object.textures[0].type === "DataTexture2D") {
-        if (object.textures[0].dataType == "float") return "floatImage";
-        return "uintImage";
-      }
-      if (object.textures[0].type === "Texture2DArray") return "uintImageArray";
-    }
-    return "mesh";
   }
 
   private getShaderProgram(type: Shader) {


### PR DESCRIPTION
### Summary
This has been a `TODO` in the code for a while. I found it hard to reason about when trying to load OrganelleBox data. I think it's easier to understand as part of the renderable object. This also makes sense to me as you can now observe the possible programs for each renderable object to ensure the object provides the required uniforms, etc.

### Related Issue
N/A, but removes a TODO from the code

### Tests & Checks
I manually checked the examples and the ultrack prototype to ensure they still work