### PR TITLE
Add optional scale prop to OmeZarrImageViewer (+source +loader)

### DIFF
--- a/packages/core/src/data/ome_zarr_image_loader.ts
+++ b/packages/core/src/data/ome_zarr_image_loader.ts
@@ -32,9 +32,10 @@ export class PromiseQueue<T> {
 // https://ngff.openmicroscopy.org/0.4/#image-layout
 export class OmeZarrImageLoader {
   root_: zarr.Group<zarr.FetchStore>;
+  scaleIndex_: number;
   metadata_: OmeNgffImage;
 
-  constructor(root: zarr.Group<zarr.FetchStore>) {
+  constructor(root: zarr.Group<zarr.FetchStore>, scaleIndex?: number) {
     this.root_ = root;
     const attrs = this.root_.attrs;
     // TODO: silly fix for removing top-level identity transform,
@@ -55,6 +56,17 @@ export class OmeZarrImageLoader {
         `Can only handle one multiscale image. Found ${this.metadata_.multiscales.length}`
       );
     }
+
+    const numScales = this.metadata_.multiscales[0].datasets.length;
+    if (scaleIndex === undefined) {
+      // default to the lowest resolution
+      this.scaleIndex_ = numScales - 1;
+    } else if (scaleIndex < 0) {
+      // allow reverse indexing with negative numbers
+      this.scaleIndex_ = Math.max(0, numScales + scaleIndex);
+    } else {
+      this.scaleIndex_ = Math.min(numScales - 1, scaleIndex);
+    }
   }
 
   async loadChunk(
@@ -64,8 +76,7 @@ export class OmeZarrImageLoader {
     const image = this.metadata_.multiscales[0];
     // TODO: use the input to determine what level to load.
     // https://github.com/chanzuckerberg/imaging-active-learning/issues/37
-    const lowestResolutionIndex = image.datasets.length - 1;
-    const dataset = image.datasets[lowestResolutionIndex];
+    const dataset = image.datasets[this.scaleIndex_];
     const scale = dataset.coordinateTransformations[0].scale;
     // TODO: fix zod to generate this type information.
     const axes = image.axes;

--- a/packages/core/src/data/ome_zarr_image_loader.ts
+++ b/packages/core/src/data/ome_zarr_image_loader.ts
@@ -59,6 +59,10 @@ export class OmeZarrImageLoader {
 
     const numScales = this.metadata_.multiscales[0].datasets.length;
     if (scaleIndex === undefined) {
+      // TODO: when undefined use the input to determine what level to load.
+      // That is, dynamically select the scale based on the size of the chunk
+      // to be loaded and how big it will be on screen.
+      // https://github.com/chanzuckerberg/imaging-active-learning/issues/37
       // default to the lowest resolution
       this.scaleIndex_ = numScales - 1;
     } else if (scaleIndex < 0) {
@@ -74,8 +78,6 @@ export class OmeZarrImageLoader {
     scheduler?: PromiseScheduler
   ): Promise<ImageChunk> {
     const image = this.metadata_.multiscales[0];
-    // TODO: use the input to determine what level to load.
-    // https://github.com/chanzuckerberg/imaging-active-learning/issues/37
     const dataset = image.datasets[this.scaleIndex_];
     const scale = dataset.coordinateTransformations[0].scale;
     // TODO: fix zod to generate this type information.

--- a/packages/core/src/data/ome_zarr_image_source.ts
+++ b/packages/core/src/data/ome_zarr_image_source.ts
@@ -3,16 +3,18 @@ import { OmeZarrImageLoader } from "data/ome_zarr_image_loader";
 
 // Opens an OME-Zarr multiscale image from the URL of its Zarr group.
 export class OmeZarrImageSource {
-  url_: string;
+  private url_: string;
+  private scaleIndex_?: number;
 
-  constructor(url: string) {
+  constructor(url: string, scaleIndex?: number) {
     this.url_ = url;
+    this.scaleIndex_ = scaleIndex;
   }
 
   async open(): Promise<OmeZarrImageLoader> {
     const store = new zarr.FetchStore(this.url_);
     const root = await zarr.open.v2(store, { kind: "group" });
     console.debug("opened root ", root, root.attrs);
-    return new OmeZarrImageLoader(root);
+    return new OmeZarrImageLoader(root, this.scaleIndex_);
   }
 }

--- a/packages/react/src/components/OmeZarrImageViewer.tsx
+++ b/packages/react/src/components/OmeZarrImageViewer.tsx
@@ -18,11 +18,13 @@ import { hexToRgb } from "lib/color";
 interface OmeZarrImageViewerProps {
   sourceUrl: string;
   region: Region;
+  scale?: number;
 }
 
 export default function OmeZarrImageViewer({
   sourceUrl,
   region,
+  scale,
 }: OmeZarrImageViewerProps) {
   const [layerManager, _setLayerManager] = useState<LayerManager>(
     new LayerManager()
@@ -35,9 +37,9 @@ export default function OmeZarrImageViewer({
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    const source = new OmeZarrImageSource(sourceUrl);
+    const source = new OmeZarrImageSource(sourceUrl, scale);
     setSource(source);
-  }, [sourceUrl]);
+  }, [sourceUrl, scale]);
 
   useEffect(() => {
     setLoading(true);


### PR DESCRIPTION
### Summary
The organelle box folks have provided us with 4-deep multiscale images. This provides a way to allow them to specify a scale to display. The only option they have without this is to re-process their data such that the lowest scale is the size they want to load in our viewer (that's how our viewer currently works).

I'm not totally sure I love this implementation, so I'm wide open to alternatives, but I think this is mostly "good enough" for now. The API preserves the idea that the default (undefined) option will intelligently load the proper scale in the future.

This allows indexing with `>=0` to select a specific scale, or `<0` to select starting at the smallest scale. It will then clamp to the bounds so it will compensate for lack of a-priori knowledge of the number of scales and not throw errors. The default behavior remains the same and will load the _last_ scale (equivalent to passing `-1`, typically the smallest image / coarsest resolution) for now.

### Tests & Checks
Added a `scale` prop to `OmeZarrImageViewer` and you can select different scales as described above by changing it.

