### PR TITLE
Add color and visibility to multi-channel properties

### DIFF
--- a/examples/image2d_from_omezarr4d_hcs/main.ts
+++ b/examples/image2d_from_omezarr4d_hcs/main.ts
@@ -53,10 +53,10 @@ const onImageChange = async () => {
     source,
     region,
     channelProps: [
-      // contrast limits manually looked up in the zarr omero metadata
-      { contrastLimits: [110, 800] },
-      { contrastLimits: [110, 250] },
-      { contrastLimits: [110, 800] },
+      // color and contrast limits manually looked up in the zarr omero metadata
+      { color: [0, 1, 1], contrastLimits: [110, 800] },
+      { color: [1, 0, 1], contrastLimits: [110, 250] },
+      { color: [1, 1, 0], contrastLimits: [110, 800] },
     ],
   });
   layerManager.add(layer);

--- a/examples/image2d_from_omezarr5d_u8/main.ts
+++ b/examples/image2d_from_omezarr5d_u8/main.ts
@@ -26,7 +26,12 @@ const region = [
   { dimension: "C", index: 0 },
   { dimension: "Z", index: 0 },
 ];
-const channelProps = [{ contrastLimits: [0, 128] as [number, number] }];
+const channelProps = [
+  {
+    color: [0, 1, 0] as [number, number, number],
+    contrastLimits: [0, 128] as [number, number],
+  },
+];
 const layer = new ImageLayer({ source, region, channelProps });
 const axes = new AxesLayer({ length: 1920, width: 0.01 });
 layerManager.add(layer);

