### PR TITLE
Ensure setProgramName is called when adding a texture on Mesh

### DIFF
--- a/src/objects/renderable/mesh.ts
+++ b/src/objects/renderable/mesh.ts
@@ -13,11 +13,15 @@ export class Mesh extends RenderableObject {
     if (texture) {
       this.addTexture(texture);
     }
-    this.setProgramName();
   }
 
   public get type() {
     return "Mesh";
+  }
+
+  public addTexture(texture: Texture) {
+    super.addTexture(texture);
+    this.setProgramName();
   }
 
   private setProgramName() {


### PR DESCRIPTION
### Summary
Sorry - I meant to include this in #161. I think it's an improvement because `addTexture` is public, and currently the program name is determined by the texture type.