### PR TITLE
fix: Add "use client" to API components

### DIFF
--- a/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { Renderer } from "./components/Renderer";
 import { useOmeZarrViewer } from "./useOmeZarrImageViewer";
 import { Region } from "@idetik/core";

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/components/ChannelControlsList/ChannelControlsList.tsx
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/components/ChannelControlsList/ChannelControlsList.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import {
   AccordionHeader,
   AccordionDetails,


### PR DESCRIPTION
I don't think this is 100% necessary, but it might be helpful for Next.js apps? Especially since I noticed the Organelle Box code was importing the viewer component dynamically?