### PR TITLE
Add label and contrast range props for channel controls

### DIFF
--- a/packages/react/src/components/Main.tsx
+++ b/packages/react/src/components/Main.tsx
@@ -10,7 +10,7 @@ const root = createRoot(domNode);
 
 root.render(
   <React.StrictMode>
-    <div className={cns("font-sds-body", "min-w-[1024px]")}>
+    <div className={cns("font-sds-body")}>
       <ThemedApp />
     </div>
   </React.StrictMode>

--- a/packages/react/src/components/OmeZarrImageViewer.tsx
+++ b/packages/react/src/components/OmeZarrImageViewer.tsx
@@ -133,7 +133,7 @@ function omeroToControlProps(
   return omeroChannels.map((channel: OmeroChannel) => {
     return {
       label: channel.label,
-      contrastRange: [0.5 * channel.window.start, 1.5 * channel.window.end],
+      contrastRange: [0.5 * channel.window.start, 1.1 * channel.window.end],
     };
   });
 }

--- a/packages/react/src/components/OmeZarrImageViewer.tsx
+++ b/packages/react/src/components/OmeZarrImageViewer.tsx
@@ -9,10 +9,12 @@ import {
   OrthographicCamera,
   Region,
   loadOmeroChannels,
+  ChannelProps,
 } from "@idetik/core";
 
 import Renderer from "./Renderer";
 import { ChannelControlsList } from "./controls/ChannelControlsList";
+import { ChannelControlProps } from "./controls/ChannelControl";
 import { hexToRgb } from "lib/color";
 
 interface OmeZarrImageViewerProps {
@@ -33,6 +35,7 @@ export default function OmeZarrImageViewer({
   const [imageLayer, setImageLayer] = useState<ImageLayer | null>(null);
   const [source, setSource] = useState<OmeZarrImageSource | null>(null);
   const [loading, setLoading] = useState(true);
+  const [controlProps, setControlProps] = useState<Partial<ChannelControlProps>[]>([]);
 
   useEffect(() => {
     const source = new OmeZarrImageSource(sourceUrl);
@@ -46,13 +49,15 @@ export default function OmeZarrImageViewer({
       // TODO: may need to accept channel properties to be possibly overridden here
       // (i.e. for initial visibility, custom colors)
       const omeroChannels = await loadOmeroChannels(sourceUrl);
-      const channelProps = omeroChannels.map((channel: OmeroChannel) => {
-        return {
-          color: hexToRgb(channel.color),
-          contrastLimits: [channel.window.start, channel.window.end],
-          // TODO: also get channel label and contrast range here
-        };
-      });
+      const channelProps = omeroToChannelProps(omeroChannels);
+      setControlProps(omeroToControlProps(omeroChannels));
+      // const channelProps = omeroChannels.map((channel: OmeroChannel) => {
+      //   return {
+      //     color: hexToRgb(channel.color),
+      //     contrastLimits: [channel.window.start, channel.window.end],
+      //     // TODO: also get channel label and contrast range here
+      //   };
+      // });
       const layer = new ImageLayer({ source, region, channelProps });
       layer.addStateChangeCallback(() => {
         if (layer.state === "ready") {
@@ -101,9 +106,30 @@ export default function OmeZarrImageViewer({
       )}
       {imageLayer && (
         <div className={cns("absolute", "top-4", "left-4", "w-[25em]")}>
-          <ChannelControlsList layer={imageLayer} />
+          <ChannelControlsList layer={imageLayer} controlProps={controlProps} />
         </div>
       )}
     </div>
   );
+}
+
+// TODO: the limits/range from the omero channels should possibly be reversed
+// (start/end for limits, min/max for range) but the organelle box data works better this way
+function omeroToChannelProps(omeroChannels: OmeroChannel[]): ChannelProps[] {
+  return omeroChannels.map((channel: OmeroChannel) => {
+    return {
+      visible: channel.active,
+      color: hexToRgb(channel.color),
+      contrastLimits: [channel.window.min, channel.window.max],
+    };
+  });
+};
+
+function omeroToControlProps(omeroChannels: OmeroChannel[]): Partial<ChannelControlProps>[] {
+  return omeroChannels.map((channel: OmeroChannel) => {
+    return {
+      label: channel.label,
+      contrastRange: [0.5 * channel.window.start, 1.5 * channel.window.end],
+    };
+  });
 }

--- a/packages/react/src/components/OmeZarrImageViewer.tsx
+++ b/packages/react/src/components/OmeZarrImageViewer.tsx
@@ -53,13 +53,6 @@ export default function OmeZarrImageViewer({
       const omeroChannels = await loadOmeroChannels(sourceUrl);
       const channelProps = omeroToChannelProps(omeroChannels);
       setControlProps(omeroToControlProps(omeroChannels));
-      // const channelProps = omeroChannels.map((channel: OmeroChannel) => {
-      //   return {
-      //     color: hexToRgb(channel.color),
-      //     contrastLimits: [channel.window.start, channel.window.end],
-      //     // TODO: also get channel label and contrast range here
-      //   };
-      // });
       const layer = new ImageLayer({ source, region, channelProps });
       layer.addStateChangeCallback(() => {
         if (layer.state === "ready") {
@@ -117,7 +110,7 @@ export default function OmeZarrImageViewer({
 
 // TODO: the limits/range from the omero channels should possibly be reversed
 // (start/end for limits, min/max for range) but the organelle box data works better this way
-function omeroToChannelProps(omeroChannels: OmeroChannel[]): ChannelProps[] {
+const omeroToChannelProps = (omeroChannels: OmeroChannel[]): ChannelProps[] => {
   return omeroChannels.map((channel: OmeroChannel) => {
     return {
       visible: channel.active,
@@ -127,12 +120,14 @@ function omeroToChannelProps(omeroChannels: OmeroChannel[]): ChannelProps[] {
   });
 }
 
-function omeroToControlProps(
+const omeroToControlProps = (
   omeroChannels: OmeroChannel[]
-): Partial<ChannelControlProps>[] {
+): Partial<ChannelControlProps>[] => {
   return omeroChannels.map((channel: OmeroChannel) => {
+    // remove prefix (number + hyphen) from label if present (seen in organelle box data)
+    const label = channel.label.replace(/^\d+-/, "");
     return {
-      label: channel.label,
+      label,
       contrastRange: [0.5 * channel.window.start, 1.1 * channel.window.end],
     };
   });

--- a/packages/react/src/components/OmeZarrImageViewer.tsx
+++ b/packages/react/src/components/OmeZarrImageViewer.tsx
@@ -35,7 +35,9 @@ export default function OmeZarrImageViewer({
   const [imageLayer, setImageLayer] = useState<ImageLayer | null>(null);
   const [source, setSource] = useState<OmeZarrImageSource | null>(null);
   const [loading, setLoading] = useState(true);
-  const [controlProps, setControlProps] = useState<Partial<ChannelControlProps>[]>([]);
+  const [controlProps, setControlProps] = useState<
+    Partial<ChannelControlProps>[]
+  >([]);
 
   useEffect(() => {
     const source = new OmeZarrImageSource(sourceUrl);
@@ -123,9 +125,11 @@ function omeroToChannelProps(omeroChannels: OmeroChannel[]): ChannelProps[] {
       contrastLimits: [channel.window.min, channel.window.max],
     };
   });
-};
+}
 
-function omeroToControlProps(omeroChannels: OmeroChannel[]): Partial<ChannelControlProps>[] {
+function omeroToControlProps(
+  omeroChannels: OmeroChannel[]
+): Partial<ChannelControlProps>[] {
   return omeroChannels.map((channel: OmeroChannel) => {
     return {
       label: channel.label,

--- a/packages/react/src/components/OmeZarrImageViewer.tsx
+++ b/packages/react/src/components/OmeZarrImageViewer.tsx
@@ -118,7 +118,7 @@ const omeroToChannelProps = (omeroChannels: OmeroChannel[]): ChannelProps[] => {
       contrastLimits: [channel.window.min, channel.window.max],
     };
   });
-}
+};
 
 const omeroToControlProps = (
   omeroChannels: OmeroChannel[]
@@ -131,4 +131,4 @@ const omeroToControlProps = (
       contrastRange: [0.5 * channel.window.start, 1.1 * channel.window.end],
     };
   });
-}
+};

--- a/packages/react/src/components/controls/ChannelControl.tsx
+++ b/packages/react/src/components/controls/ChannelControl.tsx
@@ -24,8 +24,6 @@ export function ChannelControl({
   onContrastChange,
   onColorChange,
 }: ChannelControlProps) {
-  // remove prefix (number + hyphen) from label if present
-  label = label.replace(/^\d+-/, "");
   return (
     <div className="grid grid-cols-subgrid col-start-1 col-end-5 gap-2 items-center">
       <div className="text-right text-xs">{label}</div>

--- a/packages/react/src/components/controls/ChannelControl.tsx
+++ b/packages/react/src/components/controls/ChannelControl.tsx
@@ -2,10 +2,12 @@ import { VisibilityToggle } from "./VisibilityToggle";
 import { ColorPicker } from "./ColorPicker";
 import { ContrastSlider } from "./ContrastSlider";
 
-interface ChannelControlProps {
+export interface ChannelControlProps {
   channelIndex: number;
+  label: string;
   color: [number, number, number];
   contrastLimits: [number, number];
+  contrastRange: [number, number];
   visible: boolean;
   onVisibilityChange: (visible: boolean) => void;
   onContrastChange: (limits: [number, number]) => void;
@@ -13,8 +15,10 @@ interface ChannelControlProps {
 }
 
 export function ChannelControl({
+  label,
   color,
   contrastLimits,
+  contrastRange,
   visible,
   onVisibilityChange,
   onContrastChange,
@@ -25,8 +29,14 @@ export function ChannelControl({
       <VisibilityToggle visible={visible} onChange={onVisibilityChange} />
       <ColorPicker color={color} onChange={onColorChange} />
       <div className="flex-1 ml-1 mr-1 flex items-center">
-        <ContrastSlider value={contrastLimits} onChange={onContrastChange} />
+        <ContrastSlider
+          min={contrastRange[0]}
+          max={contrastRange[1]}
+          value={contrastLimits}
+          onChange={onContrastChange}
+        />
       </div>
+      <div>{label}</div>
     </div>
   );
 }

--- a/packages/react/src/components/controls/ChannelControl.tsx
+++ b/packages/react/src/components/controls/ChannelControl.tsx
@@ -24,10 +24,12 @@ export function ChannelControl({
   onContrastChange,
   onColorChange,
 }: ChannelControlProps) {
+  // remove prefix (number + hyphen) from label if present
+  label = label.replace(/^\d+-/, "");
   return (
-    <div className="grid grid-cols-auto gap-2 items-center">
-      <div className="text-left">{label}</div>
-      <div className="flex items-center gap-2">
+    <div className="grid grid-cols-subgrid col-start-1 col-end-5 gap-2 items-center">
+      <div className="text-right text-xs">{label}</div>
+      <div className="col-span-3 flex items-center gap-2">
         <VisibilityToggle visible={visible} onChange={onVisibilityChange} />
         <ColorPicker color={color} onChange={onColorChange} />
         <div className="flex-1 ml-1 mr-1 flex items-center">

--- a/packages/react/src/components/controls/ChannelControl.tsx
+++ b/packages/react/src/components/controls/ChannelControl.tsx
@@ -25,18 +25,20 @@ export function ChannelControl({
   onColorChange,
 }: ChannelControlProps) {
   return (
-    <div className="flex items-center gap-2">
-      <VisibilityToggle visible={visible} onChange={onVisibilityChange} />
-      <ColorPicker color={color} onChange={onColorChange} />
-      <div className="flex-1 ml-1 mr-1 flex items-center">
-        <ContrastSlider
-          min={contrastRange[0]}
-          max={contrastRange[1]}
-          value={contrastLimits}
-          onChange={onContrastChange}
-        />
+    <div className="grid grid-cols-auto gap-2 items-center">
+      <div className="text-left">{label}</div>
+      <div className="flex items-center gap-2">
+        <VisibilityToggle visible={visible} onChange={onVisibilityChange} />
+        <ColorPicker color={color} onChange={onColorChange} />
+        <div className="flex-1 ml-1 mr-1 flex items-center">
+          <ContrastSlider
+            min={contrastRange[0]}
+            max={contrastRange[1]}
+            value={contrastLimits}
+            onChange={onContrastChange}
+          />
+        </div>
       </div>
-      <div>{label}</div>
     </div>
   );
 }

--- a/packages/react/src/components/controls/ChannelControlsList.tsx
+++ b/packages/react/src/components/controls/ChannelControlsList.tsx
@@ -1,22 +1,35 @@
 import { Accordion } from "@mui/material";
 import { AccordionHeader, AccordionDetails } from "@czi-sds/components";
 import cns from "classnames";
-import { ChannelControl } from "./ChannelControl";
+import { ChannelControl, ChannelControlProps } from "./ChannelControl";
 import { ImageLayer, ChannelProps } from "@idetik/core";
 import { useState, useEffect } from "react";
 
 interface ChannelControlsListProps {
   layer: ImageLayer;
+  controlProps: Partial<ChannelControlProps>[];
 }
 
-export function ChannelControlsList({ layer }: ChannelControlsListProps) {
+export function ChannelControlsList({ layer, controlProps }: ChannelControlsListProps) {
   // Keep a local copy of channelProps to trigger re-renders
   const [channelProps, setChannelProps] = useState(layer.channelProps ?? []);
 
   // Sync local state with layer's channelProps
   useEffect(() => {
+    const initialLayerChannelProps = layer.channelProps ?? [];
+    initialLayerChannelProps.map((layerChannel: ChannelProps, index: number) => {
+      const c = controlProps[index] ?? {};
+      const visible = c.visible ?? layerChannel.visible ?? true;
+      const color = c.color ?? layerChannel.color;
+      const contrastLimits = c.contrastLimits ?? layerChannel.contrastLimits;
+      return {
+        visible,
+        color,
+        contrastLimits,
+      };
+    });
     setChannelProps(layer.channelProps ?? []);
-  }, [layer]);
+  }, [layer, controlProps]);
 
   const updateChannel = (
     index: number,
@@ -38,6 +51,8 @@ export function ChannelControlsList({ layer }: ChannelControlsListProps) {
     setChannelProps(updatedChannelProps);
   };
 
+  console.log("ChannelControlsList::render", controlProps);
+
   return (
     <div className="sds-color-primitive-blue-400 p-1">
       <Accordion defaultExpanded id="channel-controls">
@@ -48,8 +63,10 @@ export function ChannelControlsList({ layer }: ChannelControlsListProps) {
               <ChannelControl
                 key={index}
                 channelIndex={index}
+                label={controlProps[index]?.label ?? `Channel ${index}`}
                 color={props.color}
                 contrastLimits={props.contrastLimits}
+                contrastRange={controlProps[index]?.contrastRange ?? props.contrastLimits}
                 visible={props.visible === undefined ? true : props.visible}
                 onVisibilityChange={(visible) =>
                   updateChannel(index, { visible })

--- a/packages/react/src/components/controls/ChannelControlsList.tsx
+++ b/packages/react/src/components/controls/ChannelControlsList.tsx
@@ -22,7 +22,7 @@ export function ChannelControlsList({
     const initialLayerChannelProps = layer.channelProps ?? [];
 
     const updatedChannelProps = initialLayerChannelProps.map(
-      (layerChannel, index) => ({
+      (layerChannel: ChannelProps, index: number) => ({
         visible:
           controlProps?.[index]?.visible ?? layerChannel?.visible ?? true,
         color: controlProps?.[index]?.color ?? layerChannel?.color,
@@ -31,7 +31,7 @@ export function ChannelControlsList({
       })
     );
 
-    setChannelProps(layer.channelProps ?? []);
+    setChannelProps(updatedChannelProps);
   }, [layer, controlProps]);
 
   const updateChannel = (

--- a/packages/react/src/components/controls/ChannelControlsList.tsx
+++ b/packages/react/src/components/controls/ChannelControlsList.tsx
@@ -10,24 +10,29 @@ interface ChannelControlsListProps {
   controlProps: Partial<ChannelControlProps>[];
 }
 
-export function ChannelControlsList({ layer, controlProps }: ChannelControlsListProps) {
+export function ChannelControlsList({
+  layer,
+  controlProps,
+}: ChannelControlsListProps) {
   // Keep a local copy of channelProps to trigger re-renders
   const [channelProps, setChannelProps] = useState(layer.channelProps ?? []);
 
   // Sync local state with layer's channelProps
   useEffect(() => {
     const initialLayerChannelProps = layer.channelProps ?? [];
-    initialLayerChannelProps.map((layerChannel: ChannelProps, index: number) => {
-      const c = controlProps[index] ?? {};
-      const visible = c.visible ?? layerChannel.visible ?? true;
-      const color = c.color ?? layerChannel.color;
-      const contrastLimits = c.contrastLimits ?? layerChannel.contrastLimits;
-      return {
-        visible,
-        color,
-        contrastLimits,
-      };
-    });
+    initialLayerChannelProps.map(
+      (layerChannel: ChannelProps, index: number) => {
+        const c = controlProps[index] ?? {};
+        const visible = c.visible ?? layerChannel.visible ?? true;
+        const color = c.color ?? layerChannel.color;
+        const contrastLimits = c.contrastLimits ?? layerChannel.contrastLimits;
+        return {
+          visible,
+          color,
+          contrastLimits,
+        };
+      }
+    );
     setChannelProps(layer.channelProps ?? []);
   }, [layer, controlProps]);
 
@@ -66,7 +71,9 @@ export function ChannelControlsList({ layer, controlProps }: ChannelControlsList
                 label={controlProps[index]?.label ?? `Channel ${index}`}
                 color={props.color}
                 contrastLimits={props.contrastLimits}
-                contrastRange={controlProps[index]?.contrastRange ?? props.contrastLimits}
+                contrastRange={
+                  controlProps[index]?.contrastRange ?? props.contrastLimits
+                }
                 visible={props.visible === undefined ? true : props.visible}
                 onVisibilityChange={(visible) =>
                   updateChannel(index, { visible })

--- a/packages/react/src/components/controls/ChannelControlsList.tsx
+++ b/packages/react/src/components/controls/ChannelControlsList.tsx
@@ -56,8 +56,6 @@ export function ChannelControlsList({
     setChannelProps(updatedChannelProps);
   };
 
-  console.log("ChannelControlsList::render", controlProps);
-
   return (
     <div className="p-1">
       <Accordion defaultExpanded id="channel-controls">

--- a/packages/react/src/components/controls/ChannelControlsList.tsx
+++ b/packages/react/src/components/controls/ChannelControlsList.tsx
@@ -63,7 +63,7 @@ export function ChannelControlsList({
       <Accordion defaultExpanded id="channel-controls">
         <AccordionHeader>Channel Controls</AccordionHeader>
         <AccordionDetails>
-          <div className={cns("grid grid-rows-auto gap-sds-xs")}>
+          <div className={cns("grid grid-cols-4 grid-rows-auto gap-sds-xs")}>
             {channelProps.map((props: ChannelProps, index: number) => (
               <ChannelControl
                 key={index}

--- a/packages/react/src/components/controls/ChannelControlsList.tsx
+++ b/packages/react/src/components/controls/ChannelControlsList.tsx
@@ -19,13 +19,17 @@ export function ChannelControlsList({
 
   // Sync local state with layer's channelProps
   useEffect(() => {
-const initialLayerChannelProps = layer.channelProps ?? [];
+    const initialLayerChannelProps = layer.channelProps ?? [];
 
-const updatedChannelProps = initialLayerChannelProps.map((layerChannel, index) => ({
-  visible: controlProps?.[index]?.visible ?? layerChannel?.visible ?? true,
-  color: controlProps?.[index]?.color ?? layerChannel?.color,
-  contrastLimits: controlProps?.[index]?.contrastLimits ?? layerChannel?.contrastLimits,
-}));
+    const updatedChannelProps = initialLayerChannelProps.map(
+      (layerChannel, index) => ({
+        visible:
+          controlProps?.[index]?.visible ?? layerChannel?.visible ?? true,
+        color: controlProps?.[index]?.color ?? layerChannel?.color,
+        contrastLimits:
+          controlProps?.[index]?.contrastLimits ?? layerChannel?.contrastLimits,
+      })
+    );
 
     setChannelProps(layer.channelProps ?? []);
   }, [layer, controlProps]);

--- a/packages/react/src/components/controls/ChannelControlsList.tsx
+++ b/packages/react/src/components/controls/ChannelControlsList.tsx
@@ -19,20 +19,14 @@ export function ChannelControlsList({
 
   // Sync local state with layer's channelProps
   useEffect(() => {
-    const initialLayerChannelProps = layer.channelProps ?? [];
-    initialLayerChannelProps.map(
-      (layerChannel: ChannelProps, index: number) => {
-        const c = controlProps[index] ?? {};
-        const visible = c.visible ?? layerChannel.visible ?? true;
-        const color = c.color ?? layerChannel.color;
-        const contrastLimits = c.contrastLimits ?? layerChannel.contrastLimits;
-        return {
-          visible,
-          color,
-          contrastLimits,
-        };
-      }
-    );
+const initialLayerChannelProps = layer.channelProps ?? [];
+
+const updatedChannelProps = initialLayerChannelProps.map((layerChannel, index) => ({
+  visible: controlProps?.[index]?.visible ?? layerChannel?.visible ?? true,
+  color: controlProps?.[index]?.color ?? layerChannel?.color,
+  contrastLimits: controlProps?.[index]?.contrastLimits ?? layerChannel?.contrastLimits,
+}));
+
     setChannelProps(layer.channelProps ?? []);
   }, [layer, controlProps]);
 

--- a/packages/react/src/components/controls/ChannelControlsList.tsx
+++ b/packages/react/src/components/controls/ChannelControlsList.tsx
@@ -59,11 +59,11 @@ export function ChannelControlsList({
   console.log("ChannelControlsList::render", controlProps);
 
   return (
-    <div className="sds-color-primitive-blue-400 p-1">
+    <div className="p-1">
       <Accordion defaultExpanded id="channel-controls">
         <AccordionHeader>Channel Controls</AccordionHeader>
         <AccordionDetails>
-          <div className={cns("flex flex-col gap-sds-xs")}>
+          <div className={cns("grid grid-rows-auto gap-sds-xs")}>
             {channelProps.map((props: ChannelProps, index: number) => (
               <ChannelControl
                 key={index}

--- a/packages/react/src/components/controls/ContrastSlider.tsx
+++ b/packages/react/src/components/controls/ContrastSlider.tsx
@@ -2,10 +2,12 @@ import { InputSlider } from "@czi-sds/components";
 
 interface ContrastSliderProps {
   value: [number, number];
+  min: number;
+  max: number;
   onChange: (limits: [number, number]) => void;
 }
 
-export function ContrastSlider({ value, onChange }: ContrastSliderProps) {
+export function ContrastSlider({ min, max, value, onChange }: ContrastSliderProps) {
   const handleChange = (_event: Event, newValue: number | number[]) => {
     const limits = newValue as number[];
     onChange([limits[0], limits[1]]);
@@ -15,8 +17,8 @@ export function ContrastSlider({ value, onChange }: ContrastSliderProps) {
     <InputSlider
       value={value}
       onChange={handleChange}
-      min={0}
-      max={1000}
+      min={min}
+      max={max}
       valueLabelDisplay="auto"
       className="w-full"
     />

--- a/packages/react/src/components/controls/ContrastSlider.tsx
+++ b/packages/react/src/components/controls/ContrastSlider.tsx
@@ -7,7 +7,12 @@ interface ContrastSliderProps {
   onChange: (limits: [number, number]) => void;
 }
 
-export function ContrastSlider({ min, max, value, onChange }: ContrastSliderProps) {
+export function ContrastSlider({
+  min,
+  max,
+  value,
+  onChange,
+}: ContrastSliderProps) {
   const handleChange = (_event: Event, newValue: number | number[]) => {
     const limits = newValue as number[];
     onChange([limits[0], limits[1]]);

--- a/packages/react/src/index.css
+++ b/packages/react/src/index.css
@@ -2,3 +2,5 @@
 @import '@czi-sds/components/dist/variables.css';
 
 @import 'tailwindcss';
+/* legacy configuration - SDS styles extend the theme via js config */
+@config "../tailwind.config.js";


### PR DESCRIPTION
### Summary
This gets the label, initial visibility, and contrast limits from the omero data.

### Related Issue
Closes #193 

### Tests & Checks
![Screenshot 2025-02-27 at 10 16 32 PM](https://github.com/user-attachments/assets/22f467e9-4188-4b22-a636-038c221b6e95)