### PR TITLE
[PoC] Chunk-caching zarr loader

### DIFF
--- a/packages/core/src/data/ome_zarr_image_loader.ts
+++ b/packages/core/src/data/ome_zarr_image_loader.ts
@@ -5,9 +5,9 @@ import { Region } from "data/region";
 import { ImageChunk, isImageChunkData } from "data/image_chunk";
 import { isTextureUnpackRowAlignment } from "objects/textures/texture";
 import { PromiseScheduler } from "./promise_scheduler";
+import { CachedZarrArray } from "./zarr_chunk_cache";
 
 import { Image as OmeNgffImage } from "data/ome_ngff/0.4/image";
-type Axis = OmeNgffImage["multiscales"][number]["axes"][number];
 
 // Implements the interface required for getting array chunks in zarrita:
 // https://github.com/manzt/zarrita.js/blob/c15c1a14e42a83516972368ac962ebdf56a6dcdb/packages/indexing/src/types.ts#L52
@@ -34,6 +34,8 @@ export class OmeZarrImageLoader {
   root_: zarr.Group<zarr.FetchStore>;
   scaleIndex_: number;
   metadata_: OmeNgffImage;
+  // Single CachedZarrArray instance for the entire loader
+  private cachedZarrArray_: CachedZarrArray | null = null;
 
   constructor(root: zarr.Group<zarr.FetchStore>, scaleIndex?: number) {
     this.root_ = root;
@@ -73,27 +75,56 @@ export class OmeZarrImageLoader {
     }
   }
 
-  async loadChunk(
-    region: Region,
-    scheduler?: PromiseScheduler
-  ): Promise<ImageChunk> {
+  // Static factory method to create and initialize a loader
+  public static async create(
+    root: zarr.Group<zarr.FetchStore>,
+    scaleIndex?: number
+  ): Promise<OmeZarrImageLoader> {
+    const loader = new OmeZarrImageLoader(root, scaleIndex);
+    await loader.initializeCache();
+    return loader;
+  }
+
+  // Explicitly initialize the cached array (should be called before loadChunk)
+  public async initializeCache(): Promise<void> {
+    if (this.cachedZarrArray_ !== null) {
+      console.debug("Cache already initialized");
+      return;
+    }
+
     const image = this.metadata_.multiscales[0];
     const dataset = image.datasets[this.scaleIndex_];
-    const scale = dataset.coordinateTransformations[0].scale;
-    // TODO: fix zod to generate this type information.
-    const axes = image.axes;
-    const translation =
-      dataset.coordinateTransformations.length === 2
-        ? dataset.coordinateTransformations[1].translation
-        : new Array(axes.length).fill(0);
-
-    const indices = regionToIndices(region, axes, scale, translation);
-    console.debug("loading dataset with indices", dataset, indices);
+    console.debug(`Initializing cache for dataset: ${dataset.path}`);
 
     const array = await zarr.open.v2(this.root_.resolve(dataset.path), {
       kind: "array",
       attrs: false,
     });
+
+    // TODO: cache should support multiple datasets (scales)
+    this.cachedZarrArray_ = new CachedZarrArray(array);
+  }
+
+  public clearCache(): void {
+    this.cachedZarrArray_?.clearCache();
+  }
+
+  async loadChunk(
+    region: Region,
+    scheduler?: PromiseScheduler
+  ): Promise<ImageChunk> {
+    console.debug("loading chunk with region", region, this.scaleIndex_);
+    const image = this.metadata_.multiscales[0];
+    const dataset = image.datasets[this.scaleIndex_];
+    const indices = this.regionToIndices(region, this.scaleIndex_);
+    console.debug("loading dataset with indices", dataset, indices);
+
+    // Get our cached array (will create one if not initialized)
+    if (!this.cachedZarrArray_) {
+      console.debug(
+        "WARNING: Cache not explicitly initialized. Call initializeCache() first for better performance."
+      );
+    }
 
     let options = {};
     if (scheduler !== undefined) {
@@ -102,11 +133,21 @@ export class OmeZarrImageLoader {
         opts: { signal: scheduler.abortSignal },
       };
     }
-    const subarray = await zarr.get(array, indices, options);
+
+    let subarray;
+    if (this.cachedZarrArray_ === null) {
+      const array = await zarr.open.v2(this.root_.resolve(dataset.path), {
+        kind: "array",
+        attrs: false,
+      });
+      subarray = await zarr.get(array, indices, options);
+    } else {
+      subarray = await this.cachedZarrArray_.get(indices, options);
+    }
 
     if (!isImageChunkData(subarray.data)) {
       throw new Error(
-        `Subarray has an unsupported data type ${subarray.data.constructor.name}`
+        `Subarray has an unsupported data type, data=${subarray.data}`
       );
     }
 
@@ -122,6 +163,13 @@ export class OmeZarrImageLoader {
         "Invalid row alignment value. Possible values are 1, 2, 4, or 8"
       );
     }
+
+    const axes = image.axes;
+    const scale = dataset.coordinateTransformations[0].scale;
+    const translation =
+      dataset.coordinateTransformations.length === 2
+        ? dataset.coordinateTransformations[1].translation
+        : new Array(axes.length).fill(0);
 
     const calculateOffset = (i: number) => {
       const index = indices[i];
@@ -147,36 +195,38 @@ export class OmeZarrImageLoader {
     return chunk;
   }
 
-  public get metadata(): OmeNgffImage {
-    return this.metadata_;
-  }
-}
+  // Converts a region to indices within an OME-Zarr image array.
+  private regionToIndices(
+    region: Region,
+    datasetIndex: number = 0
+  ): Array<Slice | number> {
+    const axes = this.metadata_.multiscales[0].axes;
+    const dataset = this.metadata_.multiscales[0].datasets[datasetIndex];
+    const scale = dataset.coordinateTransformations[0].scale;
+    const translation =
+      dataset.coordinateTransformations.length === 2
+        ? dataset.coordinateTransformations[1].translation
+        : new Array(axes.length).fill(0);
 
-// Converts a region to indices within an OME-Zarr image array.
-function regionToIndices(
-  region: Region,
-  axes: Array<Axis>,
-  scale: number[],
-  translation: number[]
-): Array<Slice | number> {
-  const indices: Array<Slice | number> = [];
-  for (const [i, axis] of axes.entries()) {
-    const match = region.find((s) => s.dimension == axis.name);
-    // If a match was not found use a null slice which represents
-    // the complete extent of a dimension like Python's `slice(None)`.
-    let index: Slice | number = zarr.slice(null);
-    if (match) {
-      const regionIndex = match.index;
-      if (typeof regionIndex === "number") {
-        index = Math.round(translation[i] + regionIndex / scale[i]);
-      } else {
-        index = zarr.slice(
-          Math.floor(translation[i] + regionIndex.start / scale[i]),
-          Math.ceil(translation[i] + regionIndex.stop / scale[i])
-        );
+    const indices: Array<Slice | number> = [];
+    for (const [i, axis] of axes.entries()) {
+      const match = region.find((s) => s.dimension == axis.name);
+      // If a match was not found use a null slice which represents
+      // the complete extent of a dimension like Python's `slice(None)`.
+      let index: Slice | number = zarr.slice(null);
+      if (match) {
+        const regionIndex = match.index;
+        if (typeof regionIndex === "number") {
+          index = Math.round(translation[i] + regionIndex / scale[i]);
+        } else {
+          index = zarr.slice(
+            Math.floor(translation[i] + regionIndex.start / scale[i]),
+            Math.ceil(translation[i] + regionIndex.stop / scale[i])
+          );
+        }
       }
+      indices.push(index);
     }
-    indices.push(index);
+    return indices;
   }
-  return indices;
 }

--- a/packages/core/src/data/zarr_chunk_cache.ts
+++ b/packages/core/src/data/zarr_chunk_cache.ts
@@ -1,0 +1,118 @@
+import * as zarr from "zarrita";
+import { GetOptions, Slice } from "@zarrita/indexing";
+
+type ChunkData = {
+  data: Uint8Array | Uint16Array | Float32Array;
+  shape: readonly number[];
+  stride: readonly number[];
+  [key: string]: unknown;
+};
+type ChunkOptions = Parameters<zarr.FetchStore["get"]>[1];
+
+// A wrapper for zarr.Array that caches chunks to avoid redundant fetches and decompression
+export class CachedZarrArray {
+  private array_: zarr.Array<zarr.DataType, zarr.FetchStore>;
+  private chunkCache_: Map<string, Promise<ChunkData>> = new Map();
+
+  constructor(array: zarr.Array<zarr.DataType, zarr.FetchStore>) {
+    this.array_ = array;
+    console.debug(`Created CachedZarrArray for path ${array.path}`);
+  }
+
+  // Get access to the underlying array
+  get underlyingArray(): zarr.Array<zarr.DataType, zarr.FetchStore> {
+    return this.array_;
+  }
+
+  // Forward properties from the underlying array
+  get shape(): readonly number[] {
+    return this.array_.shape;
+  }
+
+  get dtype(): zarr.DataType {
+    return this.array_.dtype;
+  }
+
+  get path(): string {
+    return this.array_.path;
+  }
+
+  // Create a cache key from chunk indices
+  private createChunkKey(chunkIndices: number[]): string {
+    // Use a simple string key based on indices, but add a prefix to avoid
+    // potential collisions with other string values
+    return `chunk:${chunkIndices.join(",")}`;
+  }
+
+  // Cached version of getChunk
+  public async getChunk(
+    chunkIndices: number[],
+    options: ChunkOptions = {}
+  ): Promise<ChunkData> {
+    const key = this.createChunkKey(chunkIndices);
+
+    if (!this.chunkCache_.has(key)) {
+      // Cache miss - fetch the chunk and store the promise
+      console.debug(`Cache miss for chunk ${chunkIndices.join(",")}`);
+
+      try {
+        // Create promise for fetching the chunk
+        const chunkPromise = this.array_.getChunk(
+          chunkIndices,
+          options
+        ) as Promise<ChunkData>;
+
+        // Store in cache before awaiting
+        this.chunkCache_.set(key, chunkPromise);
+
+        // Wait for the chunk
+        await chunkPromise;
+
+        console.debug(`Successfully loaded chunk ${chunkIndices.join(",")}`);
+      } catch (error) {
+        // If fetching fails, remove from cache so we can retry later
+        this.chunkCache_.delete(key);
+        throw error;
+      }
+    } else {
+      console.debug(`Cache hit for chunk ${chunkIndices.join(",")}`);
+    }
+
+    // Return the cached promise (either existing or just created)
+    return this.chunkCache_.get(key) as Promise<ChunkData>;
+  }
+
+  // Drop-in replacement for zarr.get - public method
+  public async get(
+    selection: Array<Slice | number>,
+    options?: GetOptions<ChunkOptions>
+  ): Promise<ChunkData> {
+    // Create a proper proxy of the original array
+    // Capture the getChunk method bound to this instance
+    const getChunkMethod = this.getChunk.bind(this);
+
+    const arrayWithCaching = new Proxy(this.array_, {
+      get(target, prop) {
+        if (prop === "getChunk") {
+          // Return our cached version of getChunk
+          return (chunkIndices: number[], chunkOptions?: ChunkOptions) => {
+            return getChunkMethod(chunkIndices, {
+              ...options,
+              ...chunkOptions,
+            });
+          };
+        }
+        // Return the original property
+        return Reflect.get(target, prop);
+      },
+    });
+
+    // Use zarrita's get with our cache-enabled array
+    return zarr.get(arrayWithCaching, selection, options) as Promise<ChunkData>;
+  }
+
+  // Clear the cache
+  public clearCache(): void {
+    this.chunkCache_.clear();
+  }
+}


### PR DESCRIPTION
### Summary
This is a drop-in replacement for the `OmeZarrImageLoader` that transparently caches chunks (source chunks), keeping them uncompressed. This reduces our previous reliance on the browser cache, where fetching multiple slices within the same chunk had a significant overhead for formulating the HTTP request and decompressing the (cached) response.

This is still a pretty simple mechanism that wraps the underlying zarrita object to override it's `getChunk` method with a cached version. I think we can come up with a more robust approach, but this may be worth keeping in the meantime. 

### Related Issue
Motivated by performance issues with the example introduced in #207 

### Tests & Checks
Tested all examples. Note in particular when testing the example introduced in #207 you can watch the dev tools to see significant delays in loading chunks even when hitting the disk cache. This PR eliminates that bottleneck.