--- a/examples/image_series_from_omezarr5d_u8/main.ts
+++ b/examples/image_series_from_omezarr5d_u8/main.ts
@@ -24,9 +24,18 @@ const region = [
 // Raise the contrast limits for the blue channel because there is
 // a lot of low signal that washes everything else out.
 const channelProps = [
-  { contrastLimits: [0, 255] as [number, number] },
-  { contrastLimits: [0, 255] as [number, number] },
-  { contrastLimits: [128, 255] as [number, number] },
+  {
+    color: [1, 0, 0] as [number, number, number],
+    contrastLimits: [0, 255] as [number, number],
+  },
+  {
+    color: [0, 1, 0] as [number, number, number],
+    contrastLimits: [0, 255] as [number, number],
+  },
+  {
+    color: [0, 0, 1] as [number, number, number],
+    contrastLimits: [128, 255] as [number, number],
+  },
 ];
 const layer = new ImageSeriesLayer({
   source,

--- a/examples/image_series_from_omezarr5d_u8/main.ts
+++ b/examples/image_series_from_omezarr5d_u8/main.ts
@@ -25,14 +25,17 @@ const region = [
 // a lot of low signal that washes everything else out.
 const channelProps = [
   {
+    visible: false,
     color: [1, 0, 0] as [number, number, number],
     contrastLimits: [0, 255] as [number, number],
   },
   {
+    visible: true,
     color: [0, 1, 0] as [number, number, number],
     contrastLimits: [0, 255] as [number, number],
   },
   {
+    visible: true,
     color: [0, 0, 1] as [number, number, number],
     contrastLimits: [128, 255] as [number, number],
   },

--- a/examples/tracks/main.ts
+++ b/examples/tracks/main.ts
@@ -74,9 +74,18 @@ const region = [
 // Raise the contrast limits for the blue channel because there is
 // a lot of low signal that washes everything else out.
 const channelProps = [
-  { contrastLimits: [0, 255] as [number, number] },
-  { contrastLimits: [0, 255] as [number, number] },
-  { contrastLimits: [128, 255] as [number, number] },
+  {
+    color: [1, 0, 0] as [number, number, number],
+    contrastLimits: [0, 255] as [number, number],
+  },
+  {
+    color: [0, 1, 0] as [number, number, number],
+    contrastLimits: [0, 255] as [number, number],
+  },
+  {
+    color: [0, 0, 1] as [number, number, number],
+    contrastLimits: [128, 255] as [number, number],
+  },
 ];
 const imageSeriesLayer = new ImageSeriesLayer({
   source,

--- a/src/objects/textures/channel.ts
+++ b/src/objects/textures/channel.ts
@@ -3,23 +3,29 @@ import { Texture } from "objects/textures/texture";
 type RgbColor = [number, number, number];
 
 export type ChannelProps = {
+  visible?: boolean;
   color?: RgbColor;
   contrastLimits?: [number, number];
 };
 
 export type Channel = {
+  visible: boolean;
   color: RgbColor;
   contrastLimits: [number, number];
 };
 
 export function validateChannel(
   texture: Texture,
-  { color, contrastLimits }: ChannelProps
+  { visible, color, contrastLimits }: ChannelProps
 ): Channel {
+  if (visible === undefined) {
+    visible = true;
+  }
   if (color === undefined) {
     color = [1, 1, 1];
   }
   return {
+    visible,
     color,
     contrastLimits: validateContrastLimits(contrastLimits, texture),
   };

--- a/src/objects/textures/channel.ts
+++ b/src/objects/textures/channel.ts
@@ -1,18 +1,26 @@
 import { Texture } from "objects/textures/texture";
 
+type RgbColor = [number, number, number];
+
 export type ChannelProps = {
+  color?: RgbColor;
   contrastLimits?: [number, number];
 };
 
 export type Channel = {
+  color: RgbColor;
   contrastLimits: [number, number];
 };
 
 export function validateChannel(
   texture: Texture,
-  { contrastLimits }: ChannelProps
+  { color, contrastLimits }: ChannelProps
 ): Channel {
+  if (color === undefined) {
+    color = [1, 1, 1];
+  }
   return {
+    color,
     contrastLimits: validateContrastLimits(contrastLimits, texture),
   };
 }

--- a/src/objects/textures/data_texture_2d.ts
+++ b/src/objects/textures/data_texture_2d.ts
@@ -17,13 +17,13 @@ export class DataTexture2D extends Texture {
 
   constructor(data: DataTextureTypedArray, width: number, height: number) {
     super();
+    this.dataFormat = "scalar";
+    this.dataType = bufferToDataType(data);
+
     this.data_ = data;
     this.width_ = width;
     this.height_ = height;
     this.channel_ = validateChannel(this, {});
-
-    this.dataFormat = "scalar";
-    this.dataType = bufferToDataType(data);
   }
 
   public set data(data: DataTextureTypedArray) {

--- a/src/objects/textures/texture_2d_array.ts
+++ b/src/objects/textures/texture_2d_array.ts
@@ -18,6 +18,8 @@ export class Texture2DArray extends Texture {
 
   constructor(data: DataTextureTypedArray, width: number, height: number) {
     super();
+    this.dataFormat = "scalar";
+    this.dataType = bufferToDataType(data);
 
     this.data_ = data;
     this.width_ = width;
@@ -28,9 +30,6 @@ export class Texture2DArray extends Texture {
     for (let i = 0; i < this.depth_; i++) {
       this.channels_.push(validateChannel(this, {}));
     }
-
-    this.dataFormat = "scalar";
-    this.dataType = bufferToDataType(data);
   }
 
   public get type() {

--- a/src/renderers/shaders/float_image_array_frag.glsl
+++ b/src/renderers/shaders/float_image_array_frag.glsl
@@ -5,6 +5,7 @@ precision mediump float;
 layout (location = 0) out vec4 fragColor;
 
 uniform mediump sampler2DArray texture0;
+uniform bool Visible[3];
 uniform vec3 Color[3];
 uniform float ValueOffset[3];
 uniform float ValueScale[3];
@@ -14,6 +15,7 @@ in vec2 TexCoords;
 void main() {
     vec3 rgbColor = vec3(0, 0, 0);
     for (int i = 0; i < 3; i++) {
+        if (!Visible[i]) continue;
         float texel = texture(texture0, vec3(TexCoords, i)).r;
         float value = (texel + ValueOffset[i]) * ValueScale[i];
         rgbColor += value * Color[i].rgb;

--- a/src/renderers/shaders/float_image_array_frag.glsl
+++ b/src/renderers/shaders/float_image_array_frag.glsl
@@ -5,17 +5,18 @@ precision mediump float;
 layout (location = 0) out vec4 fragColor;
 
 uniform mediump sampler2DArray texture0;
+uniform vec3 Color[3];
 uniform float ValueOffset[3];
 uniform float ValueScale[3];
 
 in vec2 TexCoords;
 
 void main() {
-    fragColor = vec4(0, 0, 0, 1);
+    vec3 rgbColor = vec3(0, 0, 0);
     for (int i = 0; i < 3; i++) {
         float texel = texture(texture0, vec3(TexCoords, i)).r;
-        vec4 color = vec4(0, 0, 0, 1);
-        color[i] = (texel + ValueOffset[i]) * ValueScale[i];
-        fragColor += color;
+        float value = (texel + ValueOffset[i]) * ValueScale[i];
+        rgbColor += value * Color[i].rgb;
     }
+    fragColor = vec4(rgbColor.rgb, 1);
 }

--- a/src/renderers/shaders/float_image_frag.glsl
+++ b/src/renderers/shaders/float_image_frag.glsl
@@ -5,6 +5,7 @@ precision mediump float;
 layout (location = 0) out vec4 fragColor;
 
 uniform mediump sampler2D texture0;
+uniform vec3 Color;
 uniform float ValueOffset;
 uniform float ValueScale;
 
@@ -13,5 +14,5 @@ in vec2 TexCoords;
 void main() {
     float texel = texture(texture0, TexCoords).r;
     float value = (texel + ValueOffset) * ValueScale;
-    fragColor = vec4(value, value, value, 1);
+    fragColor = vec4(value * Color.rgb, 1);
 }

--- a/src/renderers/shaders/uint_image_array_frag.glsl
+++ b/src/renderers/shaders/uint_image_array_frag.glsl
@@ -5,17 +5,18 @@ precision mediump float;
 layout (location = 0) out vec4 fragColor;
 
 uniform mediump usampler2DArray texture0;
+uniform vec3 Color[3];
 uniform float ValueOffset[3];
 uniform float ValueScale[3];
 
 in vec2 TexCoords;
 
 void main() {
-    fragColor = vec4(0, 0, 0, 1);
+    vec3 rgbColor = vec3(0, 0, 0);
     for (int i = 0; i < 3; i++) {
         float texel = float(texture(texture0, vec3(TexCoords, i)).r);
-        vec4 color = vec4(0, 0, 0, 1);
-        color[i] = (texel + ValueOffset[i]) * ValueScale[i];
-        fragColor += color;
+        float value = (texel + ValueOffset[i]) * ValueScale[i];
+        rgbColor += value * Color[i].rgb;
     }
+    fragColor = vec4(rgbColor.rgb, 1);
 }

--- a/src/renderers/shaders/uint_image_array_frag.glsl
+++ b/src/renderers/shaders/uint_image_array_frag.glsl
@@ -5,6 +5,7 @@ precision mediump float;
 layout (location = 0) out vec4 fragColor;
 
 uniform mediump usampler2DArray texture0;
+uniform bool Visible[3];
 uniform vec3 Color[3];
 uniform float ValueOffset[3];
 uniform float ValueScale[3];
@@ -14,6 +15,7 @@ in vec2 TexCoords;
 void main() {
     vec3 rgbColor = vec3(0, 0, 0);
     for (int i = 0; i < 3; i++) {
+        if (!Visible[i]) continue;
         float texel = float(texture(texture0, vec3(TexCoords, i)).r);
         float value = (texel + ValueOffset[i]) * ValueScale[i];
         rgbColor += value * Color[i].rgb;

--- a/src/renderers/shaders/uint_image_frag.glsl
+++ b/src/renderers/shaders/uint_image_frag.glsl
@@ -5,6 +5,7 @@ precision mediump float;
 layout (location = 0) out vec4 fragColor;
 
 uniform mediump usampler2D texture0;
+uniform vec3 Color;
 uniform float ValueOffset;
 uniform float ValueScale;
 
@@ -13,5 +14,5 @@ in vec2 TexCoords;
 void main() {
     float texel = float(texture(texture0, TexCoords).r);
     float value = (texel + ValueOffset) * ValueScale;
-    fragColor = vec4(value, value, value, 1);
+    fragColor = vec4(value * Color.rgb, 1);
 }

--- a/src/renderers/webgl_renderer.ts
+++ b/src/renderers/webgl_renderer.ts
@@ -102,17 +102,20 @@ export class WebGLRenderer extends Renderer {
         }
         case "Texture2DArray": {
           const texture2DArray = texture as Texture2DArray;
+          const visible = new Array<boolean>();
+          const color = new Array<number>();
           const valueOffset = new Array<number>();
           const valueScale = new Array<number>();
-          const color = new Array<number>();
           for (const channel of texture2DArray.channels) {
             const contrastLimits = channel.contrastLimits;
+            visible.push(channel.visible);
+            color.push(...channel.color);
             valueOffset.push(-contrastLimits[0]);
             valueScale.push(1 / (contrastLimits[1] - contrastLimits[0]));
-            color.push(...channel.color);
           }
           // TODO: we should be careful of uninitialized values here, though it appears they
           // are zero-initialized in the shaders.
+          program.setUniform("Visible[0]", visible);
           program.setUniform("Color[0]", color);
           program.setUniform("ValueOffset[0]", valueOffset);
           program.setUniform("ValueScale[0]", valueScale);

--- a/src/renderers/webgl_renderer.ts
+++ b/src/renderers/webgl_renderer.ts
@@ -95,6 +95,7 @@ export class WebGLRenderer extends Renderer {
           const contrastLimits = dataTexture.channel.contrastLimits;
           const valueOffset = -contrastLimits[0];
           const valueScale = 1 / (contrastLimits[1] - contrastLimits[0]);
+          program.setUniform("Color", dataTexture.channel.color);
           program.setUniform("ValueOffset", valueOffset);
           program.setUniform("ValueScale", valueScale);
           break;
@@ -103,13 +104,16 @@ export class WebGLRenderer extends Renderer {
           const texture2DArray = texture as Texture2DArray;
           const valueOffset = new Array<number>();
           const valueScale = new Array<number>();
+          const color = new Array<number>();
           for (const channel of texture2DArray.channels) {
             const contrastLimits = channel.contrastLimits;
             valueOffset.push(-contrastLimits[0]);
             valueScale.push(1 / (contrastLimits[1] - contrastLimits[0]));
+            color.push(...channel.color);
           }
           // TODO: we should be careful of uninitialized values here, though it appears they
           // are zero-initialized in the shaders.
+          program.setUniform("Color[0]", color);
           program.setUniform("ValueOffset[0]", valueOffset);
           program.setUniform("ValueScale[0]", valueScale);
           break;

--- a/src/renderers/webgl_shader_program.ts
+++ b/src/renderers/webgl_shader_program.ts
@@ -40,11 +40,15 @@ export class WebGLShaderProgram {
 
     const type = info.type as SupportedUniformType;
     switch (type) {
+      // There is no dedicated uniform1b in WebGL, but passing through
+      // as a float or signed integer works, so fallthrough to float
+      // for simplicity.
+      case this.gl_.BOOL:
       case this.gl_.FLOAT:
         if (typeof value === "number") {
           this.gl_.uniform1f(location, value as number);
         } else {
-          this.gl_.uniform1fv(location, value as Iterable<GLfloat>);
+          this.gl_.uniform1fv(location, value as Iterable<number>);
         }
         break;
       case this.gl_.FLOAT_VEC2:
@@ -85,6 +89,7 @@ export class WebGLShaderProgram {
         const location = this.gl_.getUniformLocation(this.program_, info.name);
         if (location) {
           this.uniformInfo_.set(info.name, [location, info]);
+          console.debug("Uniform found:", info.name, info.type, info.size);
         }
       }
     }
@@ -170,6 +175,7 @@ const SAMPLER_TYPES: ReadonlySet<GLenum> = new Set<GLenum>([
 
 // using an array and converting to a set allows us to also create a type here
 const SUPPORTED_UNIFORM_TYPES_ = [
+  WebGL2RenderingContext.BOOL,
   WebGL2RenderingContext.FLOAT,
   WebGL2RenderingContext.FLOAT_VEC2,
   WebGL2RenderingContext.FLOAT_VEC3,

--- a/ultrack-prototype/frontend/lib/tasks.ts
+++ b/ultrack-prototype/frontend/lib/tasks.ts
@@ -268,6 +268,11 @@ export class Task {
       source,
       region,
       timeDimension: imageData.timeDimension,
+      channelProps: [
+        { color: [1, 0, 0] as [number, number, number] },
+        { color: [0, 1, 0] as [number, number, number] },
+        { color: [0, 0, 1] as [number, number, number] },
+      ],
     });
     if (preLoad) {
       layer.update();


### PR DESCRIPTION
### Summary
This continues @andy-sweet's work on multi-channel support, and will serve as the base for an OrganelleBox component (previously #155 #158).

This expands the mechanism introduced in https://github.com/chanzuckerberg/imaging-active-learning/pull/152 to include additional per-channel properties for visibility and color.

This is basically #167 rebased on main.

### Related Issue
https://github.com/chanzuckerberg/imaging-active-learning/issues/141
Fixes #168 
