### PR TITLE
OmeZarrImageViewer component with declarative Renderer

### DIFF
--- a/packages/core/src/data/ome_zarr_hcs_metadata_loader.ts
+++ b/packages/core/src/data/ome_zarr_hcs_metadata_loader.ts
@@ -1,6 +1,7 @@
 import * as zarr from "zarrita";
 import { Plate } from "data/ome_ngff/0.4/plate";
 import { Well } from "data/ome_ngff/0.4/well";
+import { Image } from "data/ome_ngff/0.4/image";
 
 export async function loadOmeZarrPlate(url: string): Promise<Plate> {
   const store = new zarr.FetchStore(url);
@@ -17,4 +18,14 @@ export async function loadOmeZarrWell(
   const root = await zarr.open.v2(store, { kind: "group" });
   // Will throw validation exceptions that we can catch if we want.
   return Well.parse(root.attrs);
+}
+
+export type OmeroMetadata = NonNullable<Image["omero"]>;
+export type OmeroChannel = OmeroMetadata["channels"][number];
+
+export async function loadOmeroChannels(url: string): Promise<OmeroChannel[]> {
+  const store = new zarr.FetchStore(url);
+  const group = await zarr.open.v2(store, { kind: "group" });
+  const metadata = Image.parse(group.attrs);
+  return metadata.omero?.channels ?? [];
 }

--- a/packages/core/src/data/ome_zarr_image_loader.ts
+++ b/packages/core/src/data/ome_zarr_image_loader.ts
@@ -133,6 +133,10 @@ export class OmeZarrImageLoader {
     console.debug("loaded chunk ", chunk);
     return chunk;
   }
+
+  public get metadata(): OmeNgffImage {
+    return this.metadata_;
+  }
 }
 
 // Converts a region to indices within an OME-Zarr image array.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -24,6 +24,11 @@ export { OmeZarrImageSource } from "data/ome_zarr_image_source";
 export {
   loadOmeZarrPlate,
   loadOmeZarrWell,
+  loadOmeroChannels,
+} from "data/ome_zarr_hcs_metadata_loader";
+export type {
+  OmeroMetadata,
+  OmeroChannel,
 } from "data/ome_zarr_hcs_metadata_loader";
 export type { Region } from "data/region";
 export type { Image as OmeNgffImage } from "data/ome_ngff/0.4/image";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -31,5 +31,6 @@ export type { Image as OmeNgffImage } from "data/ome_ngff/0.4/image";
 export { WebGLRenderer } from "renderers/webgl_renderer";
 
 export { NullControls, PanZoomControls } from "objects/cameras/controls";
+export type { CameraControls } from "objects/cameras/controls";
 
 export type { ChannelProps } from "objects/textures/channel";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -26,6 +26,7 @@ export {
   loadOmeZarrWell,
 } from "data/ome_zarr_hcs_metadata_loader";
 export type { Region } from "data/region";
+export type { Image as OmeNgffImage } from "data/ome_ngff/0.4/image";
 
 export { WebGLRenderer } from "renderers/webgl_renderer";
 

