### PR TITLE
Basic multi-channel support for image layer + float data

### DIFF
--- a/examples/image2d_from_omezarr4d_hcs/main.ts
+++ b/examples/image2d_from_omezarr4d_hcs/main.ts
@@ -37,7 +37,7 @@ const camera = new OrthographicCamera(0, 840, 0, 360);
 const controls = new PanZoomControls(camera, camera.position);
 renderer.setControls(controls);
 const region = [
-  { dimension: "c", index: 0 },
+  { dimension: "c", index: { start: 0, stop: 3 } },
   { dimension: "z", index: 0 },
 ];
 

--- a/src/core/layer.ts
+++ b/src/core/layer.ts
@@ -37,7 +37,7 @@ export abstract class Layer {
   protected setState(newState: LayerState) {
     const prevState = this.state_;
     this.state_ = newState;
-    console.log(`${this.constructor.name} state change: ${newState}`);
+    console.debug(`${this.constructor.name} state change: ${newState}`);
     this.callbacks_.forEach((callback) => callback(newState, prevState));
   }
 

--- a/src/data/image_chunk.ts
+++ b/src/data/image_chunk.ts
@@ -2,11 +2,28 @@ import { Region } from "data/region";
 import { TextureUnpackRowAlignment } from "objects/textures/texture";
 import { PromiseScheduler } from "./promise_scheduler";
 
+const imageChunkDataTypes = [Uint8Array, Uint16Array, Float32Array] as const;
+type ImageChunkData = InstanceType<(typeof imageChunkDataTypes)[number]>;
+export function isImageChunkData(value: unknown): value is ImageChunkData {
+  if (
+    imageChunkDataTypes.some(
+      (ImageChunkData) => value instanceof ImageChunkData
+    )
+  ) {
+    return true;
+  }
+  const supportedDataTypeNames = imageChunkDataTypes.map((dtype) => dtype.name);
+  console.debug(
+    `Unsupported image chunk data type: ${value}. Supported data types: ${supportedDataTypeNames}`
+  );
+  return false;
+}
+
 // One 2D chunk of n-dimensional image data.
 // TODO: include the region of this chunk.
 // https://github.com/chanzuckerberg/imaging-active-learning/issues/34
 export type ImageChunk = {
-  data: Uint8Array | Uint16Array | Float32Array;
+  data: ImageChunkData;
   shape: {
     x: number;
     y: number;

--- a/src/data/ome_zarr_image_loader.ts
+++ b/src/data/ome_zarr_image_loader.ts
@@ -2,7 +2,7 @@ import * as zarr from "zarrita";
 import { Slice } from "@zarrita/indexing";
 
 import { Region } from "data/region";
-import { ImageChunk } from "data/image_chunk";
+import { ImageChunk, isImageChunkData } from "data/image_chunk";
 import { isTextureUnpackRowAlignment } from "objects/textures/texture";
 import { PromiseScheduler } from "./promise_scheduler";
 
@@ -32,14 +32,6 @@ type Multiscale = {
   axes: Array<Axis>;
   datasets: Array<Dataset>;
 };
-
-const dataTypes = [Uint8Array, Uint16Array, Float32Array] as const;
-const dataTypeNames = dataTypes.map((DataType) => DataType.name);
-type DataType = InstanceType<(typeof dataTypes)[number]>;
-
-function isDataType(value: unknown): value is DataType {
-  return dataTypes.some((DataType) => value instanceof DataType);
-}
 
 // Implements the interface required for getting array chunks in zarrita:
 // https://github.com/manzt/zarrita.js/blob/c15c1a14e42a83516972368ac962ebdf56a6dcdb/packages/indexing/src/types.ts#L52
@@ -115,9 +107,9 @@ export class OmeZarrImageLoader {
     }
     const subarray = await zarr.get(array, indices, options);
 
-    if (!isDataType(subarray.data)) {
+    if (!isImageChunkData(subarray.data)) {
       throw new Error(
-        `Subarray has an unsupported data type ${subarray.data.constructor.name}. Supported data types are ${dataTypeNames}.`
+        `Subarray has an unsupported data type ${subarray.data.constructor.name}`
       );
     }
 

--- a/src/layers/image_layer.ts
+++ b/src/layers/image_layer.ts
@@ -1,7 +1,7 @@
 import { Layer } from "core/layer";
 import { Region } from "data/region";
 import { ImageChunkSource } from "data/image_chunk";
-import { makeImageMesh, makeImageTexture } from "layers/image_utils";
+import { makeImageMesh, makeImageTextureArray } from "layers/image_utils";
 
 // Loads data from an image source into renderable objects.
 export class ImageLayer extends Layer {
@@ -39,7 +39,7 @@ export class ImageLayer extends Layer {
     this.setState("loading");
     const loader = await this.source_.open();
     const chunk = await loader.loadChunk(region);
-    const texture = makeImageTexture(chunk);
+    const texture = makeImageTextureArray(chunk);
     const mesh = makeImageMesh(chunk, texture);
     this.addObject(mesh);
     this.setState("ready");

--- a/src/objects/renderable/mesh.ts
+++ b/src/objects/renderable/mesh.ts
@@ -31,11 +31,8 @@ export class Mesh extends RenderableObject {
       this.programName =
         texture.dataType == "float" ? "floatImage" : "uintImage";
     } else if (texture.type == "Texture2DArray") {
-      if (texture.dataType == "float") {
-        throw new Error("floatImageArray not implemented");
-      } else {
-        this.programName = "uintImageArray";
-      }
+      this.programName =
+        texture.dataType == "float" ? "floatImageArray" : "uintImageArray";
     }
   }
 }

--- a/src/objects/textures/data_texture_2d.ts
+++ b/src/objects/textures/data_texture_2d.ts
@@ -1,18 +1,18 @@
-import { Texture } from "objects/textures/texture";
+import { DataTextureTypedArray, Texture } from "objects/textures/texture";
 
 export class DataTexture2D extends Texture {
-  private data_: ArrayBufferView;
+  private data_: DataTextureTypedArray;
   private readonly width_: number;
   private readonly height_: number;
 
-  constructor(data: ArrayBufferView, width: number, height: number) {
+  constructor(data: DataTextureTypedArray, width: number, height: number) {
     super();
     this.data_ = data;
     this.width_ = width;
     this.height_ = height;
   }
 
-  public set data(data: ArrayBufferView) {
+  public set data(data: DataTextureTypedArray) {
     this.data_ = data;
     this.needsUpdate = true;
   }

--- a/src/objects/textures/texture.ts
+++ b/src/objects/textures/texture.ts
@@ -10,6 +10,8 @@ export type TextureDataType = "unsigned_byte" | "unsigned_short" | "float";
 
 export type TextureUnpackRowAlignment = 1 | 2 | 4 | 8;
 
+export type DataTextureTypedArray = Uint8Array | Uint16Array | Float32Array;
+
 export function isTextureUnpackRowAlignment(
   value: number
 ): value is TextureUnpackRowAlignment {

--- a/src/objects/textures/texture_2d_array.ts
+++ b/src/objects/textures/texture_2d_array.ts
@@ -1,26 +1,26 @@
-import { Texture } from "objects/textures/texture";
+import { DataTextureTypedArray, Texture } from "objects/textures/texture";
 
 export class Texture2DArray extends Texture {
-  private data_: ArrayBufferView;
+  private data_: DataTextureTypedArray;
   private readonly width_: number;
   private readonly height_: number;
   private readonly depth_: number;
 
-  constructor(data: ArrayBufferView, width: number, height: number) {
+  constructor(data: DataTextureTypedArray, width: number, height: number) {
     super();
 
     this.data_ = data;
     this.width_ = width;
     this.height_ = height;
     // We currently assume that each slice's size is equal to the image's area
-    this.depth_ = data.byteLength / (width * height) / this.bytesPerElement;
+    this.depth_ = data.length / (width * height);
   }
 
   public get type() {
     return "Texture2DArray";
   }
 
-  public set data(data: ArrayBufferView) {
+  public set data(data: DataTextureTypedArray) {
     this.data_ = data;
     this.needsUpdate = true;
   }
@@ -39,22 +39,5 @@ export class Texture2DArray extends Texture {
 
   public get depth() {
     return this.depth_;
-  }
-
-  private get bytesPerElement(): number {
-    switch (this.data_.constructor.name) {
-      case "Uint8Array":
-      case "Int8Array":
-        return 1;
-      case "Uint16Array":
-      case "Int16Array":
-        return 2;
-      case "Uint32Array":
-      case "Int32Array":
-      case "Float32Array":
-        return 4;
-      default:
-        return 1;
-    }
   }
 }

--- a/src/objects/textures/texture_2d_array.ts
+++ b/src/objects/textures/texture_2d_array.ts
@@ -13,7 +13,7 @@ export class Texture2DArray extends Texture {
     this.width_ = width;
     this.height_ = height;
     // We currently assume that each slice's size is equal to the image's area
-    this.depth_ = data.byteLength / (width * height);
+    this.depth_ = data.byteLength / (width * height) / this.bytesPerElement;
   }
 
   public get type() {
@@ -39,5 +39,22 @@ export class Texture2DArray extends Texture {
 
   public get depth() {
     return this.depth_;
+  }
+
+  private get bytesPerElement(): number {
+    switch (this.data_.constructor.name) {
+      case "Uint8Array":
+      case "Int8Array":
+        return 1;
+      case "Uint16Array":
+      case "Int16Array":
+        return 2;
+      case "Uint32Array":
+      case "Int32Array":
+      case "Float32Array":
+        return 4;
+      default:
+        return 1;
+    }
   }
 }

--- a/src/renderers/shaders/float_image_array_frag.glsl
+++ b/src/renderers/shaders/float_image_array_frag.glsl
@@ -1,0 +1,17 @@
+#version 300 es
+
+precision mediump float;
+
+layout (location = 0) out vec4 fragColor;
+
+uniform mediump sampler2DArray texture0;
+
+in vec2 TexCoords;
+
+void main() {
+    float red = texture(texture0, vec3(TexCoords, 0)).r;
+    float green = texture(texture0, vec3(TexCoords, 1)).r;
+    float blue = texture(texture0, vec3(TexCoords, 2)).r;
+
+    fragColor = vec4(red, green, blue, 1);
+}

--- a/src/renderers/shaders/index.ts
+++ b/src/renderers/shaders/index.ts
@@ -3,15 +3,17 @@ import projectedLineFragmentShader from "./projected_line_frag.glsl";
 import meshVertexShader from "./mesh_vert.glsl";
 import meshFragmentShader from "./mesh_frag.glsl";
 import floatImageFragmentShader from "./float_image_frag.glsl";
+import floatImageArrayFragmentShader from "./float_image_array_frag.glsl";
 import uintImageFragmentShader from "./uint_image_frag.glsl";
 import uintImageArrayFragmentShader from "./uint_image_array_frag.glsl";
 
 export type Shader =
   | "projectedLine"
   | "mesh"
+  | "floatImage"
+  | "floatImageArray"
   | "uintImage"
-  | "uintImageArray"
-  | "floatImage";
+  | "uintImageArray";
 
 export const shaderCode: Record<Shader, { vertex: string; fragment: string }> =
   {
@@ -25,6 +27,14 @@ export const shaderCode: Record<Shader, { vertex: string; fragment: string }> =
       fragment: meshFragmentShader,
     },
     // TODO: consolidate image shaders
+    floatImage: {
+      vertex: meshVertexShader,
+      fragment: floatImageFragmentShader,
+    },
+    floatImageArray: {
+      vertex: meshVertexShader,
+      fragment: floatImageArrayFragmentShader,
+    },
     uintImage: {
       vertex: meshVertexShader,
       fragment: uintImageFragmentShader,
@@ -32,9 +42,5 @@ export const shaderCode: Record<Shader, { vertex: string; fragment: string }> =
     uintImageArray: {
       vertex: meshVertexShader,
       fragment: uintImageArrayFragmentShader,
-    },
-    floatImage: {
-      vertex: meshVertexShader,
-      fragment: floatImageFragmentShader,
     },
   };


### PR DESCRIPTION
### Summary
This PR adds support for float32 image chunks in the Texture2DArray class, which is used in the ImageSeriesLayer for multi-channel support. This also extends that basic multi-channel support to the regular ImageLayer.

### Related Issues
#146 
#141 

### Tests & Checks
Manual testing of examples and ultrack prototype
Testing the HCS example with data provided by BioHub SF for the OrganelleBox project
