### PR TITLE
(Small) Rename DataTexture2D to Texture2D

### DIFF
--- a/packages/core/src/layers/image_utils.ts
+++ b/packages/core/src/layers/image_utils.ts
@@ -1,4 +1,4 @@
-import { Texture2D } from "@/objects/textures/texture_2d";
+import { Texture2D } from "objects/textures/texture_2d";
 import { Texture } from "objects/textures/texture";
 import { Texture2DArray } from "objects/textures/texture_2d_array";
 import { ImageChunk } from "data/image_chunk";

--- a/packages/core/src/layers/image_utils.ts
+++ b/packages/core/src/layers/image_utils.ts
@@ -1,4 +1,4 @@
-import { DataTexture2D } from "objects/textures/data_texture_2d";
+import { Texture2D } from "@/objects/textures/texture_2d";
 import { Texture } from "objects/textures/texture";
 import { Texture2DArray } from "objects/textures/texture_2d_array";
 import { ImageChunk } from "data/image_chunk";
@@ -7,7 +7,7 @@ import { ChannelProps } from "objects/textures/channel";
 import { ImageRenderable } from "objects/renderable/image_renderable";
 
 export function makeImageTexture(chunk: ImageChunk) {
-  const texture = new DataTexture2D(chunk.data, chunk.shape.x, chunk.shape.y);
+  const texture = new Texture2D(chunk.data, chunk.shape.x, chunk.shape.y);
   texture.unpackRowLength = chunk.rowStride;
   texture.unpackAlignment = chunk.rowAlignmentBytes;
   return texture;

--- a/packages/core/src/objects/renderable/image_renderable.ts
+++ b/packages/core/src/objects/renderable/image_renderable.ts
@@ -73,7 +73,7 @@ export class ImageRenderable extends RenderableObject {
       throw new Error("No texture set");
     }
 
-    if (texture.type === "DataTexture2D") {
+    if (texture.type === "Texture2D") {
       const { color, contrastLimits } =
         this.channels_[0] ?? validateChannel(texture, {});
       return {
@@ -112,8 +112,6 @@ export class ImageRenderable extends RenderableObject {
     if (!texture) {
       throw new Error("un-textured image not implemented");
     } else if (texture.type == "Texture2D") {
-      this.programName = "mesh";
-    } else if (texture.type == "DataTexture2D") {
       this.programName =
         texture.dataType == "float" ? "floatImage" : "uintImage";
     } else if (texture.type == "Texture2DArray") {

--- a/packages/core/src/objects/textures/texture_2d.ts
+++ b/packages/core/src/objects/textures/texture_2d.ts
@@ -4,7 +4,7 @@ import {
   bufferToDataType,
 } from "objects/textures/texture";
 
-export class DataTexture2D extends Texture {
+export class Texture2D extends Texture {
   private data_: DataTextureTypedArray;
   private readonly width_: number;
   private readonly height_: number;
@@ -25,7 +25,7 @@ export class DataTexture2D extends Texture {
   }
 
   public get type() {
-    return "DataTexture2D";
+    return "Texture2D";
   }
 
   public get data() {

--- a/packages/core/src/renderers/shaders/index.ts
+++ b/packages/core/src/renderers/shaders/index.ts
@@ -1,7 +1,6 @@
 import projectedLineVertexShader from "./projected_line_vert.glsl";
 import projectedLineFragmentShader from "./projected_line_frag.glsl";
 import meshVertexShader from "./mesh_vert.glsl";
-import meshFragmentShader from "./mesh_frag.glsl";
 import floatImageFragmentShader from "./float_image_frag.glsl";
 import floatImageArrayFragmentShader from "./float_image_array_frag.glsl";
 import uintImageFragmentShader from "./uint_image_frag.glsl";
@@ -9,7 +8,6 @@ import uintImageArrayFragmentShader from "./uint_image_array_frag.glsl";
 
 export type Shader =
   | "projectedLine"
-  | "mesh"
   | "floatImage"
   | "floatImageArray"
   | "uintImage"
@@ -20,11 +18,6 @@ export const shaderCode: Record<Shader, { vertex: string; fragment: string }> =
     projectedLine: {
       vertex: projectedLineVertexShader,
       fragment: projectedLineFragmentShader,
-    },
-    // TODO: a mesh shader without a texture
-    mesh: {
-      vertex: meshVertexShader,
-      fragment: meshFragmentShader,
     },
     // TODO: consolidate image shaders
     floatImage: {

--- a/packages/core/src/renderers/webgl_textures.ts
+++ b/packages/core/src/renderers/webgl_textures.ts
@@ -6,7 +6,7 @@ import {
   TextureDataFormat,
 } from "objects/textures/texture";
 
-import { DataTexture2D } from "objects/textures/data_texture_2d";
+import { Texture2D } from "@/objects/textures/texture_2d";
 import { Texture2DArray } from "objects/textures/texture_2d_array";
 
 export class WebGLTextures {
@@ -104,7 +104,7 @@ export class WebGLTextures {
   }
 
   private allocateTextureStorage(texture: Texture) {
-    if (this.isDataTexture2D(texture)) {
+    if (this.isTexture2D(texture)) {
       this.gl_.texStorage2D(
         this.getGLTextureType(texture),
         texture.mipmapLevels,
@@ -133,7 +133,7 @@ export class WebGLTextures {
     mipmapLevel: number,
     offset: { x: number; y: number; z: number }
   ) {
-    if (this.isDataTexture2D(texture)) {
+    if (this.isTexture2D(texture)) {
       this.gl_.texSubImage2D(
         this.getGLTextureType(texture),
         mipmapLevel,
@@ -171,7 +171,7 @@ export class WebGLTextures {
   }
 
   private getGLTextureType(texture: Texture) {
-    if (this.isDataTexture2D(texture)) {
+    if (this.isTexture2D(texture)) {
       return this.gl_.TEXTURE_2D;
     } else if (this.isTexture2DArray(texture)) {
       return this.gl_.TEXTURE_2D_ARRAY;
@@ -252,8 +252,8 @@ export class WebGLTextures {
     );
   }
 
-  private isDataTexture2D(texture: Texture): texture is DataTexture2D {
-    return texture.type === "DataTexture2D";
+  private isTexture2D(texture: Texture): texture is Texture2D {
+    return texture.type === "Texture2D";
   }
 
   private isTexture2DArray(texture: Texture): texture is Texture2DArray {

--- a/packages/core/src/renderers/webgl_textures.ts
+++ b/packages/core/src/renderers/webgl_textures.ts
@@ -6,7 +6,7 @@ import {
   TextureDataFormat,
 } from "objects/textures/texture";
 
-import { Texture2D } from "@/objects/textures/texture_2d";
+import { Texture2D } from "objects/textures/texture_2d";
 import { Texture2DArray } from "objects/textures/texture_2d_array";
 
 export class WebGLTextures {


### PR DESCRIPTION
### Summary
This PR is a follow-up to #210.  
It renames `DataTexture2D` to `Texture2D` for consistency.

### Tests & Checks
- Verified that all the examples are working as expected.
- All tests/linters are passing.