### PR TITLE
feat: Improve customizability and integrator facing API of React components

### DIFF
--- a/packages/core/src/layers/image_series_layer.ts
+++ b/packages/core/src/layers/image_series_layer.ts
@@ -37,12 +37,14 @@ export class ImageSeriesLayer extends Layer {
   private readonly seriesDimensionName_: string;
   private readonly seriesIndex_: Interval | Full;
   private readonly scheduler_: PromiseScheduler = new PromiseScheduler(16);
+  private readonly initialChannelProps_?: ChannelProps[];
   private loader_: ImageChunkLoader | null = null;
   private seriesAttributes_?: SeriesAttributes;
   private loadingToken_: LoadingToken | null = null;
   private texture_: Texture2DArray | null = null;
   private dataChunks_: ImageChunk[] = [];
   private channelProps_?: ChannelProps[];
+  private channelChangeCallbacks_: Array<() => void> = [];
   private image_?: ImageRenderable;
   private extent_?: { x: number; y: number };
 
@@ -73,15 +75,38 @@ export class ImageSeriesLayer extends Layer {
     }
     this.seriesIndex_ = seriesDimensionalIndex.index;
     this.channelProps_ = channelProps;
+    this.initialChannelProps_ = channelProps;
   }
 
   public get channelProps(): ChannelProps[] | undefined {
     return this.channelProps_;
   }
