### PR TITLE
feat: [Blending Phase 1] Add transparent, opacity, and blendingMode to Layer class

### DIFF
--- a/packages/core/src/core/layer.ts
+++ b/packages/core/src/core/layer.ts
@@ -1,16 +1,40 @@
 import { RenderableObject } from "./renderable_object";
 
 export type LayerState = "initialized" | "loading" | "ready";
+export type BlendingMode = "normal" | "additive" | "subtractive" | "multiply";
+
 
 type StateChangeCallback = (
   newState: LayerState,
   prevState?: LayerState
 ) => void;
 
+export interface LayerOptions {
+  transparent?: boolean;
+  opacity?: number;
+  blendingMode?: BlendingMode;
+}
+
 export abstract class Layer {
   private objects_: RenderableObject[] = [];
   private state_: LayerState = "initialized";
   private callbacks_: StateChangeCallback[] = [];
+
+  public readonly transparent: boolean;
+  public readonly opacity: number;
+  public readonly blendingMode: BlendingMode;
+
+  /* eslint-disable @typescript-eslint/no-unused-vars -- these fields are scaffolded for upcoming blending support */
+  constructor({
+    transparent = false,
+    opacity = 1.0,
+    blendingMode = "normal"
+  }: LayerOptions = {}) {
+    this.transparent = transparent;
+    this.opacity = opacity;
+    this.blendingMode = blendingMode;
+  }
+  /* eslint-enable @typescript-eslint/no-unused-vars */
 
   public abstract update(): void;
 

--- a/packages/core/src/core/layer.ts
+++ b/packages/core/src/core/layer.ts
@@ -3,7 +3,6 @@ import { RenderableObject } from "./renderable_object";
 export type LayerState = "initialized" | "loading" | "ready";
 export type BlendingMode = "normal" | "additive" | "subtractive" | "multiply";
 
-
 type StateChangeCallback = (
   newState: LayerState,
   prevState?: LayerState
@@ -28,7 +27,7 @@ export abstract class Layer {
   constructor({
     transparent = false,
     opacity = 1.0,
-    blendingMode = "normal"
+    blendingMode = "normal",
   }: LayerOptions = {}) {
     this.transparent = transparent;
     this.opacity = opacity;

--- a/packages/core/src/core/layer.ts
+++ b/packages/core/src/core/layer.ts
@@ -10,7 +10,7 @@ type StateChangeCallback = (
 ) => void;
 
 export interface LayerOptions {
-  transparent?: boolean;
+  isTransparent?: boolean;
   opacity?: number;
   blendingMode?: BlendingMode;
 }
@@ -20,7 +20,7 @@ export abstract class Layer {
   private state_: LayerState = "initialized";
   private callbacks_: StateChangeCallback[] = [];
 
-  public readonly transparent: boolean;
+  public readonly isTransparent: boolean;
   /**
    * For layer opacity, value is clamped to the range [0.0, 1.0].
    */
@@ -29,7 +29,7 @@ export abstract class Layer {
 
   /* eslint-disable @typescript-eslint/no-unused-vars -- these fields are scaffolded for upcoming blending support */
   constructor({
-    transparent = false,
+    isTransparent = false,
     opacity = 1.0,
     blendingMode = "normal",
   }: LayerOptions = {}) {
@@ -38,7 +38,7 @@ export abstract class Layer {
         `Layer opacity out of bounds: ${opacity} — clamping to [0.0, 1.0]`
       );
     }
-    this.transparent = transparent;
+    this.isTransparent = isTransparent;
     this.opacity = clamp01(opacity);
     this.blendingMode = blendingMode;
   }

--- a/packages/core/src/core/layer.ts
+++ b/packages/core/src/core/layer.ts
@@ -1,4 +1,5 @@
 import { RenderableObject } from "./renderable_object";
+import { clamp01 } from "./utils";
 
 export type LayerState = "initialized" | "loading" | "ready";
 export type BlendingMode = "normal" | "additive" | "subtractive" | "multiply";
@@ -20,6 +21,9 @@ export abstract class Layer {
   private callbacks_: StateChangeCallback[] = [];
 
   public readonly transparent: boolean;
+  /**
+   * For layer opacity, value is clamped to the range [0.0, 1.0].
+   */
   public readonly opacity: number;
   public readonly blendingMode: BlendingMode;
 
@@ -29,8 +33,13 @@ export abstract class Layer {
     opacity = 1.0,
     blendingMode = "normal",
   }: LayerOptions = {}) {
+    if (opacity < 0 || opacity > 1) {
+      console.warn(
+        `Layer opacity out of bounds: ${opacity} — clamping to [0.0, 1.0]`
+      );
+    }
     this.transparent = transparent;
-    this.opacity = opacity;
+    this.opacity = clamp01(opacity);
     this.blendingMode = blendingMode;
   }
   /* eslint-enable @typescript-eslint/no-unused-vars */

--- a/packages/core/src/core/utils.ts
+++ b/packages/core/src/core/utils.ts
@@ -41,3 +41,10 @@ export function generateUUID() {
     // .toLowerCase() flattens concatenated strings to save heap memory space.
     return uuid.toLowerCase();
 }
+
+export function clamp01(value: number): number {
+  if (value < 0 || value > 1) {
+    return Math.max(0.0, Math.min(1.0, value));
+  }
+  return value;
+}


### PR DESCRIPTION
## Summary

This PR lays some of the groundwork for upcoming blending support in the Viz renderer.

- Adds `transparent`, `opacity`, and `blendingMode` fields to the `Layer` base class
- Uses safe defaults and optional constructor params to preserve backward compatibility
- Includes ESLint suppression for temporarily-unused fields (these will be used in later phases; the suppression will be removed accordingly)

## Notes

These fields are not yet used in the rendering logic. They will be integrated in:

- **Phase 2**: Opaque/transparent layer partitioning
- **Phase 3**: Update the renderer to receive and apply blending-related metadata

## Testing

tested all examples
