### PR TITLE
OrganelleBox V1 component

### DIFF
--- a/packages/core/src/data/ome_zarr_hcs_metadata_loader.ts
+++ b/packages/core/src/data/ome_zarr_hcs_metadata_loader.ts
@@ -26,9 +26,25 @@ export type OmeroChannel = OmeroMetadata["channels"][number];
 export async function loadOmeroChannels(url: string): Promise<OmeroChannel[]> {
   const store = new zarr.FetchStore(url);
   const group = await zarr.open.v2(store, { kind: "group" });
-  // TODO: silly fix for removing top-level identity transform
-  // (same as ome_zarr_image_loader.ts)
-  const attrs = group.attrs;
+  const metadata = parseOmeNgffImage(group);
+  return metadata.omero?.channels ?? [];
+}
+
+export async function loadOmeroDefaultZ(url: string): Promise<number> {
+  const store = new zarr.FetchStore(url);
+  const group = await zarr.open.v2(store, { kind: "group" });
+  // @ts-expect-error rdefs is not in the provided schema
+  return group.attrs?.omero?.rdefs?.defaultZ ?? 0;
+}
+
+export function parseOmeNgffImage(group: zarr.Group<zarr.FetchStore>): Image {
+  // copy attrs to avoid mutating the original
+  const attrs = { ...group.attrs };
+  // TODO: silly fix for removing top-level identity transform,
+  // which is not allowed by spec but may have been written by
+  // some writers.
+  // This may need to be done for top-level `coordinateTransformations` as well.
+  // https://github.com/ome/ngff/pull/152
   if (
     Array.isArray(attrs?.multiscales) &&
     Array.isArray(attrs.multiscales[0]?.coordinateTransformations) &&
@@ -36,6 +52,5 @@ export async function loadOmeroChannels(url: string): Promise<OmeroChannel[]> {
   ) {
     delete attrs.multiscales[0].coordinateTransformations;
   }
-  const metadata = Image.parse(group.attrs);
-  return metadata.omero?.channels ?? [];
+  return Image.parse(attrs);
 }

--- a/packages/core/src/data/ome_zarr_image_loader.ts
+++ b/packages/core/src/data/ome_zarr_image_loader.ts
@@ -11,6 +11,7 @@ import { isTextureUnpackRowAlignment } from "objects/textures/texture";
 import { PromiseScheduler } from "./promise_scheduler";
 
 import { Image as OmeNgffImage } from "data/ome_ngff/0.4/image";
+import { parseOmeNgffImage } from "data/ome_zarr_hcs_metadata_loader";
 
 // Implements the interface required for getting array chunks in zarrita:
 // https://github.com/manzt/zarrita.js/blob/c15c1a14e42a83516972368ac962ebdf56a6dcdb/packages/indexing/src/types.ts#L52
@@ -40,20 +41,7 @@ export class OmeZarrImageLoader {
 
   constructor(root: zarr.Group<zarr.FetchStore>, scaleIndex?: number) {
     this.root_ = root;
-    const attrs = this.root_.attrs;
-    // TODO: silly fix for removing top-level identity transform,
-    // which is not allowed by spec but may have been written by
-    // some writers.
-    // This may need to be done for top-level `coordinateTransformations` as well.
-    // https://github.com/ome/ngff/pull/152
-    if (
-      Array.isArray(attrs?.multiscales) &&
-      Array.isArray(attrs.multiscales[0]?.coordinateTransformations) &&
-      attrs.multiscales[0].coordinateTransformations[0]?.type === "identity"
-    ) {
-      delete attrs.multiscales[0].coordinateTransformations;
-    }
-    this.metadata_ = OmeNgffImage.parse(this.root_.attrs);
+    this.metadata_ = parseOmeNgffImage(this.root_);
     if (this.metadata_.multiscales.length !== 1) {
       throw new Error(
         `Can only handle one multiscale image. Found ${this.metadata_.multiscales.length}`

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -20,9 +20,10 @@ export { ImageSeriesLayer } from "layers/image_series_layer";
 
 export { OmeZarrImageSource } from "data/ome_zarr_image_source";
 export {
+  loadOmeroChannels,
+  loadOmeroDefaultZ,
   loadOmeZarrPlate,
   loadOmeZarrWell,
-  loadOmeroChannels,
 } from "data/ome_zarr_hcs_metadata_loader";
 export type {
   OmeroMetadata,

--- a/packages/core/src/layers/image_series_layer.ts
+++ b/packages/core/src/layers/image_series_layer.ts
@@ -247,7 +247,8 @@ export class ImageSeriesLayer extends Layer {
     for (const result of results) {
       if (result.status === "rejected") {
         if (result.reason instanceof AbortError) {
-          console.debug("Loading aborted.");
+          // reject the promise because this means the layer was closed
+          return Promise.reject(result.reason);
         } else {
           console.error(`Error loading slice: ${result.reason}`);
         }

--- a/packages/core/src/objects/cameras/controls.ts
+++ b/packages/core/src/objects/cameras/controls.ts
@@ -55,9 +55,9 @@ export class PanZoomControls implements CameraControls {
     const clientPos = vec2.fromValues(event.clientX, event.clientY);
     const preZoomPos = clientToWorld(clientPos, this.clipDepth);
     if (event.deltaY < 0) {
-      this.camera_.zoom *= 1.1;
+      this.camera_.zoom *= 1.05;
     } else {
-      this.camera_.zoom /= 1.1;
+      this.camera_.zoom /= 1.05;
     }
     // pan to zoom in on the mouse position
     const postZoomPos = clientToWorld(clientPos, this.clipDepth);

--- a/packages/core/src/objects/cameras/controls.ts
+++ b/packages/core/src/objects/cameras/controls.ts
@@ -55,9 +55,9 @@ export class PanZoomControls implements CameraControls {
     const clientPos = vec2.fromValues(event.clientX, event.clientY);
     const preZoomPos = clientToWorld(clientPos, this.clipDepth);
     if (event.deltaY < 0) {
-      this.camera_.zoom *= 1.05;
+      this.camera_.zoom *= 1.1;
     } else {
-      this.camera_.zoom /= 1.05;
+      this.camera_.zoom /= 1.1;
     }
     // pan to zoom in on the mouse position
     const postZoomPos = clientToWorld(clientPos, this.clipDepth);

--- a/packages/core/vite.config.js
+++ b/packages/core/vite.config.js
@@ -44,7 +44,7 @@ export default defineConfig(({ mode }) => {
       outDir: 'dist',
       // TODO: set these by build mode or something
       sourcemap: true,
-      minify: false,
+      // minify: false,
       lib: {
         entry: path.resolve(_dirname, 'src/index.ts'),
         name: 'idetik-core',

--- a/packages/react/src/components/App.tsx
+++ b/packages/react/src/components/App.tsx
@@ -1,7 +1,7 @@
 import cns from "classnames";
 import { Region } from "@idetik/core";
 import { OmeZarrImageViewer } from "./viewers/OmeZarrImageViewer";
-import { useState } from "react";
+import { useCallback, useRef, useState } from "react";
 
 const sourceUrl =
   "https://public.czbiohub.org/organelle_box/datasets/A549/organelle_box_crop_v1.zarr";
@@ -21,6 +21,53 @@ export default function App() {
 
   const imagePath = imagePaths[imageIndex];
   const imageUrl = `${sourceUrl}/${wellPath}/${imagePath}`;
+
+  const layerCreatedTime = useRef<number | undefined>(undefined);
+  const loadAllSlicesClickedTime = useRef<number | undefined>(undefined);
+
+  const handleLayerCreated = useCallback(() => {
+    layerCreatedTime.current = performance.now();
+    console.log(`Layer created at ${layerCreatedTime.current}`);
+  }, []);
+
+  const handleFirstSliceLoaded = useCallback(() => {
+    if (layerCreatedTime.current !== undefined) {
+      const time = performance.now() - layerCreatedTime.current;
+      console.log(`First slice loaded after ${time} ms`);
+    } else {
+      console.log("First slice loaded, but layer created time is undefined");
+    }
+  }, []);
+
+  const handleLoadAllSlicesClicked = useCallback(() => {
+    loadAllSlicesClickedTime.current = performance.now();
+    console.log(
+      `Load all slices clicked at ${loadAllSlicesClickedTime.current}`
+    );
+  }, []);
+
+  const handleAllSlicesLoaded = useCallback(() => {
+    if (loadAllSlicesClickedTime.current !== undefined) {
+      const time = performance.now() - loadAllSlicesClickedTime.current;
+      console.log(`All slices loaded after ${time} ms`);
+    } else {
+      console.log(
+        "All slices loaded, but load all slices clicked time is undefined"
+      );
+    }
+  }, []);
+
+  const handleLoadAllSlicesAborted = useCallback(() => {
+    if (loadAllSlicesClickedTime.current !== undefined) {
+      const time = performance.now() - loadAllSlicesClickedTime.current;
+      console.log(`Load all slices aborted after ${time} ms`);
+    } else {
+      console.log(
+        "Load all slices aborted, but load all slices clicked time is undefined"
+      );
+    }
+  }, []);
+
   return (
     <div className={cns("h-screen", "flex", "flex-row", "gap-4", "p-4")}>
       <div
@@ -37,13 +84,12 @@ export default function App() {
           sourceUrl={imageUrl}
           region={region}
           seriesDimensionName="Z"
-          highResSizeEstimate="200 MB"
-          onFirstSliceLoaded={(msTimeToLoad) => {
-            console.log(`First slice loaded in ${msTimeToLoad} ms`);
-          }}
-          onAllSlicesLoaded={(msTimeToLoad) => {
-            console.log(`All slices loaded in ${msTimeToLoad} ms`);
-          }}
+          allSlicesSizeEstimate="250 MB"
+          onLayerCreated={handleLayerCreated}
+          onFirstSliceLoaded={handleFirstSliceLoaded}
+          onLoadAllSlicesClicked={handleLoadAllSlicesClicked}
+          onAllSlicesLoaded={handleAllSlicesLoaded}
+          onLoadAllSlicesAborted={handleLoadAllSlicesAborted}
         />
       </div>
       <input

--- a/packages/react/src/components/App.tsx
+++ b/packages/react/src/components/App.tsx
@@ -4,8 +4,8 @@ import { OmeZarrImageViewer } from "./viewers/OmeZarrImageViewer";
 
 const sourceUrl =
   "https://public.czbiohub.org/organelle_box/datasets/A549/organelle_box_crop_v1.zarr";
-const wellPath = "GOLGA2/Live";
-const imagePath = "000002";
+const wellPath = "ATG101/MeOH";
+const imagePath = "000001";
 const imageUrl = `${sourceUrl}/${wellPath}/${imagePath}`;
 const region: Region = [
   { dimension: "T", index: { type: "point", value: 0 } },
@@ -32,7 +32,6 @@ export default function App() {
           sourceUrl={imageUrl}
           region={region}
           seriesDimensionName="Z"
-          loadHighResButton
           highResSizeEstimate="200 MB"
         />
       </div>

--- a/packages/react/src/components/App.tsx
+++ b/packages/react/src/components/App.tsx
@@ -1,12 +1,13 @@
 import cns from "classnames";
 import { Region } from "@idetik/core";
 import { OmeZarrImageViewer } from "./viewers/OmeZarrImageViewer";
+import { useState } from "react";
 
 const sourceUrl =
   "https://public.czbiohub.org/organelle_box/datasets/A549/organelle_box_crop_v1.zarr";
 const wellPath = "ATG101/MeOH";
-const imagePath = "000001";
-const imageUrl = `${sourceUrl}/${wellPath}/${imagePath}`;
+// const imagePath = "000002";
+// const imageUrl = `${sourceUrl}/${wellPath}/${imagePath}`;
 const region: Region = [
   { dimension: "T", index: { type: "point", value: 0 } },
   { dimension: "C", index: { type: "full" } },
@@ -16,6 +17,9 @@ const region: Region = [
 ];
 
 export default function App() {
+  const [imagePath, setImagePath] = useState("000001");
+
+  const imageUrl = `${sourceUrl}/${wellPath}/${imagePath}`;
   return (
     <div className={cns("h-screen", "flex", "flex-row", "gap-4", "p-4")}>
       <div
@@ -35,6 +39,11 @@ export default function App() {
           highResSizeEstimate="200 MB"
         />
       </div>
+      <input
+        type="button"
+        value="Next Image"
+        onClick={() => setImagePath("000002")}
+      />
     </div>
   );
 }

--- a/packages/react/src/components/App.tsx
+++ b/packages/react/src/components/App.tsx
@@ -32,7 +32,8 @@ export default function App() {
           sourceUrl={imageUrl}
           region={region}
           seriesDimensionName="Z"
-          scale={-2}
+          loadHighResButton
+          highResSizeEstimate="200 MB"
         />
       </div>
     </div>

--- a/packages/react/src/components/App.tsx
+++ b/packages/react/src/components/App.tsx
@@ -6,8 +6,6 @@ import { useState } from "react";
 const sourceUrl =
   "https://public.czbiohub.org/organelle_box/datasets/A549/organelle_box_crop_v1.zarr";
 const wellPath = "ATG101/MeOH";
-// const imagePath = "000002";
-// const imageUrl = `${sourceUrl}/${wellPath}/${imagePath}`;
 const region: Region = [
   { dimension: "T", index: { type: "point", value: 0 } },
   { dimension: "C", index: { type: "full" } },
@@ -16,9 +14,12 @@ const region: Region = [
   { dimension: "X", index: { type: "full" } },
 ];
 
-export default function App() {
-  const [imagePath, setImagePath] = useState("000001");
+const imagePaths = ["000000", "000001", "000002", "001000", "001001", "001002"];
 
+export default function App() {
+  const [imageIndex, setImageIndex] = useState(0);
+
+  const imagePath = imagePaths[imageIndex];
   const imageUrl = `${sourceUrl}/${wellPath}/${imagePath}`;
   return (
     <div className={cns("h-screen", "flex", "flex-row", "gap-4", "p-4")}>
@@ -37,12 +38,18 @@ export default function App() {
           region={region}
           seriesDimensionName="Z"
           highResSizeEstimate="200 MB"
+          onFirstSliceLoaded={(msTimeToLoad) => {
+            console.log(`First slice loaded in ${msTimeToLoad} ms`);
+          }}
+          onAllSlicesLoaded={(msTimeToLoad) => {
+            console.log(`All slices loaded in ${msTimeToLoad} ms`);
+          }}
         />
       </div>
       <input
         type="button"
-        value="Next Image"
-        onClick={() => setImagePath("000002")}
+        value="Switch Image"
+        onClick={() => setImageIndex((imageIndex + 1) % imagePaths.length)}
       />
     </div>
   );

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
@@ -173,6 +173,8 @@ export function OmeZarrImageViewer({
     } catch {
       console.debug("Load 3D high-res aborted - likely selected new condition");
       return;
+    } finally {
+      setLoading(false);
     }
     setAllSlicesLoaded(true);
   }, [imageLayer]);

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from "react";
 import cns from "classnames";
-import CircularProgress from "@mui/material/CircularProgress";
-import { InputSlider } from "@czi-sds/components";
+import { Button, InputSlider, LoadingIndicator } from "@czi-sds/components";
 import {
   ImageSeriesLayer,
   LayerManager,
@@ -20,14 +19,25 @@ interface OmeZarrImageViewerProps {
   sourceUrl: string;
   region: Region;
   seriesDimensionName: string;
-  scale?: number;
+  initialScale?: number;
+  loadHighResButton?: boolean;
+  highResSizeEstimate?: string;
+}
+
+// consolidated state to prevent effects from firing multiple times
+interface SourceState {
+  source: OmeZarrImageSource | null;
+  url: string;
+  isHighRes: boolean;
 }
 
 export function OmeZarrImageViewer({
   sourceUrl,
   region,
-  scale,
   seriesDimensionName,
+  initialScale,
+  loadHighResButton,
+  highResSizeEstimate,
 }: OmeZarrImageViewerProps) {
   const [layerManager, _setLayerManager] = useState<LayerManager>(
     new LayerManager()
@@ -35,48 +45,86 @@ export function OmeZarrImageViewer({
   const [camera, _setCamera] = useState<OrthographicCamera>(
     new OrthographicCamera(0, 128, 0, 128)
   );
-  const [imageLayer, setImageLayer] = useState<ImageSeriesLayer | null>(null);
-  const [source, setSource] = useState<OmeZarrImageSource | null>(null);
+  const [source, setSource] = useState<SourceState>({
+    source: null,
+    url: sourceUrl,
+    isHighRes: initialScale === 0 || !loadHighResButton,
+  });
   const [loading, setLoading] = useState(true);
+  const [imageLayer, setImageLayer] = useState<ImageSeriesLayer | null>(null);
+
   const [controlProps, setControlProps] = useState<
     Partial<ChannelControlProps>[]
   >([]);
   const [zRange, setZRange] = useState<[number, number]>([0, 0]);
-  const [zIndex, setZIndex] = useState(0);
+  const [zValue, setZValue] = useState(0.5);
+
+  // set a new source whenever *any* prop changes to force reload
+  useEffect(() => {
+    const source = new OmeZarrImageSource(sourceUrl, initialScale);
+    setSource({
+      source,
+      url: sourceUrl,
+      isHighRes: initialScale === 0 || !loadHighResButton,
+    });
+  }, [
+    sourceUrl,
+    region,
+    seriesDimensionName,
+    initialScale,
+    loadHighResButton,
+    highResSizeEstimate,
+  ]);
 
   useEffect(() => {
-    const source = new OmeZarrImageSource(sourceUrl, scale);
-    setSource(source);
-  }, [sourceUrl, scale]);
-
-  useEffect(() => {
-    setLoading(true);
+    const setZRangeFromData = async () => {
+      if (!source.source) return;
+      const loader = await source.source.open();
+      const attributes = await loader.loadAttributes();
+      const zAxisIndex = attributes.dimensionNames.findIndex(
+        (dim) => dim === seriesDimensionName
+      );
+      const min = 0;
+      const max = attributes.shape[zAxisIndex] - 1;
+      setZRange([min, max]);
+    };
     const getLayer = async () => {
-      if (!source) return;
+      setLoading(true);
+      if (!source.source) return;
       // TODO: may need to accept channel properties to be possibly overridden here
       // (i.e. for initial visibility, custom colors)
-      const omeroChannels = await loadOmeroChannels(sourceUrl);
+      const omeroChannels = await loadOmeroChannels(source.url);
       const channelProps = omeroToChannelProps(omeroChannels);
       setControlProps(omeroToControlProps(omeroChannels));
       const layer = new ImageSeriesLayer({
-        source,
+        source: source.source,
         region,
         seriesDimensionName,
         channelProps,
       });
-      layer.preloadSeries().then(() => setLoading(false));
-      const setCamera = () => {
-        if (layer.extent !== undefined) {
-          camera.setFrame(0, layer.extent.x, 0, layer.extent.y);
-          camera.update();
-          layer.removeStateChangeCallback(setCamera);
-        }
-      };
-      layer.addStateChangeCallback(setCamera);
-      setImageLayer(layer);
+      const isFirstLoad = !loadHighResButton || initialScale === 0 || !source.isHighRes;
+      if (isFirstLoad) {
+        setImageLayer(layer);
+        layer.preloadSeries();
+        await setZRangeFromData();
+        const setCamera = () => {
+          if (layer.extent !== undefined) {
+            setLoading(false);
+            camera.setFrame(0, layer.extent.x, 0, layer.extent.y);
+            camera.update();
+            layer.removeStateChangeCallback(setCamera);
+          }
+        };
+        layer.addStateChangeCallback(setCamera);
+      } else {
+        await layer.preloadSeries();
+        await setZRangeFromData();
+        setLoading(false);
+        setImageLayer(layer);
+      }
     };
     getLayer();
-  }, [source, sourceUrl, region, camera, seriesDimensionName]);
+  }, [initialScale, loadHighResButton, source, region, camera, seriesDimensionName]);
 
   useEffect(() => {
     if (imageLayer) {
@@ -85,24 +133,10 @@ export function OmeZarrImageViewer({
     }
   }, [imageLayer, layerManager]);
 
+  const zIndex = Math.round(zValue * (zRange[1] - zRange[0]) + zRange[0]);
   useEffect(() => {
-    if (seriesDimensionName !== undefined && source !== null) {
-      const setZRangeFromData = async () => {
-        const loader = await source.open();
-        const attributes = await loader.loadAttributes();
-        const zAxisIndex = attributes.dimensionNames.findIndex(
-          (dim) => dim === seriesDimensionName
-        );
-        const min = 0;
-        const max = attributes.shape[zAxisIndex] - 1;
-        setZRange([min, max]);
-        setZIndex(Math.floor((min + max) / 2));
-      };
-      setZRangeFromData();
-    }
-  }, [source, seriesDimensionName]);
-
-  imageLayer?.setIndex(zIndex);
+    imageLayer?.setIndex(zIndex);
+  }, [zIndex, imageLayer]);
 
   return (
     <div
@@ -125,50 +159,65 @@ export function OmeZarrImageViewer({
         camera={camera}
         cameraControls="panzoom"
       />
-      {loading && (
-        <div className={cns("absolute", "top-1/2", "left-1/2")}>
-          <CircularProgress />
-        </div>
-      )}
       {imageLayer && (
         <div className={cns("absolute", "top-0", "left-0", "w-1/2")}>
           <ChannelControlsList layer={imageLayer} controlProps={controlProps} />
         </div>
       )}
-      {seriesDimensionName && (
-        <div
-          className={cns(
-            "absolute",
-            "bottom-0",
-            "right-3",
-            "w-1/2",
-            "px-5",
-            "py-3",
-            "before:absolute",
-            "before:left-0",
-            "before:top-0",
-            "before:w-full",
-            "before:h-full",
-            "before:bg-[--sds-color-semantic-base-background-primary]",
-            "before:opacity-50",
-            "before:content-['']",
-            "flex",
-            "items-center"
-          )}
-        >
-          <InputSlider
-            min={zRange[0]}
-            max={zRange[1]}
-            value={zIndex}
-            onChange={(_, slice: number | number[]) => {
-              if (typeof slice === "number") {
-                setZIndex(slice);
-              }
-            }}
-            disabled={loading}
-          />
+      {loading && (
+        <div className={cns("absolute", "bottom-0", "left-3", "px-5", "py-3")}>
+          <LoadingIndicator sdsStyle="tag" />
         </div>
       )}
+      {!loading && !source.isHighRes && (
+        <div className={cns("absolute", "bottom-0", "left-3", "px-5", "py-3")}>
+          <Button
+            sdsType="primary"
+            sdsStyle="rounded"
+            onClick={() => {
+              const newSource = new OmeZarrImageSource(sourceUrl, 0);
+              setSource({ source: newSource, url: sourceUrl, isHighRes: true });
+            }}
+          >
+            {highResSizeEstimate
+              ? `Load high res (${highResSizeEstimate})`
+              : "Load high res"}
+          </Button>
+        </div>
+      )}
+      <div
+        className={cns(
+          "absolute",
+          "bottom-0",
+          "right-0",
+          "w-1/2",
+          "px-5",
+          "py-3",
+          "before:absolute",
+          "before:left-0",
+          "before:top-0",
+          "before:w-full",
+          "before:h-full",
+          "before:bg-[--sds-color-semantic-base-background-primary]",
+          "before:opacity-35",
+          "before:content-['']",
+          "flex",
+          "items-center"
+        )}
+      >
+        <InputSlider
+          min={0}
+          max={1}
+          step={1 / (zRange[1] - zRange[0])}
+          value={zValue}
+          onChange={(_, value: number | number[]) => {
+            if (typeof value === "number") {
+              setZValue(value);
+            }
+          }}
+          disabled={loading && !source.isHighRes}
+        />
+      </div>
     </div>
   );
 }

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
@@ -57,6 +57,8 @@ export function OmeZarrImageViewer({
   const [controlProps, setControlProps] = useState<
     Partial<ChannelControlProps>[]
   >([]);
+  const [needChannelsReset, setNeedChannelsReset] = useState(false);
+
   const [zRange, setZRange] = useState<[number, number]>([0, 0]);
   const [zValue, setZValue] = useState(0.5);
 
@@ -122,6 +124,7 @@ export function OmeZarrImageViewer({
     return () => {
       layer?.close();
       shouldSetLayer = false;
+      setNeedChannelsReset(true);
     };
   }, [source, region, camera, seriesDimensionName]);
 
@@ -129,6 +132,7 @@ export function OmeZarrImageViewer({
     if (imageLayer) {
       layerManager.layers.length = 0;
       layerManager.add(imageLayer);
+      setNeedChannelsReset(false);
     }
   }, [imageLayer, layerManager]);
 
@@ -185,6 +189,7 @@ export function OmeZarrImageViewer({
           <ChannelControlsList
             layer={imageLayer}
             controlProps={controlProps}
+            reset={needChannelsReset}
             resetCallback={resetChannelsCallback}
           />
         </div>

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
@@ -43,9 +43,7 @@ export function OmeZarrImageViewer({
   const [layerManager, _setLayerManager] = useState<LayerManager>(
     new LayerManager()
   );
-  const [camera, _setCamera] = useState<OrthographicCamera>(
-    new OrthographicCamera(0, 128, 0, 128)
-  );
+  const [camera, setCamera] = useState<OrthographicCamera | null>(null);
   const [source, setSource] = useState<SourceState>({
     source: null,
     url: sourceUrl,
@@ -109,15 +107,20 @@ export function OmeZarrImageViewer({
       }
       setImageLayer(layer);
       await setZRangeFromData();
-      const setCamera = () => {
+      const zoomToFit = () => {
         if (layer?.extent !== undefined) {
           setLoading(false);
-          camera.setFrame(0, layer.extent.x, 0, layer.extent.y);
-          camera.update();
-          layer.removeStateChangeCallback(setCamera);
+          const newCamera = new OrthographicCamera(
+            0,
+            layer.extent.x,
+            0,
+            layer.extent.y
+          );
+          setCamera(newCamera);
+          layer.removeStateChangeCallback(zoomToFit);
         }
       };
-      layer.addStateChangeCallback(setCamera);
+      layer.addStateChangeCallback(zoomToFit);
     };
     getLayer();
 
@@ -125,8 +128,9 @@ export function OmeZarrImageViewer({
       layer?.close();
       shouldSetLayer = false;
       setNeedChannelsReset(true);
+      setImageLayer(null);
     };
-  }, [source, region, camera, seriesDimensionName]);
+  }, [source, region, seriesDimensionName]);
 
   useEffect(() => {
     if (imageLayer) {
@@ -160,6 +164,17 @@ export function OmeZarrImageViewer({
     imageLayer?.setChannelProps(channelProps);
     setControlProps(omeroToControlProps(omeroChannels));
   }, [source.url, imageLayer]);
+
+  const loadAllSlicesCallback = useCallback(async () => {
+    setLoading(true);
+    try {
+      await imageLayer?.preloadSeries();
+    } catch {
+      console.debug("Load 3D high-res aborted - likely selected new condition");
+      return;
+    }
+    setAllSlicesLoaded(true);
+  }, [imageLayer]);
 
   const zIndex = Math.round(zValue * (zRange[1] - zRange[0]) + zRange[0]);
 
@@ -222,13 +237,7 @@ export function OmeZarrImageViewer({
               sdsStyle="rounded"
               size="small"
               disabled={loading}
-              onClick={() => {
-                setLoading(true);
-                imageLayer?.preloadSeries().then(() => {
-                  setLoading(false);
-                  setAllSlicesLoaded(true);
-                });
-              }}
+              onClick={loadAllSlicesCallback}
             >
               {highResSizeEstimate
                 ? `Load 3D high-res (${highResSizeEstimate})`

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
@@ -26,6 +26,8 @@ interface OmeZarrImageViewerProps {
   region: Region;
   seriesDimensionName: string;
   highResSizeEstimate?: string;
+  onFirstSliceLoaded?: (msTimeToLoad: number) => void;
+  onAllSlicesLoaded?: (msTimeToLoad: number) => void;
 }
 
 // consolidated state to prevent effects from firing multiple times
@@ -34,19 +36,14 @@ interface SourceState {
   url: string;
 }
 
-export function OmeZarrImageViewer({
-  sourceUrl,
-  region,
-  seriesDimensionName,
-  highResSizeEstimate,
-}: OmeZarrImageViewerProps) {
-  const [layerManager, _setLayerManager] = useState<LayerManager>(
+export function OmeZarrImageViewer(props: OmeZarrImageViewerProps) {
+  const [layerManager, setLayerManager] = useState<LayerManager>(
     new LayerManager()
   );
   const [camera, setCamera] = useState<OrthographicCamera | null>(null);
   const [source, setSource] = useState<SourceState>({
     source: null,
-    url: sourceUrl,
+    url: props.sourceUrl,
   });
   const [loading, setLoading] = useState(true);
   const [allSlicesLoaded, setAllSlicesLoaded] = useState(false);
@@ -55,7 +52,6 @@ export function OmeZarrImageViewer({
   const [controlProps, setControlProps] = useState<
     Partial<ChannelControlProps>[]
   >([]);
-  const [needChannelsReset, setNeedChannelsReset] = useState(false);
 
   const [zRange, setZRange] = useState<[number, number]>([0, 0]);
   const [zValue, setZValue] = useState(0.5);
@@ -63,17 +59,73 @@ export function OmeZarrImageViewer({
   // set a new source whenever *any* prop changes to force reload
   useEffect(() => {
     // 0 is the highest resolution
-    const source = new OmeZarrImageSource(sourceUrl, 0);
+    const source = new OmeZarrImageSource(props.sourceUrl, 0);
     setSource({
       source,
-      url: sourceUrl,
+      url: props.sourceUrl,
     });
     setAllSlicesLoaded(false);
-  }, [sourceUrl, region, seriesDimensionName, highResSizeEstimate]);
+  }, [props]);
 
+  const zoomToFit = useCallback((layer: ImageSeriesLayer) => {
+    if (layer.extent !== undefined) {
+      const newCamera = new OrthographicCamera(
+        0,
+        layer.extent.x,
+        0,
+        layer.extent.y
+      );
+      setCamera(newCamera);
+      return true;
+    }
+    return false;
+  }, [setCamera]);
+
+  const { region, seriesDimensionName, onFirstSliceLoaded, onAllSlicesLoaded} = props;
   useEffect(() => {
     let shouldSetLayer = true;
     let layer: ImageSeriesLayer | null = null;
+    const createLayer = async () => {
+      setLoading(true);
+      if (!source.source) return;
+      // TODO: may need to accept channel properties to be possibly overridden here
+      // (i.e. for initial visibility, custom colors)
+      const omeroChannels = await loadOmeroChannels(source.url);
+      const channelProps = omeroToChannelProps(omeroChannels);
+      setControlProps(omeroToControlProps(omeroChannels));
+      layer = new ImageSeriesLayer({
+        source: source.source,
+        region,
+        seriesDimensionName,
+        channelProps,
+      });
+      const timeLayerCreated = performance.now();
+      const onFirstLoad = () => {
+        if (!layer || !shouldSetLayer) {
+          return;
+        }
+        if (zoomToFit(layer)) {
+          setLoading(false);
+          const timeToLoad = performance.now() - timeLayerCreated;
+          onFirstSliceLoaded?.(timeToLoad);
+          layer.removeStateChangeCallback(onFirstLoad);
+        }
+      };
+      layer?.addStateChangeCallback(onFirstLoad);
+      if (shouldSetLayer) {
+        setImageLayer(layer);
+      }
+    };
+    createLayer();
+
+    return () => {
+      layer?.close();
+      shouldSetLayer = false;
+      setImageLayer(null);
+    };
+  }, [region, source, seriesDimensionName, onFirstSliceLoaded, zoomToFit]);
+
+  useEffect(() => {
     const setZRangeFromData = async () => {
       if (!source.source) return;
       const loader = await source.source.open();
@@ -88,57 +140,16 @@ export function OmeZarrImageViewer({
       setZValue(omeroDefaultZ / (max - min));
       setZRange([min, max]);
     };
-    const getLayer = async () => {
-      setLoading(true);
-      if (!source.source) return;
-      // TODO: may need to accept channel properties to be possibly overridden here
-      // (i.e. for initial visibility, custom colors)
-      const omeroChannels = await loadOmeroChannels(source.url);
-      const channelProps = omeroToChannelProps(omeroChannels);
-      setControlProps(omeroToControlProps(omeroChannels));
-      layer = new ImageSeriesLayer({
-        source: source.source,
-        region,
-        seriesDimensionName,
-        channelProps,
-      });
-      if (!shouldSetLayer) {
-        return;
-      }
-      setImageLayer(layer);
-      await setZRangeFromData();
-      const zoomToFit = () => {
-        if (layer?.extent !== undefined) {
-          setLoading(false);
-          const newCamera = new OrthographicCamera(
-            0,
-            layer.extent.x,
-            0,
-            layer.extent.y
-          );
-          setCamera(newCamera);
-          layer.removeStateChangeCallback(zoomToFit);
-        }
-      };
-      layer.addStateChangeCallback(zoomToFit);
-    };
-    getLayer();
-
-    return () => {
-      layer?.close();
-      shouldSetLayer = false;
-      setNeedChannelsReset(true);
-      setImageLayer(null);
-    };
-  }, [source, region, seriesDimensionName]);
+    setZRangeFromData();
+  }, [source, seriesDimensionName]);
 
   useEffect(() => {
     if (imageLayer) {
-      layerManager.layers.length = 0;
-      layerManager.add(imageLayer);
-      setNeedChannelsReset(false);
+      const newLayerManager = new LayerManager();
+      newLayerManager.add(imageLayer);
+      setLayerManager(newLayerManager);
     }
-  }, [imageLayer, layerManager]);
+  }, [imageLayer]);
 
   const zIndex = Math.round(zValue * (zRange[1] - zRange[0]) + zRange[0]);
 
@@ -150,10 +161,16 @@ export function OmeZarrImageViewer({
         setLoading(true);
         didSetLoadingTrue = true;
       }, 50);
-      await imageLayer.setIndex(zIndex);
-      clearTimeout(t);
-      if (didSetLoadingTrue) {
-        setLoading(false);
+      try {
+        await imageLayer.setIndex(zIndex);
+      } catch {
+        console.debug("Load slice aborted - likely selected new condition");
+        return;
+      } finally {
+        clearTimeout(t);
+        if (didSetLoadingTrue) {
+          setLoading(false);
+        }
       }
     };
     setIndex();
@@ -168,6 +185,7 @@ export function OmeZarrImageViewer({
 
   const loadAllSlicesCallback = useCallback(async () => {
     setLoading(true);
+    const timeLoadAllSlicesClicked = performance.now();
     try {
       await imageLayer?.preloadSeries();
     } catch {
@@ -176,8 +194,10 @@ export function OmeZarrImageViewer({
     } finally {
       setLoading(false);
     }
+    const timeToLoad = performance.now() - timeLoadAllSlicesClicked;
+    onAllSlicesLoaded?.(timeToLoad);
     setAllSlicesLoaded(true);
-  }, [imageLayer]);
+  }, [imageLayer, onAllSlicesLoaded]);
 
   return (
     <div
@@ -205,7 +225,6 @@ export function OmeZarrImageViewer({
           <ChannelControlsList
             layer={imageLayer}
             controlProps={controlProps}
-            reset={needChannelsReset}
             resetCallback={resetChannelsCallback}
           />
         </div>
@@ -240,8 +259,8 @@ export function OmeZarrImageViewer({
               disabled={loading}
               onClick={loadAllSlicesCallback}
             >
-              {highResSizeEstimate
-                ? `Load 3D high-res (${highResSizeEstimate})`
+              {props.highResSizeEstimate
+                ? `Load 3D high-res (${props.highResSizeEstimate})`
                 : "Load 3D high-res"}
             </Button>
           )}

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
@@ -76,6 +76,9 @@ export function OmeZarrImageViewer({
     highResSizeEstimate,
   ]);
 
+  const isFirstLoad =
+    !loadHighResButton || initialScale === 0 || !source.isHighRes;
+
   useEffect(() => {
     const setZRangeFromData = async () => {
       if (!source.source) return;
@@ -102,7 +105,6 @@ export function OmeZarrImageViewer({
         seriesDimensionName,
         channelProps,
       });
-      const isFirstLoad = !loadHighResButton || initialScale === 0 || !source.isHighRes;
       if (isFirstLoad) {
         setImageLayer(layer);
         layer.preloadSeries();
@@ -124,7 +126,7 @@ export function OmeZarrImageViewer({
       }
     };
     getLayer();
-  }, [initialScale, loadHighResButton, source, region, camera, seriesDimensionName]);
+  }, [isFirstLoad, source, region, camera, seriesDimensionName]);
 
   useEffect(() => {
     if (imageLayer) {
@@ -161,7 +163,11 @@ export function OmeZarrImageViewer({
       />
       {imageLayer && (
         <div className={cns("absolute", "top-0", "left-0", "w-1/2")}>
-          <ChannelControlsList layer={imageLayer} controlProps={controlProps} />
+          <ChannelControlsList
+            layer={imageLayer}
+            controlProps={controlProps}
+            reset={isFirstLoad}
+          />
         </div>
       )}
       {loading && (

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
@@ -140,9 +140,10 @@ export function OmeZarrImageViewer({
     }
   }, [imageLayer, layerManager]);
 
+  const zIndex = Math.round(zValue * (zRange[1] - zRange[0]) + zRange[0]);
+
   useEffect(() => {
     if (!imageLayer) return;
-    const zIndex = Math.round(zValue * (zRange[1] - zRange[0]) + zRange[0]);
     let didSetLoadingTrue = false;
     const setIndex = async () => {
       const t = setTimeout(() => {
@@ -156,7 +157,7 @@ export function OmeZarrImageViewer({
       }
     };
     setIndex();
-  }, [imageLayer, zValue, zRange]);
+  }, [imageLayer, zIndex]);
 
   const resetChannelsCallback = useCallback(async () => {
     const omeroChannels = await loadOmeroChannels(source.url);
@@ -175,8 +176,6 @@ export function OmeZarrImageViewer({
     }
     setAllSlicesLoaded(true);
   }, [imageLayer]);
-
-  const zIndex = Math.round(zValue * (zRange[1] - zRange[0]) + zRange[0]);
 
   return (
     <div
@@ -246,8 +245,7 @@ export function OmeZarrImageViewer({
           )}
           <div className={cns("flex", "justify-end", "w-1/3")}>
             {!loading && (
-              // TODO: I can't figure out how to properly style this with tailwind
-              // so I use a disabled button instead
+              // TODO: "tag" is not very semantic but this looks okay
               <Tag
                 label={`slice ${zIndex}/${zRange[1] - zRange[0]}`}
                 sdsStyle="square"

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
@@ -1,6 +1,11 @@
 import { useCallback, useEffect, useState } from "react";
 import cns from "classnames";
-import { Button, InputSlider, LoadingIndicator } from "@czi-sds/components";
+import {
+  Button,
+  InputSlider,
+  LoadingIndicator,
+  Tag,
+} from "@czi-sds/components";
 import {
   ImageSeriesLayer,
   LayerManager,
@@ -8,6 +13,7 @@ import {
   OrthographicCamera,
   Region,
   loadOmeroChannels,
+  loadOmeroDefaultZ,
 } from "@idetik/core";
 
 import { Renderer } from "./components/Renderer";
@@ -19,8 +25,6 @@ interface OmeZarrImageViewerProps {
   sourceUrl: string;
   region: Region;
   seriesDimensionName: string;
-  initialScale?: number;
-  loadHighResButton?: boolean;
   highResSizeEstimate?: string;
 }
 
@@ -28,15 +32,12 @@ interface OmeZarrImageViewerProps {
 interface SourceState {
   source: OmeZarrImageSource | null;
   url: string;
-  isHighRes: boolean;
 }
 
 export function OmeZarrImageViewer({
   sourceUrl,
   region,
   seriesDimensionName,
-  initialScale,
-  loadHighResButton,
   highResSizeEstimate,
 }: OmeZarrImageViewerProps) {
   const [layerManager, _setLayerManager] = useState<LayerManager>(
@@ -48,9 +49,9 @@ export function OmeZarrImageViewer({
   const [source, setSource] = useState<SourceState>({
     source: null,
     url: sourceUrl,
-    isHighRes: initialScale === 0 || !loadHighResButton,
   });
   const [loading, setLoading] = useState(true);
+  const [allSlicesLoaded, setAllSlicesLoaded] = useState(false);
   const [imageLayer, setImageLayer] = useState<ImageSeriesLayer | null>(null);
 
   const [controlProps, setControlProps] = useState<
@@ -61,23 +62,14 @@ export function OmeZarrImageViewer({
 
   // set a new source whenever *any* prop changes to force reload
   useEffect(() => {
-    const source = new OmeZarrImageSource(sourceUrl, initialScale);
+    // 0 is the highest resolution
+    const source = new OmeZarrImageSource(sourceUrl, 0);
     setSource({
       source,
       url: sourceUrl,
-      isHighRes: initialScale === 0 || !loadHighResButton,
     });
-  }, [
-    sourceUrl,
-    region,
-    seriesDimensionName,
-    initialScale,
-    loadHighResButton,
-    highResSizeEstimate,
-  ]);
-
-  const isFirstLoad =
-    !loadHighResButton || initialScale === 0 || !source.isHighRes;
+    setAllSlicesLoaded(false);
+  }, [sourceUrl, region, seriesDimensionName, highResSizeEstimate]);
 
   useEffect(() => {
     let shouldSetLayer = true;
@@ -86,11 +78,14 @@ export function OmeZarrImageViewer({
       if (!source.source) return;
       const loader = await source.source.open();
       const attributes = await loader.loadAttributes();
+      // TODO: this only supports "full" range and expects the series dimension to be Z
       const zAxisIndex = attributes.dimensionNames.findIndex(
         (dim) => dim === seriesDimensionName
       );
       const min = 0;
       const max = attributes.shape[zAxisIndex] - 1;
+      const omeroDefaultZ = await loadOmeroDefaultZ(source.url);
+      setZValue(omeroDefaultZ / (max - min));
       setZRange([min, max]);
     };
     const getLayer = async () => {
@@ -110,28 +105,17 @@ export function OmeZarrImageViewer({
       if (!shouldSetLayer) {
         return;
       }
-      if (isFirstLoad) {
-        setImageLayer(layer);
-        layer.preloadSeries();
-        await setZRangeFromData();
-        const setCamera = () => {
-          if (layer?.extent !== undefined) {
-            setLoading(false);
-            camera.setFrame(0, layer.extent.x, 0, layer.extent.y);
-            camera.update();
-            layer.removeStateChangeCallback(setCamera);
-          }
-        };
-        layer.addStateChangeCallback(setCamera);
-      } else {
-        await layer.preloadSeries();
-        if (!shouldSetLayer) {
-          return;
+      setImageLayer(layer);
+      await setZRangeFromData();
+      const setCamera = () => {
+        if (layer?.extent !== undefined) {
+          setLoading(false);
+          camera.setFrame(0, layer.extent.x, 0, layer.extent.y);
+          camera.update();
+          layer.removeStateChangeCallback(setCamera);
         }
-        await setZRangeFromData();
-        setLoading(false);
-        setImageLayer(layer);
-      }
+      };
+      layer.addStateChangeCallback(setCamera);
     };
     getLayer();
 
@@ -139,7 +123,7 @@ export function OmeZarrImageViewer({
       layer?.close();
       shouldSetLayer = false;
     };
-  }, [isFirstLoad, source, region, camera, seriesDimensionName]);
+  }, [source, region, camera, seriesDimensionName]);
 
   useEffect(() => {
     if (imageLayer) {
@@ -148,10 +132,23 @@ export function OmeZarrImageViewer({
     }
   }, [imageLayer, layerManager]);
 
-  const zIndex = Math.round(zValue * (zRange[1] - zRange[0]) + zRange[0]);
   useEffect(() => {
-    imageLayer?.setIndex(zIndex);
-  }, [zIndex, imageLayer]);
+    if (!imageLayer) return;
+    const zIndex = Math.round(zValue * (zRange[1] - zRange[0]) + zRange[0]);
+    let didSetLoadingTrue = false;
+    const setIndex = async () => {
+      const t = setTimeout(() => {
+        setLoading(true);
+        didSetLoadingTrue = true;
+      }, 50);
+      await imageLayer.setIndex(zIndex);
+      clearTimeout(t);
+      if (didSetLoadingTrue) {
+        setLoading(false);
+      }
+    };
+    setIndex();
+  }, [imageLayer, zValue, zRange]);
 
   const resetChannelsCallback = useCallback(async () => {
     const omeroChannels = await loadOmeroChannels(source.url);
@@ -159,6 +156,8 @@ export function OmeZarrImageViewer({
     imageLayer?.setChannelProps(channelProps);
     setControlProps(omeroToControlProps(omeroChannels));
   }, [source.url, imageLayer]);
+
+  const zIndex = Math.round(zValue * (zRange[1] - zRange[0]) + zRange[0]);
 
   return (
     <div
@@ -182,34 +181,12 @@ export function OmeZarrImageViewer({
         cameraControls="panzoom"
       />
       {imageLayer && (
-        <div className={cns("absolute", "top-0", "left-0", "w-1/2")}>
+        <div className={cns("absolute", "top-0", "left-0", "w-3/4")}>
           <ChannelControlsList
             layer={imageLayer}
             controlProps={controlProps}
-            reset={isFirstLoad}
             resetCallback={resetChannelsCallback}
           />
-        </div>
-      )}
-      {loading && (
-        <div className={cns("absolute", "bottom-0", "left-3", "px-5", "py-3")}>
-          <LoadingIndicator sdsStyle="tag" />
-        </div>
-      )}
-      {!loading && !source.isHighRes && (
-        <div className={cns("absolute", "bottom-0", "left-3", "px-5", "py-3")}>
-          <Button
-            sdsType="primary"
-            sdsStyle="rounded"
-            onClick={() => {
-              const newSource = new OmeZarrImageSource(sourceUrl, 0);
-              setSource({ source: newSource, url: sourceUrl, isHighRes: true });
-            }}
-          >
-            {highResSizeEstimate
-              ? `Load high res (${highResSizeEstimate})`
-              : "Load high res"}
-          </Button>
         </div>
       )}
       <div
@@ -217,33 +194,79 @@ export function OmeZarrImageViewer({
           "absolute",
           "bottom-0",
           "right-0",
-          "w-1/2",
+          "w-full",
           "px-5",
           "py-3",
-          "before:absolute",
-          "before:left-0",
-          "before:top-0",
-          "before:w-full",
-          "before:h-full",
-          "before:bg-[--sds-color-semantic-base-background-primary]",
-          "before:opacity-35",
-          "before:content-['']",
           "flex",
-          "items-center"
+          "flex-col",
+          "items-end"
         )}
       >
-        <InputSlider
-          min={0}
-          max={1}
-          step={1 / (zRange[1] - zRange[0])}
-          value={zValue}
-          onChange={(_, value: number | number[]) => {
-            if (typeof value === "number") {
-              setZValue(value);
-            }
-          }}
-          disabled={loading && !source.isHighRes}
-        />
+        <div
+          className={cns(
+            "flex",
+            "justify-end",
+            "items-center",
+            "w-full",
+            "h-6"
+          )}
+        >
+          {!allSlicesLoaded && (
+            <Button
+              sdsType="primary"
+              sdsStyle="rounded"
+              size="small"
+              disabled={loading}
+              onClick={() => {
+                setLoading(true);
+                imageLayer?.preloadSeries().then(() => {
+                  setLoading(false);
+                  setAllSlicesLoaded(true);
+                });
+              }}
+            >
+              {highResSizeEstimate
+                ? `Load 3D high-res (${highResSizeEstimate})`
+                : "Load 3D high-res"}
+            </Button>
+          )}
+          <div className={cns("flex", "justify-end", "w-1/3")}>
+            {!loading && (
+              // TODO: I can't figure out how to properly style this with tailwind
+              // so I use a disabled button instead
+              <Tag
+                label={`slice ${zIndex}/${zRange[1] - zRange[0]}`}
+                sdsStyle="square"
+                sdsType="secondary"
+                hover={false}
+              />
+            )}
+            {loading && <LoadingIndicator sdsStyle="tag" />}
+          </div>
+        </div>
+        {allSlicesLoaded && (
+          <div
+            className={cns(
+              "w-2/3",
+              "flex",
+              "justify-center",
+              "items-center",
+              "gap-2"
+            )}
+          >
+            <InputSlider
+              min={0}
+              max={1}
+              step={1 / (zRange[1] - zRange[0])}
+              value={zValue}
+              onChange={(_, value: number | number[]) => {
+                if (typeof value === "number") {
+                  setZValue(value);
+                }
+              }}
+            />
+          </div>
+        )}
       </div>
     </div>
   );

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
@@ -25,9 +25,15 @@ interface OmeZarrImageViewerProps {
   sourceUrl: string;
   region: Region;
   seriesDimensionName: string;
-  highResSizeEstimate?: string;
-  onFirstSliceLoaded?: (msTimeToLoad: number) => void;
-  onAllSlicesLoaded?: (msTimeToLoad: number) => void;
+  allSlicesSizeEstimate?: string;
+}
+
+interface OmeZarrImageViewerEvents {
+  onLayerCreated?: () => void;
+  onFirstSliceLoaded?: () => void;
+  onLoadAllSlicesClicked?: () => void;
+  onAllSlicesLoaded?: () => void;
+  onLoadAllSlicesAborted?: () => void;
 }
 
 // consolidated state to prevent effects from firing multiple times
@@ -36,7 +42,9 @@ interface SourceState {
   url: string;
 }
 
-export function OmeZarrImageViewer(props: OmeZarrImageViewerProps) {
+export function OmeZarrImageViewer(
+  props: OmeZarrImageViewerProps & OmeZarrImageViewerEvents
+) {
   const [layerManager, setLayerManager] = useState<LayerManager>(
     new LayerManager()
   );
@@ -67,25 +75,39 @@ export function OmeZarrImageViewer(props: OmeZarrImageViewerProps) {
     setAllSlicesLoaded(false);
   }, [props]);
 
-  const zoomToFit = useCallback((layer: ImageSeriesLayer) => {
-    if (layer.extent !== undefined) {
-      const newCamera = new OrthographicCamera(
-        0,
-        layer.extent.x,
-        0,
-        layer.extent.y
-      );
-      setCamera(newCamera);
-      return true;
-    }
-    return false;
-  }, [setCamera]);
+  const zoomToFit = useCallback(
+    (layer: ImageSeriesLayer) => {
+      if (layer.extent !== undefined) {
+        const newCamera = new OrthographicCamera(
+          0,
+          layer.extent.x,
+          0,
+          layer.extent.y
+        );
+        setCamera(newCamera);
+        return true;
+      }
+      return false;
+    },
+    [setCamera]
+  );
 
-  const { region, seriesDimensionName, onFirstSliceLoaded, onAllSlicesLoaded} = props;
+  // destructure props to narrow useEffect dependencies
+  const {
+    region,
+    seriesDimensionName,
+    onLayerCreated,
+    onFirstSliceLoaded,
+    onLoadAllSlicesClicked,
+    onAllSlicesLoaded,
+    onLoadAllSlicesAborted,
+  } = props;
+
   useEffect(() => {
+    console.log("Creating image layer", source.url);
     let shouldSetLayer = true;
     let layer: ImageSeriesLayer | null = null;
-    const createLayer = async () => {
+    const createImageLayer = async () => {
       setLoading(true);
       if (!source.source) return;
       // TODO: may need to accept channel properties to be possibly overridden here
@@ -99,15 +121,14 @@ export function OmeZarrImageViewer(props: OmeZarrImageViewerProps) {
         seriesDimensionName,
         channelProps,
       });
-      const timeLayerCreated = performance.now();
+      onLayerCreated?.();
       const onFirstLoad = () => {
         if (!layer || !shouldSetLayer) {
           return;
         }
         if (zoomToFit(layer)) {
           setLoading(false);
-          const timeToLoad = performance.now() - timeLayerCreated;
-          onFirstSliceLoaded?.(timeToLoad);
+          onFirstSliceLoaded?.();
           layer.removeStateChangeCallback(onFirstLoad);
         }
       };
@@ -116,14 +137,21 @@ export function OmeZarrImageViewer(props: OmeZarrImageViewerProps) {
         setImageLayer(layer);
       }
     };
-    createLayer();
+    createImageLayer();
 
     return () => {
       layer?.close();
       shouldSetLayer = false;
       setImageLayer(null);
     };
-  }, [region, source, seriesDimensionName, onFirstSliceLoaded, zoomToFit]);
+  }, [
+    region,
+    source,
+    seriesDimensionName,
+    onLayerCreated,
+    onFirstSliceLoaded,
+    zoomToFit,
+  ]);
 
   useEffect(() => {
     const setZRangeFromData = async () => {
@@ -184,20 +212,25 @@ export function OmeZarrImageViewer(props: OmeZarrImageViewerProps) {
   }, [source.url, imageLayer]);
 
   const loadAllSlicesCallback = useCallback(async () => {
+    onLoadAllSlicesClicked?.();
     setLoading(true);
-    const timeLoadAllSlicesClicked = performance.now();
     try {
       await imageLayer?.preloadSeries();
     } catch {
       console.debug("Load 3D high-res aborted - likely selected new condition");
+      onLoadAllSlicesAborted?.();
       return;
     } finally {
       setLoading(false);
     }
-    const timeToLoad = performance.now() - timeLoadAllSlicesClicked;
-    onAllSlicesLoaded?.(timeToLoad);
+    onAllSlicesLoaded?.();
     setAllSlicesLoaded(true);
-  }, [imageLayer, onAllSlicesLoaded]);
+  }, [
+    imageLayer,
+    onLoadAllSlicesClicked,
+    onAllSlicesLoaded,
+    onLoadAllSlicesAborted,
+  ]);
 
   return (
     <div
@@ -259,8 +292,8 @@ export function OmeZarrImageViewer(props: OmeZarrImageViewerProps) {
               disabled={loading}
               onClick={loadAllSlicesCallback}
             >
-              {props.highResSizeEstimate
-                ? `Load 3D high-res (${props.highResSizeEstimate})`
+              {props.allSlicesSizeEstimate
+                ? `Load 3D high-res (${props.allSlicesSizeEstimate})`
                 : "Load 3D high-res"}
             </Button>
           )}

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import cns from "classnames";
 import { Button, InputSlider, LoadingIndicator } from "@czi-sds/components";
 import {
@@ -140,6 +140,13 @@ export function OmeZarrImageViewer({
     imageLayer?.setIndex(zIndex);
   }, [zIndex, imageLayer]);
 
+  const resetChannelsCallback = useCallback(async () => {
+    const omeroChannels = await loadOmeroChannels(source.url);
+    const channelProps = omeroToChannelProps(omeroChannels);
+    imageLayer?.setChannelProps(channelProps);
+    setControlProps(omeroToControlProps(omeroChannels));
+  }, [source.url, imageLayer]);
+
   return (
     <div
       className={cns(
@@ -167,6 +174,7 @@ export function OmeZarrImageViewer({
             layer={imageLayer}
             controlProps={controlProps}
             reset={isFirstLoad}
+            resetCallback={resetChannelsCallback}
           />
         </div>
       )}

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
@@ -80,6 +80,8 @@ export function OmeZarrImageViewer({
     !loadHighResButton || initialScale === 0 || !source.isHighRes;
 
   useEffect(() => {
+    let shouldSetLayer = true;
+    let layer: ImageSeriesLayer | null = null;
     const setZRangeFromData = async () => {
       if (!source.source) return;
       const loader = await source.source.open();
@@ -99,18 +101,21 @@ export function OmeZarrImageViewer({
       const omeroChannels = await loadOmeroChannels(source.url);
       const channelProps = omeroToChannelProps(omeroChannels);
       setControlProps(omeroToControlProps(omeroChannels));
-      const layer = new ImageSeriesLayer({
+      layer = new ImageSeriesLayer({
         source: source.source,
         region,
         seriesDimensionName,
         channelProps,
       });
+      if (!shouldSetLayer) {
+        return;
+      }
       if (isFirstLoad) {
         setImageLayer(layer);
         layer.preloadSeries();
         await setZRangeFromData();
         const setCamera = () => {
-          if (layer.extent !== undefined) {
+          if (layer?.extent !== undefined) {
             setLoading(false);
             camera.setFrame(0, layer.extent.x, 0, layer.extent.y);
             camera.update();
@@ -120,12 +125,20 @@ export function OmeZarrImageViewer({
         layer.addStateChangeCallback(setCamera);
       } else {
         await layer.preloadSeries();
+        if (!shouldSetLayer) {
+          return;
+        }
         await setZRangeFromData();
         setLoading(false);
         setImageLayer(layer);
       }
     };
     getLayer();
+
+    return () => {
+      layer?.close();
+      shouldSetLayer = false;
+    };
   }, [isFirstLoad, source, region, camera, seriesDimensionName]);
 
   useEffect(() => {

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/components/ChannelControlsList/ChannelControlsList.tsx
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/components/ChannelControlsList/ChannelControlsList.tsx
@@ -2,6 +2,7 @@ import {
   AccordionHeader,
   AccordionDetails,
   Accordion,
+  Button,
 } from "@czi-sds/components";
 import cns from "classnames";
 import {
@@ -15,12 +16,14 @@ interface ChannelControlsListProps {
   layer: ImageSeriesLayer;
   controlProps: Partial<ChannelControlProps>[];
   reset?: boolean;
+  resetCallback?: () => Promise<void>;
 }
 
 export function ChannelControlsList({
   layer,
   controlProps,
   reset,
+  resetCallback,
 }: ChannelControlsListProps) {
   // Keep a local copy of channelProps to trigger re-renders
   const [channelProps, setChannelProps] = useState(layer.channelProps ?? []);
@@ -90,7 +93,7 @@ export function ChannelControlsList({
             "w-full",
             "[&_.MuiAccordionSummary-root]:!flex-grow",
             "[&_.Mui-expanded]:!min-h-0",
-            "[&_.MuiSvgIcon-root]:!fill-[--sds-color-semantic-text-primary]"
+            "[&_.MuiSvgIcon-root]:!fill-[--sds-color-semantic-base-text-primary]"
           )}
         >
           <AccordionHeader>
@@ -140,6 +143,21 @@ export function ChannelControlsList({
               );
             })}
           </div>
+          {resetCallback && (
+            <span className={cns("flex", "justify-end", "mt-sds-xs")}>
+              <Button
+                sdsStyle="minimal"
+                sdsType="secondary"
+                onClick={() => {
+                  resetCallback().then(() => {
+                    setChannelProps(layer.channelProps ?? []);
+                  });
+                }}
+              >
+                Reset channels
+              </Button>
+            </span>
+          )}
         </AccordionDetails>
       </Accordion>
     </div>

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/components/ChannelControlsList/ChannelControlsList.tsx
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/components/ChannelControlsList/ChannelControlsList.tsx
@@ -9,39 +9,33 @@ import {
   ChannelControlProps,
 } from "./components/ChannelControl";
 import { ImageSeriesLayer, ChannelProps } from "@idetik/core";
-import { useState, useEffect } from "react";
+import { useEffect, useState } from "react";
 
 interface ChannelControlsListProps {
   layer: ImageSeriesLayer;
   controlProps: Partial<ChannelControlProps>[];
+  reset?: boolean;
 }
 
 export function ChannelControlsList({
   layer,
   controlProps,
+  reset,
 }: ChannelControlsListProps) {
   // Keep a local copy of channelProps to trigger re-renders
   const [channelProps, setChannelProps] = useState(layer.channelProps ?? []);
 
-  // Sync local state with layer's channelProps
+  // initial sync of local state with layer's channelProps
   useEffect(() => {
-    const initialLayerChannelProps = layer.channelProps ?? [];
+    if (reset || layer.channelProps?.length !== channelProps.length) {
+      setChannelProps(layer.channelProps ?? []);
+    }
+  }, [layer, reset, channelProps.length]);
 
-    const updatedChannelProps = initialLayerChannelProps.map(
-      (layerChannel: ChannelProps, index: number) => ({
-        visible:
-          controlProps?.[index]?.visible ?? layerChannel?.visible ?? true,
-        color: controlProps?.[index]?.color ?? layerChannel?.color,
-        contrastLimits:
-          controlProps?.[index]?.contrastLimits ?? layerChannel?.contrastLimits,
-      })
-    );
-
-    // Update both the layer and local state to keep them in sync
-    // TODO: use a dispatcher?
-    layer.setChannelProps(updatedChannelProps);
-    setChannelProps(updatedChannelProps);
-  }, [layer, controlProps]);
+  // update layer's channelProps when local state changes
+  useEffect(() => {
+    layer.setChannelProps(channelProps);
+  }, [channelProps, layer]);
 
   const updateChannel = (
     index: number,
@@ -58,8 +52,6 @@ export function ChannelControlsList({
       ...updates,
     };
 
-    // Update both the layer and local state to keep them in sync
-    layer.setChannelProps(updatedChannelProps);
     setChannelProps(updatedChannelProps);
   };
 

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/components/ChannelControlsList/ChannelControlsList.tsx
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/components/ChannelControlsList/ChannelControlsList.tsx
@@ -10,34 +10,35 @@ import {
   ChannelControlProps,
 } from "./components/ChannelControl";
 import { ImageSeriesLayer, ChannelProps } from "@idetik/core";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 interface ChannelControlsListProps {
   layer: ImageSeriesLayer;
   controlProps: Partial<ChannelControlProps>[];
-  reset?: boolean;
   resetCallback?: () => Promise<void>;
 }
 
 export function ChannelControlsList({
   layer,
   controlProps,
-  reset,
   resetCallback,
 }: ChannelControlsListProps) {
   // Keep a local copy of channelProps to trigger re-renders
   const [channelProps, setChannelProps] = useState(layer.channelProps ?? []);
+  const isInternalUpdate = useRef(false);
 
   // initial sync of local state with layer's channelProps
+  // props change indicates this is not an internal update
   useEffect(() => {
-    if (reset || layer.channelProps?.length !== channelProps.length) {
-      setChannelProps(layer.channelProps ?? []);
-    }
-  }, [layer, reset, channelProps.length]);
+    isInternalUpdate.current = false;
+    setChannelProps(layer.channelProps ?? []);
+  }, [layer, controlProps, resetCallback]);
 
   // update layer's channelProps when local state changes
   useEffect(() => {
-    layer.setChannelProps(channelProps);
+    if (isInternalUpdate.current) {
+      layer.setChannelProps(channelProps);
+    }
   }, [channelProps, layer]);
 
   const updateChannel = (
@@ -48,6 +49,7 @@ export function ChannelControlsList({
       contrastLimits: [number, number];
     }>
   ) => {
+    isInternalUpdate.current = true;
     const updatedChannelProps = [...channelProps];
 
     updatedChannelProps[index] = {

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/components/ChannelControlsList/ChannelControlsList.tsx
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/components/ChannelControlsList/ChannelControlsList.tsx
@@ -1,15 +1,18 @@
-import { Accordion } from "@mui/material";
-import { AccordionHeader, AccordionDetails } from "@czi-sds/components";
+import {
+  AccordionHeader,
+  AccordionDetails,
+  Accordion,
+} from "@czi-sds/components";
 import cns from "classnames";
 import {
   ChannelControl,
   ChannelControlProps,
 } from "./components/ChannelControl";
-import { ImageLayer, ImageSeriesLayer, ChannelProps } from "@idetik/core";
+import { ImageSeriesLayer, ChannelProps } from "@idetik/core";
 import { useState, useEffect } from "react";
 
 interface ChannelControlsListProps {
-  layer: ImageLayer | ImageSeriesLayer;
+  layer: ImageSeriesLayer;
   controlProps: Partial<ChannelControlProps>[];
 }
 
@@ -78,7 +81,7 @@ export function ChannelControlsList({
         "before:w-full",
         "before:h-full",
         "before:bg-[--sds-color-semantic-base-background-primary]",
-        "before:opacity-50",
+        "before:opacity-35",
         "before:content-['']"
       )}
     >
@@ -94,7 +97,8 @@ export function ChannelControlsList({
             "flex",
             "w-full",
             "[&_.MuiAccordionSummary-root]:!flex-grow",
-            "[&_.Mui-expanded]:!min-h-0"
+            "[&_.Mui-expanded]:!min-h-0",
+            "[&_.MuiSvgIcon-root]:!fill-[--sds-color-semantic-text-primary]"
           )}
         >
           <AccordionHeader>

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/components/ChannelControlsList/ChannelControlsList.tsx
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/components/ChannelControlsList/ChannelControlsList.tsx
@@ -61,7 +61,6 @@ export function ChannelControlsList({
   return (
     <div
       className={cns(
-        "z-[999]",
         "backdrop-blur-md",
         "transition-[left]",
         "duration-300",
@@ -83,7 +82,6 @@ export function ChannelControlsList({
       <Accordion
         id="channel-controls"
         className="flex-grow"
-        defaultExpanded
         square
         elevation={0}
       >

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/components/Renderer/Renderer.tsx
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/components/Renderer/Renderer.tsx
@@ -12,7 +12,7 @@ type ControlType = "panzoom" | "none";
 
 interface RendererProps {
   layerManager: LayerManager;
-  camera: OrthographicCamera;
+  camera: OrthographicCamera | null;
   cameraControls?: ControlType;
   canvasId?: string;
 }
@@ -26,15 +26,15 @@ export function Renderer({
   const renderer = useRef<WebGLRenderer | null>(null);
   const controls = useRef<CameraControls>(new NullControls());
 
-  switch (cameraControls) {
-    case "panzoom":
+  useEffect(() => {
+    console.debug("Renderer::setControls");
+    if (camera && cameraControls === "panzoom") {
       controls.current = new PanZoomControls(camera, camera.position);
-      break;
-    case "none":
+    } else {
       controls.current = new NullControls();
-      break;
-  }
-  renderer.current?.setControls(controls.current);
+    }
+    renderer.current?.setControls(controls.current);
+  }, [camera, cameraControls]);
 
   // Use the mount-effect so that the renderer can find the corresponding
   // element by its ID.
@@ -47,6 +47,9 @@ export function Renderer({
       renderer.current.setControls(controls.current);
     }
     function animate() {
+      if (!camera) {
+        return;
+      }
       renderer.current?.render(layerManager, camera);
       lastRequestId = requestAnimationFrame(animate);
     }


### PR DESCRIPTION
### Summary
Introduces a new "load high res" button based on BioHub SF requests and @Janeece's designs:
![Screenshot 2025-03-13 at 12 02 19 PM](https://github.com/user-attachments/assets/56adb621-c09d-4add-bc41-7dd6d30ce7ab)

I also added a "reset channels" button to the channel controls. @phoenixAja I simplified the code in the channel control list to not do full two-way syncing of the controls with the layer. I think this may be "good enough" for now but lmk what you think.

I'm still concerned a "reset camera" button would clutter the viewer, so I left it out. Previous discussions suggested a page refresh may be sufficient. Otherwise maybe it can be implemented as a button on the portal.

Here is a recording of this branch:

https://github.com/user-attachments/assets/f028964b-d5e8-49da-9dba-8eede7b6f738

### Related Issue
Replaces #208

### Tests & Checks
Tested in react workspace
Added a button to set a new url to test how the carousel will work