-
   public setChannelProps(channelProps: ChannelProps[]) {
     this.channelProps_ = channelProps;
     this.image_?.setChannelProps(channelProps);
+    this.channelChangeCallbacks_.forEach((callback) => {
+      callback();
+    });
+  }
+  public resetChannelProps(): void {
+    if (this.initialChannelProps_ !== undefined) {
+      this.setChannelProps(this.initialChannelProps_);
+    }
+  }
+
+  /** useSyncExternalStore() compatible subscribe function. */
+  addChannelChangeCallback = (callback: () => void): (() => void) => {
+    this.channelChangeCallbacks_.push(callback);
+    return () => {
+      this.removeChannelChangeCallback(callback);
+    };
+  };
+  public removeChannelChangeCallback(callback: () => void): void {
+    const index = this.channelChangeCallbacks_.indexOf(callback);
+    if (index === undefined) {
+      throw new Error(`Callback to remove could not be found: ${callback}`);
+    }
+    this.channelChangeCallbacks_.splice(index, 1);
   }
 
   public update() {

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -12,14 +12,43 @@ npm install @idetik/react @idetik/core
 
 ### Basic Usage
 
-1. Wrap your application in the
+1. Wrap your application in `<IdetikProvider>`.
 
-### Available Components
+```tsx
+import { IdetikProvider } from '@idetik/react';
 
-The package provides several components for viewing and interacting with scientific image data:
+...
 
-- `OmeZarrImageViewer`: TODO
-- `ChannelControlsList`: TODO
+<IdetikProvider>
+   <App />
+</IdetikProvider>,
+```
+
+2. Insert `<OmeZarrImageViewer>` anywhere in your application.
+
+```tsx
+<OmeZarrImageViewer
+   sourceUrl={imageUrl}
+   region={region}
+   seriesDimensionName="Z"
+   allSlicesSizeEstimate="250 MB"
+   classNames={{
+      root: "your-css-class",
+   }}
+   onLayerCreated={handleLayerCreated}
+   onFirstSliceLoaded={handleFirstSliceLoaded}
+   onLoadAllSlicesClicked={handleLoadAllSlicesClicked}
+   onAllSlicesLoaded={handleAllSlicesLoaded}
+   onLoadAllSlicesAborted={handleLoadAllSlicesAborted}
+/>
+```
+
+3. Insert `<ChannelControlsList>` anywhere in your application.
+
+### Advanced usage
+
+To write custom control components, use the `useIdetik()` hook to access and update the global
+Idetik state.
 
 ## For Internal Developers
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -2,7 +2,28 @@
 
 React components for image viewers - wrapping idetik/core functionality
 
-## Getting Started
+## For Integrators: Using @idetik/react Components
+
+### Installation
+
+```bash
+npm install @idetik/react @idetik/core
+```
+
+### Basic Usage
+
+1. Wrap your application in the
+
+### Available Components
+
+The package provides several components for viewing and interacting with scientific image data:
+
+- `OmeZarrImageViewer`: TODO
+- `ChannelControlsList`: TODO
+
+## For Internal Developers
+
+### Getting Started
 
 ```bash
 # Install dependencies from root directory
@@ -28,11 +49,11 @@ If you make changes to the `@idetik/core` package, you'll need to:
 
 This ensures your React components use the latest version of the core package.
 
-## Component Development Guidelines
+### Component Development Guidelines
 
 Pure TypeScript code (has no react dependencies) should go in the `lib/` directory.
 
-### File Structure
+#### File Structure
 Each component should have its own directory with the following structure:
 ```
 ComponentName/
@@ -42,7 +63,7 @@ ComponentName/
 └── components/      # Sub-components (if needed)
 ```
 
-### Best Practices
+#### Best Practices
 
 1. **Exports**
    - Use named exports instead of default exports
@@ -97,7 +118,7 @@ ComponentName/
    );
    ```
 
-## Available Scripts
+### Available Scripts
 
 - `npm run dev` - Start the Vite development server
 - `npm run compile` - Run TypeScript compilation

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -45,6 +45,10 @@ import { IdetikProvider } from '@idetik/react';
 
 3. Insert `<ChannelControlsList>` anywhere in your application.
 
+```tsx
+<ChannelControlsList />
+```
+
 ### Advanced usage
 
 To write custom control components, use the `useIdetik()` hook to access and update the global

--- a/packages/react/src/components/App.tsx
+++ b/packages/react/src/components/App.tsx
@@ -27,8 +27,6 @@ export default function App() {
   const layerCreatedTime = useRef<number | undefined>(undefined);
   const loadAllSlicesClickedTime = useRef<number | undefined>(undefined);
 
-  const { imageLayer } = useIdetik();
-
   const handleLayerCreated = useCallback(() => {
     layerCreatedTime.current = performance.now();
     console.log(`Layer created at ${layerCreatedTime.current}`);
@@ -74,20 +72,17 @@ export default function App() {
 
   return (
     <div className="h-screen flex flex-col">
-      {imageLayer && (
-        <div className="absolute top-0 left-0 w-full md:!w-[400px]">
-          <ChannelControlsList
-            layer={imageLayer}
-            controlProps={controlProps}
-            resetCallback={resetChannelsCallback}
-          />
-        </div>
-      )}
+      <div className="absolute top-0 left-0 w-full md:!w-[400px]">
+        <ChannelControlsList />
+      </div>
       <OmeZarrImageViewer
         sourceUrl={imageUrl}
         region={region}
         seriesDimensionName="Z"
         allSlicesSizeEstimate="250 MB"
+        classNames={{
+          root: "bg-dark-sds-color-primitive-gray-100",
+        }}
         onLayerCreated={handleLayerCreated}
         onFirstSliceLoaded={handleFirstSliceLoaded}
         onLoadAllSlicesClicked={handleLoadAllSlicesClicked}

--- a/packages/react/src/components/App.tsx
+++ b/packages/react/src/components/App.tsx
@@ -16,6 +16,7 @@ const region: Region = [
 
 const imagePaths = ["000000", "000001", "000002", "001000", "001001", "001002"];
 
+/** Demo. */
 export default function App() {
   const [imageIndex, setImageIndex] = useState(0);
 

--- a/packages/react/src/components/App.tsx
+++ b/packages/react/src/components/App.tsx
@@ -1,7 +1,8 @@
-import cns from "classnames";
 import { Region } from "@idetik/core";
 import { OmeZarrImageViewer } from "./viewers/OmeZarrImageViewer";
 import { useCallback, useRef, useState } from "react";
+import { ChannelControlsList } from "./viewers/OmeZarrImageViewer/components/ChannelControlsList";
+import { useIdetik } from "./hooks";
 
 const sourceUrl =
   "https://public.czbiohub.org/organelle_box/datasets/A549/organelle_box_crop_v1.zarr";
@@ -25,6 +26,8 @@ export default function App() {
 
   const layerCreatedTime = useRef<number | undefined>(undefined);
   const loadAllSlicesClickedTime = useRef<number | undefined>(undefined);
+
+  const { imageLayer } = useIdetik();
 
   const handleLayerCreated = useCallback(() => {
     layerCreatedTime.current = performance.now();
@@ -70,17 +73,16 @@ export default function App() {
   }, []);
 
   return (
-    <div
-      className={cns(
-        "container",
-        "mx-auto",
-        "h-screen",
-        "flex",
-        "flex-col",
-        "overflow-hidden",
-        "bg-dark-sds-color-primitive-gray-100"
+    <div className="h-screen flex flex-col">
+      {imageLayer && (
+        <div className="absolute top-0 left-0 w-full md:!w-[400px]">
+          <ChannelControlsList
+            layer={imageLayer}
+            controlProps={controlProps}
+            resetCallback={resetChannelsCallback}
+          />
+        </div>
       )}
-    >
       <OmeZarrImageViewer
         sourceUrl={imageUrl}
         region={region}

--- a/packages/react/src/components/App.tsx
+++ b/packages/react/src/components/App.tsx
@@ -2,7 +2,6 @@ import { Region } from "@idetik/core";
 import { OmeZarrImageViewer } from "./viewers/OmeZarrImageViewer";
 import { useCallback, useRef, useState } from "react";
 import { ChannelControlsList } from "./viewers/OmeZarrImageViewer/components/ChannelControlsList";
-import { useIdetik } from "./hooks";
 
 const sourceUrl =
   "https://public.czbiohub.org/organelle_box/datasets/A549/organelle_box_crop_v1.zarr";

--- a/packages/react/src/components/App.tsx
+++ b/packages/react/src/components/App.tsx
@@ -72,7 +72,6 @@ export default function App() {
     <div
       className={cns(
         "container",
-        "max-w-[713px]",
         "mx-auto",
         "h-screen",
         "flex",

--- a/packages/react/src/components/App.tsx
+++ b/packages/react/src/components/App.tsx
@@ -71,9 +71,6 @@ export default function App() {
 
   return (
     <div className="h-screen flex flex-col">
-      <div className="absolute top-0 left-0 w-full md:!w-[400px]">
-        <ChannelControlsList />
-      </div>
       <OmeZarrImageViewer
         sourceUrl={imageUrl}
         region={region}
@@ -88,6 +85,9 @@ export default function App() {
         onAllSlicesLoaded={handleAllSlicesLoaded}
         onLoadAllSlicesAborted={handleLoadAllSlicesAborted}
       />
+      <div className="absolute top-0 left-0 w-full md:!w-[400px]">
+        <ChannelControlsList />
+      </div>
       <input
         type="button"
         value="Switch Image"

--- a/packages/react/src/components/App.tsx
+++ b/packages/react/src/components/App.tsx
@@ -70,7 +70,6 @@ export default function App() {
 
   return (
     <div
-      // Container represents how it'll look in the Organelle Box portal
       className={cns(
         "container",
         "max-w-[713px]",
@@ -79,24 +78,20 @@ export default function App() {
         "flex",
         "flex-col",
         "overflow-hidden",
-        // Organelle Box is using bg-dark-sds-color-primitive-gray-100
-        // behind the image viewer
         "bg-dark-sds-color-primitive-gray-100"
       )}
     >
-      <div className={cns("aspect-[4/5] md:aspect-square")}>
-        <OmeZarrImageViewer
-          sourceUrl={imageUrl}
-          region={region}
-          seriesDimensionName="Z"
-          allSlicesSizeEstimate="250 MB"
-          onLayerCreated={handleLayerCreated}
-          onFirstSliceLoaded={handleFirstSliceLoaded}
-          onLoadAllSlicesClicked={handleLoadAllSlicesClicked}
-          onAllSlicesLoaded={handleAllSlicesLoaded}
-          onLoadAllSlicesAborted={handleLoadAllSlicesAborted}
-        />
-      </div>
+      <OmeZarrImageViewer
+        sourceUrl={imageUrl}
+        region={region}
+        seriesDimensionName="Z"
+        allSlicesSizeEstimate="250 MB"
+        onLayerCreated={handleLayerCreated}
+        onFirstSliceLoaded={handleFirstSliceLoaded}
+        onLoadAllSlicesClicked={handleLoadAllSlicesClicked}
+        onAllSlicesLoaded={handleAllSlicesLoaded}
+        onLoadAllSlicesAborted={handleLoadAllSlicesAborted}
+      />
       <input
         type="button"
         value="Switch Image"

--- a/packages/react/src/components/AppWithProviders.tsx
+++ b/packages/react/src/components/AppWithProviders.tsx
@@ -5,9 +5,10 @@ import CssBaseline from "@mui/material/CssBaseline";
 import useMediaQuery from "@mui/material/useMediaQuery";
 
 import App from "./App";
+import { IdetikProvider } from "./providers/IdetikProvider";
 
-// Create a wrapper component to handle theme and useMediaQuery
-export default function ThemedApp() {
+// Create a wrapper component to handle providers
+export default function AppWithProviders() {
   const prefersDarkMode = useMediaQuery("(prefers-color-scheme: dark)");
   const theme = prefersDarkMode ? Theme("dark") : Theme("light");
 
@@ -16,7 +17,9 @@ export default function ThemedApp() {
       <ThemeProvider theme={theme}>
         <EmotionThemeProvider theme={theme}>
           <CssBaseline />
-          <App />
+          <IdetikProvider>
+            <App />
+          </IdetikProvider>
         </EmotionThemeProvider>
       </ThemeProvider>
     </StyledEngineProvider>

--- a/packages/react/src/components/Main.tsx
+++ b/packages/react/src/components/Main.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { createRoot } from "react-dom/client";
 import cns from "classnames";
 
-import ThemedApp from "./ThemedApp";
+import AppWithProviders from "./AppWithProviders.tsx";
 import "../input.css";
 
 const domNode = document.getElementById("app")!;
@@ -11,7 +11,7 @@ const root = createRoot(domNode);
 root.render(
   <React.StrictMode>
     <div className={cns("font-sds-body")}>
-      <ThemedApp />
+      <AppWithProviders />
     </div>
   </React.StrictMode>
 );

--- a/packages/react/src/components/hooks/index.ts
+++ b/packages/react/src/components/hooks/index.ts
@@ -1,0 +1,1 @@
+export { useIdetik } from "./useIdetik";

--- a/packages/react/src/components/hooks/useIdetik.ts
+++ b/packages/react/src/components/hooks/useIdetik.ts
@@ -1,0 +1,29 @@
+import { ImageSeriesLayer } from "@idetik/core";
+import { createContext, useContext } from "react";
+
+export interface IdetikContextValue {
+  imageSeriesLayer?: ImageSeriesLayer;
+  setImageSeriesLayer: (imageLayer: ImageSeriesLayer) => void;
+}
+
+export const IdetikContext = createContext<IdetikContextValue>({
+  setImageSeriesLayer: () => {
+    throw new Error(
+      "<OmeZarrImageViewer> was initialized but your application was not wrapped with <IdetikProvider>."
+    );
+  },
+});
+
+/**
+ * Gives you access to Idetik global state to write our own custom components.
+ *
+ * TODO(bchu): Make more global state available, make easier abstractions.
+ */
+export function useIdetik() {
+  const { imageSeriesLayer, setImageSeriesLayer } = useContext(IdetikContext);
+
+  return {
+    imageSeriesLayer,
+    setImageSeriesLayer,
+  };
+}

--- a/packages/react/src/components/hooks/useIdetik.ts
+++ b/packages/react/src/components/hooks/useIdetik.ts
@@ -1,9 +1,20 @@
-import { ImageSeriesLayer } from "@idetik/core";
-import { createContext, useContext } from "react";
+import { ChannelProps, ImageSeriesLayer } from "@idetik/core";
+import { createContext, useCallback, useContext } from "react";
+
+export interface ChannelControl {
+  label: string;
+  contrastRange: [number, number];
+}
 
 export interface IdetikContextValue {
   imageSeriesLayer?: ImageSeriesLayer;
-  setImageSeriesLayer: (imageLayer: ImageSeriesLayer) => void;
+  setImageSeriesLayer: React.Dispatch<
+    React.SetStateAction<ImageSeriesLayer | undefined>
+  >;
+  channelControls?: ChannelControl[]; // Same order as ImageSeriesLayer.channelProps
+  setChannelControls: React.Dispatch<
+    React.SetStateAction<ChannelControl[] | undefined>
+  >;
 }
 
 export const IdetikContext = createContext<IdetikContextValue>({
@@ -12,18 +23,41 @@ export const IdetikContext = createContext<IdetikContextValue>({
       "<OmeZarrImageViewer> was initialized but your application was not wrapped with <IdetikProvider>."
     );
   },
+  setChannelControls: () => {
+    throw new Error(
+      "Viewer controls were initialized but your application was not wrapped with <IdetikProvider>."
+    );
+  },
 });
 
-/**
- * Gives you access to Idetik global state to write our own custom components.
- *
- * TODO(bchu): Make more global state available, make easier abstractions.
- */
+/** Gives you access to Idetik global state to write our own custom components. */
 export function useIdetik() {
-  const { imageSeriesLayer, setImageSeriesLayer } = useContext(IdetikContext);
-
-  return {
+  const {
     imageSeriesLayer,
     setImageSeriesLayer,
+    channelControls,
+    setChannelControls,
+  } = useContext(IdetikContext);
+
+  const clearImageSeriesLayer = useCallback(() => {
+    imageSeriesLayer?.close();
+    setImageSeriesLayer(undefined);
+  }, [imageSeriesLayer, setImageSeriesLayer]);
+  const setChannels = useCallback(
+    (channelProps: ChannelProps[]) => {
+      imageSeriesLayer?.setChannelProps(channelProps);
+    },
+    [imageSeriesLayer]
+  );
+
+  return {
+    channels: imageSeriesLayer?.channelProps,
+    setChannels,
+
+    setImageSeriesLayer,
+    clearImageSeriesLayer,
+
+    channelControls,
+    setChannelControls,
   };
 }

--- a/packages/react/src/components/hooks/useIdetik.ts
+++ b/packages/react/src/components/hooks/useIdetik.ts
@@ -1,5 +1,5 @@
 import { ChannelProps, ImageSeriesLayer } from "@idetik/core";
-import { createContext, useCallback, useContext } from "react";
+import { createContext, useContext } from "react";
 
 export interface ChannelControl {
   label: string;
@@ -7,57 +7,33 @@ export interface ChannelControl {
 }
 
 export interface IdetikContextValue {
-  imageSeriesLayer?: ImageSeriesLayer;
-  setImageSeriesLayer: React.Dispatch<
-    React.SetStateAction<ImageSeriesLayer | undefined>
-  >;
-  channelControls?: ChannelControl[]; // Same order as ImageSeriesLayer.channelProps
+  isInitialized: boolean;
+
+  channels: ChannelProps[];
+  setChannels: (channels: ChannelProps[]) => void;
+  resetChannels: () => void;
+
+  channelControls: ChannelControl[]; // Same order as channels.
   setChannelControls: React.Dispatch<
     React.SetStateAction<ChannelControl[] | undefined>
   >;
+
+  setImageSeriesLayer: React.Dispatch<
+    React.SetStateAction<ImageSeriesLayer | undefined>
+  >;
+  clearImageSeriesLayer: () => void;
 }
 
-export const IdetikContext = createContext<IdetikContextValue>({
-  setImageSeriesLayer: () => {
-    throw new Error(
-      "<OmeZarrImageViewer> was initialized but your application was not wrapped with <IdetikProvider>."
-    );
-  },
-  setChannelControls: () => {
-    throw new Error(
-      "Viewer controls were initialized but your application was not wrapped with <IdetikProvider>."
-    );
-  },
-});
+export const IdetikContext = createContext<IdetikContextValue | undefined>(
+  undefined
+);
 
 /** Gives you access to Idetik global state to write our own custom components. */
-export function useIdetik() {
-  const {
-    imageSeriesLayer,
-    setImageSeriesLayer,
-    channelControls,
-    setChannelControls,
-  } = useContext(IdetikContext);
+export function useIdetik(): IdetikContextValue {
+  const contextValue = useContext(IdetikContext);
+  if (contextValue === undefined) {
+    throw new Error("You must wrap your application in <IdetikProvider>.");
+  }
 
-  const clearImageSeriesLayer = useCallback(() => {
-    imageSeriesLayer?.close();
-    setImageSeriesLayer(undefined);
-  }, [imageSeriesLayer, setImageSeriesLayer]);
-  const setChannels = useCallback(
-    (channelProps: ChannelProps[]) => {
-      imageSeriesLayer?.setChannelProps(channelProps);
-    },
-    [imageSeriesLayer]
-  );
-
-  return {
-    channels: imageSeriesLayer?.channelProps,
-    setChannels,
-
-    setImageSeriesLayer,
-    clearImageSeriesLayer,
-
-    channelControls,
-    setChannelControls,
-  };
+  return contextValue;
 }

--- a/packages/react/src/components/providers/IdetikProvider.tsx
+++ b/packages/react/src/components/providers/IdetikProvider.tsx
@@ -2,17 +2,29 @@
 
 import { ImageSeriesLayer } from "@idetik/core";
 import { PropsWithChildren, useMemo, useState } from "react";
-import { IdetikContext, IdetikContextValue } from "../hooks/useIdetik";
+import {
+  ChannelControl,
+  IdetikContext,
+  IdetikContextValue,
+} from "../hooks/useIdetik";
 
 /** Global Idetik state provider that you must wrap your application in. */
 export const IdetikProvider = ({ children }: PropsWithChildren) => {
   const [imageSeriesLayer, setImageSeriesLayer] = useState<
     ImageSeriesLayer | undefined
   >(undefined);
+  const [channelControls, setChannelControls] = useState<
+    Array<ChannelControl> | undefined
+  >(undefined);
 
   const contextValue = useMemo<IdetikContextValue>(
-    () => ({ imageSeriesLayer, setImageSeriesLayer }),
-    [imageSeriesLayer]
+    () => ({
+      imageSeriesLayer,
+      setImageSeriesLayer,
+      channelControls,
+      setChannelControls,
+    }),
+    [imageSeriesLayer, channelControls]
   );
 
   return (

--- a/packages/react/src/components/providers/IdetikProvider.tsx
+++ b/packages/react/src/components/providers/IdetikProvider.tsx
@@ -1,30 +1,72 @@
 "use client";
 
-import { ImageSeriesLayer } from "@idetik/core";
-import { PropsWithChildren, useMemo, useState } from "react";
+import { ChannelProps, ImageSeriesLayer } from "@idetik/core";
+import {
+  PropsWithChildren,
+  useCallback,
+  useMemo,
+  useState,
+  useSyncExternalStore,
+} from "react";
 import {
   ChannelControl,
   IdetikContext,
   IdetikContextValue,
 } from "../hooks/useIdetik";
 
+// The return value of the getSnapshot() argument to useSyncExternalStore() must be memoized to
+// prevent infinite rerenders.
+const EMPTY_ARRAY: never[] = [];
+
 /** Global Idetik state provider that you must wrap your application in. */
 export const IdetikProvider = ({ children }: PropsWithChildren) => {
+  // Global state:
   const [imageSeriesLayer, setImageSeriesLayer] = useState<
     ImageSeriesLayer | undefined
   >(undefined);
+  const channels = useSyncExternalStore(
+    imageSeriesLayer?.addChannelChangeCallback ?? (() => () => {}),
+    () => imageSeriesLayer?.channelProps ?? EMPTY_ARRAY
+  );
   const [channelControls, setChannelControls] = useState<
     Array<ChannelControl> | undefined
   >(undefined);
 
+  // Memoized callbacks:
+  const clearImageSeriesLayer = useCallback(() => {
+    imageSeriesLayer?.close();
+    setImageSeriesLayer(undefined);
+  }, [imageSeriesLayer, setImageSeriesLayer]);
+  const setChannels = useCallback(
+    (channelProps: ChannelProps[]) => {
+      imageSeriesLayer?.setChannelProps(channelProps);
+    },
+    [imageSeriesLayer]
+  );
+  const resetChannels = useCallback(() => {
+    imageSeriesLayer?.resetChannelProps();
+  }, [imageSeriesLayer]);
+
+  // Context value:
   const contextValue = useMemo<IdetikContextValue>(
     () => ({
-      imageSeriesLayer,
-      setImageSeriesLayer,
-      channelControls,
+      isInitialized: imageSeriesLayer !== undefined,
+      channels,
+      setChannels,
+      resetChannels,
+      channelControls: channelControls ?? [],
       setChannelControls,
+      setImageSeriesLayer,
+      clearImageSeriesLayer,
     }),
-    [imageSeriesLayer, channelControls]
+    [
+      channels,
+      imageSeriesLayer,
+      channelControls,
+      clearImageSeriesLayer,
+      setChannels,
+      resetChannels,
+    ]
   );
 
   return (

--- a/packages/react/src/components/providers/IdetikProvider.tsx
+++ b/packages/react/src/components/providers/IdetikProvider.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { ImageSeriesLayer } from "@idetik/core";
+import { PropsWithChildren, useMemo, useState } from "react";
+import { IdetikContext, IdetikContextValue } from "../hooks/useIdetik";
+
+/** Global Idetik state provider that you must wrap your application in. */
+export const IdetikProvider = ({ children }: PropsWithChildren) => {
+  const [imageSeriesLayer, setImageSeriesLayer] = useState<
+    ImageSeriesLayer | undefined
+  >(undefined);
+
+  const contextValue = useMemo<IdetikContextValue>(
+    () => ({ imageSeriesLayer, setImageSeriesLayer }),
+    [imageSeriesLayer]
+  );
+
+  return (
+    <IdetikContext.Provider value={contextValue}>
+      {children}
+    </IdetikContext.Provider>
+  );
+};

--- a/packages/react/src/components/providers/index.ts
+++ b/packages/react/src/components/providers/index.ts
@@ -1,0 +1,1 @@
+export { IdetikProvider } from "./IdetikProvider";

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
@@ -11,6 +11,9 @@ interface OmeZarrViewerContainerProps {
   region: Region;
   seriesDimensionName: string;
   allSlicesSizeEstimate?: string;
+  classNames?: {
+    root?: string;
+  };
   onLayerCreated?: () => void;
   onFirstSliceLoaded?: () => void;
   onLoadAllSlicesClicked?: () => void;
@@ -24,6 +27,7 @@ export function OmeZarrImageViewer(props: OmeZarrViewerContainerProps) {
     region,
     seriesDimensionName,
     allSlicesSizeEstimate,
+    classNames,
     onLayerCreated,
     onFirstSliceLoaded,
     onLoadAllSlicesClicked,
@@ -34,15 +38,12 @@ export function OmeZarrImageViewer(props: OmeZarrViewerContainerProps) {
   const {
     layerManager,
     camera,
-    imageLayer,
-    controlProps,
     zRange,
     zValue,
     zIndex,
     setZValue,
     loading,
     allSlicesLoaded,
-    resetChannelsCallback,
     loadAllSlicesCallback,
   } = useOmeZarrViewer({
     sourceUrl,
@@ -64,7 +65,8 @@ export function OmeZarrImageViewer(props: OmeZarrViewerContainerProps) {
         "flex-1",
         "gap-4",
         "min-h-0",
-        "relative"
+        "relative",
+        classNames?.root
       )}
     >
       <Renderer
@@ -72,26 +74,6 @@ export function OmeZarrImageViewer(props: OmeZarrViewerContainerProps) {
         camera={camera}
         cameraControls="panzoom"
       />
-
-      {imageLayer && (
-        <div
-          className={cns(
-            "absolute",
-            "top-0",
-            "left-0",
-            "w-full",
-            "md:!w-[400px]" // For some reason, this gets overwritten when compiled
-            // so make it important
-          )}
-        >
-          <ChannelControlsList
-            layer={imageLayer}
-            controlProps={controlProps}
-            resetCallback={resetChannelsCallback}
-          />
-        </div>
-      )}
-
       <div
         className={cns(
           "absolute",

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
@@ -1,4 +1,3 @@
-import { ChannelControlsList } from "./components/ChannelControlsList";
 import { Renderer } from "./components/Renderer";
 import { useOmeZarrViewer } from "./useOmeZarrImageViewer";
 import { Region } from "@idetik/core";

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/components/ChannelControlsList/ChannelControlsList.tsx
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/components/ChannelControlsList/ChannelControlsList.tsx
@@ -7,35 +7,16 @@ import {
 import cns from "classnames";
 import { ChannelControl } from "./components/ChannelControl";
 import { ChannelProps } from "@idetik/core";
-import { useEffect, useRef, useState } from "react";
 import { useIdetik } from "components/hooks";
 
-interface ChannelControlsListProps {
-  resetCallback?: () => Promise<void>;
-}
-
-export function ChannelControlsList({
-  resetCallback,
-}: ChannelControlsListProps) {
-  const { channels, setChannels, channelControls } = useIdetik();
-
-  // Keep a local copy of channelProps to trigger re-renders
-  const [channelProps, setChannelProps] = useState(channels ?? []);
-  const isInternalUpdate = useRef(false);
-
-  // initial sync of local state with layer's channelProps
-  // props change indicates this is not an internal update
-  useEffect(() => {
-    isInternalUpdate.current = false;
-    setChannelProps(channels ?? []);
-  }, [channels, resetCallback]);
-
-  // update layer's channelProps when local state changes
-  useEffect(() => {
-    if (isInternalUpdate.current) {
-      setChannels(channelProps);
-    }
-  }, [channelProps, setChannels]);
+export function ChannelControlsList() {
+  const {
+    isInitialized,
+    channels,
+    setChannels,
+    resetChannels,
+    channelControls,
+  } = useIdetik();
 
   const updateChannel = (
     index: number,
@@ -45,28 +26,17 @@ export function ChannelControlsList({
       contrastLimits: [number, number];
     }>
   ) => {
-    isInternalUpdate.current = true;
-    const updatedChannelProps = [...channelProps];
-
-    updatedChannelProps[index] = {
-      ...channelProps[index],
+    const updatedChannels = [...channels];
+    updatedChannels[index] = {
+      ...channels[index],
       ...updates,
     };
-
-    setChannelProps(updatedChannelProps);
+    setChannels(updatedChannels);
   };
 
-  // ImageSeriesLayer has not been initialized.
-  if (channels === undefined || channelControls === undefined) {
+  if (!isInitialized) {
     return null;
   }
-
-  // const resetCallback = useCallback(async () => {
-  //   if (!source || !imageLayer) return;
-  //   const omeroChannels = await loadOmeroChannels(sourceUrl);
-  //   imageLayer.setChannelProps(omeroToChannelProps(omeroChannels));
-  //   setChannelControls(omeroToChannelControls(omeroChannels));
-  // }, [source, sourceUrl, imageLayer, setChannelControls]);
 
   return (
     <div
@@ -148,23 +118,19 @@ export function ChannelControlsList({
               );
             })}
           </div>
-          {resetCallback && (
-            <span className={cns("flex", "justify-end", "mt-sds-xs")}>
-              <Button
-                sdsStyle="minimal"
-                sdsType="primary"
-                // Force dark mode styles on hover
-                className="text-white hover:!text-white hover:!bg-dark-sds-color-semantic-base-fill-hover"
-                onClick={() => {
-                  resetCallback().then(() => {
-                    setChannelProps(channels ?? []);
-                  });
-                }}
-              >
-                Reset channels
-              </Button>
-            </span>
-          )}
+          <span className={cns("flex", "justify-end", "mt-sds-xs")}>
+            <Button
+              sdsStyle="minimal"
+              sdsType="primary"
+              // Force dark mode styles on hover
+              className="text-white hover:!text-white hover:!bg-dark-sds-color-semantic-base-fill-hover"
+              onClick={() => {
+                resetChannels();
+              }}
+            >
+              Reset channels
+            </Button>
+          </span>
         </AccordionDetails>
       </Accordion>
     </div>

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/components/ChannelControlsList/ChannelControlsList.tsx
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/components/ChannelControlsList/ChannelControlsList.tsx
@@ -9,7 +9,6 @@ import { ChannelControl } from "./components/ChannelControl";
 import { ChannelProps } from "@idetik/core";
 import { useEffect, useRef, useState } from "react";
 import { useIdetik } from "components/hooks";
-import { omeroToControlProps } from "../../utils";
 
 interface ChannelControlsListProps {
   resetCallback?: () => Promise<void>;
@@ -18,29 +17,26 @@ interface ChannelControlsListProps {
 export function ChannelControlsList({
   resetCallback,
 }: ChannelControlsListProps) {
-  const { imageSeriesLayer } = useIdetik();
+  const { channels, setChannels, channelControls } = useIdetik();
 
   // Keep a local copy of channelProps to trigger re-renders
-  const [channelProps, setChannelProps] = useState(
-    imageSeriesLayer?.channelProps ?? []
-  );
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const [channelProps, setChannelProps] = useState(channels ?? []);
   const isInternalUpdate = useRef(false);
 
   // initial sync of local state with layer's channelProps
   // props change indicates this is not an internal update
   useEffect(() => {
     isInternalUpdate.current = false;
-    setChannelProps(imageSeriesLayer?.channelProps ?? []);
-  }, [imageSeriesLayer, resetCallback]);
+    setChannelProps(channels ?? []);
+  }, [channels, resetCallback]);
 
   // update layer's channelProps when local state changes
   useEffect(() => {
     if (isInternalUpdate.current) {
-      imageSeriesLayer?.setChannelProps(channelProps);
+      setChannels(channelProps);
     }
-  }, [channelProps, imageSeriesLayer]);
-
-  const controlProps = omeroToControlProps(imageSeriesLayer?.channelProps);
+  }, [channelProps, setChannels]);
 
   const updateChannel = (
     index: number,
@@ -61,9 +57,17 @@ export function ChannelControlsList({
     setChannelProps(updatedChannelProps);
   };
 
-  if (imageSeriesLayer === undefined) {
+  // ImageSeriesLayer has not been initialized.
+  if (channels === undefined || channelControls === undefined) {
     return null;
   }
+
+  // const resetCallback = useCallback(async () => {
+  //   if (!source || !imageLayer) return;
+  //   const omeroChannels = await loadOmeroChannels(sourceUrl);
+  //   imageLayer.setChannelProps(omeroToChannelProps(omeroChannels));
+  //   setChannelControls(omeroToChannelControls(omeroChannels));
+  // }, [source, sourceUrl, imageLayer, setChannelControls]);
 
   return (
     <div
@@ -105,7 +109,7 @@ export function ChannelControlsList({
 
         <AccordionDetails>
           <div className={cns("grid grid-cols-4 grid-rows-auto")}>
-            {channelProps.map((props: ChannelProps, index: number) => {
+            {channels.map((props: ChannelProps, index: number) => {
               // TODO: can possibly clean this up with better types
               // error on undefined values - we're setting defaults
               // and merging objects in too many places
@@ -117,7 +121,7 @@ export function ChannelControlsList({
                   `Contrast limits not defined for channel ${index}`
                 );
               }
-              const contrastRange = (controlProps[index]?.contrastRange ??
+              const contrastRange = (channelControls[index]?.contrastRange ??
                 props.contrastLimits)!;
               if (contrastRange === undefined) {
                 throw new Error(
@@ -129,7 +133,7 @@ export function ChannelControlsList({
                 <ChannelControl
                   key={index}
                   channelIndex={index}
-                  label={controlProps[index]?.label ?? `Channel ${index}`}
+                  label={channelControls[index]?.label ?? `Channel ${index}`}
                   color={props.color}
                   contrastLimits={props.contrastLimits}
                   contrastRange={contrastRange}
@@ -154,7 +158,7 @@ export function ChannelControlsList({
                 className="text-white hover:!text-white hover:!bg-dark-sds-color-semantic-base-fill-hover"
                 onClick={() => {
                   resetCallback().then(() => {
-                    setChannelProps(imageSeriesLayer.channelProps ?? []);
+                    setChannelProps(channels ?? []);
                   });
                 }}
               >

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/components/ChannelControlsList/ChannelControlsList.tsx
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/components/ChannelControlsList/ChannelControlsList.tsx
@@ -5,41 +5,39 @@ import {
   Button,
 } from "@czi-sds/components";
 import cns from "classnames";
-import {
-  ChannelControl,
-  ChannelControlProps,
-} from "./components/ChannelControl";
-import { ImageSeriesLayer, ChannelProps } from "@idetik/core";
+import { ChannelControl } from "./components/ChannelControl";
+import { ChannelProps } from "@idetik/core";
 import { useEffect, useRef, useState } from "react";
+import { useIdetik } from "components/hooks";
 
 interface ChannelControlsListProps {
-  layer: ImageSeriesLayer;
-  controlProps: Partial<ChannelControlProps>[];
   resetCallback?: () => Promise<void>;
 }
 
 export function ChannelControlsList({
-  layer,
-  controlProps,
   resetCallback,
 }: ChannelControlsListProps) {
+  const { imageSeriesLayer } = useIdetik();
+
   // Keep a local copy of channelProps to trigger re-renders
-  const [channelProps, setChannelProps] = useState(layer.channelProps ?? []);
+  const [channelProps, setChannelProps] = useState(
+    imageSeriesLayer?.channelProps ?? []
+  );
   const isInternalUpdate = useRef(false);
 
   // initial sync of local state with layer's channelProps
   // props change indicates this is not an internal update
   useEffect(() => {
     isInternalUpdate.current = false;
-    setChannelProps(layer.channelProps ?? []);
-  }, [layer, controlProps, resetCallback]);
+    setChannelProps(imageSeriesLayer?.channelProps ?? []);
+  }, [imageSeriesLayer, resetCallback]);
 
   // update layer's channelProps when local state changes
   useEffect(() => {
     if (isInternalUpdate.current) {
-      layer.setChannelProps(channelProps);
+      imageSeriesLayer?.setChannelProps(channelProps);
     }
-  }, [channelProps, layer]);
+  }, [channelProps, imageSeriesLayer]);
 
   const updateChannel = (
     index: number,
@@ -59,6 +57,10 @@ export function ChannelControlsList({
 
     setChannelProps(updatedChannelProps);
   };
+
+  if (imageSeriesLayer === undefined) {
+    return null;
+  }
 
   return (
     <div
@@ -149,7 +151,7 @@ export function ChannelControlsList({
                 className="text-white hover:!text-white hover:!bg-dark-sds-color-semantic-base-fill-hover"
                 onClick={() => {
                   resetCallback().then(() => {
-                    setChannelProps(layer.channelProps ?? []);
+                    setChannelProps(imageSeriesLayer.channelProps ?? []);
                   });
                 }}
               >

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/components/ChannelControlsList/ChannelControlsList.tsx
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/components/ChannelControlsList/ChannelControlsList.tsx
@@ -20,7 +20,6 @@ export function ChannelControlsList({
   const { channels, setChannels, channelControls } = useIdetik();
 
   // Keep a local copy of channelProps to trigger re-renders
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [channelProps, setChannelProps] = useState(channels ?? []);
   const isInternalUpdate = useRef(false);
 

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/components/ChannelControlsList/ChannelControlsList.tsx
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/components/ChannelControlsList/ChannelControlsList.tsx
@@ -9,6 +9,7 @@ import { ChannelControl } from "./components/ChannelControl";
 import { ChannelProps } from "@idetik/core";
 import { useEffect, useRef, useState } from "react";
 import { useIdetik } from "components/hooks";
+import { omeroToControlProps } from "../../utils";
 
 interface ChannelControlsListProps {
   resetCallback?: () => Promise<void>;
@@ -38,6 +39,8 @@ export function ChannelControlsList({
       imageSeriesLayer?.setChannelProps(channelProps);
     }
   }, [channelProps, imageSeriesLayer]);
+
+  const controlProps = omeroToControlProps(imageSeriesLayer?.channelProps);
 
   const updateChannel = (
     index: number,

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/useOmeZarrImageViewer.ts
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/useOmeZarrImageViewer.ts
@@ -37,9 +37,6 @@ export function useOmeZarrViewer({
   const [layerManager, setLayerManager] = useState(() => new LayerManager());
   const [camera, setCamera] = useState<OrthographicCamera | null>(null);
   const [imageLayer, setImageLayer] = useState<ImageSeriesLayer | null>(null);
-  const [controlProps, setControlProps] = useState<
-    Partial<ChannelControlProps>[]
-  >([]);
   const [zRange, setZRange] = useState<[number, number]>([0, 0]);
   const [zValue, setZValue] = useState(0.5);
   const [loading, setLoading] = useState(true);
@@ -79,7 +76,6 @@ export function useOmeZarrViewer({
       setLoading(true);
       const omeroChannels = await loadOmeroChannels(sourceUrl);
       const channelProps = omeroToChannelProps(omeroChannels);
-      setControlProps(omeroToControlProps(omeroChannels));
 
       layer = new ImageSeriesLayer({
         source,
@@ -178,7 +174,6 @@ export function useOmeZarrViewer({
     if (!source || !imageLayer) return;
     const omeroChannels = await loadOmeroChannels(sourceUrl);
     imageLayer.setChannelProps(omeroToChannelProps(omeroChannels));
-    setControlProps(omeroToControlProps(omeroChannels));
   }, [source, sourceUrl, imageLayer]);
 
   const loadAllSlicesCallback = useCallback(async () => {

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/useOmeZarrImageViewer.ts
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/useOmeZarrImageViewer.ts
@@ -9,8 +9,8 @@ import {
   loadOmeroDefaultZ,
 } from "@idetik/core";
 
-import { omeroToChannelProps, omeroToControlProps } from "./utils";
-import { ChannelControlProps } from "./components/ChannelControlsList/components/ChannelControl";
+import { omeroToChannelProps, omeroToChannelControls } from "./utils";
+import { useIdetik } from "components/hooks";
 
 interface UseOmeZarrViewerProps {
   sourceUrl: string;
@@ -41,6 +41,8 @@ export function useOmeZarrViewer({
   const [zValue, setZValue] = useState(0.5);
   const [loading, setLoading] = useState(true);
   const [allSlicesLoaded, setAllSlicesLoaded] = useState(false);
+  const { setImageSeriesLayer, clearImageSeriesLayer, setChannelControls } =
+    useIdetik();
 
   useEffect(() => {
     if (imageLayer) {
@@ -100,6 +102,8 @@ export function useOmeZarrViewer({
 
       if (shouldSetLayer) {
         setImageLayer(layer);
+        setImageSeriesLayer(layer);
+        setChannelControls(omeroToChannelControls(omeroChannels));
       }
     };
 
@@ -109,6 +113,7 @@ export function useOmeZarrViewer({
       shouldSetLayer = false;
       layer?.close();
       setImageLayer(null);
+      clearImageSeriesLayer();
     };
   }, [
     source,
@@ -118,6 +123,9 @@ export function useOmeZarrViewer({
     zoomToFit,
     onLayerCreated,
     onFirstSliceLoaded,
+    clearImageSeriesLayer,
+    setChannelControls,
+    setImageSeriesLayer,
   ]);
 
   // Fetch Z range from metadata
@@ -169,12 +177,6 @@ export function useOmeZarrViewer({
 
     updateIndex();
   }, [zIndex, imageLayer]);
-
-  const resetChannelsCallback = useCallback(async () => {
-    if (!source || !imageLayer) return;
-    const omeroChannels = await loadOmeroChannels(sourceUrl);
-    imageLayer.setChannelProps(omeroToChannelProps(omeroChannels));
-  }, [source, sourceUrl, imageLayer]);
 
   const loadAllSlicesCallback = useCallback(async () => {
     if (!imageLayer) return;

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/useOmeZarrImageViewer.ts
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/useOmeZarrImageViewer.ts
@@ -115,18 +115,8 @@ export function useOmeZarrViewer({
       setImageLayer(null);
       clearImageSeriesLayer();
     };
-  }, [
-    source,
-    sourceUrl,
-    region,
-    seriesDimensionName,
-    zoomToFit,
-    onLayerCreated,
-    onFirstSliceLoaded,
-    clearImageSeriesLayer,
-    setChannelControls,
-    setImageSeriesLayer,
-  ]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- Deps that trigger layer creation.
+  }, [source, sourceUrl, region, seriesDimensionName]);
 
   // Fetch Z range from metadata
   useEffect(() => {

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/useOmeZarrImageViewer.ts
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/useOmeZarrImageViewer.ts
@@ -205,15 +205,12 @@ export function useOmeZarrViewer({
   return {
     layerManager,
     camera,
-    imageLayer,
-    controlProps,
     zRange,
     zValue,
     zIndex,
     setZValue,
     loading,
     allSlicesLoaded,
-    resetChannelsCallback,
     loadAllSlicesCallback,
   };
 }

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/utils.ts
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/utils.ts
@@ -1,11 +1,6 @@
 import { OmeroChannel, ChannelProps } from "@idetik/core";
 import { hexToRgb } from "lib/color";
-
-export interface ChannelControlConfig {
-  channelProps: ChannelProps;
-  label: string;
-  ocntrastRange: [number, number];
-}
+import { ChannelControl } from "components/hooks/useIdetik";
 
 // TODO: the limits/range from the omero channels should possibly be reversed
 // (start/end for limits, min/max for range) but the organelle box data works better this way
@@ -13,13 +8,24 @@ export interface ChannelControlConfig {
 export const omeroToChannelProps = (
   omeroChannels: OmeroChannel[]
 ): ChannelProps[] => {
-  return omeroChannels.map((channel, i) => {
+  return omeroChannels.map((channel) => {
     const { start, end, min, max } = channel.window;
     return {
       visible: channel.active,
       color: hexToRgb(channel.color),
       contrastLimits: [Math.max(start, min), Math.min(end, max)],
-      label: (channel.label ?? `Ch${i}`).replace(/^\d+-/, ""),
+    };
+  });
+};
+
+export const omeroToChannelControls = (
+  omeroChannels: OmeroChannel[]
+): ChannelControl[] => {
+  return omeroChannels.map((channel, index) => {
+    // remove prefix (number + hyphen) from label if present (seen in organelle box data)
+    const label = (channel.label ?? `Ch${index}`).replace(/^\d+-/, "");
+    return {
+      label,
       contrastRange: [0.5 * channel.window.start, 1.1 * channel.window.end],
     };
   });

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/utils.ts
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/utils.ts
@@ -1,6 +1,12 @@
 import { OmeroChannel, ChannelProps } from "@idetik/core";
 import { hexToRgb } from "lib/color";
 
+export interface ChannelControlConfig {
+  channelProps: ChannelProps;
+  label: string;
+  ocntrastRange: [number, number];
+}
+
 // TODO: the limits/range from the omero channels should possibly be reversed
 // (start/end for limits, min/max for range) but the organelle box data works better this way
 // TODO: provide a way to get our own limits automatically from the data instead of the metadata

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/utils.ts
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/utils.ts
@@ -1,5 +1,4 @@
 import { OmeroChannel, ChannelProps } from "@idetik/core";
-import type { ChannelControlProps } from "./components/ChannelControlsList/components/ChannelControl";
 import { hexToRgb } from "lib/color";
 
 // TODO: the limits/range from the omero channels should possibly be reversed
@@ -8,24 +7,13 @@ import { hexToRgb } from "lib/color";
 export const omeroToChannelProps = (
   omeroChannels: OmeroChannel[]
 ): ChannelProps[] => {
-  return omeroChannels.map((channel) => {
+  return omeroChannels.map((channel, i) => {
     const { start, end, min, max } = channel.window;
     return {
       visible: channel.active,
       color: hexToRgb(channel.color),
       contrastLimits: [Math.max(start, min), Math.min(end, max)],
-    };
-  });
-};
-
-export const omeroToControlProps = (
-  omeroChannels: OmeroChannel[]
-): Partial<ChannelControlProps>[] => {
-  return omeroChannels.map((channel, index) => {
-    // remove prefix (number + hyphen) from label if present (seen in organelle box data)
-    const label = (channel.label ?? `Ch${index}`).replace(/^\d+-/, "");
-    return {
-      label,
+      label: (channel.label ?? `Ch${i}`).replace(/^\d+-/, ""),
       contrastRange: [0.5 * channel.window.start, 1.1 * channel.window.end],
     };
   });


### PR DESCRIPTION
 - Removes duplicate state in controls components, adds callbacks to ImageSeriesLayer.ts so that React can hook into its state directly using `useSyncExternalStore()`.
 - Caches the initial channels metadata response so that resetting controls doesn't require a refetch (in the future I think this the logic for fetching could probably benefit from moving outside of the viewer component as well).
 - Updates README to include instructions for integrators.
 - Removes some Organelle Box specific styles from the demo `<App>`.
 - Adds CSS customizability to the viewer component.
 - Moves `<ChannelControlsList>` out of the viewer. Removes all props from the component so it just works by itself. More will be done to this component later.
 - Creates a provider `<IdetikProvider>` to store global state. Integrators must now wrap their application in this component.
 - Creates a helper hook `useIdetik()` to access the provider's state.
 - Hooks `<ChannelControlsList>` into `<IdetikProvider>`.
 - Moves some state from `useOmeZarrImageViewer()` into the global provider.

Next PR: Remove more hardcoded styles, add more CSS customizability.