### PR TITLE
refactor: export new hooks and components, organize indexes, update usage doc, finalize z range display

### DIFF
--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -12,7 +12,7 @@ npm install @idetik/react @idetik/core
 
 ### Basic Usage
 
-Here is an example of using the `OmeZarrImageViewer` component in a Next.js app:
+Here is an example of using the `OmeZarrImageViewer` component:
 ```tsx
 "use client";
 import { IdetikProvider, OmeZarrImageViewer, ChannelControlsList } from "@idetik/react";

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -15,28 +15,7 @@ npm install @idetik/react @idetik/core
 Here is an example of using the `OmeZarrImageViewer` component in a Next.js app:
 ```tsx
 "use client";
-// Regular import (works in standard React apps)
-// import { IdetikProvider, OmeZarrImageViewer, ChannelControlsList, Region } from "@idetik/react";
-
-// If using Next.js, use dynamic import to avoid SSR issues
-import dynamic from "next/dynamic";
-import { IdetikProvider, ChannelControlsList, Region } from "@idetik/react";
-
-// Define a simple loading component
-const LoadingComponent = () => (
-  <div className="flex items-center justify-center w-full h-full">
-    <div>Loading...</div>
-  </div>
-);
-
-// Dynamic import for Next.js
-const OmeZarrImageViewer = dynamic(
-  () => import("@idetik/react").then((mod) => mod.OmeZarrImageViewer),
-  {
-    ssr: false,
-    loading: () => <LoadingComponent />,
-  }
-);
+import { IdetikProvider, OmeZarrImageViewer, ChannelControlsList, Region } from "@idetik/react";
 
 // Define the region to view
 const region: Region = [

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -15,7 +15,8 @@ npm install @idetik/react @idetik/core
 Here is an example of using the `OmeZarrImageViewer` component in a Next.js app:
 ```tsx
 "use client";
-import { IdetikProvider, OmeZarrImageViewer, ChannelControlsList, Region } from "@idetik/react";
+import { IdetikProvider, OmeZarrImageViewer, ChannelControlsList } from "@idetik/react";
+import { Region } from "@idetik/core";
 
 // Define the region to view
 const region: Region = [

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -12,47 +12,71 @@ npm install @idetik/react @idetik/core
 
 ### Basic Usage
 
-1. Wrap your application in `<IdetikProvider>`.
-
 ```tsx
-import { IdetikProvider } from '@idetik/react';
+// Regular import (works in standard React apps)
+// import { IdetikProvider, OmeZarrImageViewer, ChannelControlsList, Region } from "@idetik/react";
 
-...
+// If using Next.js, use dynamic import to avoid SSR issues
+import dynamic from "next/dynamic";
+import { IdetikProvider, ChannelControlsList, Region } from "@idetik/react";
 
-<IdetikProvider>
-   <App />
-</IdetikProvider>,
-```
+// Define a simple loading component
+const LoadingComponent = () => (
+  <div className="flex items-center justify-center w-full h-full">
+    <div>Loading...</div>
+  </div>
+);
 
-2. Insert `<OmeZarrImageViewer>` anywhere in your application.
+// Dynamic import for Next.js
+const OmeZarrImageViewer = dynamic(
+  () => import("@idetik/react").then((mod) => mod.OmeZarrImageViewer),
+  {
+    ssr: false,
+    loading: () => <LoadingComponent />,
+  }
+);
 
-```tsx
-<OmeZarrImageViewer
-   sourceUrl={imageUrl}
-   region={region}
-   seriesDimensionName="Z"
-   allSlicesSizeEstimate="250 MB"
-   classNames={{
-      root: "your-css-class",
-   }}
-   onLayerCreated={handleLayerCreated}
-   onFirstSliceLoaded={handleFirstSliceLoaded}
-   onLoadAllSlicesClicked={handleLoadAllSlicesClicked}
-   onAllSlicesLoaded={handleAllSlicesLoaded}
-   onLoadAllSlicesAborted={handleLoadAllSlicesAborted}
-/>
-```
+// Define the region to view
+const region: Region = [
+  { dimension: "T", index: { type: "point", value: 0 } },
+  { dimension: "C", index: { type: "full" } },
+  { dimension: "Z", index: { type: "full" } },
+  { dimension: "Y", index: { type: "full" } },
+  { dimension: "X", index: { type: "full" } },
+];
 
-3. Insert `<ChannelControlsList>` anywhere in your application.
-
-```tsx
-<ChannelControlsList />
+export function ImageViewer({ zarrUrl }) {
+  return (
+    <IdetikProvider>
+      <div className="relative w-full h-full">
+        <div className="absolute top-0 left-0 z-10">
+          <ChannelControlsList />
+        </div>
+        <OmeZarrImageViewer
+          sourceUrl={zarrUrl}
+          region={region}
+          seriesDimensionName="Z"
+        />
+      </div>
+    </IdetikProvider>
+  );
+}
 ```
 
 ### Advanced usage
 
 To write custom control components, use the `useIdetik()` hook to access and update the global
 Idetik state.
+
+#### Tracking Metrics
+
+To track metrics, the `OmeZarrImageViewer` component accepts optional callbacks for the following events:
+
+- `onLayerCreated`
+- `onFirstSliceLoaded`
+- `onLoadAllSlicesClicked`
+- `onAllSlicesLoaded`
+- `onLoadAllSlicesAborted`
 
 ## For Internal Developers
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -12,7 +12,7 @@ npm install @idetik/react @idetik/core
 
 ### Basic Usage
 
-Here is an example of wrapping the `OmeZarrImageViewer` component for a Next.js app:
+Here is an example of using the `OmeZarrImageViewer` component in a Next.js app:
 ```tsx
 "use client";
 // Regular import (works in standard React apps)

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -12,7 +12,9 @@ npm install @idetik/react @idetik/core
 
 ### Basic Usage
 
+Here is an example of wrapping the `OmeZarrImageViewer` component for a Next.js app:
 ```tsx
+"use client";
 // Regular import (works in standard React apps)
 // import { IdetikProvider, OmeZarrImageViewer, ChannelControlsList, Region } from "@idetik/react";
 
@@ -45,7 +47,7 @@ const region: Region = [
   { dimension: "X", index: { type: "full" } },
 ];
 
-export function ImageViewer({ zarrUrl }) {
+export function ImageViewer({ zarrUrl }: { zarrUrl: string }) {
   return (
     <IdetikProvider>
       <div className="relative w-full h-full">
@@ -56,6 +58,7 @@ export function ImageViewer({ zarrUrl }) {
           sourceUrl={zarrUrl}
           region={region}
           seriesDimensionName="Z"
+          allSlicesSizeEstimate="250 MB" // Shows on the "Load 3D high-res" button
         />
       </div>
     </IdetikProvider>

--- a/packages/react/src/components/hooks/index.ts
+++ b/packages/react/src/components/hooks/index.ts
@@ -1,1 +1,2 @@
 export { useIdetik } from "./useIdetik";
+export { useOmeZarrViewer } from "./useOmeZarrImageViewer";

--- a/packages/react/src/components/hooks/useOmeZarrImageViewer.ts
+++ b/packages/react/src/components/hooks/useOmeZarrImageViewer.ts
@@ -14,8 +14,8 @@ import {
   omeroToChannelControls,
   getGrayscaleChannelProp,
   defaultGreyscaleChannel,
-} from "./utils";
-import { useIdetik } from "../../hooks";
+} from "../viewers/OmeZarrImageViewer/utils";
+import { useIdetik } from ".";
 
 interface UseOmeZarrViewerProps {
   sourceUrl: string;

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
@@ -97,8 +97,7 @@ export function OmeZarrImageViewer(props: OmeZarrViewerContainerProps) {
               classNames?.sliceIndicator
             )}
           >
-            Slice {zIndex.toString().padStart(2, "0")}/
-            {(zRange[1] - zRange[0]).toString().padStart(2, "0")}
+            Slice {zIndex}/{zRange[1] - zRange[0]}
           </div>
         ) : (
           <LoadingIndicator sdsStyle="tag" />

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
@@ -97,7 +97,8 @@ export function OmeZarrImageViewer(props: OmeZarrViewerContainerProps) {
               classNames?.sliceIndicator
             )}
           >
-            Slice {zIndex.toString().padStart(2, "0")}/{zRange[1] - zRange[0]}
+            Slice {zIndex.toString().padStart(2, "0")}/
+            {(zRange[1] - zRange[0]).toString().padStart(2, "0")}
           </div>
         ) : (
           <LoadingIndicator sdsStyle="tag" />

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
@@ -1,5 +1,5 @@
 import { Renderer } from "./components/Renderer";
-import { useOmeZarrViewer } from "./useOmeZarrImageViewer";
+import { useOmeZarrViewer } from "../../hooks/useOmeZarrImageViewer";
 import { Region } from "@idetik/core";
 import { Button, InputSlider, LoadingIndicator } from "@czi-sds/components";
 import cns from "classnames";

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/index.tsx
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/index.tsx
@@ -1,1 +1,2 @@
 export { OmeZarrImageViewer } from "./OmeZarrImageViewer";
+export { ChannelControlsList } from "./components/ChannelControlsList";

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,7 +1,18 @@
 // import css so it gets packaged with the library
 import "./input.css";
 import { Renderer } from "./components/viewers/OmeZarrImageViewer/components/Renderer";
-import { OmeZarrImageViewer } from "./components/viewers/OmeZarrImageViewer";
-import { useOmeZarrViewer } from "./components/viewers/OmeZarrImageViewer/useOmeZarrImageViewer";
+import {
+  OmeZarrImageViewer,
+  ChannelControlsList,
+} from "./components/viewers/OmeZarrImageViewer";
+import { useIdetik, useOmeZarrViewer } from "./components/hooks";
+import { IdetikProvider } from "./components/providers";
 
-export { Renderer, OmeZarrImageViewer, useOmeZarrViewer };
+export {
+  Renderer,
+  OmeZarrImageViewer,
+  ChannelControlsList,
+  useIdetik,
+  useOmeZarrViewer,
+  IdetikProvider,
+};


### PR DESCRIPTION
### Summary
<!---
  Please try to cover the following questions in your summary:
  1. Describe the product (or technical) problem you are solving.
  2. Explain the engineering solution you have chosen.
  3. Discuss the implementation choices/tradeoffs you have made.
-->
I found that the new hooks and components weren't exported when I tried to install them into the OrganelleBox portal, so this PR adds the exports, as well as two other changes:

- **export new hooks and components, organize indexes**
- **update usage section in with a Next.js example in react library README** (this also shows how to install this in a Next.js app with disabling SSR, and installing into a regular React app as well)
- **pad 0s for z range display**

Preview link in OrganelleBox portal: https://organelle-box-portal-git-latest-idetik-20250417-czbiohub.vercel.app/gene/2025_03_31_A549_ACTB

### Related Issue
Closes #<issue-number>

### Tests & Checks
<!---
  How did you validate that your changes were implemented correctly?
  
  Please think about the following prompts:
  1. I wrote automated tests.
  2. I manually tested my changes, and here's what I did:
-->
