### PR TITLE
Extract clamp to a separate module

### DIFF
--- a/packages/core/src/core/layer.ts
+++ b/packages/core/src/core/layer.ts
@@ -1,5 +1,5 @@
 import { RenderableObject } from "./renderable_object";
-import { clamp01 } from "./utils";
+import { clamp } from "utilities/clamp";
 
 export type LayerState = "initialized" | "loading" | "ready";
 export type BlendingMode = "normal" | "additive" | "subtractive" | "multiply";
@@ -18,16 +18,12 @@ export interface LayerOptions {
 export abstract class Layer {
   private objects_: RenderableObject[] = [];
   private state_: LayerState = "initialized";
-  private callbacks_: StateChangeCallback[] = [];
+  private readonly callbacks_: StateChangeCallback[] = [];
 
   public readonly isTransparent: boolean;
-  /**
-   * For layer opacity, value is clamped to the range [0.0, 1.0].
-   */
   public readonly opacity: number;
   public readonly blendingMode: BlendingMode;
 
-  /* eslint-disable @typescript-eslint/no-unused-vars -- these fields are scaffolded for upcoming blending support */
   constructor({
     isTransparent = false,
     opacity = 1.0,
@@ -39,10 +35,9 @@ export abstract class Layer {
       );
     }
     this.isTransparent = isTransparent;
-    this.opacity = clamp01(opacity);
+    this.opacity = clamp(opacity, 0.0, 1.0);
     this.blendingMode = blendingMode;
   }
-  /* eslint-enable @typescript-eslint/no-unused-vars */
 
   public abstract update(): void;
 

--- a/packages/core/src/core/utils.ts
+++ b/packages/core/src/core/utils.ts
@@ -41,10 +41,3 @@ export function generateUUID() {
     // .toLowerCase() flattens concatenated strings to save heap memory space.
     return uuid.toLowerCase();
 }
-
-export function clamp01(value: number): number {
-  if (value < 0 || value > 1) {
-    return Math.max(0.0, Math.min(1.0, value));
-  }
-  return value;
-}

--- a/packages/core/src/utilities/clamp.ts
+++ b/packages/core/src/utilities/clamp.ts
@@ -1,0 +1,3 @@
+export function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}


### PR DESCRIPTION
### Summary

This PR extracts the `clamp` function into a standalone module. This change is
necessary because the previous PR (currently under review) removes the original
`utils` file. Additionally, the clamp function has been generalized, and an
unnecessary `if`-guard was removed to avoid redundant checks at this level.

### Related PRs
- #223

### Tests & Checks
- Verified that all the examples are working as expected.
- All tests/linters are passing.
