### PR TITLE
feat: add grayscale fallback and contrast limits to OmeZarrImageViewer

### DIFF
--- a/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
@@ -10,6 +10,7 @@ interface OmeZarrViewerContainerProps {
   region: Region;
   seriesDimensionName: string;
   allSlicesSizeEstimate?: string;
+  contrastLimits?: [number, number];
   classNames?: {
     root?: string;
   };
@@ -26,6 +27,7 @@ export function OmeZarrImageViewer(props: OmeZarrViewerContainerProps) {
     region,
     seriesDimensionName,
     allSlicesSizeEstimate,
+    contrastLimits,
     classNames,
     onLayerCreated,
     onFirstSliceLoaded,
@@ -48,6 +50,7 @@ export function OmeZarrImageViewer(props: OmeZarrViewerContainerProps) {
     sourceUrl,
     region,
     seriesDimensionName,
+    contrastLimits,
     onLayerCreated,
     onFirstSliceLoaded,
     onLoadAllSlicesClicked,

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
@@ -130,38 +130,38 @@ export function OmeZarrImageViewer(props: OmeZarrViewerContainerProps) {
               : "Load 3D high-res"}
           </Button>
         )}
-        {/* {allSlicesLoaded && ( */}
-        <div
-          className={cns(
-            // When using width 100%, the slider goes out of the
-            // container, just undo it by subtracting the margin
-            // of the container
-            "w-[calc(100%-2*theme(spacing.sds-l))] md:w-[200px]",
-            "flex",
-            "justify-center",
-            "items-center",
-            "gap-2",
-            "mt-sds-l",
-            "bg-black/75",
-            "backdrop-blur-md",
-            "rounded-sds-m",
-            "shadow-sds-m",
-            "py-sds-xs",
-            "px-sds-m"
-          )}
-        >
-          <InputSlider
-            min={0}
-            max={1}
-            step={1 / (zRange[1] - zRange[0])}
-            value={zValue}
-            {...MODIFIED_SLIDER_STYLES}
-            onChange={(_, val: number | number[]) => {
-              if (typeof val === "number") setZValue(val);
-            }}
-          />
-        </div>
-        {/* )} */}
+        {allSlicesLoaded && (
+          <div
+            className={cns(
+              // When using width 100%, the slider goes out of the
+              // container, just undo it by subtracting the margin
+              // of the container
+              "w-[calc(100%-2*theme(spacing.sds-l))] md:w-[200px]",
+              "flex",
+              "justify-center",
+              "items-center",
+              "gap-2",
+              "mt-sds-l",
+              "bg-black/75",
+              "backdrop-blur-md",
+              "rounded-sds-m",
+              "shadow-sds-m",
+              "py-sds-xs",
+              "px-sds-m"
+            )}
+          >
+            <InputSlider
+              min={0}
+              max={1}
+              step={1 / (zRange[1] - zRange[0])}
+              value={zValue}
+              {...MODIFIED_SLIDER_STYLES}
+              onChange={(_, val: number | number[]) => {
+                if (typeof val === "number") setZValue(val);
+              }}
+            />
+          </div>
+        )}
       </div>
     </div>
   );

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
@@ -130,38 +130,38 @@ export function OmeZarrImageViewer(props: OmeZarrViewerContainerProps) {
               : "Load 3D high-res"}
           </Button>
         )}
