### PR TITLE
Create a simple logger class

### DIFF
--- a/packages/core/src/renderers/webgl_renderer.ts
+++ b/packages/core/src/renderers/webgl_renderer.ts
@@ -34,7 +34,10 @@ export class WebGLRenderer extends Renderer {
     if (!this.gl_) {
       throw new Error(`Failed to initialize WebGL2 context`);
     }
-    Logger.info(`WebGL version ${this.gl.getParameter(this.gl.VERSION)}`);
+    Logger.info(
+      "WebGLRenderer",
+      `WebGL version ${this.gl.getParameter(this.gl.VERSION)}`
+    );
 
     this.shaders_ = new Map<Shader, WebGLShaderProgram>();
     this.bindings_ = new WebGLBuffers(this.gl);

--- a/packages/core/src/renderers/webgl_renderer.ts
+++ b/packages/core/src/renderers/webgl_renderer.ts
@@ -1,6 +1,7 @@
 import { Renderer } from "core/renderer";
 import { RenderableObject } from "core/renderable_object";
 import { WebGLShaderProgram } from "./webgl_shader_program";
+import { Logger } from "utilities/logger";
 
 import { Shader, shaderCode } from "./shaders";
 import { WebGLBuffers } from "./webgl_buffers";
@@ -33,7 +34,7 @@ export class WebGLRenderer extends Renderer {
     if (!this.gl_) {
       throw new Error(`Failed to initialize WebGL2 context`);
     }
-    console.log(`WebGL version ${this.gl.getParameter(this.gl.VERSION)}`);
+    Logger.info(`WebGL version ${this.gl.getParameter(this.gl.VERSION)}`);
 
     this.shaders_ = new Map<Shader, WebGLShaderProgram>();
     this.bindings_ = new WebGLBuffers(this.gl);

--- a/packages/core/src/renderers/webgl_shader_program.ts
+++ b/packages/core/src/renderers/webgl_shader_program.ts
@@ -46,7 +46,7 @@ export class WebGLShaderProgram {
       case this.gl_.BOOL:
       case this.gl_.FLOAT:
         if (typeof value === "number") {
-          this.gl_.uniform1f(location, value as number);
+          this.gl_.uniform1f(location, value);
         } else {
           this.gl_.uniform1fv(location, value as Iterable<number>);
         }

--- a/packages/core/src/utilities/logger.ts
+++ b/packages/core/src/utilities/logger.ts
@@ -1,0 +1,108 @@
+type LogLevel = "info" | "warn" | "error" | "debug";
+
+const Levels = {
+  debug: 10,
+  info: 20,
+  warn: 30,
+  error: 40,
+} satisfies Record<LogLevel, number>;
+
+const Colors = {
+  debug: "\x1b[90m", // gray
+  info: "\x1b[36m", // cyan
+  warn: "\x1b[33m", // yellow
+  error: "\x1b[31m", // red
+} satisfies Record<LogLevel, string>;
+
+const regex = /at new\s+(.*)\s+\(/;
+
+export class Logger {
+  private static logLevel_: LogLevel =
+    import.meta.env.MODE === "production" ? "warn" : "debug";
+
+  public static setLogLevel(level: LogLevel) {
+    Logger.logLevel_ = level;
+  }
+
+  public static debug(
+    message: string,
+    moduleName?: string,
+    ...params: unknown[]
+  ) {
+    Logger.log("debug", message, moduleName, ...params);
+  }
+
+  public static info(
+    message: string,
+    moduleName?: string,
+    ...params: unknown[]
+  ) {
+    Logger.log("info", message, moduleName, ...params);
+  }
+
+  public static warn(
+    message: string,
+    moduleName?: string,
+    ...params: unknown[]
+  ) {
+    Logger.log("warn", message, moduleName, ...params);
+  }
+
+  public static error(
+    message: string,
+    moduleName?: string,
+    ...params: unknown[]
+  ) {
+    Logger.log("error", message, moduleName, ...params);
+  }
+
+  private static log(
+    level: LogLevel,
+    message: string,
+    moduleName?: string,
+    ...args: unknown[]
+  ) {
+    if (Levels[level] < Levels[Logger.logLevel_]) return;
+
+    const timestamp = new Date().toISOString();
+    const module = moduleName ?? Logger.detectModuleName();
+    const color = Colors[level];
+    const tag = `[${timestamp}][${level.toUpperCase()}][${module}]`;
+    const output = [`${color}${tag}`, message, ...args];
+
+    switch (level) {
+      case "debug":
+        console.debug(...output);
+        break;
+      case "info":
+        console.info(...output);
+        break;
+      case "warn":
+        console.warn(...output);
+        break;
+      case "error":
+        console.error(...output);
+        break;
+    }
+  }
+
+  private static detectModuleName(): string {
+    // This logic is based on the format of the stack trace in the V8 engine
+    // (used by Node.js and Chrome). It also makes some assumptions about the
+    // calling context of the logger. It's very brittle and may break in future
+    // versions of Node.js or Chrome. Let's keep it simple for now and improve
+    // it later if needed.
+    try {
+      const err = new Error();
+      const stack = err.stack?.split("\n");
+      if (!stack || stack.length < 4) return "unknown";
+      const callerLine = stack[4]; // "at new ModuleName (file:line)"
+      const match = regex.exec(callerLine);
+      if (match) return match[1].trim();
+    } catch {
+      // ignore errors
+    }
+
+    return "unknown";
+  }
+}

--- a/packages/core/src/utilities/logger.ts
+++ b/packages/core/src/utilities/logger.ts
@@ -14,7 +14,8 @@ const Colors = {
   error: "\x1b[31m", // red
 } satisfies Record<LogLevel, string>;
 
-const regex = /at new\s+(.*)\s+\(/;
+// Add new module names here as needed to represent different parts of the application
+type Module = "WebGLRenderer" | "WebGLShaderProgram";
 
 export class Logger {
   private static logLevel_: LogLevel =
@@ -25,49 +26,48 @@ export class Logger {
   }
 
   public static debug(
+    moduleName: Module,
     message: string,
-    moduleName?: string,
     ...params: unknown[]
   ) {
-    Logger.log("debug", message, moduleName, ...params);
+    Logger.log("debug", moduleName, message, ...params);
   }
 
   public static info(
+    moduleName: Module,
     message: string,
-    moduleName?: string,
     ...params: unknown[]
   ) {
-    Logger.log("info", message, moduleName, ...params);
+    Logger.log("info", moduleName, message, ...params);
   }
 
   public static warn(
+    moduleName: Module,
     message: string,
-    moduleName?: string,
     ...params: unknown[]
   ) {
-    Logger.log("warn", message, moduleName, ...params);
+    Logger.log("warn", moduleName, message, ...params);
   }
 
   public static error(
+    moduleName: Module,
     message: string,
-    moduleName?: string,
     ...params: unknown[]
   ) {
-    Logger.log("error", message, moduleName, ...params);
+    Logger.log("error", moduleName, message, ...params);
   }
 
   private static log(
     level: LogLevel,
+    moduleName: Module,
     message: string,
-    moduleName?: string,
     ...args: unknown[]
   ) {
     if (Levels[level] < Levels[Logger.logLevel_]) return;
 
     const timestamp = new Date().toISOString();
-    const module = moduleName ?? Logger.detectModuleName();
     const color = Colors[level];
-    const tag = `[${timestamp}][${level.toUpperCase()}][${module}]`;
+    const tag = `[${timestamp}][${level.toUpperCase()}][${moduleName}]`;
     const output = [`${color}${tag}`, message, ...args];
 
     switch (level) {
@@ -84,25 +84,5 @@ export class Logger {
         console.error(...output);
         break;
     }
-  }
-
-  private static detectModuleName(): string {
-    // This logic is based on the format of the stack trace in the V8 engine
-    // (used by Node.js and Chrome). It also makes some assumptions about the
-    // calling context of the logger. It's very brittle and may break in future
-    // versions of Node.js or Chrome. Let's keep it simple for now and improve
-    // it later if needed.
-    try {
-      const err = new Error();
-      const stack = err.stack?.split("\n");
-      if (!stack || stack.length < 4) return "unknown";
-      const callerLine = stack[4]; // "at new ModuleName (file:line)"
-      const match = regex.exec(callerLine);
-      if (match) return match[1].trim();
-    } catch {
-      // ignore errors
-    }
-
-    return "unknown";
   }
 }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -31,7 +31,7 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
 
-    "types": ["vite-plugin-glsl/ext"]
+    "types": ["vite-plugin-glsl/ext", "vite/client"]
   },
   "include": ["examples", "src", "test"]
 }


### PR DESCRIPTION
### Summary

This PR introduces a centralized Logger class for consistent logging:

- Supports debug, info, warn, and error log levels
- Color-coded output for improved terminal readability
- Timestamps included on all logs
- Optional module/class tagging (auto-detected via stack trace)
- Log level filtering based on env

It also includes a usage example.

### Related Issue
Closes #42 

### Tests & Checks

![Screenshot 2025-04-18 at 9 53 17 AM](https://github.com/user-attachments/assets/6e45a4ac-5565-49f9-bc01-33b8401d0c65)

- Verified that all the examples are working as expected.
- All tests/linters are passing.
