### PR TITLE
Changes to make it work in organelle-box-portal project

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   ],
   "scripts": {
     "build": "npm run build --workspace=@idetik/core",
+    "build:all": "npm run build --workspaces",
     "examples": "npm run dev --workspace=@idetik/core",
     "ultrack": "npm run dev --workspace=ultrack-prototype"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,6 +25,12 @@
       "import": "./dist/index.js",
       "require": "./dist/index.umd.cjs"
     },
+    "./*": {
+      "types": "./dist/*/index.d.ts"
+    },
+    "./**/*": {
+      "types": "./dist/**/*.d.ts"
+    },
     "./dist/*.js.map": "./dist/*.js.map",
     "./dist/*.d.ts.map": "./dist/*.d.ts.map"
   },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -25,6 +25,7 @@ export {
   loadOmeZarrPlate,
   loadOmeZarrWell,
 } from "data/ome_zarr_hcs_metadata_loader";
+export type { Region } from "data/region";
 
 export { WebGLRenderer } from "renderers/webgl_renderer";
 

--- a/packages/core/src/layers/image_layer.ts
+++ b/packages/core/src/layers/image_layer.ts
@@ -6,7 +6,7 @@ import { makeImageTextureArray, makeImageRenderable } from "layers/image_utils";
 import { ChannelProps } from "objects/textures/channel";
 import { ImageRenderable } from "objects/renderable/image_renderable";
 
-type ImageLayerProps = {
+export type ImageLayerProps = {
   source: ImageChunkSource;
   region: Region;
   channelProps?: ChannelProps[];

--- a/packages/core/src/objects/cameras/index.ts
+++ b/packages/core/src/objects/cameras/index.ts
@@ -1,3 +1,0 @@
-export * from './perspective_camera';
-export * from './orthographic_camera';
-export * from './controls';

--- a/packages/core/src/objects/cameras/index.ts
+++ b/packages/core/src/objects/cameras/index.ts
@@ -1,0 +1,3 @@
+export * from './perspective_camera';
+export * from './orthographic_camera';
+export * from './controls';

--- a/packages/core/vite.config.js
+++ b/packages/core/vite.config.js
@@ -39,7 +39,7 @@ export default defineConfig(({ mode }) => {
         entry: path.resolve(_dirname, 'src/index.ts'),
         name: 'idetik-core',
         fileName: "index",
-      }
+      },
     },
     resolve: {
       alias: {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -27,6 +27,16 @@
     "react-dom": "^18.3.1"
   },
   "description": "idetik react components",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.umd.cjs"
+    },
+    "./dist/*.js.map": "./dist/*.js.map"
+  },
+  "files": [
+    "dist"
+  ],
   "author": "",
   "license": "ISC"
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "compile": "tsc",
-    "build": "tsc && vite build",
+    "build": "vite build && tsc --project tsconfig.build.json",
     "format": "prettier --write './**/*.{ts,tsx,html,json}'",
     "format-check": "prettier --check './**/*.{ts,tsx,html,json}'",
     "lint": "eslint ."
@@ -29,10 +29,12 @@
   "description": "idetik react components",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.umd.cjs"
     },