-        {allSlicesLoaded && (
-          <div
-            className={cns(
-              // When using width 100%, the slider goes out of the
-              // container, just undo it by subtracting the margin
-              // of the container
-              "w-[calc(100%-2*theme(spacing.sds-l))] md:w-[200px]",
-              "flex",
-              "justify-center",
-              "items-center",
-              "gap-2",
-              "mt-sds-l",
-              "bg-black/75",
-              "backdrop-blur-md",
-              "rounded-sds-m",
-              "shadow-sds-m",
-              "py-sds-xs",
-              "px-sds-m"
-            )}
-          >
-            <InputSlider
-              min={0}
-              max={1}
-              step={1 / (zRange[1] - zRange[0])}
-              value={zValue}
-              {...MODIFIED_SLIDER_STYLES}
-              onChange={(_, val: number | number[]) => {
-                if (typeof val === "number") setZValue(val);
-              }}
-            />
-          </div>
-        )}
+        {/* {allSlicesLoaded && ( */}
+        <div
+          className={cns(
+            // When using width 100%, the slider goes out of the
+            // container, just undo it by subtracting the margin
+            // of the container
+            "w-[calc(100%-2*theme(spacing.sds-l))] md:w-[200px]",
+            "flex",
+            "justify-center",
+            "items-center",
+            "gap-2",
+            "mt-sds-l",
+            "bg-black/75",
+            "backdrop-blur-md",
+            "rounded-sds-m",
+            "shadow-sds-m",
+            "py-sds-xs",
+            "px-sds-m"
+          )}
+        >
+          <InputSlider
+            min={0}
+            max={1}
+            step={1 / (zRange[1] - zRange[0])}
+            value={zValue}
+            {...MODIFIED_SLIDER_STYLES}
+            onChange={(_, val: number | number[]) => {
+              if (typeof val === "number") setZValue(val);
+            }}
+          />
+        </div>
+        {/* )} */}
       </div>
     </div>
   );

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/useOmeZarrImageViewer.ts
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/useOmeZarrImageViewer.ts
@@ -57,7 +57,7 @@ export function useOmeZarrViewer({
   }, [imageLayer]);
 
   useEffect(() => {
-    const newSource = new OmeZarrImageSource(sourceUrl, 0);
+    const newSource = new OmeZarrImageSource(sourceUrl);
     setSource(newSource);
     setAllSlicesLoaded(false);
   }, [sourceUrl]);

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/useOmeZarrImageViewer.ts
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/useOmeZarrImageViewer.ts
@@ -9,7 +9,7 @@ import {
   loadOmeroDefaultZ,
 } from "@idetik/core";
 