--- a/packages/core/src/layers/image_layer.ts
+++ b/packages/core/src/layers/image_layer.ts
@@ -19,8 +19,10 @@ export class ImageLayer extends Layer {
   // https://github.com/chanzuckerberg/imaging-active-learning/issues/33
   private readonly region_: Region;
   private channelProps_?: ChannelProps[];
+  // TODO: we don't need this texture_ field anymore
   private texture_?: Texture2DArray;
   private renderable_?: ImageRenderable;
+  private extent_?: { x: number; y: number };
 
   constructor({ source, region, channelProps }: ImageLayerProps) {
     super();
@@ -61,6 +63,10 @@ export class ImageLayer extends Layer {
     this.setState("loading");
     const loader = await this.source_.open();
     const chunk = await loader.loadChunk(region);
+    this.extent_ = {
+      x: chunk.shape.x * chunk.scale.x,
+      y: chunk.shape.y * chunk.scale.y,
+    };
     this.texture_ = makeImageTextureArray(chunk);
     this.renderable_ = makeImageRenderable(
       chunk,
@@ -69,5 +75,11 @@ export class ImageLayer extends Layer {
     );
     this.addObject(this.renderable_);
     this.setState("ready");
+  }
+
+  // TODO: we probably want something like this, but it should be unified across layers
+  // see TracksLayer for another example
+  public get extent(): { x: number; y: number } | undefined {
+    return this.extent_;
   }
 }

--- a/packages/core/src/objects/cameras/orthographic_camera.ts
+++ b/packages/core/src/objects/cameras/orthographic_camera.ts
@@ -3,8 +3,8 @@ import { mat4 } from "gl-matrix";
 
 export class OrthographicCamera extends Camera {
   // width_ and height_ should always be defined by constructor (see setFrame)
-  private width_: number | undefined;
-  private height_: number | undefined;
+  private width_: number = 128;
+  private height_: number = 128;
   private viewportAspectRatio_: number = 1;
 
   constructor(
@@ -40,11 +40,6 @@ export class OrthographicCamera extends Camera {
   }
 
   protected updateProjectionMatrix() {
-    if (!this.width_ || !this.height_) {
-      throw new Error(
-        "OrthographicCamera frame must be defined before updating projection matrix"
-      );
-    }
     // The following code ensures that the orthographic projection matrix
     // is updated so that the aspect ratio of renderable objects is respected
     // (e.g. image pixels are isotropic) by padding the camera frame to form

--- a/packages/core/src/objects/cameras/orthographic_camera.ts
+++ b/packages/core/src/objects/cameras/orthographic_camera.ts
@@ -2,8 +2,9 @@ import { Camera } from "./camera";
 import { mat4 } from "gl-matrix";
 
 export class OrthographicCamera extends Camera {
-  private width_: number;
-  private height_: number;
+  // width_ and height_ should always be defined by constructor (see setFrame)
+  private width_: number | undefined;
+  private height_: number | undefined;
   private viewportAspectRatio_: number = 1;
 
   constructor(
@@ -15,19 +16,9 @@ export class OrthographicCamera extends Camera {
     far = 100.0
   ) {
     super();
-
-    // this keeps the camera frame centered at the origin
-    // use camera.pan or set its *position* (this.transform) to move the center
-    this.width_ = Math.abs(right - left);
-    this.height_ = Math.abs(top - bottom);
-    const centerX = 0.5 * (left + right);
-    const centerY = 0.5 * (bottom + top);
-    this.transform.setTranslation([centerX, centerY, 0]);
-    this.setFrame(left, right, bottom, top);
-
     this.near_ = near;
     this.far_ = far;
-
+    this.setFrame(left, right, bottom, top);
     this.updateProjectionMatrix();
   }
 
@@ -49,6 +40,11 @@ export class OrthographicCamera extends Camera {
   }
 
   protected updateProjectionMatrix() {
+    if (!this.width_ || !this.height_) {
+      throw new Error(
+        "OrthographicCamera frame must be defined before updating projection matrix"
+      );
+    }
     // The following code ensures that the orthographic projection matrix
     // is updated so that the aspect ratio of renderable objects is respected
     // (e.g. image pixels are isotropic) by padding the camera frame to form

--- a/packages/react/src/components/App.tsx
+++ b/packages/react/src/components/App.tsx
@@ -5,7 +5,6 @@ const plateUrl =
   "http://localhost:8080/20200812-CardiomyocyteDifferentiation14-Cycle1_mip.zarr";
 const imageUrl = plateUrl + "/B/03/0";
 const region = [
-  { dimension: "c", index: { start: 0, stop: 3 } },
   { dimension: "z", index: 0 },
 ];
 

--- a/packages/react/src/components/App.tsx
+++ b/packages/react/src/components/App.tsx
@@ -1,11 +1,15 @@
 import { Box } from "@mui/system";
-import Renderer from "./Renderer";
-import { ChannelControlsList } from "./controls/ChannelControlsList";
-import { useState } from "react";
-import { ImageLayer } from "@idetik/core";
+import OmeZarrImageViewer from "./OmeZarrImageViewer";
+
+const plateUrl =
+  "http://localhost:8080/20200812-CardiomyocyteDifferentiation14-Cycle1_mip.zarr";
+const imageUrl = plateUrl + "/B/03/0";
+const region = [
+  { dimension: "c", index: { start: 0, stop: 3 } },
+  { dimension: "z", index: 0 },
+];
 
 export default function App() {
-  const [imageLayer, setImageLayer] = useState<ImageLayer | null>(null);
 
   return (
     <Box
@@ -26,12 +30,13 @@ export default function App() {
           flexDirection: "column",
           flex: 1,
           gap: "1em",
+          border: "1px solid black",
         }}
       >
-        <Renderer onLayerReady={setImageLayer} />
-      </Box>
-      <Box sx={{ width: 300 }}>
-        {imageLayer && <ChannelControlsList layer={imageLayer} />}
+        <OmeZarrImageViewer
+          sourceUrl={imageUrl}
+          region={region}
+        />
       </Box>
     </Box>
   );

--- a/packages/react/src/components/OmeZarrImageViewer.tsx
+++ b/packages/react/src/components/OmeZarrImageViewer.tsx
@@ -4,26 +4,26 @@ import CircularProgress from '@mui/material/CircularProgress';
 import {
   ImageLayer,
   LayerManager,
-  OmeNgffImage,
+  OmeroChannel,
   OmeZarrImageSource,
   OrthographicCamera,
   Region,
+  loadOmeroChannels,
 } from "@idetik/core";
 
 import Renderer from "./Renderer";
 import { ChannelControlsList } from "./controls/ChannelControlsList";
-import { hexToRgb } from "../lib/color";
+import { hexToRgb } from "lib/color";
 
-
-type OmeroChannel = OmeNgffImage["omero"]["channels"][number];
+interface OmeZarrImageViewerProps {
+  sourceUrl: string;
+  region: Region;
+}
 
 export default function OmeZarrImageViewer({
   sourceUrl,
   region,
-}: {
-  sourceUrl: string;
-  region: Region;
-}) {
+}: OmeZarrImageViewerProps) {
   const [layerManager, _setLayerManager] = useState<LayerManager>(new LayerManager());
   const [camera, _setCamera] = useState<OrthographicCamera>(new OrthographicCamera(0, 128, 0, 128));
   const [imageLayer, setImageLayer] = useState<ImageLayer | null>(null);
@@ -39,16 +39,16 @@ export default function OmeZarrImageViewer({
     setLoading(true);
     const getLayer = async () => {
       if (!source) return;
-      const loader = await source?.open();
-      // TODO: should getting channel properties from the source go in the library?
       // TODO: may need to accept channel properties to be possibly overridden here
       // (i.e. for initial visibility, custom colors)
-      const channelProps = loader?.metadata.omero?.channels.map((channel: OmeroChannel) => {
+      const omeroChannels = await loadOmeroChannels(sourceUrl);
+      const channelProps = omeroChannels.map((channel: OmeroChannel) => {
         return {
           color: hexToRgb(channel.color),
           contrastLimits: [channel.window.start, channel.window.end],
+          // TODO: also get channel label and contrast range here
         };
-      }) ?? [];
+      });
       const layer = new ImageLayer({ source, region, channelProps });
       layer.addStateChangeCallback(() => {
         if (layer.state === "ready") {
@@ -60,12 +60,10 @@ export default function OmeZarrImageViewer({
       setImageLayer(layer);
     };
     getLayer();
-  }, [source, region, camera]);
+  }, [source, sourceUrl, region, camera]);
 
   useEffect(() => {
     if (imageLayer) {
-      // TODO: do we really want to clear the layer list? we only have one layer anyway...
-      // TODO: dispose objects owned by old layers
       layerManager.layers.length = 0;
       layerManager.add(imageLayer);
     }

--- a/packages/react/src/components/OmeZarrImageViewer.tsx
+++ b/packages/react/src/components/OmeZarrImageViewer.tsx
@@ -9,7 +9,11 @@ import {
   OrthographicCamera,
   Region,
 } from "@idetik/core";
+
 import Renderer from "./Renderer";
+import { ChannelControlsList } from "./controls/ChannelControlsList";
+import { hexToRgb } from "../lib/color";
+
 
 type OmeroChannel = OmeNgffImage["omero"]["channels"][number];
 
@@ -56,7 +60,7 @@ export default function OmeZarrImageViewer({
       setImageLayer(layer);
     };
     getLayer();
-  }, [source, region, camera, setLoading]);
+  }, [source, region, camera]);
 
   useEffect(() => {
     if (imageLayer) {
@@ -66,7 +70,8 @@ export default function OmeZarrImageViewer({
       layerManager.add(imageLayer);
     }
   }, [imageLayer, layerManager]);
-  console.log("loading", loading);
+
+  console.log("OmeZarrImageViewer::render", loading);
 
   return (
     <Box
@@ -87,21 +92,16 @@ export default function OmeZarrImageViewer({
       />
       {
         loading &&
-        <Box sx={{ position: "absolute", top: "50%", left: "50%" }}>
+        <Box sx={{ position: "fixed", top: "50%", left: "50%" }}>
           <CircularProgress />
+        </Box>
+      }
+      {
+        imageLayer &&
+        <Box sx={{ position: "fixed", top: "3em", left: "3em", width: "25em" }}>
+          <ChannelControlsList layer={imageLayer} />
         </Box>
       }
     </Box>
   );
 }
-
-// TODO: taken from Phoenix's code, should be consolidated
-const hexToRgb = (hex: string): [number, number, number] => {
-  const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
-  if (!result) return [0, 0, 0];
-  return [
-    parseInt(result[1], 16) / 255,
-    parseInt(result[2], 16) / 255,
-    parseInt(result[3], 16) / 255,
-  ];
-};

--- a/packages/react/src/components/OmeZarrImageViewer.tsx
+++ b/packages/react/src/components/OmeZarrImageViewer.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useState } from "react";
+import { Box } from "@mui/system";
+import CircularProgress from '@mui/material/CircularProgress';
 import {
   ImageLayer,
   LayerManager,
@@ -19,9 +21,10 @@ export default function OmeZarrImageViewer({
   region: Region;
 }) {
   const [layerManager, _setLayerManager] = useState<LayerManager>(new LayerManager());
-  const [camera, _setCamera] = useState<OrthographicCamera>(new OrthographicCamera(0, 832, 0, 351));
+  const [camera, _setCamera] = useState<OrthographicCamera>(new OrthographicCamera(0, 128, 0, 128));
   const [imageLayer, setImageLayer] = useState<ImageLayer | null>(null);
   const [source, setSource] = useState<OmeZarrImageSource | null>(null);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     const source = new OmeZarrImageSource(sourceUrl);
@@ -29,10 +32,13 @@ export default function OmeZarrImageViewer({
   }, [sourceUrl]);
 
   useEffect(() => {
+    setLoading(true);
     const getLayer = async () => {
       if (!source) return;
       const loader = await source?.open();
       // TODO: should getting channel properties from the source go in the library?
+      // TODO: may need to accept channel properties to be possibly overridden here
+      // (i.e. for initial visibility, custom colors)
       const channelProps = loader?.metadata.omero?.channels.map((channel: OmeroChannel) => {
         return {
           color: hexToRgb(channel.color),
@@ -42,6 +48,7 @@ export default function OmeZarrImageViewer({
       const layer = new ImageLayer({ source, region, channelProps });
       layer.addStateChangeCallback(() => {
         if (layer.state === "ready") {
+          setLoading(false);
           camera.setFrame(0, layer.extent.x, 0, layer.extent.y);
           camera.update();
         }
@@ -49,7 +56,7 @@ export default function OmeZarrImageViewer({
       setImageLayer(layer);
     };
     getLayer();
-  }, [source, region, camera]);
+  }, [source, region, camera, setLoading]);
 
   useEffect(() => {
     if (imageLayer) {
@@ -59,13 +66,32 @@ export default function OmeZarrImageViewer({
       layerManager.add(imageLayer);
     }
   }, [imageLayer, layerManager]);
+  console.log("loading", loading);
 
   return (
-    <Renderer
-      layerManager={layerManager}
-      camera={camera}
-      cameraControls="panzoom"
-    />
+    <Box
+      sx={{
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        flexDirection: "column",
+        flex: 1,
+        gap: "1em",
+        border: "1px solid black",
+      }}
+    >
+      <Renderer
+        layerManager={layerManager}
+        camera={camera}
+        cameraControls="panzoom"
+      />
+      {
+        loading &&
+        <Box sx={{ position: "absolute", top: "50%", left: "50%" }}>
+          <CircularProgress />
+        </Box>
+      }
+    </Box>
   );
 }
 

--- a/packages/react/src/components/OmeZarrImageViewer.tsx
+++ b/packages/react/src/components/OmeZarrImageViewer.tsx
@@ -69,8 +69,6 @@ export default function OmeZarrImageViewer({
     }
   }, [imageLayer, layerManager]);
 
-  console.log("OmeZarrImageViewer::render", loading);
-
   return (
     <Box
       sx={{

--- a/packages/react/src/components/OmeZarrImageViewer.tsx
+++ b/packages/react/src/components/OmeZarrImageViewer.tsx
@@ -1,0 +1,83 @@
+import { useEffect, useState } from "react";
+import {
+  ImageLayer,
+  LayerManager,
+  OmeNgffImage,
+  OmeZarrImageSource,
+  OrthographicCamera,
+  Region,
+} from "@idetik/core";
+import Renderer from "./Renderer";
+
+type OmeroChannel = OmeNgffImage["omero"]["channels"][number];
+
+export default function OmeZarrImageViewer({
+  sourceUrl,
+  region,
+}: {
+  sourceUrl: string;
+  region: Region;
+}) {
+  const [layerManager, _setLayerManager] = useState<LayerManager>(new LayerManager());
+  const [camera, _setCamera] = useState<OrthographicCamera>(new OrthographicCamera(0, 832, 0, 351));
+  const [imageLayer, setImageLayer] = useState<ImageLayer | null>(null);
+  const [source, setSource] = useState<OmeZarrImageSource | null>(null);
+
+  useEffect(() => {
+    const source = new OmeZarrImageSource(sourceUrl);
+    setSource(source);
+  }, [sourceUrl]);
+
+  useEffect(() => {
+    const getLayer = async () => {
+      if (!source) return;
+      const loader = await source?.open();
+      // TODO: should getting channel properties from the source go in the library?
+      const channelProps = loader?.metadata.omero?.channels.map((channel: OmeroChannel) => {
+        return {
+          color: hexToRgb(channel.color),
+          contrastLimits: [channel.window.start, channel.window.end],
+        };
+      }) ?? [];
+      const layer = new ImageLayer({ source, region, channelProps });
+      layer.addStateChangeCallback(() => {
+        if (layer.state === "ready") {
+          console.log("ImageLayer is ready", layer.extent);
+          camera.setFrame(0, layer.extent.x, 0, layer.extent.y);
+          camera.updateProjectionMatrix();
+        }
+      });
+
+      setImageLayer(layer);
+    };
+    getLayer();
+  }, [source, region, camera]);
+
+  useEffect(() => {
+    if (imageLayer) {
+      // TODO: do we really want to clear any old layers?
+      // TODO: dispose objects owned by old layers
+      layerManager.layers.length = 0;
+      layerManager.add(imageLayer);
+    }
+  }, [imageLayer, layerManager]);
+
+  return (
+    <Renderer
+      layerManager={layerManager}
+      camera={camera}
+      enableControls={true}
+    />
+  );
+}
+
+// TODO: taken from Phoenix's code, should be consolidated
+const hexToRgb = (hex: string): [number, number, number] => {
+  const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+  if (!result) return [0, 0, 0];
+  return [
+    parseInt(result[1], 16) / 255,
+    parseInt(result[2], 16) / 255,
+    parseInt(result[3], 16) / 255,
+  ];
+};

--- a/packages/react/src/components/OmeZarrImageViewer.tsx
+++ b/packages/react/src/components/OmeZarrImageViewer.tsx
@@ -42,12 +42,10 @@ export default function OmeZarrImageViewer({
       const layer = new ImageLayer({ source, region, channelProps });
       layer.addStateChangeCallback(() => {
         if (layer.state === "ready") {
-          console.log("ImageLayer is ready", layer.extent);
           camera.setFrame(0, layer.extent.x, 0, layer.extent.y);
-          camera.updateProjectionMatrix();
+          camera.update();
         }
       });
-
       setImageLayer(layer);
     };
     getLayer();
@@ -55,7 +53,7 @@ export default function OmeZarrImageViewer({
 
   useEffect(() => {
     if (imageLayer) {
-      // TODO: do we really want to clear any old layers?
+      // TODO: do we really want to clear the layer list? we only have one layer anyway...
       // TODO: dispose objects owned by old layers
       layerManager.layers.length = 0;
       layerManager.add(imageLayer);
@@ -66,7 +64,7 @@ export default function OmeZarrImageViewer({
     <Renderer
       layerManager={layerManager}
       camera={camera}
-      enableControls={true}
+      cameraControls="panzoom"
     />
   );
 }

--- a/packages/react/src/components/Renderer.tsx
+++ b/packages/react/src/components/Renderer.tsx
@@ -1,66 +1,49 @@
 import { useEffect, useRef } from "react";
 import {
-  ImageLayer,
-  OmeZarrImageSource,
   LayerManager,
   OrthographicCamera,
   PanZoomControls,
+  NullControls,
   WebGLRenderer,
 } from "@idetik/core";
 
-// TODO: needs to be unique so we can have more than one on the page
-const canvasId = "canvas";
+type Controls = PanZoomControls | NullControls;
 
-// TODO: useRef for some of these objects
-const camera = new OrthographicCamera(0, 825, 0, 500);
-const layerManager = new LayerManager();
-
-// TODO: use props to pass in most of this config
-const plateUrl =
-  "http://localhost:8080/20200812-CardiomyocyteDifferentiation14-Cycle1_mip.zarr";
-const imageUrl = plateUrl + "/B/03/0";
-console.debug(`Loading image from ${imageUrl}`);
-const source = new OmeZarrImageSource(imageUrl);
-const region = [
-  { dimension: "c", index: { start: 0, stop: 3 } },
-  { dimension: "z", index: 0 },
-];
-
-// colors and limits come from the OME-Zarr metadata
-// http://localhost:8080/20200812-CardiomyocyteDifferentiation14-Cycle1_mip.zarr/B/03/0/.zattrs
-const channelProps = [
-  { color: [0, 1, 1], contrastLimits: [110, 800] },
-  { color: [1, 0, 1], contrastLimits: [110, 250] },
-  { color: [1, 1, 0], contrastLimits: [110, 800] },
-];
-// TODO: typescript is not checking the types of the arguments to the constructor
-// see https://github.com/chanzuckerberg/imaging-active-learning/issues/174
-const layer = new ImageLayer({ source, region, channelProps });
-layerManager.add(layer);
-
-interface RendererProps {
-  onLayerReady?: (layer: ImageLayer) => void;
-}
-
-export default function Renderer({ onLayerReady }: RendererProps) {
+export default function Renderer({
+  layerManager,
+  camera,
+  enableControls = true,
+  canvasId = "renderer",
+}: {
+  layerManager: LayerManager,
+  camera: OrthographicCamera,
+  // TODO: in the future this could be an enum for control type or something
+  enableControls: boolean,
+  canvasId?: string,  // allows for multiple renderers on the page
+}) {
+  console.log("Renderer::", layerManager, camera, enableControls, canvasId);
   const renderer = useRef<WebGLRenderer | null>(null);
+  const controls = useRef<Controls>(() => new NullControls());
 
+  if (enableControls) {
+    controls.current = new PanZoomControls(camera, camera.position);
+  } else if (!enableControls && controls.current !== null) {
+    controls.current = new NullControls();
+  }
+  renderer.current?.setControls(controls.current);
+
+  // Use the mount-effect so that the renderer can find the corresponding
+  // element by its ID.
   useEffect(() => {
     console.debug("Renderer::mount");
     let lastRequestId = 0;
-
-    // Initialize renderer if not already done
-    if (renderer.current === null) {
+    if (!renderer.current) {
       renderer.current = new WebGLRenderer(`#${canvasId}`);
-      const controls = new PanZoomControls(camera, camera.position);
-      renderer.current.setControls(controls);
-
-      // Notify parent about the layer
-      onLayerReady?.(layer);
+      console.debug(`Created WebGLRenderer for ${canvasId}`, renderer.current);
+      renderer.current.setControls(controls.current);
     }
-
     function animate() {
-      renderer.current?.render(layerManager, camera);
+      renderer.current.render(layerManager, camera);
       lastRequestId = requestAnimationFrame(animate);
     }
     animate();
@@ -71,7 +54,7 @@ export default function Renderer({ onLayerReady }: RendererProps) {
         cancelAnimationFrame(lastRequestId);
       }
     };
-  }, [onLayerReady]);
+  }, [canvasId, camera, layerManager]);
 
   return <canvas id={canvasId} style={{ width: "100%", height: "100%" }} />;
 }

--- a/packages/react/src/components/Renderer.tsx
+++ b/packages/react/src/components/Renderer.tsx
@@ -10,17 +10,19 @@ import {
 
 type ControlType = "panzoom" | "none";
 
+interface RendererProps {
+  layerManager: LayerManager;
+  camera: OrthographicCamera;
+  cameraControls?: ControlType;
+  canvasId?: string;
+}
+
 export default function Renderer({
   layerManager,
   camera,
   cameraControls = "panzoom",
   canvasId = "renderer",
-}: {
-  layerManager: LayerManager,
-  camera: OrthographicCamera,
-  cameraControls: ControlType,
-  canvasId?: string,  // allows for multiple renderers on the page
-}) {
+}: RendererProps) {
   const renderer = useRef<WebGLRenderer | null>(null);
   const controls = useRef<CameraControls>(() => new NullControls());
 

--- a/packages/react/src/components/Renderer.tsx
+++ b/packages/react/src/components/Renderer.tsx
@@ -2,33 +2,35 @@ import { useEffect, useRef } from "react";
 import {
   LayerManager,
   OrthographicCamera,
+  CameraControls,
   PanZoomControls,
   NullControls,
   WebGLRenderer,
 } from "@idetik/core";
 
-type Controls = PanZoomControls | NullControls;
+type ControlType = "panzoom" | "none";
 
 export default function Renderer({
   layerManager,
   camera,
-  enableControls = true,
+  cameraControls = "panzoom",
   canvasId = "renderer",
 }: {
   layerManager: LayerManager,
   camera: OrthographicCamera,
-  // TODO: in the future this could be an enum for control type or something
-  enableControls: boolean,
+  cameraControls: ControlType,
   canvasId?: string,  // allows for multiple renderers on the page
 }) {
-  console.log("Renderer::", layerManager, camera, enableControls, canvasId);
   const renderer = useRef<WebGLRenderer | null>(null);
-  const controls = useRef<Controls>(() => new NullControls());
+  const controls = useRef<CameraControls>(() => new NullControls());
 
-  if (enableControls) {
-    controls.current = new PanZoomControls(camera, camera.position);
-  } else if (!enableControls && controls.current !== null) {
-    controls.current = new NullControls();
+  switch (cameraControls) {
+    case "panzoom":
+      controls.current = new PanZoomControls(camera, camera.position);
+      break;
+    case "none":
+      controls.current = new NullControls();
+      break;
   }
   renderer.current?.setControls(controls.current);
 
@@ -47,7 +49,6 @@ export default function Renderer({
       lastRequestId = requestAnimationFrame(animate);
     }
     animate();
-
     return () => {
       if (lastRequestId > 0) {
         console.debug(`Cancelling animation frame ${lastRequestId}`);

--- a/packages/react/src/components/controls/ColorPicker.tsx
+++ b/packages/react/src/components/controls/ColorPicker.tsx
@@ -1,5 +1,5 @@
 import { Box } from "@mui/material";
-import { hexToRgb } from "../../lib/color";
+import { hexToRgb } from "lib/color";
 
 interface ColorPickerProps {
   color: [number, number, number];

--- a/packages/react/src/components/controls/ColorPicker.tsx
+++ b/packages/react/src/components/controls/ColorPicker.tsx
@@ -1,4 +1,5 @@
 import { Box } from "@mui/material";
+import { hexToRgb } from "../../lib/color";
 
 interface ColorPickerProps {
   color: [number, number, number];
@@ -13,17 +14,6 @@ export function ColorPicker({ color, onChange }: ColorPickerProps) {
       return hex.length === 1 ? "0" + hex : hex;
     };
     return `#${toHex(rgb[0])}${toHex(rgb[1])}${toHex(rgb[2])}`;
-  };
-
-  // Convert hex string to RGB [0-1] values
-  const hexToRgb = (hex: string): [number, number, number] => {
-    const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
-    if (!result) return [0, 0, 0];
-    return [
-      parseInt(result[1], 16) / 255,
-      parseInt(result[2], 16) / 255,
-      parseInt(result[3], 16) / 255,
-    ];
   };
 
   return (

--- a/packages/react/src/lib/color.ts
+++ b/packages/react/src/lib/color.ts
@@ -1,0 +1,10 @@
+// TODO: taken from Phoenix's code, should be consolidated
+export const hexToRgb = (hex: string): [number, number, number] => {
+  const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+  if (!result) return [0, 0, 0];
+  return [
+    parseInt(result[1], 16) / 255,
+    parseInt(result[2], 16) / 255,
+    parseInt(result[3], 16) / 255,
+  ];
+};


### PR DESCRIPTION
### Summary
This refactors the `Renderer` component to be more declarative. For now it's still basically intended for 2D, but that's mostly a limitation of our camera controls.

This also then creates a new `OmeZarrImageViewer` component that is intended to be the component used on the organellebox portal. This component takes a URL for a Zarr and a `Region`. The component handles creating the source/loader and setting up an `ImageLayer` to be passed to the renderer. It also attempts to read/set channel information (color, contrast limits) from the `omero` section of the zattrs for the image. Finally, it attempts to set the initial camera frame based on the image size once the region is loaded.

Main changes in `core` are:
* Add `extent` to `ImageLayer`
* Add `metadata` property to `OmeZarrImageLoader` to provide access to omero channel data
* Some orthographic camera implementation cleanup

### Related Issue
Closes #176
(Integration with #183 is TODO and required for #142 to be closed)

### Tests & Checks
Tested manually using 20200812-CardiomyocyteDifferentiation14-Cycle1_mip.zarr 