### PR TITLE
feat: Clean up styles in viewer component

### DIFF
--- a/packages/react/src/components/App.tsx
+++ b/packages/react/src/components/App.tsx
@@ -85,9 +85,9 @@ export default function App() {
         onAllSlicesLoaded={handleAllSlicesLoaded}
         onLoadAllSlicesAborted={handleLoadAllSlicesAborted}
       />
-      <ChannelControlsList
-        classNames={{ root: "absolute top-0 left-0 w-full md:!w-[400px]" }}
-      />
+      <div className="absolute top-0 left-0 w-full md:!w-[400px]">
+        <ChannelControlsList />
+      </div>
       <input
         type="button"
         value="Switch Image"

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
@@ -97,7 +97,7 @@ export function OmeZarrImageViewer({
         ) : (
           <LoadingIndicator sdsStyle="tag" />
         )}
-        {allSlicesLoaded ? (
+        {!allSlicesLoaded ? (
           <Button
             sdsType="primary"
             sdsStyle="square"
@@ -113,13 +113,8 @@ export function OmeZarrImageViewer({
         ) : (
           <div
             className={cns(
-              // When using width 100%, the slider goes out of the
-              // container, just undo it by subtracting the margin
-              // of the container
-              "w-[calc(100%-2*theme(spacing.sds-l))] md:w-[200px]",
+              "w-full md:w-[200px]",
               "flex",
-              "justify-center",
-              "items-center",
               "bg-black/75",
               "rounded-sds-m",
               "shadow-sds-m",

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
@@ -20,20 +20,18 @@ interface OmeZarrViewerContainerProps {
   onLoadAllSlicesAborted?: () => void;
 }
 
-export function OmeZarrImageViewer(props: OmeZarrViewerContainerProps) {
-  const {
-    sourceUrl,
-    region,
-    seriesDimensionName,
-    allSlicesSizeEstimate,
-    classNames,
-    onLayerCreated,
-    onFirstSliceLoaded,
-    onLoadAllSlicesClicked,
-    onAllSlicesLoaded,
-    onLoadAllSlicesAborted,
-  } = props;
-
+export function OmeZarrImageViewer({
+  sourceUrl,
+  region,
+  seriesDimensionName,
+  allSlicesSizeEstimate,
+  classNames,
+  onLayerCreated,
+  onFirstSliceLoaded,
+  onLoadAllSlicesClicked,
+  onAllSlicesLoaded,
+  onLoadAllSlicesAborted,
+}: OmeZarrViewerContainerProps) {
   const {
     layerManager,
     camera,
@@ -54,6 +52,7 @@ export function OmeZarrImageViewer(props: OmeZarrViewerContainerProps) {
     onAllSlicesLoaded,
     onLoadAllSlicesAborted,
   });
+
   return (
     <div className={cns("w-full", "h-full", "relative", classNames?.root)}>
       <Renderer
@@ -72,7 +71,7 @@ export function OmeZarrImageViewer(props: OmeZarrViewerContainerProps) {
           "items-end"
         )}
       >
-        {!loading && (
+        {!loading ? (
           <div
             // These share styles with ChannelControlsList
             className={cns(
@@ -88,9 +87,10 @@ export function OmeZarrImageViewer(props: OmeZarrViewerContainerProps) {
           >
             Slice {zIndex.toString().padStart(2, "0")}/{zRange[1] - zRange[0]}
           </div>
+        ) : (
+          <LoadingIndicator sdsStyle="tag" />
         )}
-        {loading && <LoadingIndicator sdsStyle="tag" />}
-        {!allSlicesLoaded && (
+        {!allSlicesLoaded ? (
           <Button
             sdsType="primary"
             sdsStyle="square"
@@ -103,8 +103,7 @@ export function OmeZarrImageViewer(props: OmeZarrViewerContainerProps) {
               ? `Load 3D high-res (${allSlicesSizeEstimate})`
               : "Load 3D high-res"}
           </Button>
-        )}
-        {allSlicesLoaded && (
+        ) : (
           <div
             className={cns(
               // When using width 100%, the slider goes out of the

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
@@ -55,19 +55,7 @@ export function OmeZarrImageViewer(props: OmeZarrViewerContainerProps) {
     onLoadAllSlicesAborted,
   });
   return (
-    <div
-      className={cns(
-        "w-full",
-        "h-full",
-        "flex",
-        "flex-col",
-        "flex-1",
-        "gap-4",
-        "min-h-0",
-        "relative",
-        classNames?.root
-      )}
-    >
+    <div className={cns("w-full", "h-full", "relative", classNames?.root)}>
       <Renderer
         layerManager={layerManager}
         camera={camera}
@@ -78,44 +66,30 @@ export function OmeZarrImageViewer(props: OmeZarrViewerContainerProps) {
           "absolute",
           "bottom-0",
           "right-0",
-          "w-full",
           "m-sds-l",
           "flex",
           "flex-col",
           "items-end"
         )}
       >
-        <div
-          className={cns(
-            "flex",
-            "justify-end",
-            "items-center",
-            "w-full",
-            "h-6"
-          )}
-        >
-          <div className={cns("flex", "justify-end", "w-1/3")}>
-            {!loading && (
-              <div
-                // These share styles with ChannelControlsList
-                className={cns(
-                  "text-white",
-                  "text-sm",
-                  "bg-black/75",
-                  "backdrop-blur-md",
-                  "p-sds-xs",
-                  "rounded-sds-m",
-                  "shadow-sds-m",
-                  "font-sds-code"
-                )}
-              >
-                Slice {zIndex.toString().padStart(2, "0")}/
-                {zRange[1] - zRange[0]}
-              </div>
+        {!loading && (
+          <div
+            // These share styles with ChannelControlsList
+            className={cns(
+              "text-white",
+              "text-sm",
+              "bg-black/75",
+              "backdrop-blur-md",
+              "p-sds-xs",
+              "rounded-sds-m",
+              "shadow-sds-m",
+              "font-sds-code"
             )}
-            {loading && <LoadingIndicator sdsStyle="tag" />}
+          >
+            Slice {zIndex.toString().padStart(2, "0")}/{zRange[1] - zRange[0]}
           </div>
-        </div>
+        )}
+        {loading && <LoadingIndicator sdsStyle="tag" />}
         {!allSlicesLoaded && (
           <Button
             sdsType="primary"

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
@@ -15,6 +15,7 @@ interface OmeZarrViewerContainerProps {
     sliceMetadataContainer?: string;
     sliceIndicator?: string;
     load3dButton?: string;
+    sliceSliderContainer?: string;
   };
   onLayerCreated?: () => void;
   onFirstSliceLoaded?: () => void;
@@ -68,7 +69,8 @@ export function OmeZarrImageViewer({
           "absolute",
           "bottom-0",
           "right-0",
-          "m-sds-l",
+          "w-full",
+          "p-sds-l",
           "flex",
           "flex-col",
           "items-end",
@@ -122,7 +124,8 @@ export function OmeZarrImageViewer({
               "rounded-sds-m",
               "shadow-sds-m",
               "py-sds-xs",
-              "px-sds-m"
+              "px-sds-m",
+              classNames?.sliceSliderContainer
             )}
           >
             <InputSlider

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
@@ -83,7 +83,6 @@ export function OmeZarrImageViewer({
               "text-white",
               "text-sm",
               "bg-black/75",
-              "backdrop-blur-md",
               "p-sds-xs",
               "rounded-sds-m",
               "shadow-sds-m",
@@ -96,7 +95,7 @@ export function OmeZarrImageViewer({
         ) : (
           <LoadingIndicator sdsStyle="tag" />
         )}
-        {!allSlicesLoaded ? (
+        {allSlicesLoaded ? (
           <Button
             sdsType="primary"
             sdsStyle="square"
@@ -119,9 +118,7 @@ export function OmeZarrImageViewer({
               "flex",
               "justify-center",
               "items-center",
-              "gap-2",
               "bg-black/75",
-              "backdrop-blur-md",
               "rounded-sds-m",
               "shadow-sds-m",
               "py-sds-xs",

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
@@ -12,6 +12,9 @@ interface OmeZarrViewerContainerProps {
   allSlicesSizeEstimate?: string;
   classNames?: {
     root?: string;
+    sliceMetadataContainer?: string;
+    sliceIndicator?: string;
+    load3dButton?: string;
   };
   onLayerCreated?: () => void;
   onFirstSliceLoaded?: () => void;
@@ -68,7 +71,9 @@ export function OmeZarrImageViewer({
           "m-sds-l",
           "flex",
           "flex-col",
-          "items-end"
+          "items-end",
+          "gap-sds-l",
+          classNames?.sliceMetadataContainer
         )}
       >
         {!loading ? (
@@ -82,7 +87,8 @@ export function OmeZarrImageViewer({
               "p-sds-xs",
               "rounded-sds-m",
               "shadow-sds-m",
-              "font-sds-code"
+              "font-sds-code",
+              classNames?.sliceIndicator
             )}
           >
             Slice {zIndex.toString().padStart(2, "0")}/{zRange[1] - zRange[0]}
@@ -97,7 +103,7 @@ export function OmeZarrImageViewer({
             size="small"
             disabled={loading}
             onClick={loadAllSlicesCallback}
-            className="mt-sds-l shadow-sds-m"
+            className={cns("shadow-sds-m", classNames?.load3dButton)}
           >
             {allSlicesSizeEstimate
               ? `Load 3D high-res (${allSlicesSizeEstimate})`
@@ -114,7 +120,6 @@ export function OmeZarrImageViewer({
               "justify-center",
               "items-center",
               "gap-2",
-              "mt-sds-l",
               "bg-black/75",
               "backdrop-blur-md",
               "rounded-sds-m",


### PR DESCRIPTION
 - Re-adds wrapper component for controls list in demo (required to show full width for mobile viewport).
 - Adds more custom CSS classes to viewer component.
 - Removes some no-op flex, width, and blur rules.
 - Removes some unnecessary wrapper `<div>`s.
 - Switches some `margin`s to `gap`.
 - Removes need for `calc()` for full width slice slider by making parent use `padding` instead of `margin`.

(FYI I think the planned code changes that affect integrators should be done now...)