### PR TITLE
Prevent scrolling when zooming and suppress console warnings

### DIFF
--- a/packages/core/src/core/renderer.ts
+++ b/packages/core/src/core/renderer.ts
@@ -69,7 +69,7 @@ export abstract class Renderer {
       clientToClip
     );
     this.controlCallbacks_.forEach(([event, listener]) => {
-      this.canvas.addEventListener(event, listener);
+      this.canvas.addEventListener(event, listener, { passive: false });
     });
   }
 

--- a/packages/core/src/objects/cameras/controls.ts
+++ b/packages/core/src/objects/cameras/controls.ts
@@ -51,6 +51,7 @@ export class PanZoomControls implements CameraControls {
   }
 
   private wheel(event: WheelEvent, clientToWorld: ClientToWorld): void {
+    event.preventDefault();
     const clientPos = vec2.fromValues(event.clientX, event.clientY);
     const preZoomPos = clientToWorld(clientPos, this.clipDepth);
     if (event.deltaY < 0) {


### PR DESCRIPTION
### Summary
On a page with scrollbars, zooming with the pan/zoom controls would also scroll the page. Also there was a consistent warning in the logs related to ["passive" event listeners](https://github.com/WICG/EventListenerOptions/blob/gh-pages/explainer.md).

### Related Issue
N/A

### Tests & Checks
Tested with the react demo page by adding content to induce a scrollbar.