### PR TITLE
fix: fix bugs and quirks in ImageSeriesLayer loading

### DIFF
--- a/packages/core/examples/image2d_from_omezarr4d_hcs/main.ts
+++ b/packages/core/examples/image2d_from_omezarr4d_hcs/main.ts
@@ -110,8 +110,11 @@ const onWellChange = async () => {
 wellSelector.addEventListener("change", onWellChange);
 imageSelector.addEventListener("change", onImageChange);
 
-// load initial well
-await onWellChange();
+const loadInitialWell = async () => {
+  await onWellChange();
+};
+
+loadInitialWell();
 
 function animate() {
   renderer.render(layerManager, camera);

--- a/packages/core/examples/image2d_from_omezarr4d_hcs/main.ts
+++ b/packages/core/examples/image2d_from_omezarr4d_hcs/main.ts
@@ -6,20 +6,19 @@ import {
   PanZoomControls,
   Region,
   WebGLRenderer,
-} from "@";
-import {
+  loadOmeroChannels,
+  loadOmeroDefaultZ,
   loadOmeZarrPlate,
   loadOmeZarrWell,
-} from "@/data/ome_zarr_hcs_metadata_loader";
+} from "@";
 
-// The following data comes from Zenodo: https://zenodo.org/records/11262587
-// First download and unpack it. Then host the containing directory locally
-// with something like:
-// http-server --cors -p 8080
 const plateUrl =
   "https://public.czbiohub.org/organelle_box/datasets/A549/organelle_box_crop_v1.zarr/";
-const initialWellPath = "GOLGA2/Live";
-const initialImagePath = "000002";
+const initialWellPath = "CLTA/PFA";
+const initialImagePath = "002000";
+const LOW_RES_Z_SCALE = 0.78939; // micrometers per pixel
+const HIGH_RES_NUM_SLICES = 38;
+
 const plate = await loadOmeZarrPlate(plateUrl);
 console.debug("plate", plate);
 if (plate.plate === undefined) {
@@ -42,8 +41,8 @@ const controls = new PanZoomControls(camera, camera.position);
 renderer.setControls(controls);
 const region: Region = [
   { dimension: "T", index: { type: "point", value: 0 } },
-  { dimension: "C", index: { type: "interval", start: 0, stop: 3 } },
-  { dimension: "Z", index: { type: "point", value: 5.1 } },
+  { dimension: "C", index: { type: "interval", start: 1, stop: 3 } },
+  { dimension: "Z", index: { type: "point", value: 0 } },
   { dimension: "Y", index: { type: "full" } },
   { dimension: "X", index: { type: "full" } },
 ];
@@ -55,15 +54,26 @@ const onImageChange = async () => {
   layerManager.layers.length = 0;
   const imageUrl =
     plateUrl + "/" + wellSelector.value + "/" + imageSelector.value;
-  const source = new OmeZarrImageSource(imageUrl);
+  const source = new OmeZarrImageSource(imageUrl, 0);
+  const omeroDefaultZ = await loadOmeroDefaultZ(imageUrl);
+  region[2] = {
+    dimension: "Z",
+    index: {
+      type: "point",
+      value: (omeroDefaultZ / HIGH_RES_NUM_SLICES) * LOW_RES_Z_SCALE,
+    },
+  };
+  const omeroChannels = await loadOmeroChannels(imageUrl);
+  const contrastLimits: [number, number][] = [
+    [omeroChannels[1].window.start, omeroChannels[1].window.end],
+    [omeroChannels[2].window.start, omeroChannels[2].window.end],
+  ];
   const layer = new ImageLayer({
     source,
     region,
     channelProps: [
-      // color and contrast limits manually looked up in the zarr omero metadata
-      { color: [0, 1, 1], contrastLimits: [110, 800] },
-      { color: [1, 0, 1], contrastLimits: [110, 250] },
-      { color: [1, 1, 0], contrastLimits: [110, 800] },
+      { color: [0, 1, 1], contrastLimits: contrastLimits[0] },
+      { color: [1, 0, 1], contrastLimits: contrastLimits[1] },
     ],
   });
   layerManager.add(layer);
@@ -99,6 +109,8 @@ const onWellChange = async () => {
 
 wellSelector.addEventListener("change", onWellChange);
 imageSelector.addEventListener("change", onImageChange);
+
+// load initial well
 await onWellChange();
 
 function animate() {

--- a/packages/core/examples/image_stack_from_omezarr3d_f32/index.html
+++ b/packages/core/examples/image_stack_from_omezarr3d_f32/index.html
@@ -69,34 +69,6 @@
           Layer State: &nbsp; <span id="layer-state">initialized</span>
           <input type="button" id="load-all" value="Load all slices" />
         </div>
-        <div class="control-row">
-          <div class="control-label">Min Value:</div>
-          <div class="slider-container">
-            <input
-              type="range"
-              id="min-slider"
-              min="-1"
-              max="0"
-              step="0.01"
-              value="-0.5"
-            />
-          </div>
-          <div class="value-label"><span id="min-value">-0.5</span></div>
-        </div>
-        <div class="control-row">
-          <div class="control-label">Max Value:</div>
-          <div class="slider-container">
-            <input
-              type="range"
-              id="max-slider"
-              min="0"
-              max="1"
-              step="0.01"
-              value="0.5"
-            />
-          </div>
-          <div class="value-label"><span id="max-value">0.5</span></div>
-        </div>
       </div>
     </div>
     <script type="module" src="./main.ts"></script>

--- a/packages/core/examples/image_stack_from_omezarr3d_f32/main.ts
+++ b/packages/core/examples/image_stack_from_omezarr3d_f32/main.ts
@@ -32,16 +32,12 @@ const region: Region = [
   { dimension: "y", index: { type: "full" } },
 ];
 
-// Initial contrast limits for grayscale electron microscopy data
-const initialMinValue = -0.00001;
-const initialMaxValue = 0.00001;
-
 // This dataset is grayscale electron microscopy data
 const channelProps: ChannelProps[] = [
   {
     visible: true,
     color: [1, 1, 1],
-    contrastLimits: [initialMinValue, initialMaxValue],
+    contrastLimits: [-0.00001, 0.00001],
   },
 ];
 
@@ -51,15 +47,15 @@ const layer = new ImageSeriesLayer({
   seriesDimensionName: zDimName,
   channelProps,
 });
+layer.addStateChangeCallback((newState: LayerState) => {
+  stateEl!.textContent = newState;
+});
+
 layerManager.add(layer);
 
 const zSlider = document.querySelector<HTMLInputElement>("#z-slider")!;
 const zIndexEl = document.querySelector<HTMLSpanElement>("#z-index")!;
 const zTotalEl = document.querySelector<HTMLSpanElement>("#z-total")!;
-const minSlider = document.querySelector<HTMLInputElement>("#min-slider")!;
-const maxSlider = document.querySelector<HTMLInputElement>("#max-slider")!;
-const minValueEl = document.querySelector<HTMLSpanElement>("#min-value")!;
-const maxValueEl = document.querySelector<HTMLSpanElement>("#max-value")!;
 const stateEl = document.querySelector<HTMLSpanElement>("#layer-state")!;
 const loadAllButton = document.querySelector<HTMLButtonElement>("#load-all")!;
 
@@ -69,60 +65,16 @@ zSlider.max = `${zMax - 1}`;
 zSlider.value = "0";
 zTotalEl.textContent = `${zMax - zMin - 1}`;
 
-minSlider.min = "-0.000010";
-minSlider.max = "0";
-minSlider.step = "0.000001";
-minSlider.value = `${initialMinValue.toFixed(6)}`;
-
-maxSlider.min = "0";
-maxSlider.max = "0.00001";
-maxSlider.step = "0.000001";
-maxSlider.value = `${initialMaxValue.toFixed(6)}`;
-
-minValueEl.textContent = `${initialMinValue}`;
-maxValueEl.textContent = `${initialMaxValue}`;
-
-// Set up event handlers for contrast sliders
-minSlider.addEventListener("input", (event) => {
-  const minValue = (event.target as HTMLInputElement).valueAsNumber;
-  const maxValue = maxSlider.valueAsNumber;
-  minValueEl.textContent = minValue.toFixed(6);
-  // Update channel properties
-  layer.setChannelProps([
-    {
-      visible: true,
-      color: [1, 1, 1],
-      contrastLimits: [minValue, maxValue],
-    },
-  ]);
-});
-
-maxSlider.addEventListener("input", (event) => {
-  const maxValue = (event.target as HTMLInputElement).valueAsNumber;
-  const minValue = minSlider.valueAsNumber;
-  maxValueEl.textContent = maxValue.toFixed(6);
-  // Update channel properties
-  layer.setChannelProps([
-    {
-      visible: true,
-      color: [1, 1, 1],
-      contrastLimits: [minValue, maxValue],
-    },
-  ]);
-});
-
 // set up event handler with debouncing
 let debounce: ReturnType<typeof setTimeout>;
 zSlider.addEventListener("input", (event) => {
   clearTimeout(debounce);
   const value = (event.target as HTMLInputElement).valueAsNumber;
   debounce = setTimeout(() => {
-    layer.setIndex(value);
-    zIndexEl.textContent = `${value}`;
+    setLayerIndex(value);
   }, 20);
 });
 
-layer.setIndex(zSlider.valueAsNumber);
 const setCameraFrame = (newState: LayerState) => {
   if (newState === "ready" && layer.extent !== undefined) {
     camera.setFrame(0, layer.extent.x, 0, layer.extent.y);
@@ -133,22 +85,36 @@ const setCameraFrame = (newState: LayerState) => {
   }
 };
 layer.addStateChangeCallback(setCameraFrame);
-layer.addStateChangeCallback((newState: LayerState) => {
-  stateEl!.textContent = newState;
-});
+setLayerIndex(zSlider.valueAsNumber);
 
 loadAllButton.addEventListener("click", () => {
-  console.log("loading all slices");
-  loadAllButton.disabled = true;
-  loadAllButton.value = "Loading all slices...";
-  layer.preloadSeries().then(() => {
-    loadAllButton.value = "Loaded all slices";
-  });
+  try {
+    preloadAllSlices();
+  } catch (error) {
+    console.error("Error preloading slices:", error);
+    loadAllButton.value = "Error loading slices";
+  }
 });
 
 function animate() {
   renderer.render(layerManager, camera);
   requestAnimationFrame(animate);
+}
+
+async function preloadAllSlices() {
+  console.log("loading all slices");
+  loadAllButton.disabled = true;
+  loadAllButton.value = "Loading all slices...";
+  await layer.preloadSeries();
+  loadAllButton.value = "Loaded all slices";
+}
+
+async function setLayerIndex(index: number) {
+  zIndexEl!.textContent = "...";
+  const result = await layer.setIndex(index);
+  if (result.success) {
+    zIndexEl!.textContent = `${index}`;
+  }
 }
 
 animate();

--- a/packages/core/src/layers/image_series_layer.ts
+++ b/packages/core/src/layers/image_series_layer.ts
@@ -30,6 +30,11 @@ type LoadingToken = {
   index: number;
 };
 
+type SetIndexResult = {
+  success: boolean;
+  reason?: "duplicate" | "canceled";
+};
+
 // Loads 2D+z image data (Z-stack) from an image source into renderable objects.
 export class ImageSeriesLayer extends Layer {
   private readonly source_: ImageChunkSource;
@@ -90,20 +95,20 @@ export class ImageSeriesLayer extends Layer {
     }
   }
 
-  public async setPosition(position: number) {
+  public async setPosition(position: number): Promise<SetIndexResult> {
     const seriesAttributes = await this.loadSeriesAttributes();
     const index = Math.round(
       (position - seriesAttributes.start) / seriesAttributes.scale
     );
-    this.setIndex(index);
+    return await this.setIndex(index);
   }
 
-  public async setIndex(index: number) {
+  public async setIndex(index: number): Promise<SetIndexResult> {
     const token = this.loadingToken_;
     if (token) {
       if (token.index === index && !token.canceled) {
         console.debug("Ignoring duplicate active setIndex request");
-        return;
+        return { success: false, reason: "duplicate" };
       } else {
         console.debug(
           `Cancelling setIndex request for index ${token.index}, new requested index is ${index}`
@@ -114,11 +119,14 @@ export class ImageSeriesLayer extends Layer {
 
     const chunk = this.dataChunks_[index];
     if (chunk === undefined) {
-      this.loadingToken_ = { canceled: false, index: index };
-      await this.loadAndSetIndex(index, this.loadingToken_);
-      return;
+      const newToken = { canceled: false, index: index };
+      this.loadingToken_ = newToken;
+      await this.loadAndSetIndex(index, newToken);
+      if (newToken.canceled) return { success: false, reason: "canceled" };
+    } else {
+      this.setData(chunk);
     }
-    this.setData(chunk);
+    return { success: true };
   }
 
   private setData(chunk: ImageChunk) {
@@ -145,7 +153,6 @@ export class ImageSeriesLayer extends Layer {
     if (this.seriesAttributes_) {
       return this.seriesAttributes_;
     }
-    this.setState("loading");
     const loader = await this.getLoader();
 
     const attributes = await loader.loadAttributes();
@@ -175,13 +182,10 @@ export class ImageSeriesLayer extends Layer {
       scale: seriesDimScale,
       length: seriesLength,
     };
-    this.setState("ready");
     return this.seriesAttributes_;
   }
 
   private async loadAndSetIndex(index: number, token?: LoadingToken) {
-    this.setLoadingStateFromToken(token);
-
     const seriesAttributes = await this.loadSeriesAttributes();
     if (index < 0 || index >= seriesAttributes.length) {
       throw new Error(
@@ -262,12 +266,6 @@ export class ImageSeriesLayer extends Layer {
   private async getLoader() {
     this.loader_ ??= await this.source_.open();
     return this.loader_;
-  }
-
-  private setLoadingStateFromToken(token?: LoadingToken) {
-    if (!!token && !token.canceled && this.state !== "loading") {
-      this.setState("loading");
-    }
   }
 
   private createImage(

--- a/packages/ultrack-prototype/frontend/lib/tasks.ts
+++ b/packages/ultrack-prototype/frontend/lib/tasks.ts
@@ -285,8 +285,9 @@ export class Task {
       ],
     });
     if (preLoad) {
-      layer.setIndex(0);
-      layer.preloadSeries();
+      layer.setIndex(0).then(() => {
+        layer.preloadSeries();
+      });
     }
     return layer;
   }


### PR DESCRIPTION
### Summary
This fixes a few bugs/quirks in the loading of the ImageSeriesLayer. More changes are likely in the near future, but this is still an improved user experience.

The main feature here is that lazy-loading slices no longer puts the layer into a "loading" state, which causes flashing to white (background) when changing slices/timepoints. I also simplified the example for lazy-loading to focus on the loading states/async returns.

At the same time I fixed:
* hidden async behavior in `setPosition` where `setIndex` was not awaited
* ambiguous return types from `setPosition` and `setIndex` - now the caller can determine if a request was cancelled (duplicate or obsolete)
* the HCS example was just broken, due to a change to the OrganelleBox dataset that removed the initial value

### Related Issue
N/A

### Tests & Checks
Tested all examples, including ultrack and react projects
