### PR TITLE
feat: Simplify <IdetikProvider>

### DIFF
--- a/packages/react/src/components/hooks/useIdetik.ts
+++ b/packages/react/src/components/hooks/useIdetik.ts
@@ -9,7 +9,7 @@ export interface ChannelControl {
 export type IdetikContextValue =
   | {
       isInitialized: true;
-      imageSeriesLayer: ImageSeriesLayer;
+      imageSeriesLayer: ImageSeriesLayer; // Only defined when isInitialized.
       channels: ChannelProps[];
       channelControls: ChannelControl[]; // Same order as channels.
       setImageSeriesLayer: React.Dispatch<
@@ -22,9 +22,13 @@ export type IdetikContextValue =
     }
   | {
       isInitialized: false;
+      imageSeriesLayer: undefined;
+      channels: ChannelProps[];
+      channelControls: ChannelControl[];
       setImageSeriesLayer: React.Dispatch<
         React.SetStateAction<ImageSeriesLayer | undefined>
       >;
+      clearImageSeriesLayer: () => void;
       setChannelControls: React.Dispatch<
         React.SetStateAction<Array<ChannelControl>>
       >;

--- a/packages/react/src/components/hooks/useIdetik.ts
+++ b/packages/react/src/components/hooks/useIdetik.ts
@@ -6,23 +6,29 @@ export interface ChannelControl {
   contrastRange: [number, number];
 }
 
-export interface IdetikContextValue {
-  isInitialized: boolean;
-
-  channels: ChannelProps[];
-  setChannels: (channels: ChannelProps[]) => void;
-  resetChannels: () => void;
-
-  channelControls: ChannelControl[]; // Same order as channels.
-  setChannelControls: React.Dispatch<
-    React.SetStateAction<ChannelControl[] | undefined>
-  >;
-
-  setImageSeriesLayer: React.Dispatch<
-    React.SetStateAction<ImageSeriesLayer | undefined>
-  >;
-  clearImageSeriesLayer: () => void;
-}
+export type IdetikContextValue =
+  | {
+      isInitialized: true;
+      imageSeriesLayer: ImageSeriesLayer;
+      channels: ChannelProps[];
+      channelControls: ChannelControl[]; // Same order as channels.
+      setImageSeriesLayer: React.Dispatch<
+        React.SetStateAction<ImageSeriesLayer | undefined>
+      >;
+      clearImageSeriesLayer: () => void;
+      setChannelControls: React.Dispatch<
+        React.SetStateAction<Array<ChannelControl>>
+      >;
+    }
+  | {
+      isInitialized: false;
+      setImageSeriesLayer: React.Dispatch<
+        React.SetStateAction<ImageSeriesLayer | undefined>
+      >;
+      setChannelControls: React.Dispatch<
+        React.SetStateAction<Array<ChannelControl>>
+      >;
+    };
 
 export const IdetikContext = createContext<IdetikContextValue | undefined>(
   undefined

--- a/packages/react/src/components/providers/IdetikProvider.tsx
+++ b/packages/react/src/components/providers/IdetikProvider.tsx
@@ -54,7 +54,11 @@ export const IdetikProvider = ({ children }: PropsWithChildren) => {
           }
         : {
             isInitialized: false,
+            imageSeriesLayer: undefined,
+            channels,
+            channelControls,
             setChannelControls,
+            clearImageSeriesLayer,
             setImageSeriesLayer,
           },
     [channels, imageSeriesLayer, channelControls, clearImageSeriesLayer]

--- a/packages/react/src/components/providers/IdetikProvider.tsx
+++ b/packages/react/src/components/providers/IdetikProvider.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ChannelProps, ImageSeriesLayer } from "@idetik/core";
+import { ImageSeriesLayer } from "@idetik/core";
 import {
   PropsWithChildren,
   useCallback,
@@ -29,45 +29,35 @@ export const IdetikProvider = ({ children }: PropsWithChildren) => {
     () => imageSeriesLayer?.channelProps ?? EMPTY_ARRAY,
     () => EMPTY_ARRAY // Doesn't render anything on SSR
   );
-  const [channelControls, setChannelControls] = useState<
-    Array<ChannelControl> | undefined
-  >(undefined);
+  const [channelControls, setChannelControls] = useState<Array<ChannelControl>>(
+    []
+  );
 
   // Memoized callbacks:
   const clearImageSeriesLayer = useCallback(() => {
     imageSeriesLayer?.close();
     setImageSeriesLayer(undefined);
   }, [imageSeriesLayer, setImageSeriesLayer]);
-  const setChannels = useCallback(
-    (channelProps: ChannelProps[]) => {
-      imageSeriesLayer?.setChannelProps(channelProps);
-    },
-    [imageSeriesLayer]
-  );
-  const resetChannels = useCallback(() => {
-    imageSeriesLayer?.resetChannelProps();
-  }, [imageSeriesLayer]);
 
   // Context value:
   const contextValue = useMemo<IdetikContextValue>(
-    () => ({
-      isInitialized: imageSeriesLayer !== undefined,
-      channels,
-      setChannels,
-      resetChannels,
-      channelControls: channelControls ?? [],
-      setChannelControls,
-      setImageSeriesLayer,
-      clearImageSeriesLayer,
-    }),
-    [
-      channels,
-      imageSeriesLayer,
-      channelControls,
-      clearImageSeriesLayer,
-      setChannels,
-      resetChannels,
-    ]
+    () =>
+      imageSeriesLayer !== undefined
+        ? {
+            isInitialized: true,
+            imageSeriesLayer,
+            channels,
+            channelControls,
+            setImageSeriesLayer,
+            clearImageSeriesLayer,
+            setChannelControls,
+          }
+        : {
+            isInitialized: false,
+            setChannelControls,
+            setImageSeriesLayer,
+          },
+    [channels, imageSeriesLayer, channelControls, clearImageSeriesLayer]
   );
 
   return (

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/components/ChannelControlsList/ChannelControlsList.tsx
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/components/ChannelControlsList/ChannelControlsList.tsx
@@ -16,7 +16,8 @@ export interface ChannelControlsListProps {
 }
 
 export function ChannelControlsList({ classNames }: ChannelControlsListProps) {
-  const idetikContext = useIdetik();
+  const { isInitialized, imageSeriesLayer, channels, channelControls } =
+    useIdetik();
 
   const updateChannel = (
     index: number,
@@ -26,18 +27,18 @@ export function ChannelControlsList({ classNames }: ChannelControlsListProps) {
       contrastLimits: [number, number];
     }>
   ) => {
-    if (!idetikContext.isInitialized) {
+    if (!isInitialized) {
       return;
     }
-    const updatedChannels = [...idetikContext.channels];
+    const updatedChannels = [...channels];
     updatedChannels[index] = {
-      ...idetikContext.channels[index],
+      ...channels[index],
       ...updates,
     };
-    idetikContext.imageSeriesLayer.setChannelProps(updatedChannels);
+    imageSeriesLayer.setChannelProps(updatedChannels);
   };
 
-  if (!idetikContext.isInitialized) {
+  if (!isInitialized) {
     return null;
   }
 
@@ -82,50 +83,45 @@ export function ChannelControlsList({ classNames }: ChannelControlsListProps) {
 
         <AccordionDetails>
           <div className={cns("grid grid-cols-4 grid-rows-auto")}>
-            {idetikContext.channels.map(
-              (props: ChannelProps, index: number) => {
-                // TODO: can possibly clean this up with better types
-                // error on undefined values - we're setting defaults
-                // and merging objects in too many places
-                if (props.color === undefined) {
-                  throw new Error(`Color not defined for channel ${index}`);
-                }
-                if (props.contrastLimits === undefined) {
-                  throw new Error(
-                    `Contrast limits not defined for channel ${index}`
-                  );
-                }
-                const contrastRange = (idetikContext.channelControls[index]
-                  ?.contrastRange ?? props.contrastLimits)!;
-                if (contrastRange === undefined) {
-                  throw new Error(
-                    `Contrast range not defined for channel ${index}`
-                  );
-                }
-
-                return (
-                  <ChannelControl
-                    key={index}
-                    channelIndex={index}
-                    label={
-                      idetikContext.channelControls[index]?.label ??
-                      `Channel ${index}`
-                    }
-                    color={props.color}
-                    contrastLimits={props.contrastLimits}
-                    contrastRange={contrastRange}
-                    visible={props.visible === undefined ? true : props.visible}
-                    onVisibilityChange={(visible) =>
-                      updateChannel(index, { visible })
-                    }
-                    onColorChange={(color) => updateChannel(index, { color })}
-                    onContrastChange={(contrastLimits) =>
-                      updateChannel(index, { contrastLimits })
-                    }
-                  />
+            {channels.map((props: ChannelProps, index: number) => {
+              // TODO: can possibly clean this up with better types
+              // error on undefined values - we're setting defaults
+              // and merging objects in too many places
+              if (props.color === undefined) {
+                throw new Error(`Color not defined for channel ${index}`);
+              }
+              if (props.contrastLimits === undefined) {
+                throw new Error(
+                  `Contrast limits not defined for channel ${index}`
                 );
               }
-            )}
+              const contrastRange = (channelControls[index]?.contrastRange ??
+                props.contrastLimits)!;
+              if (contrastRange === undefined) {
+                throw new Error(
+                  `Contrast range not defined for channel ${index}`
+                );
+              }
+
+              return (
+                <ChannelControl
+                  key={index}
+                  channelIndex={index}
+                  label={channelControls[index]?.label ?? `Channel ${index}`}
+                  color={props.color}
+                  contrastLimits={props.contrastLimits}
+                  contrastRange={contrastRange}
+                  visible={props.visible === undefined ? true : props.visible}
+                  onVisibilityChange={(visible) =>
+                    updateChannel(index, { visible })
+                  }
+                  onColorChange={(color) => updateChannel(index, { color })}
+                  onContrastChange={(contrastLimits) =>
+                    updateChannel(index, { contrastLimits })
+                  }
+                />
+              );
+            })}
           </div>
           <span className={cns("flex", "justify-end", "mt-sds-xs")}>
             <Button
@@ -134,7 +130,7 @@ export function ChannelControlsList({ classNames }: ChannelControlsListProps) {
               // Force dark mode styles on hover
               className="text-white hover:!text-white hover:!bg-dark-sds-color-semantic-base-fill-hover"
               onClick={() => {
-                resetChannels();
+                imageSeriesLayer.resetChannelProps();
               }}
             >
               Reset channels

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/components/ChannelControlsList/ChannelControlsList.tsx
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/components/ChannelControlsList/ChannelControlsList.tsx
@@ -34,10 +34,10 @@ export function ChannelControlsList({ classNames }: ChannelControlsListProps) {
       ...idetikContext.channels[index],
       ...updates,
     };
-    idetikContext.imageSeriesLayer.setChannels(updatedChannels);
+    idetikContext.imageSeriesLayer.setChannelProps(updatedChannels);
   };
 
-  if (!isInitialized) {
+  if (!idetikContext.isInitialized) {
     return null;
   }
 
@@ -82,45 +82,50 @@ export function ChannelControlsList({ classNames }: ChannelControlsListProps) {
 
         <AccordionDetails>
           <div className={cns("grid grid-cols-4 grid-rows-auto")}>
-            {channels.map((props: ChannelProps, index: number) => {
-              // TODO: can possibly clean this up with better types
-              // error on undefined values - we're setting defaults
-              // and merging objects in too many places
-              if (props.color === undefined) {
-                throw new Error(`Color not defined for channel ${index}`);
-              }
-              if (props.contrastLimits === undefined) {
-                throw new Error(
-                  `Contrast limits not defined for channel ${index}`
-                );
-              }
-              const contrastRange = (channelControls[index]?.contrastRange ??
-                props.contrastLimits)!;
-              if (contrastRange === undefined) {
-                throw new Error(
-                  `Contrast range not defined for channel ${index}`
-                );
-              }
+            {idetikContext.channels.map(
+              (props: ChannelProps, index: number) => {
+                // TODO: can possibly clean this up with better types
+                // error on undefined values - we're setting defaults
+                // and merging objects in too many places
+                if (props.color === undefined) {
+                  throw new Error(`Color not defined for channel ${index}`);
+                }
+                if (props.contrastLimits === undefined) {
+                  throw new Error(
+                    `Contrast limits not defined for channel ${index}`
+                  );
+                }
+                const contrastRange = (idetikContext.channelControls[index]
+                  ?.contrastRange ?? props.contrastLimits)!;
+                if (contrastRange === undefined) {
+                  throw new Error(
+                    `Contrast range not defined for channel ${index}`
+                  );
+                }
 
-              return (
-                <ChannelControl
-                  key={index}
-                  channelIndex={index}
-                  label={channelControls[index]?.label ?? `Channel ${index}`}
-                  color={props.color}
-                  contrastLimits={props.contrastLimits}
-                  contrastRange={contrastRange}
-                  visible={props.visible === undefined ? true : props.visible}
-                  onVisibilityChange={(visible) =>
-                    updateChannel(index, { visible })
-                  }
-                  onColorChange={(color) => updateChannel(index, { color })}
-                  onContrastChange={(contrastLimits) =>
-                    updateChannel(index, { contrastLimits })
-                  }
-                />
-              );
-            })}
+                return (
+                  <ChannelControl
+                    key={index}
+                    channelIndex={index}
+                    label={
+                      idetikContext.channelControls[index]?.label ??
+                      `Channel ${index}`
+                    }
+                    color={props.color}
+                    contrastLimits={props.contrastLimits}
+                    contrastRange={contrastRange}
+                    visible={props.visible === undefined ? true : props.visible}
+                    onVisibilityChange={(visible) =>
+                      updateChannel(index, { visible })
+                    }
+                    onColorChange={(color) => updateChannel(index, { color })}
+                    onContrastChange={(contrastLimits) =>
+                      updateChannel(index, { contrastLimits })
+                    }
+                  />
+                );
+              }
+            )}
           </div>
           <span className={cns("flex", "justify-end", "mt-sds-xs")}>
             <Button

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/components/ChannelControlsList/ChannelControlsList.tsx
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/components/ChannelControlsList/ChannelControlsList.tsx
@@ -16,13 +16,7 @@ export interface ChannelControlsListProps {
 }
 
 export function ChannelControlsList({ classNames }: ChannelControlsListProps) {
-  const {
-    isInitialized,
-    channels,
-    setChannels,
-    resetChannels,
-    channelControls,
-  } = useIdetik();
+  const idetikContext = useIdetik();
 
   const updateChannel = (
     index: number,
@@ -32,12 +26,15 @@ export function ChannelControlsList({ classNames }: ChannelControlsListProps) {
       contrastLimits: [number, number];
     }>
   ) => {
-    const updatedChannels = [...channels];
+    if (!idetikContext.isInitialized) {
+      return;
+    }
+    const updatedChannels = [...idetikContext.channels];
     updatedChannels[index] = {
-      ...channels[index],
+      ...idetikContext.channels[index],
       ...updates,
     };
-    setChannels(updatedChannels);
+    idetikContext.imageSeriesLayer.setChannels(updatedChannels);
   };
 
   if (!isInitialized) {

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/useOmeZarrImageViewer.ts
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/useOmeZarrImageViewer.ts
@@ -53,6 +53,8 @@ export function useOmeZarrViewer({
   }, [imageLayer]);
 
   useEffect(() => {
+    const newSource = new OmeZarrImageSource(sourceUrl, 0);
+    setSource(newSource);
     setAllSlicesLoaded(false);
   }, [sourceUrl]);
 
@@ -67,6 +69,7 @@ export function useOmeZarrViewer({
 
   // Create Image Layer
   useEffect(() => {
+    if (!source) return;
     let shouldSetLayer = true;
     let layer: ImageSeriesLayer | null = null;
     console.log("[Viewer] Creating image layer");
@@ -77,7 +80,7 @@ export function useOmeZarrViewer({
       const channelProps = omeroToChannelProps(omeroChannels);
 
       layer = new ImageSeriesLayer({
-        source: new OmeZarrImageSource(sourceUrl, 0),
+        source,
         region,
         seriesDimensionName,
         channelProps,
@@ -113,13 +116,14 @@ export function useOmeZarrViewer({
       clearImageSeriesLayer();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps -- Deps that trigger layer creation.
-  }, [sourceUrl, region, seriesDimensionName]);
+  }, [source, sourceUrl, region, seriesDimensionName]);
 
   // Fetch Z range from metadata
   useEffect(() => {
     const fetchZRange = async () => {
-      const loader = await openImageSeriesLayer();
-      const attrs = await loader!.loadAttributes();
+      if (!source) return;
+      const loader = await source.open();
+      const attrs = await loader.loadAttributes();
 
       const zIdx = attrs.dimensionNames.findIndex(
         (d: string) => d === seriesDimensionName

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/useOmeZarrImageViewer.ts
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/useOmeZarrImageViewer.ts
@@ -41,7 +41,8 @@ export function useOmeZarrViewer({
   const [zValue, setZValue] = useState(0.5);
   const [loading, setLoading] = useState(true);
   const [allSlicesLoaded, setAllSlicesLoaded] = useState(false);
-  const idetikContext = useIdetik();
+  const { setImageSeriesLayer, clearImageSeriesLayer, setChannelControls } =
+    useIdetik();
 
   useEffect(() => {
     if (imageLayer) {
@@ -52,8 +53,6 @@ export function useOmeZarrViewer({
   }, [imageLayer]);
 
   useEffect(() => {
-    const newSource = new OmeZarrImageSource(sourceUrl, 0);
-    setSource(newSource);
     setAllSlicesLoaded(false);
   }, [sourceUrl]);
 
@@ -68,7 +67,6 @@ export function useOmeZarrViewer({
 
   // Create Image Layer
   useEffect(() => {
-    if (!source) return;
     let shouldSetLayer = true;
     let layer: ImageSeriesLayer | null = null;
     console.log("[Viewer] Creating image layer");
@@ -79,7 +77,7 @@ export function useOmeZarrViewer({
       const channelProps = omeroToChannelProps(omeroChannels);
 
       layer = new ImageSeriesLayer({
-        source,
+        source: new OmeZarrImageSource(sourceUrl, 0),
         region,
         seriesDimensionName,
         channelProps,
@@ -101,8 +99,8 @@ export function useOmeZarrViewer({
 
       if (shouldSetLayer) {
         setImageLayer(layer);
-        idetikContext.setImageSeriesLayer(layer);
-        idetikContext.setChannelControls(omeroToChannelControls(omeroChannels));
+        setImageSeriesLayer(layer);
+        setChannelControls(omeroToChannelControls(omeroChannels));
       }
     };
 
@@ -112,19 +110,16 @@ export function useOmeZarrViewer({
       shouldSetLayer = false;
       layer?.close();
       setImageLayer(null);
-      if (idetikContext.isInitialized) {
-        idetikContext.clearImageSeriesLayer();
-      }
+      clearImageSeriesLayer();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps -- Deps that trigger layer creation.
-  }, [source, sourceUrl, region, seriesDimensionName]);
+  }, [sourceUrl, region, seriesDimensionName]);
 
   // Fetch Z range from metadata
   useEffect(() => {
     const fetchZRange = async () => {
-      if (!source) return;
-      const loader = await source.open();
-      const attrs = await loader.loadAttributes();
+      const loader = await openImageSeriesLayer();
+      const attrs = await loader!.loadAttributes();
 
       const zIdx = attrs.dimensionNames.findIndex(
         (d: string) => d === seriesDimensionName

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/useOmeZarrImageViewer.ts
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/useOmeZarrImageViewer.ts
@@ -41,8 +41,7 @@ export function useOmeZarrViewer({
   const [zValue, setZValue] = useState(0.5);
   const [loading, setLoading] = useState(true);
   const [allSlicesLoaded, setAllSlicesLoaded] = useState(false);
-  const { setImageSeriesLayer, clearImageSeriesLayer, setChannelControls } =
-    useIdetik();
+  const idetikContext = useIdetik();
 
   useEffect(() => {
     if (imageLayer) {
@@ -102,8 +101,8 @@ export function useOmeZarrViewer({
 
       if (shouldSetLayer) {
         setImageLayer(layer);
-        setImageSeriesLayer(layer);
-        setChannelControls(omeroToChannelControls(omeroChannels));
+        idetikContext.setImageSeriesLayer(layer);
+        idetikContext.setChannelControls(omeroToChannelControls(omeroChannels));
       }
     };
 
@@ -113,7 +112,9 @@ export function useOmeZarrViewer({
       shouldSetLayer = false;
       layer?.close();
       setImageLayer(null);
-      clearImageSeriesLayer();
+      if (idetikContext.isInitialized) {
+        idetikContext.clearImageSeriesLayer();
+      }
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps -- Deps that trigger layer creation.
   }, [source, sourceUrl, region, seriesDimensionName]);


### PR DESCRIPTION
In preparation for final refactoring PR, condense the context value by deleting properties derived from `imageSeriesLayer` and just exposing it directly.

Also add type safety to correlate `isInitialized` to `imageSeriesLayer` being defined.