-    "./dist/*.js.map": "./dist/*.js.map"
+    "./dist/*.js.map": "./dist/*.js.map",
+    "./dist/*.d.ts.map": "./dist/*.d.ts.map"
   },
   "files": [
     "dist"

--- a/packages/react/src/components/Renderer.tsx
+++ b/packages/react/src/components/Renderer.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import {
   ImageLayer,
   OmeZarrImageSource,
@@ -55,16 +55,20 @@ const layer = new ImageLayer({ source, region, channelProps });
 layerManager.add(layer);
 
 export default function Renderer() {
+  const renderer = useRef<WebGLRenderer | null>(null);
   // Use the mount-effect so that the renderer can find the corresponding
   // element by its ID.
   useEffect(() => {
     console.debug("Renderer::mount");
     let lastRequestId = 0;
-    const renderer = new WebGLRenderer(`#${canvasId}`);
-    const controls = new PanZoomControls(camera, camera.position);
-    renderer.setControls(controls);
+    if (renderer.current === null) {
+      renderer.current = new WebGLRenderer(`#${canvasId}`);
+      const controls = new PanZoomControls(camera, camera.position);
+      renderer.current.setControls(controls);
+    }
+    console.debug("Renderer::mount: setting controls");
     function animate() {
-      renderer.render(layerManager, camera);
+      renderer.current?.render(layerManager, camera);
       lastRequestId = requestAnimationFrame(animate);
     }
     animate();

--- a/packages/react/src/components/Renderer.tsx
+++ b/packages/react/src/components/Renderer.tsx
@@ -6,8 +6,6 @@ import {
   OrthographicCamera,
   PanZoomControls,
   WebGLRenderer,
-  //loadOmeZarrPlate,
-  //loadOmeZarrWell,
 } from "@idetik/core";
 
 // TODO: needs to be unique so we can have more than one on the page
@@ -20,19 +18,6 @@ const layerManager = new LayerManager();
 // TODO: use props to pass in most of this config
 const plateUrl =
   "http://localhost:8080/20200812-CardiomyocyteDifferentiation14-Cycle1_mip.zarr";
-// const plate = await loadOmeZarrPlate(plateUrl);
-// //@ts-expect-error TODO: export more types?
-// const wellPaths = plate.plate?.wells.map((well) => well.path);
-// if (!wellPaths) {
-//   throw new Error("No wells found in plate");
-// }
-// const well = await loadOmeZarrWell(plateUrl, wellPaths[0]);
-// //@ts-expect-error TODO: export more types?
-// const imagePaths = well.well?.images.map((image) => image.path);
-// if (!imagePaths) {
-//   throw new Error("No images found in well");
-// }
-// const imageUrl = plateUrl + "/" + wellPaths[0] + "/" + imagePaths[0];
 const imageUrl = plateUrl + "/B/03/0";
 console.debug(`Loading image from ${imageUrl}`);
 const source = new OmeZarrImageSource(imageUrl);
@@ -43,14 +28,13 @@ const region = [
 
 // colors and limits come from the OME-Zarr metadata
 // http://localhost:8080/20200812-CardiomyocyteDifferentiation14-Cycle1_mip.zarr/B/03/0/.zattrs
-// ...but they look bad? especially the third channel is very bright and yellow
 const channelProps = [
-  { color: [0, 1, 1], contrastLimits: [0, 800] },
-  { color: [1, 0, 1], contrastLimits: [0, 250] },
-  { color: [1, 1, 0], contrastLimits: [0, 800], visible: false },
+  { color: [0, 1, 1], contrastLimits: [110, 800] },
+  { color: [1, 0, 1], contrastLimits: [110, 250] },
+  { color: [1, 1, 0], contrastLimits: [110, 800] },
 ];
-// TODO: why does TypeScript allow the wrong args here?
-// const layer = new ImageLayer(123);
+// TODO: typescript is not checking the types of the arguments to the constructor
+// see https://github.com/chanzuckerberg/imaging-active-learning/issues/174
 const layer = new ImageLayer({ source, region, channelProps });
 layerManager.add(layer);
 

--- a/packages/react/src/components/Renderer.tsx
+++ b/packages/react/src/components/Renderer.tsx
@@ -6,8 +6,8 @@ import {
   OrthographicCamera,
   PanZoomControls,
   WebGLRenderer,
-  loadOmeZarrPlate,
-  loadOmeZarrWell,
+  //loadOmeZarrPlate,
+  //loadOmeZarrWell,
 } from "@idetik/core";
 
 // TODO: needs to be unique so we can have more than one on the page
@@ -20,19 +20,20 @@ const layerManager = new LayerManager();
 // TODO: use props to pass in most of this config
 const plateUrl =
   "http://localhost:8080/20200812-CardiomyocyteDifferentiation14-Cycle1_mip.zarr";
-const plate = await loadOmeZarrPlate(plateUrl);
-//@ts-expect-error TODO: export more types?
-const wellPaths = plate.plate?.wells.map((well) => well.path);
-if (!wellPaths) {
-  throw new Error("No wells found in plate");
-}
-const well = await loadOmeZarrWell(plateUrl, wellPaths[0]);
-//@ts-expect-error TODO: export more types?
-const imagePaths = well.well?.images.map((image) => image.path);
-if (!imagePaths) {
-  throw new Error("No images found in well");
-}
-const imageUrl = plateUrl + "/" + wellPaths[0] + "/" + imagePaths[0];
+// const plate = await loadOmeZarrPlate(plateUrl);
+// //@ts-expect-error TODO: export more types?
+// const wellPaths = plate.plate?.wells.map((well) => well.path);
+// if (!wellPaths) {
+//   throw new Error("No wells found in plate");
+// }
+// const well = await loadOmeZarrWell(plateUrl, wellPaths[0]);
+// //@ts-expect-error TODO: export more types?
+// const imagePaths = well.well?.images.map((image) => image.path);
+// if (!imagePaths) {
+//   throw new Error("No images found in well");
+// }
+// const imageUrl = plateUrl + "/" + wellPaths[0] + "/" + imagePaths[0];
+const imageUrl = plateUrl + "/B/03/0";
 console.debug(`Loading image from ${imageUrl}`);
 const source = new OmeZarrImageSource(imageUrl);
 const region = [

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,0 +1,2 @@
+import Renderer from "components/Renderer";
+export { Renderer };

--- a/packages/react/src/vite-env.d.ts
+++ b/packages/react/src/vite-env.d.ts
@@ -1,2 +1,0 @@
-/// <reference types="vite/client" />
-/// <reference types="vite/types/importMeta.d.ts" />

--- a/packages/react/tsconfig.build.json
+++ b/packages/react/tsconfig.build.json
@@ -1,0 +1,12 @@
+// This configuration is used to generate type definitions (.d.ts files) for the library.
+// It is used by the `tsc` command to generate the type definitions in the `dist` folder.
+// It has to run *after* the vite build, because otherwise the files just get removed.
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true
+  },
+}

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -15,6 +15,7 @@
     "isolatedModules": true,
     "moduleDetection": "force",
     "noEmit": true,
+    "outDir": "dist",
 
     /* Linting */
     "strict": true,

--- a/packages/react/vite.config.js
+++ b/packages/react/vite.config.js
@@ -21,11 +21,23 @@ export default defineConfig(() => {
     publicDir: path.resolve(_dirname, 'public'),
     build: {
       outDir: 'dist',
+      // TODO: set these by build mode or something
+      sourcemap: true,
+      minify: false,
       lib: {
         entry: path.resolve(_dirname, 'src/index.ts'),
         name: 'idetik-react',
         fileName: "index",
-      }
+      },
+      rollupOptions: {
+        external: ['react', 'react-dom'],
+        output: {
+          globals: {
+            'react': 'React',
+            'react-dom': 'ReactDOM',
+          },
+        },
+      },
     },
     resolve: {
       alias: {

--- a/packages/ultrack-prototype/frontend/components/Renderer.tsx
+++ b/packages/ultrack-prototype/frontend/components/Renderer.tsx
@@ -64,7 +64,7 @@ export default function Renderer({
     lastTaskId.current = task.taskId;
     const { tracksLayer, imageSeriesLayer } = task.layers();
     imageSeriesLayer.update();
-    setImageSeriesLayer((prevLayer) => {
+    setImageSeriesLayer((prevLayer: ImageSeriesLayer | null) => {
       if (prevLayer !== null) prevLayer.close();
       return imageSeriesLayer;
     });

--- a/packages/ultrack-prototype/frontend/components/TaskItem.tsx
+++ b/packages/ultrack-prototype/frontend/components/TaskItem.tsx
@@ -47,7 +47,6 @@ export default function TaskItem({
       endIcon={
         <Icon
           sdsIcon={sdsIcon(answer)}
-          sdsType="static"
           sdsSize="s"
           color={sdsIconColor(syncStatus)}
         />

--- a/packages/ultrack-prototype/frontend/lib/tasks.ts
+++ b/packages/ultrack-prototype/frontend/lib/tasks.ts
@@ -1,7 +1,6 @@
 import { vec2, vec3 } from "gl-matrix";
 
-import { ImageSeriesLayer, OmeZarrImageSource, TracksLayer } from "@idetik/core";
-import { Region } from "@idetik/core/data/region";
+import { ImageSeriesLayer, OmeZarrImageSource, Region, TracksLayer } from "@idetik/core";
 
 type Track = {
   trackId: number;


### PR DESCRIPTION
### Summary
I tested our `Renderer` component in the organelle-box-portal project and ran into a few issues.

* Exclude react and react-dom in rollup packaging
* Can't use `await` at top-level in a next.js app
* Temporarily export the source map and skip minification while we're debugging

### Related Issue
#181 
#174 
#185 

### Tests & Checks
I created a test page in a local version of the organelle-box-portal project and added the `@idetik/react` `Renderer` component to the page.

![Screenshot 2025-02-20 at 12 13 04 PM](https://github.com/user-attachments/assets/7a65d416-f970-4f36-abde-e12eae4b3c77)