### PR TITLE
fix(react): update css filename in exports

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -29,14 +29,15 @@
   "main": "./dist/index.umd.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "style": "./dist/style.css",
+  "style": "./dist/index.css",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.umd.cjs"
     },
-    "./style.css": "./dist/style.css",
+    "./style.css": "./dist/index.css",
+    "./index.css": "./dist/index.css",
     "./dist/*.js.map": "./dist/*.js.map",
     "./dist/*.cjs.map": "./dist/*.cjs.map",
     "./dist/*.d.ts.map": "./dist/*.d.ts.map"


### PR DESCRIPTION
### Summary
<!---
  Please try to cover the following questions in your summary:
  1. Describe the product (or technical) problem you are solving.
  2. Explain the engineering solution you have chosen.
  3. Discuss the implementation choices/tradeoffs you have made.
-->
Importing the React library using `@import "@idetik/react/style.css";` does not work anymore.

I think with the new Vite updates, there was a change of the output CSS filename. In the `dist` folder, it is now `index.css`, instead of `style.css`. I updated the `package.json` to update the filename, keeping `@import "@idetik/react/style.css";` valid, while also adding support for `@import "@idetik/react/index.css";`

### Related Issue
Closes #<issue-number>

### Tests & Checks
<!---
  How did you validate that your changes were implemented correctly?
  
  Please think about the following prompts:
  1. I wrote automated tests.
  2. I manually tested my changes, and here's what I did:
-->
