### PR TITLE
Fix channel blending by clamping extracted texture value

### DIFF
--- a/packages/core/src/renderers/shaders/float_image_array_frag.glsl
+++ b/packages/core/src/renderers/shaders/float_image_array_frag.glsl
@@ -20,6 +20,8 @@ void main() {
         if (!Visible[i]) continue;
         float texel = texture(texture0, vec3(TexCoords, i)).r;
         float value = (texel + ValueOffset[i]) * ValueScale[i];
+        // clamp to [0, 1] because contrast limits may put values out of this range,
+        // which distorts colors in other channels
         value = clamp(value, 0.0, 1.0);
         rgbColor += value * Color[i].rgb;
     }

--- a/packages/core/src/renderers/shaders/float_image_array_frag.glsl
+++ b/packages/core/src/renderers/shaders/float_image_array_frag.glsl
@@ -20,6 +20,7 @@ void main() {
         if (!Visible[i]) continue;
         float texel = texture(texture0, vec3(TexCoords, i)).r;
         float value = (texel + ValueOffset[i]) * ValueScale[i];
+        value = clamp(value, 0.0, 1.0);
         rgbColor += value * Color[i].rgb;
     }
     fragColor = vec4(rgbColor.rgb, 1);

--- a/packages/core/src/renderers/shaders/uint_image_array_frag.glsl
+++ b/packages/core/src/renderers/shaders/uint_image_array_frag.glsl
@@ -20,6 +20,7 @@ void main() {
         if (!Visible[i]) continue;
         float texel = float(texture(texture0, vec3(TexCoords, i)).r);
         float value = (texel + ValueOffset[i]) * ValueScale[i];
+        value = clamp(value, 0.0, 1.0);
         rgbColor += value * Color[i].rgb;
     }
     fragColor = vec4(rgbColor.rgb, 1);

--- a/packages/core/src/renderers/shaders/uint_image_array_frag.glsl
+++ b/packages/core/src/renderers/shaders/uint_image_array_frag.glsl
@@ -20,6 +20,8 @@ void main() {
         if (!Visible[i]) continue;
         float texel = float(texture(texture0, vec3(TexCoords, i)).r);
         float value = (texel + ValueOffset[i]) * ValueScale[i];
+        // clamp to [0, 1] because contrast limits may put values out of this range,
+        // which distorts colors in other channels
         value = clamp(value, 0.0, 1.0);
         rgbColor += value * Color[i].rgb;
     }


### PR DESCRIPTION
### Summary
When contrast limits are applied in the shader, we can actually end up with a negative value. This messes with the colors of other channels.

### Related Issue
Closes #195 

### Tests & Checks
Tested with organelle box data and no longer seeing yellow tinted background when scaling the blue channel
