### PR TITLE
refactor: improve fallback handling for greyscale defaults in OmeZarr viewer

### DIFF
--- a/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
@@ -10,7 +10,7 @@ interface OmeZarrViewerContainerProps {
   region: Region;
   seriesDimensionName: string;
   allSlicesSizeEstimate?: string;
-  contrastLimits?: [number, number];
+  fallbackContrastLimits?: [number, number];
   classNames?: {
     root?: string;
     sliceMetadataContainer?: string;
@@ -31,7 +31,7 @@ export function OmeZarrImageViewer(props: OmeZarrViewerContainerProps) {
     region,
     seriesDimensionName,
     allSlicesSizeEstimate,
-    contrastLimits,
+    fallbackContrastLimits,
     classNames,
     onLayerCreated,
     onFirstSliceLoaded,
@@ -54,7 +54,7 @@ export function OmeZarrImageViewer(props: OmeZarrViewerContainerProps) {
     sourceUrl,
     region,
     seriesDimensionName,
-    contrastLimits,
+    fallbackContrastLimits,
     onLayerCreated,
     onFirstSliceLoaded,
     onLoadAllSlicesClicked,

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/useOmeZarrImageViewer.ts
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/useOmeZarrImageViewer.ts
@@ -90,9 +90,7 @@ export function useOmeZarrViewer({
           console.warn(
             "No OMERO channels found. Falling back to 1 grayscale channel."
           );
-          channelProps = [
-            getGrayscaleChannelProp(fallbackContrastLimits)
-          ];
+          channelProps = [getGrayscaleChannelProp(fallbackContrastLimits)];
         } else {
           channelProps = omeroToChannelProps(omeroChannels);
         }
@@ -121,7 +119,12 @@ export function useOmeZarrViewer({
         if (shouldSetLayer) {
           setImageLayer(layer);
           setImageSeriesLayer(layer);
-          setChannelControls(omeroToChannelControls(omeroChannels, defaultGreyscaleChannel(fallbackContrastLimits)));
+          setChannelControls(
+            omeroToChannelControls(
+              omeroChannels,
+              defaultGreyscaleChannel(fallbackContrastLimits)
+            )
+          );
         }
       } catch (err) {
         console.error("[Viewer] Failed to load OMERO metadata:", err);
@@ -138,7 +141,6 @@ export function useOmeZarrViewer({
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps -- Deps that trigger layer creation.
   }, [source, sourceUrl, region, seriesDimensionName]);
-
 
   // Fetch Z range from metadata
   useEffect(() => {

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/useOmeZarrImageViewer.ts
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/useOmeZarrImageViewer.ts
@@ -13,6 +13,7 @@ import {
   omeroToChannelProps,
   omeroToChannelControls,
   getGrayscaleChannelProp,
+  defaultGreyscaleChannel,
 } from "./utils";
 import { useIdetik } from "../../hooks";
 
@@ -25,7 +26,7 @@ interface UseOmeZarrViewerProps {
   onLoadAllSlicesClicked?: () => void;
   onAllSlicesLoaded?: () => void;
   onLoadAllSlicesAborted?: () => void;
-  contrastLimits?: [number, number];
+  fallbackContrastLimits?: [number, number];
 }
 
 export function useOmeZarrViewer({
@@ -37,7 +38,7 @@ export function useOmeZarrViewer({
   onLoadAllSlicesClicked,
   onAllSlicesLoaded,
   onLoadAllSlicesAborted,
-  contrastLimits,
+  fallbackContrastLimits,
 }: UseOmeZarrViewerProps) {
   const [source, setSource] = useState<OmeZarrImageSource | null>(null);
   const [layerManager, setLayerManager] = useState(() => new LayerManager());
@@ -90,9 +91,7 @@ export function useOmeZarrViewer({
             "No OMERO channels found. Falling back to 1 grayscale channel."
           );
           channelProps = [
-            contrastLimits
-              ? getGrayscaleChannelProp(contrastLimits)
-              : getGrayscaleChannelProp(),
+            getGrayscaleChannelProp(fallbackContrastLimits)
           ];
         } else {
           channelProps = omeroToChannelProps(omeroChannels);
@@ -122,7 +121,7 @@ export function useOmeZarrViewer({
         if (shouldSetLayer) {
           setImageLayer(layer);
           setImageSeriesLayer(layer);
-          setChannelControls(omeroToChannelControls(omeroChannels));
+          setChannelControls(omeroToChannelControls(omeroChannels, defaultGreyscaleChannel(fallbackContrastLimits)));
         }
       } catch (err) {
         console.error("[Viewer] Failed to load OMERO metadata:", err);
@@ -140,21 +139,6 @@ export function useOmeZarrViewer({
     // eslint-disable-next-line react-hooks/exhaustive-deps -- Deps that trigger layer creation.
   }, [source, sourceUrl, region, seriesDimensionName]);
 
-  useEffect(() => {
-    if (!imageLayer || !contrastLimits) return;
-    const channelProps = imageLayer.channelProps
-      ? [...imageLayer.channelProps]
-      : [];
-    // Update all channels
-    for (let i = 0; i < channelProps.length; i++) {
-      channelProps[i] = {
-        ...channelProps[i],
-        contrastLimits,
-      };
-    }
-    imageLayer.setChannelProps(channelProps);
-    imageLayer.update();
-  }, [contrastLimits, imageLayer]);
 
   // Fetch Z range from metadata
   useEffect(() => {
@@ -231,7 +215,7 @@ export function useOmeZarrViewer({
     try {
       await imageLayer.preloadSeries();
     } catch (err) {
-      console.error("Failed to load all slices", err);
+      console.warn("load all slices failed or was aborted", err);
       onLoadAllSlicesAborted?.();
       return;
     } finally {

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/utils.ts
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/utils.ts
@@ -18,9 +18,21 @@ export const omeroToChannelProps = (
   });
 };
 
+export const defaultGreyscaleChannel = (
+  contrastLimits: [number, number] = [0, 1]
+): ChannelControl => ({
+  label: "Greyscale",
+  contrastRange: contrastLimits,
+});
+
 export const omeroToChannelControls = (
-  omeroChannels: OmeroChannel[]
+  omeroChannels: OmeroChannel[] | undefined,
+  defaultChannel?: ChannelControl
 ): ChannelControl[] => {
+  if (!omeroChannels || omeroChannels.length === 0) {
+    // No OMERO channels, return the default greyscale channel if provided
+    return defaultChannel ? [defaultChannel] : [];
+  }
   return omeroChannels.map((channel, index) => {
     // remove prefix (number + hyphen) from label if present (seen in organelle box data)
     const label = (channel.label ?? `Ch${index}`).replace(/^\d+-/, "");


### PR DESCRIPTION
This PR addresses feedback on how greyscale defaults are handled when OMERO channels are unavailable:

* Renamed contrastLimits to fallbackContrastLimits to better convey its intended usage.
* Introduced defaultGreyscaleChannel() to standardize fallback channel creation with optional contrast limits.
* Updated omeroToChannelControls() to accept an optional default channel for cases where OMERO channel metadata is absent.
* Removed a redundant useEffect that applied contrastLimits directly to imageLayer channels; updates are now handled via the useIdetik context store.
* Downgraded console.error to console.warn for preload slice failures, reflecting that these are non-critical (ex: in organellebox).