-import { omeroToChannelProps, omeroToChannelControls } from "./utils";
+import { omeroToChannelProps, omeroToChannelControls, getGrayscaleChannelProp } from "./utils";
 import { useIdetik } from "../../hooks";
 
 interface UseOmeZarrViewerProps {
@@ -76,34 +76,46 @@ export function useOmeZarrViewer({
     console.log("[Viewer] Loading omero channels from", sourceUrl);
     const createLayer = async () => {
       setLoading(true);
-      const omeroChannels = await loadOmeroChannels(sourceUrl);
-      const channelProps = omeroToChannelProps(omeroChannels);
 
-      layer = new ImageSeriesLayer({
-        source,
-        region,
-        seriesDimensionName,
-        channelProps,
-      });
+      try {
+        const omeroChannels = await loadOmeroChannels(sourceUrl);
+        let channelProps;
 
-      onLayerCreated?.();
-
-      const onFirstLoad = () => {
-        console.log("[Viewer] First slice loaded");
-        if (!shouldSetLayer) return;
-        if (zoomToFit(layer!)) {
-          setLoading(false);
-          onFirstSliceLoaded?.();
-          layer?.removeStateChangeCallback(onFirstLoad);
+        if (omeroChannels.length === 0) {
+          console.warn("No OMERO channels found. Falling back to 1 grayscale channel.");
+          channelProps = [getGrayscaleChannelProp()];
+        } else {
+          channelProps = omeroToChannelProps(omeroChannels);
         }
-      };
 
-      layer.addStateChangeCallback(onFirstLoad);
+        layer = new ImageSeriesLayer({
+          source,
+          region,
+          seriesDimensionName,
+          channelProps,
+        });
 
-      if (shouldSetLayer) {
-        setImageLayer(layer);
-        setImageSeriesLayer(layer);
-        setChannelControls(omeroToChannelControls(omeroChannels));
+        onLayerCreated?.();
+
+        const onFirstLoad = () => {
+          console.log("[Viewer] First slice loaded");
+          if (!shouldSetLayer) return;
+          if (zoomToFit(layer!)) {
+            setLoading(false);
+            onFirstSliceLoaded?.();
+            layer?.removeStateChangeCallback(onFirstLoad);
+          }
+        };
+
+        layer.addStateChangeCallback(onFirstLoad);
+
+        if (shouldSetLayer) {
+          setImageLayer(layer);
+          setImageSeriesLayer(layer);
+          setChannelControls(omeroToChannelControls(omeroChannels));
+        }
+      } catch (err) {
+        console.error("[Viewer] Failed to load OMERO metadata:", err);
       }
     };
 
@@ -125,22 +137,44 @@ export function useOmeZarrViewer({
       const loader = await source.open();
       const attrs = await loader.loadAttributes();
 
+      // console.log("[Viewer] attrs.dimensionNames:", attrs.dimensionNames);
+      // console.log("[Viewer] attrs.shape:", attrs.shape);
       const zIdx = attrs.dimensionNames.findIndex(
-        (d: string) => d === seriesDimensionName
+        (d: string) => d.toUpperCase() === seriesDimensionName.toUpperCase()
       );
+
+      // const zIdx = attrs.dimensionNames.findIndex(
+      //   (d: string) => d === seriesDimensionName
+      // );
       const min = 0;
       const max = attrs.shape[zIdx] - 1;
-      const defaultZ = await loadOmeroDefaultZ(sourceUrl);
 
-      setZValue(defaultZ / (max - min));
+      if (max - min <= 0) {
+        console.warn(`Invalid Z range: max ${max} <= min ${min}`);
+        setZRange([0, 0]);
+        setZValue(0);
+        return;
+      }
+
+      const defaultZ = await loadOmeroDefaultZ(sourceUrl);
+      const zNormalized = defaultZ / (max - min);
+
+      if (Number.isNaN(zNormalized)) {
+        console.warn(`Computed zValue is NaN. defaultZ: ${defaultZ}, max: ${max}, min: ${min}`);
+        setZValue(0.5);
+      } else {
+        setZValue(zNormalized);
+      }
+
       setZRange([min, max]);
     };
 
     fetchZRange();
+    // console.log("z range loaded");
   }, [source, seriesDimensionName, sourceUrl]);
 
   const zIndex = Math.round(zValue * (zRange[1] - zRange[0]) + zRange[0]);
-  console.log("[Viewer] zRange", zRange, "zValue", zValue, "zIndex", zIndex);
+  // console.log("[Viewer] zRange", zRange, "zValue", zValue, "zIndex", zIndex);
 
   // Update imageLayer's index on Z change
   useEffect(() => {
@@ -155,8 +189,9 @@ export function useOmeZarrViewer({
 
       try {
         await imageLayer.setIndex(zIndex);
-      } catch {
+      } catch (err) {
         console.debug("Z index load aborted");
+        console.error("Z index load aborted", err);
       } finally {
         clearTimeout(t);
         if (didSetLoadingTrue) {

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/useOmeZarrImageViewer.ts
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/useOmeZarrImageViewer.ts
@@ -25,6 +25,7 @@ interface UseOmeZarrViewerProps {
   onLoadAllSlicesClicked?: () => void;
   onAllSlicesLoaded?: () => void;
   onLoadAllSlicesAborted?: () => void;
+  contrastLimits?: [number, number];
 }
 
 export function useOmeZarrViewer({
@@ -36,6 +37,7 @@ export function useOmeZarrViewer({
   onLoadAllSlicesClicked,
   onAllSlicesLoaded,
   onLoadAllSlicesAborted,
+  contrastLimits,
 }: UseOmeZarrViewerProps) {
   const [source, setSource] = useState<OmeZarrImageSource | null>(null);
   const [layerManager, setLayerManager] = useState(() => new LayerManager());
@@ -76,8 +78,6 @@ export function useOmeZarrViewer({
     if (!source) return;
     let shouldSetLayer = true;
     let layer: ImageSeriesLayer | null = null;
-    console.log("[Viewer] Creating image layer");
-    console.log("[Viewer] Loading omero channels from", sourceUrl);
     const createLayer = async () => {
       setLoading(true);
 
@@ -89,7 +89,11 @@ export function useOmeZarrViewer({
           console.warn(
             "No OMERO channels found. Falling back to 1 grayscale channel."
           );
-          channelProps = [getGrayscaleChannelProp()];
+          channelProps = [
+            contrastLimits
+              ? getGrayscaleChannelProp(contrastLimits)
+              : getGrayscaleChannelProp(),
+          ];
         } else {
           channelProps = omeroToChannelProps(omeroChannels);
         }
@@ -143,15 +147,10 @@ export function useOmeZarrViewer({
       const loader = await source.open();
       const attrs = await loader.loadAttributes();
 
-      // console.log("[Viewer] attrs.dimensionNames:", attrs.dimensionNames);
-      // console.log("[Viewer] attrs.shape:", attrs.shape);
       const zIdx = attrs.dimensionNames.findIndex(
         (d: string) => d.toUpperCase() === seriesDimensionName.toUpperCase()
       );
 
-      // const zIdx = attrs.dimensionNames.findIndex(
-      //   (d: string) => d === seriesDimensionName
-      // );
       const min = 0;
       const max = attrs.shape[zIdx] - 1;
 
@@ -178,11 +177,9 @@ export function useOmeZarrViewer({
     };
 
     fetchZRange();
-    // console.log("z range loaded");
   }, [source, seriesDimensionName, sourceUrl]);
 
   const zIndex = Math.round(zValue * (zRange[1] - zRange[0]) + zRange[0]);
-  // console.log("[Viewer] zRange", zRange, "zValue", zValue, "zIndex", zIndex);
 
   // Update imageLayer's index on Z change
   useEffect(() => {
@@ -217,7 +214,8 @@ export function useOmeZarrViewer({
     setLoading(true);
     try {
       await imageLayer.preloadSeries();
-    } catch {
+    } catch (err) {
+      console.error("Failed to load all slices", err);
       onLoadAllSlicesAborted?.();
       return;
     } finally {

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/useOmeZarrImageViewer.ts
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/useOmeZarrImageViewer.ts
@@ -9,7 +9,11 @@ import {
   loadOmeroDefaultZ,
 } from "@idetik/core";
 
-import { omeroToChannelProps, omeroToChannelControls, getGrayscaleChannelProp } from "./utils";
+import {
+  omeroToChannelProps,
+  omeroToChannelControls,
+  getGrayscaleChannelProp,
+} from "./utils";
 import { useIdetik } from "../../hooks";
 
 interface UseOmeZarrViewerProps {
@@ -82,7 +86,9 @@ export function useOmeZarrViewer({
         let channelProps;
 
         if (omeroChannels.length === 0) {
-          console.warn("No OMERO channels found. Falling back to 1 grayscale channel.");
+          console.warn(
+            "No OMERO channels found. Falling back to 1 grayscale channel."
+          );
           channelProps = [getGrayscaleChannelProp()];
         } else {
           channelProps = omeroToChannelProps(omeroChannels);
@@ -160,7 +166,9 @@ export function useOmeZarrViewer({
       const zNormalized = defaultZ / (max - min);
 
       if (Number.isNaN(zNormalized)) {
-        console.warn(`Computed zValue is NaN. defaultZ: ${defaultZ}, max: ${max}, min: ${min}`);
+        console.warn(
+          `Computed zValue is NaN. defaultZ: ${defaultZ}, max: ${max}, min: ${min}`
+        );
         setZValue(0.5);
       } else {
         setZValue(zNormalized);

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/utils.ts
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/utils.ts
@@ -35,6 +35,6 @@ export function getGrayscaleChannelProp(): ChannelProps {
   return {
     color: [1, 1, 1],
     visible: true,
-    contrastLimits: [-0.001, 0.001]
-  }
+    contrastLimits: [-0.00001, 0.00001],
+  };
 }

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/utils.ts
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/utils.ts
@@ -31,10 +31,12 @@ export const omeroToChannelControls = (
   });
 };
 
-export function getGrayscaleChannelProp(): ChannelProps {
+export function getGrayscaleChannelProp(
+  contrastLimits?: [number, number]
+): ChannelProps {
   return {
     color: [1, 1, 1],
     visible: true,
-    contrastLimits: [-0.00001, 0.00001],
+    contrastLimits: contrastLimits ?? [-0.00001, 0.00001],
   };
 }

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/utils.ts
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/utils.ts
@@ -30,3 +30,11 @@ export const omeroToChannelControls = (
     };
   });
 };
+
+export function getGrayscaleChannelProp(): ChannelProps {
+  return {
+    color: [1, 1, 1],
+    visible: true,
+    contrastLimits: [-0.001, 0.001]
+  }
+}


### PR DESCRIPTION
## Summary

This PR enhances the `OmeZarrImageViewer` component to support:

- A fallback grayscale channel when no OMERO metadata is present
- Optional `contrastLimits` prop to control the grayscale rendering range
- Improved robustness in Z-dimension handling and metadata loading

---

## Changes

- **Add `contrastLimits?: [number, number]` prop** to:
  - `OmeZarrImageViewer`
  - `useOmeZarrImageViewer`
- **Introduce `getGrayscaleChannelProp()`** utility to generate a default grayscale channel
- Fallback to a grayscale rendering path if `loadOmeroChannels()` returns an empty array
- Normalize `seriesDimensionName` to be case-insensitive when looking up Z-index
- Handle edge cases where `max - min <= 0` in Z range
- Add checks and logging for NaN `zValue` and other loading errors
- Improve logging and error handling for:
  - Z-index load failures
  - Preloading series data
  - OMERO metadata fetch errors

---

## Motivation

- Ensures graceful rendering of datasets lacking OMERO metadata
- Enables external control over grayscale visualization via `contrastLimits`
- Improves debugging and resilience in viewer initialization

