### PR TITLE
fix: Fix errors when integrating in SSR context

### DIFF
--- a/packages/core/src/renderers/webgl_shader_program.ts
+++ b/packages/core/src/renderers/webgl_shader_program.ts
@@ -157,34 +157,40 @@ export class WebGLShaderProgram {
   }
 }
 
-const SAMPLER_TYPES: ReadonlySet<GLenum> = new Set<GLenum>([
-  WebGL2RenderingContext.SAMPLER_2D,
-  WebGL2RenderingContext.SAMPLER_CUBE,
-  WebGL2RenderingContext.SAMPLER_3D,
-  WebGL2RenderingContext.SAMPLER_2D_ARRAY,
-  WebGL2RenderingContext.SAMPLER_2D_SHADOW,
-  WebGL2RenderingContext.SAMPLER_CUBE_SHADOW,
-  WebGL2RenderingContext.SAMPLER_2D_ARRAY_SHADOW,
-  WebGL2RenderingContext.INT_SAMPLER_2D,
-  WebGL2RenderingContext.INT_SAMPLER_3D,
-  WebGL2RenderingContext.INT_SAMPLER_CUBE,
-  WebGL2RenderingContext.INT_SAMPLER_2D_ARRAY,
-  WebGL2RenderingContext.UNSIGNED_INT_SAMPLER_2D,
-  WebGL2RenderingContext.UNSIGNED_INT_SAMPLER_3D,
-  WebGL2RenderingContext.UNSIGNED_INT_SAMPLER_CUBE,
-  WebGL2RenderingContext.UNSIGNED_INT_SAMPLER_2D_ARRAY,
-  WebGL2RenderingContext.MAX_SAMPLES,
-  WebGL2RenderingContext.SAMPLER_BINDING,
-]);
+const SAMPLER_TYPES: ReadonlySet<GLenum> =
+  typeof window !== "undefined" // Don't error in SSR contexts.
+    ? new Set<GLenum>([
+        WebGL2RenderingContext.SAMPLER_2D,
+        WebGL2RenderingContext.SAMPLER_CUBE,
+        WebGL2RenderingContext.SAMPLER_3D,
+        WebGL2RenderingContext.SAMPLER_2D_ARRAY,
+        WebGL2RenderingContext.SAMPLER_2D_SHADOW,
+        WebGL2RenderingContext.SAMPLER_CUBE_SHADOW,
+        WebGL2RenderingContext.SAMPLER_2D_ARRAY_SHADOW,
+        WebGL2RenderingContext.INT_SAMPLER_2D,
+        WebGL2RenderingContext.INT_SAMPLER_3D,
+        WebGL2RenderingContext.INT_SAMPLER_CUBE,
+        WebGL2RenderingContext.INT_SAMPLER_2D_ARRAY,
+        WebGL2RenderingContext.UNSIGNED_INT_SAMPLER_2D,
+        WebGL2RenderingContext.UNSIGNED_INT_SAMPLER_3D,
+        WebGL2RenderingContext.UNSIGNED_INT_SAMPLER_CUBE,
+        WebGL2RenderingContext.UNSIGNED_INT_SAMPLER_2D_ARRAY,
+        WebGL2RenderingContext.MAX_SAMPLES,
+        WebGL2RenderingContext.SAMPLER_BINDING,
+      ])
+    : new Set();
 
 // using an array and converting to a set allows us to also create a type here
-const SUPPORTED_UNIFORM_TYPES_ = [
-  WebGL2RenderingContext.BOOL,
-  WebGL2RenderingContext.FLOAT,
-  WebGL2RenderingContext.FLOAT_VEC2,
-  WebGL2RenderingContext.FLOAT_VEC3,
-  WebGL2RenderingContext.FLOAT_MAT4,
-] as const;
+const SUPPORTED_UNIFORM_TYPES_ =
+  typeof window !== "undefined" // Don't error in SSR contexts.
+    ? [
+        WebGL2RenderingContext.BOOL,
+        WebGL2RenderingContext.FLOAT,
+        WebGL2RenderingContext.FLOAT_VEC2,
+        WebGL2RenderingContext.FLOAT_VEC3,
+        WebGL2RenderingContext.FLOAT_MAT4,
+      ]
+    : [];
 type SupportedUniformType = (typeof SUPPORTED_UNIFORM_TYPES_)[GLenum];
 const SUPPORTED_UNIFORM_TYPES: ReadonlySet<GLenum> = new Set<GLenum>(
   SUPPORTED_UNIFORM_TYPES_

--- a/packages/react/src/components/Main.tsx
+++ b/packages/react/src/components/Main.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { createRoot } from "react-dom/client";
 import cns from "classnames";
 
-import AppWithProviders from "./AppWithProviders.tsx";
+import AppWithProviders from "./AppWithProviders";
 import "../input.css";
 
 const domNode = document.getElementById("app")!;

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/components/ChannelControlsList/ChannelControlsList.tsx
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/components/ChannelControlsList/ChannelControlsList.tsx
@@ -7,7 +7,7 @@ import {
 import cns from "classnames";
 import { ChannelControl } from "./components/ChannelControl";
 import { ChannelProps } from "@idetik/core";
-import { useIdetik } from "components/hooks";
+import { useIdetik } from "../../../../hooks";
 
 export interface ChannelControlsListProps {
   classNames?: {

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/utils.ts
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/utils.ts
@@ -1,6 +1,6 @@
 import { OmeroChannel, ChannelProps } from "@idetik/core";
 import { hexToRgb } from "lib/color";
-import { ChannelControl } from "components/hooks/useIdetik";
+import { ChannelControl } from "../../hooks/useIdetik";
 
 // TODO: the limits/range from the omero channels should possibly be reversed
 // (start/end for limits, min/max for range) but the organelle box data works better this way


### PR DESCRIPTION
This should remove the need (for now...) of dynamically importing the library.

 - Removes immediate execution of code that references variables that only exist in the browser.
 - Updates more relative imports.