### PR TITLE
fix: Fix SSR useSyncExternalStore() bug and switch to relative import

### DIFF
--- a/packages/react/src/components/providers/IdetikProvider.tsx
+++ b/packages/react/src/components/providers/IdetikProvider.tsx
@@ -26,7 +26,8 @@ export const IdetikProvider = ({ children }: PropsWithChildren) => {
   >(undefined);
   const channels = useSyncExternalStore(
     imageSeriesLayer?.addChannelChangeCallback ?? (() => () => {}),
-    () => imageSeriesLayer?.channelProps ?? EMPTY_ARRAY
+    () => imageSeriesLayer?.channelProps ?? EMPTY_ARRAY,
+    () => EMPTY_ARRAY // Doesn't render anything on SSR
   );
   const [channelControls, setChannelControls] = useState<
     Array<ChannelControl> | undefined

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/useOmeZarrImageViewer.ts
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/useOmeZarrImageViewer.ts
@@ -10,7 +10,7 @@ import {
 } from "@idetik/core";
 
 import { omeroToChannelProps, omeroToChannelControls } from "./utils";
-import { useIdetik } from "components/hooks";
+import { useIdetik } from "../../hooks";
 
 interface UseOmeZarrViewerProps {
   sourceUrl: string;


### PR DESCRIPTION
 - Next.js will error if `useSyncExternalStore()` does not supply a third `getServerSnapshot` argument.
 - The lack of relative import was making `useOmeZarrImageViewer.ts` fail to compile in a submodule.