### PR TITLE
chore: apply internal type fixes for yarn workspace resolution

### DIFF
--- a/packages/core/examples/image_stack_from_omezarr3d_f32/main.ts
+++ b/packages/core/examples/image_stack_from_omezarr3d_f32/main.ts
@@ -112,7 +112,7 @@ maxSlider.addEventListener("input", (event) => {
 });
 
 // set up event handler with debouncing
-let debounce: number;
+let debounce: ReturnType<typeof setTimeout>;
 zSlider.addEventListener("input", (event) => {
   clearTimeout(debounce);
   const value = (event.target as HTMLInputElement).valueAsNumber;

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/useOmeZarrImageViewer.ts
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/useOmeZarrImageViewer.ts
@@ -132,7 +132,7 @@ export function useOmeZarrViewer({
       const attrs = await loader.loadAttributes();
 
       const zIdx = attrs.dimensionNames.findIndex(
-        (d) => d === seriesDimensionName
+        (d: string) => d === seriesDimensionName
       );
       const min = 0;
       const max = attrs.shape[zIdx] - 1;

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -2,4 +2,6 @@
 import "./input.css";
 import { Renderer } from "./components/viewers/OmeZarrImageViewer/components/Renderer";
 import { OmeZarrImageViewer } from "./components/viewers/OmeZarrImageViewer";
-export { Renderer, OmeZarrImageViewer };
+import { useOmeZarrViewer } from "./components/viewers/OmeZarrImageViewer/useOmeZarrImageViewer";
+
+export { Renderer, OmeZarrImageViewer, useOmeZarrViewer };

--- a/packages/ultrack-prototype/package.json
+++ b/packages/ultrack-prototype/package.json
@@ -12,12 +12,12 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "@idetik/core": "^0.0.1",
     "@czi-sds/components": "^21.2.0",
     "@emotion/css": "^11.13.0",
     "@emotion/react": "^11.13.3",
     "@emotion/styled": "^11.13.0",
     "@eslint/js": "^9.9.0",
+    "@idetik/core": "^0.0.1",
     "@mui/base": "^5.0.0-beta.58",
     "@mui/icons-material": "^5.16.7",
     "@mui/lab": "^5.0.0-alpha.173",


### PR DESCRIPTION
This PR includes minor, non-functional changes made to satisfy Yarn's strict workspace resolution in parent monorepo projects:

- Updated type of `debounce` in `image_stack_from_omezarr3d_f32/main.ts` to avoid TS ambiguity
- Added explicit type annotation in `useOmeZarrImageViewer.ts` for TS strict mode
- export `useOmeZarrViewer` hook

These changes are internal and do not affect runtime behavior. They were made to allow `yarn install` to succeed in the parent project context, where `imaging-active-learning` is used as a Git submodule workspace.
