### PR TITLE
refactor: support middle-Z initialization and resolution selection

### DIFF
--- a/packages/core/src/data/ome_zarr_hcs_metadata_loader.ts
+++ b/packages/core/src/data/ome_zarr_hcs_metadata_loader.ts
@@ -34,7 +34,11 @@ export async function loadOmeroDefaultZ(url: string): Promise<number> {
   const store = new zarr.FetchStore(url);
   const group = await zarr.open.v2(store, { kind: "group" });
   // @ts-expect-error rdefs is not in the provided schema
-  return group.attrs?.omero?.rdefs?.defaultZ ?? 0;
+  if (!group.attrs?.omero?.rdefs?.defaultZ) {
+    console.warn("No defaultZ found in OME-Zarr metadata, returning 0");
+    return 0;
+  }
+  return group.attrs?.omero?.rdefs?.defaultZ;
 }
 
 export function parseOmeNgffImage(group: zarr.Group<zarr.FetchStore>): Image {

--- a/packages/core/src/data/ome_zarr_hcs_metadata_loader.ts
+++ b/packages/core/src/data/ome_zarr_hcs_metadata_loader.ts
@@ -34,11 +34,7 @@ export async function loadOmeroDefaultZ(url: string): Promise<number> {
   const store = new zarr.FetchStore(url);
   const group = await zarr.open.v2(store, { kind: "group" });
   // @ts-expect-error rdefs is not in the provided schema
-  if (!group.attrs?.omero?.rdefs?.defaultZ) {
-    console.warn("No defaultZ found in OME-Zarr metadata, returning 0");
-    return 0;
-  }
-  return group.attrs?.omero?.rdefs?.defaultZ;
+  return group.attrs?.omero?.rdefs?.defaultZ ?? 0;
 }
 
 export function parseOmeNgffImage(group: zarr.Group<zarr.FetchStore>): Image {

--- a/packages/core/src/layers/image_series_layer.ts
+++ b/packages/core/src/layers/image_series_layer.ts
@@ -232,32 +232,16 @@ export class ImageSeriesLayer extends Layer {
     const chunk = await loader.loadChunk(pointRegion, this.scheduler_);
 
     this.dataChunks_[index] = chunk;
-    // console.debug(
-    //   `Loaded data for position ${position} (array index ${index})`
-    // );
     if (!token) {
-      // console.debug(
-      //   `Not setting data for position ${position} (array index ${index}) - loaded in background`
-      // );
       return;
     }
 
-    if (token.canceled) {
-      // console.debug(
-      //   `Not setting data for position ${position} (array index ${index}) - canceled by subsequent request`
-      // );
-    } else {
-      // console.debug(
-      //   `Setting data for position ${position} (array index ${index})`
-      // );
-      this.loadingToken_ = null;
-      this.setData(chunk);
-      this.setState("ready");
-    }
+    this.loadingToken_ = null;
+    this.setData(chunk);
+    this.setState("ready");
   }
 
   public async preloadSeries() {
-    console.debug(`Preloading series for dim ${this.seriesDimensionName_}`);
     const { length } = await this.loadSeriesAttributes();
     // Load remaining slices concurrently, exclude the token so they don't get set
     const loadPromises = [];
@@ -276,11 +260,6 @@ export class ImageSeriesLayer extends Layer {
           console.error(`Error loading slice: ${result.reason}`);
         }
       }
-    }
-    if (!results.some((result) => result.status === "rejected")) {
-      console.debug(
-        `Loaded all ${this.dataChunks_.length} slices for dim ${this.seriesDimensionName_}`
-      );
     }
   }
 

--- a/packages/core/src/layers/image_series_layer.ts
+++ b/packages/core/src/layers/image_series_layer.ts
@@ -235,10 +235,11 @@ export class ImageSeriesLayer extends Layer {
     if (!token) {
       return;
     }
-
-    this.loadingToken_ = null;
-    this.setData(chunk);
-    this.setState("ready");
+    if (!token.canceled) {
+      this.loadingToken_ = null;
+      this.setData(chunk);
+      this.setState("ready");
+    }
   }
 
   public async preloadSeries() {

--- a/packages/core/src/layers/image_series_layer.ts
+++ b/packages/core/src/layers/image_series_layer.ts
@@ -232,10 +232,8 @@ export class ImageSeriesLayer extends Layer {
     const chunk = await loader.loadChunk(pointRegion, this.scheduler_);
 
     this.dataChunks_[index] = chunk;
-    if (!token) {
-      return;
-    }
-    if (!token.canceled) {
+
+    if (token && !token.canceled) {
       this.loadingToken_ = null;
       this.setData(chunk);
       this.setState("ready");

--- a/packages/core/src/layers/image_series_layer.ts
+++ b/packages/core/src/layers/image_series_layer.ts
@@ -232,24 +232,24 @@ export class ImageSeriesLayer extends Layer {
     const chunk = await loader.loadChunk(pointRegion, this.scheduler_);
 
     this.dataChunks_[index] = chunk;
-    console.debug(
-      `Loaded data for position ${position} (array index ${index})`
-    );
+    // console.debug(
+    //   `Loaded data for position ${position} (array index ${index})`
+    // );
     if (!token) {
-      console.debug(
-        `Not setting data for position ${position} (array index ${index}) - loaded in background`
-      );
+      // console.debug(
+      //   `Not setting data for position ${position} (array index ${index}) - loaded in background`
+      // );
       return;
     }
 
     if (token.canceled) {
-      console.debug(
-        `Not setting data for position ${position} (array index ${index}) - canceled by subsequent request`
-      );
+      // console.debug(
+      //   `Not setting data for position ${position} (array index ${index}) - canceled by subsequent request`
+      // );
     } else {
-      console.debug(
-        `Setting data for position ${position} (array index ${index})`
-      );
+      // console.debug(
+      //   `Setting data for position ${position} (array index ${index})`
+      // );
       this.loadingToken_ = null;
       this.setData(chunk);
       this.setState("ready");

--- a/packages/react/src/components/hooks/useOmeZarrImageViewer.ts
+++ b/packages/react/src/components/hooks/useOmeZarrImageViewer.ts
@@ -43,7 +43,7 @@ export function useOmeZarrViewer({
   onLoadAllSlicesAborted,
   fallbackContrastLimits,
   resolutionLevel = 0,
-  shouldAutoLoadAllSlices = true,
+  shouldAutoLoadAllSlices = false,
   shouldLoadMiddleZ = false,
 }: UseOmeZarrViewerProps) {
   console.log("useOmeZarrViewer hook called with:", {
@@ -59,6 +59,7 @@ export function useOmeZarrViewer({
   const [imageLayer, setImageLayer] = useState<ImageSeriesLayer | null>(null);
   const [zRange, setZRange] = useState<[number, number]>([0, 0]);
   const [zValue, setZValue] = useState(0.5);
+  const [zIndex, setZIndex] = useState(0);
   const [loading, setLoading] = useState(true);
   const [allSlicesLoaded, setAllSlicesLoaded] = useState(false);
   const { setImageSeriesLayer, clearImageSeriesLayer, setChannelControls } =
@@ -68,7 +69,7 @@ export function useOmeZarrViewer({
     if (imageLayer) {
       imageLayer.setIndex(zIndex);
     }
-  }, [imageLayer, zValue]);
+  }, [imageLayer, zIndex]);
 
   useEffect(() => {
     if (imageLayer) {
@@ -196,6 +197,7 @@ export function useOmeZarrViewer({
       if (max - min <= 0) {
         setZRange([0, 0]);
         setZValue(0);
+        setZIndex(0);
         return;
       }
 
@@ -225,7 +227,10 @@ export function useOmeZarrViewer({
     fetchZRange();
   }, [source, seriesDimensionName, sourceUrl, shouldLoadMiddleZ]);
 
-  const zIndex = Math.round(zValue * (zRange[1] - zRange[0]) + zRange[0]);
+  // Calculate zIndex whenever zValue or zRange changes
+  useEffect(() => {
+    setZIndex(Math.round(zValue * (zRange[1] - zRange[0]) + zRange[0]));
+  }, [zValue, zRange]);
 
   // Update imageLayer's index on Z change
   useEffect(() => {

--- a/packages/react/src/components/hooks/useOmeZarrImageViewer.ts
+++ b/packages/react/src/components/hooks/useOmeZarrImageViewer.ts
@@ -28,7 +28,8 @@ interface UseOmeZarrViewerProps {
   onLoadAllSlicesAborted?: () => void;
   fallbackContrastLimits?: [number, number];
   resolutionLevel?: number;
-  autoLoadAllSlices?: boolean;
+  shouldAutoLoadAllSlices?: boolean;
+  shouldLoadMiddleZ?: boolean;
 }
 
 export function useOmeZarrViewer({
@@ -42,8 +43,16 @@ export function useOmeZarrViewer({
   onLoadAllSlicesAborted,
   fallbackContrastLimits,
   resolutionLevel = 0,
-  autoLoadAllSlices = false,
+  shouldAutoLoadAllSlices = true,
+  shouldLoadMiddleZ = false,
 }: UseOmeZarrViewerProps) {
+  console.log("useOmeZarrViewer hook called with:", {
+    sourceUrl,
+    region,
+    seriesDimensionName,
+    resolutionLevel,
+    shouldAutoLoadAllSlices,
+  });
   const [source, setSource] = useState<OmeZarrImageSource | null>(null);
   const [layerManager, setLayerManager] = useState(() => new LayerManager());
   const [camera, setCamera] = useState<OrthographicCamera | null>(null);
@@ -54,6 +63,12 @@ export function useOmeZarrViewer({
   const [allSlicesLoaded, setAllSlicesLoaded] = useState(false);
   const { setImageSeriesLayer, clearImageSeriesLayer, setChannelControls } =
     useIdetik();
+
+  useEffect(() => {
+    if (imageLayer) {
+      imageLayer.setIndex(zIndex);
+    }
+  }, [imageLayer, zValue]);
 
   useEffect(() => {
     if (imageLayer) {
@@ -117,7 +132,7 @@ export function useOmeZarrViewer({
             layer.removeStateChangeCallback(onFirstLoad);
 
             // Auto load all slices after first slice is loaded if enabled
-            if (autoLoadAllSlices && shouldSetLayer) {
+            if (shouldAutoLoadAllSlices && shouldSetLayer) {
               setLoading(true);
               try {
                 await layer.preloadSeries();
@@ -159,21 +174,33 @@ export function useOmeZarrViewer({
       clearImageSeriesLayer();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps -- Deps that trigger layer creation.
-  }, [source, sourceUrl, region, seriesDimensionName, autoLoadAllSlices]);
+  }, [source, sourceUrl, region, seriesDimensionName, shouldAutoLoadAllSlices]);
 
   // Fetch Z range from metadata
   useEffect(() => {
+    console.log("useEffect triggered with:", {
+      source,
+      seriesDimensionName,
+      sourceUrl,
+    });
     const fetchZRange = async () => {
-      if (!source) return;
+      console.log("fetchZRange");
+      if (!source) {
+        console.log("No source available, returning early");
+        return;
+      }
       const loader = await source.open();
       const attrs = await loader.loadAttributes();
+      console.log("attrs", attrs);
 
       const zIdx = attrs.dimensionNames.findIndex(
         (d: string) => d.toUpperCase() === seriesDimensionName.toUpperCase()
       );
+      console.log("Found zIdx:", zIdx);
 
       const min = 0;
       const max = attrs.shape[zIdx] - 1;
+      console.log("Calculated range:", { min, max });
 
       if (max - min <= 0) {
         console.warn(`Invalid Z range: max ${max} <= min ${min}`);
@@ -182,23 +209,38 @@ export function useOmeZarrViewer({
         return;
       }
 
-      const defaultZ = await loadOmeroDefaultZ(sourceUrl);
-      const zNormalized = defaultZ / (max - min);
+      console.log("ATTRS!!", attrs);
+
+      let initialZ: number;
+      if (shouldLoadMiddleZ) {
+        // Calculate middle z value from shape array
+        const zShape = attrs.shape[zIdx];
+        initialZ = Math.floor(zShape / 2);
+        console.log("Using middle Z:", initialZ);
+      } else {
+        // Use default Z from metadata
+        initialZ = await loadOmeroDefaultZ(sourceUrl);
+        console.log("Using default Z:", initialZ);
+      }
+
+      const zNormalized = initialZ / (max - min);
+      console.log("Calculated zNormalized:", zNormalized);
 
       if (Number.isNaN(zNormalized)) {
         console.warn(
-          `Computed zValue is NaN. defaultZ: ${defaultZ}, max: ${max}, min: ${min}`
+          `Computed zValue is NaN. initialZ: ${initialZ}, max: ${max}, min: ${min}`
         );
         setZValue(0.5);
       } else {
         setZValue(zNormalized);
       }
 
+      console.log("zRange", min, max);
       setZRange([min, max]);
     };
-
+    console.log("fetchZRange before func call");
     fetchZRange();
-  }, [source, seriesDimensionName, sourceUrl]);
+  }, [source, seriesDimensionName, sourceUrl, shouldLoadMiddleZ]);
 
   const zIndex = Math.round(zValue * (zRange[1] - zRange[0]) + zRange[0]);
 

--- a/packages/react/src/components/hooks/useOmeZarrImageViewer.ts
+++ b/packages/react/src/components/hooks/useOmeZarrImageViewer.ts
@@ -219,7 +219,6 @@ export function useOmeZarrViewer({
     fetchZRange();
   }, [source, seriesDimensionName, sourceUrl, shouldLoadMiddleZ]);
 
-  // Calculate zIndex whenever zValue or zRange changes
   useEffect(() => {
     setZIndex(Math.round(zValue * (zRange[1] - zRange[0]) + zRange[0]));
   }, [zValue, zRange]);

--- a/packages/react/src/components/hooks/useOmeZarrImageViewer.ts
+++ b/packages/react/src/components/hooks/useOmeZarrImageViewer.ts
@@ -27,6 +27,7 @@ interface UseOmeZarrViewerProps {
   onAllSlicesLoaded?: () => void;
   onLoadAllSlicesAborted?: () => void;
   fallbackContrastLimits?: [number, number];
+  autoLoadAllSlices?: boolean;
 }
 
 export function useOmeZarrViewer({
@@ -39,6 +40,7 @@ export function useOmeZarrViewer({
   onAllSlicesLoaded,
   onLoadAllSlicesAborted,
   fallbackContrastLimits,
+  autoLoadAllSlices = false,
 }: UseOmeZarrViewerProps) {
   const [source, setSource] = useState<OmeZarrImageSource | null>(null);
   const [layerManager, setLayerManager] = useState(() => new LayerManager());
@@ -51,6 +53,7 @@ export function useOmeZarrViewer({
   const { setImageSeriesLayer, clearImageSeriesLayer, setChannelControls } =
     useIdetik();
 
+  console.log("autoLoadAllSlices: ", autoLoadAllSlices);
   useEffect(() => {
     if (imageLayer) {
       const newManager = new LayerManager();
@@ -104,13 +107,29 @@ export function useOmeZarrViewer({
 
         onLayerCreated?.();
 
-        const onFirstLoad = () => {
+        const onFirstLoad = async () => {
           console.log("[Viewer] First slice loaded");
-          if (!shouldSetLayer) return;
-          if (zoomToFit(layer!)) {
+          if (!shouldSetLayer || !layer) return;
+          if (zoomToFit(layer)) {
             setLoading(false);
             onFirstSliceLoaded?.();
-            layer?.removeStateChangeCallback(onFirstLoad);
+            layer.removeStateChangeCallback(onFirstLoad);
+
+            // Auto load all slices after first slice is loaded if enabled
+            if (autoLoadAllSlices && shouldSetLayer) {
+              console.log("Auto-loading all slices...");
+              setLoading(true);
+              try {
+                await layer.preloadSeries();
+                onAllSlicesLoaded?.();
+                setAllSlicesLoaded(true);
+              } catch (err) {
+                console.warn("Auto-load all slices failed or was aborted", err);
+                onLoadAllSlicesAborted?.();
+              } finally {
+                setLoading(false);
+              }
+            }
           }
         };
 
@@ -140,7 +159,7 @@ export function useOmeZarrViewer({
       clearImageSeriesLayer();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps -- Deps that trigger layer creation.
-  }, [source, sourceUrl, region, seriesDimensionName]);
+  }, [source, sourceUrl, region, seriesDimensionName, autoLoadAllSlices]);
 
   // Fetch Z range from metadata
   useEffect(() => {

--- a/packages/react/src/components/hooks/useOmeZarrImageViewer.ts
+++ b/packages/react/src/components/hooks/useOmeZarrImageViewer.ts
@@ -27,6 +27,7 @@ interface UseOmeZarrViewerProps {
   onAllSlicesLoaded?: () => void;
   onLoadAllSlicesAborted?: () => void;
   fallbackContrastLimits?: [number, number];
+  resolutionLevel?: number;
   autoLoadAllSlices?: boolean;
 }
 
@@ -40,6 +41,7 @@ export function useOmeZarrViewer({
   onAllSlicesLoaded,
   onLoadAllSlicesAborted,
   fallbackContrastLimits,
+  resolutionLevel = 0,
   autoLoadAllSlices = false,
 }: UseOmeZarrViewerProps) {
   const [source, setSource] = useState<OmeZarrImageSource | null>(null);
@@ -53,7 +55,6 @@ export function useOmeZarrViewer({
   const { setImageSeriesLayer, clearImageSeriesLayer, setChannelControls } =
     useIdetik();
 
-  console.log("autoLoadAllSlices: ", autoLoadAllSlices);
   useEffect(() => {
     if (imageLayer) {
       const newManager = new LayerManager();
@@ -63,10 +64,10 @@ export function useOmeZarrViewer({
   }, [imageLayer]);
 
   useEffect(() => {
-    const newSource = new OmeZarrImageSource(sourceUrl);
+    const newSource = new OmeZarrImageSource(sourceUrl, resolutionLevel);
     setSource(newSource);
     setAllSlicesLoaded(false);
-  }, [sourceUrl]);
+  }, [sourceUrl, resolutionLevel]);
 
   const zoomToFit = useCallback((layer: ImageSeriesLayer) => {
     if (layer.extent) {

--- a/packages/react/src/components/hooks/useOmeZarrImageViewer.ts
+++ b/packages/react/src/components/hooks/useOmeZarrImageViewer.ts
@@ -194,16 +194,40 @@ export function useOmeZarrViewer({
       }
 
       let initialZ: number;
-      if (shouldLoadMiddleZ) {
-        // Calculate middle z value from shape array
-        const zShape = attrs.shape[zIdx];
-        initialZ = Math.floor(zShape / 2);
+      // Find the Z region and check if it is 'full'
+      const zRegion = region.find(
+        (d) => d.dimension.toUpperCase() === seriesDimensionName.toUpperCase()
+      );
+      const isFullZ = zRegion && zRegion.index?.type === "full";
+
+      if (isFullZ) {
+        if (shouldLoadMiddleZ) {
+          const zShape = attrs.shape[zIdx];
+          initialZ = Math.floor(zShape / 2);
+        } else {
+          initialZ = await loadOmeroDefaultZ(sourceUrl);
+        }
+      } else if (zRegion) {
+        switch (zRegion.index?.type) {
+          case "point":
+            initialZ = zRegion.index.value;
+            break;
+          case "interval":
+            initialZ = Math.floor(
+              (zRegion.index.start + zRegion.index.stop - 1) / 2
+            );
+            break;
+          default:
+            initialZ = 0;
+        }
       } else {
-        // Use default Z from metadata
-        initialZ = await loadOmeroDefaultZ(sourceUrl);
+        initialZ = 0;
       }
 
-      const zNormalized = initialZ / (max - min);
+      // Clamp initialZ to valid range
+      initialZ = Math.max(min, Math.min(max, initialZ));
+
+      const zNormalized = max - min > 0 ? initialZ / (max - min) : 0;
 
       if (Number.isNaN(zNormalized)) {
         console.warn(

--- a/packages/react/src/components/hooks/useOmeZarrImageViewer.ts
+++ b/packages/react/src/components/hooks/useOmeZarrImageViewer.ts
@@ -52,7 +52,6 @@ export function useOmeZarrViewer({
   const [imageLayer, setImageLayer] = useState<ImageSeriesLayer | null>(null);
   const [zRange, setZRange] = useState<[number, number]>([0, 0]);
   const [zValue, setZValue] = useState(0.5);
-  const [zIndex, setZIndex] = useState(0);
   const [loading, setLoading] = useState(true);
   const [allSlicesLoaded, setAllSlicesLoaded] = useState(false);
   const { setImageSeriesLayer, clearImageSeriesLayer, setChannelControls } =
@@ -60,9 +59,11 @@ export function useOmeZarrViewer({
 
   useEffect(() => {
     if (imageLayer) {
+      // Compute zIndex from zValue and zRange
+      const zIndex = Math.round(zValue * (zRange[1] - zRange[0]) + zRange[0]);
       imageLayer.setIndex(zIndex);
     }
-  }, [imageLayer, zIndex]);
+  }, [imageLayer, zValue, zRange]);
 
   useEffect(() => {
     if (imageLayer) {
@@ -189,7 +190,6 @@ export function useOmeZarrViewer({
       if (max - min <= 0) {
         setZRange([0, 0]);
         setZValue(0);
-        setZIndex(0);
         return;
       }
 
@@ -219,10 +219,6 @@ export function useOmeZarrViewer({
     fetchZRange();
   }, [source, seriesDimensionName, sourceUrl, shouldLoadMiddleZ]);
 
-  useEffect(() => {
-    setZIndex(Math.round(zValue * (zRange[1] - zRange[0]) + zRange[0]));
-  }, [zValue, zRange]);
-
   // Update imageLayer's index on Z change
   useEffect(() => {
     if (!imageLayer) return;
@@ -235,6 +231,8 @@ export function useOmeZarrViewer({
       }, 50);
 
       try {
+        // Compute zIndex from zValue and zRange
+        const zIndex = Math.round(zValue * (zRange[1] - zRange[0]) + zRange[0]);
         await imageLayer.setIndex(zIndex);
       } catch (err) {
         console.debug("Z index load aborted", err);
@@ -247,7 +245,7 @@ export function useOmeZarrViewer({
     };
 
     updateIndex();
-  }, [zIndex, imageLayer]);
+  }, [zValue, zRange, imageLayer]);
 
   const loadAllSlicesCallback = useCallback(async () => {
     if (!imageLayer) return;
@@ -276,7 +274,6 @@ export function useOmeZarrViewer({
     camera,
     zRange,
     zValue,
-    zIndex,
     setZValue,
     loading,
     allSlicesLoaded,

--- a/packages/react/src/components/hooks/useOmeZarrImageViewer.ts
+++ b/packages/react/src/components/hooks/useOmeZarrImageViewer.ts
@@ -46,13 +46,6 @@ export function useOmeZarrViewer({
   shouldAutoLoadAllSlices = false,
   shouldLoadMiddleZ = false,
 }: UseOmeZarrViewerProps) {
-  console.log("useOmeZarrViewer hook called with:", {
-    sourceUrl,
-    region,
-    seriesDimensionName,
-    resolutionLevel,
-    shouldAutoLoadAllSlices,
-  });
   const [source, setSource] = useState<OmeZarrImageSource | null>(null);
   const [layerManager, setLayerManager] = useState(() => new LayerManager());
   const [camera, setCamera] = useState<OrthographicCamera | null>(null);
@@ -125,7 +118,6 @@ export function useOmeZarrViewer({
         onLayerCreated?.();
 
         const onFirstLoad = async () => {
-          console.log("[Viewer] First slice loaded");
           if (!shouldSetLayer || !layer) return;
           if (zoomToFit(layer)) {
             setLoading(false);

--- a/packages/react/src/components/hooks/useOmeZarrImageViewer.ts
+++ b/packages/react/src/components/hooks/useOmeZarrImageViewer.ts
@@ -118,7 +118,6 @@ export function useOmeZarrViewer({
 
             // Auto load all slices after first slice is loaded if enabled
             if (autoLoadAllSlices && shouldSetLayer) {
-              console.log("Auto-loading all slices...");
               setLoading(true);
               try {
                 await layer.preloadSeries();

--- a/packages/react/src/components/hooks/useOmeZarrImageViewer.ts
+++ b/packages/react/src/components/hooks/useOmeZarrImageViewer.ts
@@ -178,53 +178,38 @@ export function useOmeZarrViewer({
 
   // Fetch Z range from metadata
   useEffect(() => {
-    console.log("useEffect triggered with:", {
-      source,
-      seriesDimensionName,
-      sourceUrl,
-    });
     const fetchZRange = async () => {
-      console.log("fetchZRange");
       if (!source) {
-        console.log("No source available, returning early");
+        console.warn("No source available, returning early on fetchZRange");
         return;
       }
       const loader = await source.open();
       const attrs = await loader.loadAttributes();
-      console.log("attrs", attrs);
 
       const zIdx = attrs.dimensionNames.findIndex(
         (d: string) => d.toUpperCase() === seriesDimensionName.toUpperCase()
       );
-      console.log("Found zIdx:", zIdx);
 
       const min = 0;
       const max = attrs.shape[zIdx] - 1;
-      console.log("Calculated range:", { min, max });
 
       if (max - min <= 0) {
-        console.warn(`Invalid Z range: max ${max} <= min ${min}`);
         setZRange([0, 0]);
         setZValue(0);
         return;
       }
-
-      console.log("ATTRS!!", attrs);
 
       let initialZ: number;
       if (shouldLoadMiddleZ) {
         // Calculate middle z value from shape array
         const zShape = attrs.shape[zIdx];
         initialZ = Math.floor(zShape / 2);
-        console.log("Using middle Z:", initialZ);
       } else {
         // Use default Z from metadata
         initialZ = await loadOmeroDefaultZ(sourceUrl);
-        console.log("Using default Z:", initialZ);
       }
 
       const zNormalized = initialZ / (max - min);
-      console.log("Calculated zNormalized:", zNormalized);
 
       if (Number.isNaN(zNormalized)) {
         console.warn(
@@ -235,10 +220,8 @@ export function useOmeZarrViewer({
         setZValue(zNormalized);
       }
 
-      console.log("zRange", min, max);
       setZRange([min, max]);
     };
-    console.log("fetchZRange before func call");
     fetchZRange();
   }, [source, seriesDimensionName, sourceUrl, shouldLoadMiddleZ]);
 
@@ -258,8 +241,7 @@ export function useOmeZarrViewer({
       try {
         await imageLayer.setIndex(zIndex);
       } catch (err) {
-        console.debug("Z index load aborted");
-        console.error("Z index load aborted", err);
+        console.debug("Z index load aborted", err);
       } finally {
         clearTimeout(t);
         if (didSetLoadingTrue) {
@@ -278,7 +260,7 @@ export function useOmeZarrViewer({
     try {
       await imageLayer.preloadSeries();
     } catch (err) {
-      console.warn("load all slices failed or was aborted", err);
+      console.info("load all slices failed or was aborted", err);
       onLoadAllSlicesAborted?.();
       return;
     } finally {

--- a/packages/react/src/components/hooks/useOmeZarrImageViewer.ts
+++ b/packages/react/src/components/hooks/useOmeZarrImageViewer.ts
@@ -57,13 +57,12 @@ export function useOmeZarrViewer({
   const { setImageSeriesLayer, clearImageSeriesLayer, setChannelControls } =
     useIdetik();
 
+  const zIndex = Math.round(zValue * (zRange[1] - zRange[0]) + zRange[0]);
   useEffect(() => {
     if (imageLayer) {
-      // Compute zIndex from zValue and zRange
-      const zIndex = Math.round(zValue * (zRange[1] - zRange[0]) + zRange[0]);
       imageLayer.setIndex(zIndex);
     }
-  }, [imageLayer, zValue, zRange]);
+  }, [imageLayer, zIndex]);
 
   useEffect(() => {
     if (imageLayer) {

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
@@ -23,6 +23,7 @@ interface OmeZarrViewerContainerProps {
   onLoadAllSlicesClicked?: () => void;
   onAllSlicesLoaded?: () => void;
   onLoadAllSlicesAborted?: () => void;
+  resolutionLevel?: number;
 }
 
 export function OmeZarrImageViewer(props: OmeZarrViewerContainerProps) {
@@ -38,6 +39,7 @@ export function OmeZarrImageViewer(props: OmeZarrViewerContainerProps) {
     onLoadAllSlicesClicked,
     onAllSlicesLoaded,
     onLoadAllSlicesAborted,
+    resolutionLevel,
   } = props;
 
   const {
@@ -60,6 +62,7 @@ export function OmeZarrImageViewer(props: OmeZarrViewerContainerProps) {
     onLoadAllSlicesClicked,
     onAllSlicesLoaded,
     onLoadAllSlicesAborted,
+    resolutionLevel,
     autoLoadAllSlices: true,
   });
   console.log("allSlicesLoaded: ", allSlicesLoaded);

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
@@ -63,7 +63,7 @@ export function OmeZarrImageViewer(props: OmeZarrViewerContainerProps) {
     onAllSlicesLoaded,
     onLoadAllSlicesAborted,
     resolutionLevel,
-    autoLoadAllSlices: true,
+    autoLoadAllSlices: false,
   });
   return (
     <div className={cns("w-full", "h-full", "relative", classNames?.root)}>

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
@@ -24,6 +24,8 @@ interface OmeZarrViewerContainerProps {
   onAllSlicesLoaded?: () => void;
   onLoadAllSlicesAborted?: () => void;
   resolutionLevel?: number;
+  shouldAutoLoadAllSlices?: boolean;
+  shouldLoadMiddleZ?: boolean;
 }
 
 export function OmeZarrImageViewer(props: OmeZarrViewerContainerProps) {
@@ -40,6 +42,7 @@ export function OmeZarrImageViewer(props: OmeZarrViewerContainerProps) {
     onAllSlicesLoaded,
     onLoadAllSlicesAborted,
     resolutionLevel,
+    shouldLoadMiddleZ,
   } = props;
 
   const {
@@ -63,7 +66,8 @@ export function OmeZarrImageViewer(props: OmeZarrViewerContainerProps) {
     onAllSlicesLoaded,
     onLoadAllSlicesAborted,
     resolutionLevel,
-    autoLoadAllSlices: false,
+    shouldAutoLoadAllSlices: true,
+    shouldLoadMiddleZ,
   });
   return (
     <div className={cns("w-full", "h-full", "relative", classNames?.root)}>

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
@@ -50,7 +50,6 @@ export function OmeZarrImageViewer(props: OmeZarrViewerContainerProps) {
     camera,
     zRange,
     zValue,
-    zIndex,
     setZValue,
     loading,
     allSlicesLoaded,
@@ -69,6 +68,8 @@ export function OmeZarrImageViewer(props: OmeZarrViewerContainerProps) {
     shouldAutoLoadAllSlices: true,
     shouldLoadMiddleZ,
   });
+  // Compute zIndex for display
+  const zIndex = Math.round(zValue * (zRange[1] - zRange[0]) + zRange[0]);
   return (
     <div className={cns("w-full", "h-full", "relative", classNames?.root)}>
       <Renderer

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
@@ -65,7 +65,6 @@ export function OmeZarrImageViewer(props: OmeZarrViewerContainerProps) {
     resolutionLevel,
     autoLoadAllSlices: true,
   });
-  console.log("allSlicesLoaded: ", allSlicesLoaded);
   return (
     <div className={cns("w-full", "h-full", "relative", classNames?.root)}>
       <Renderer

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
@@ -60,8 +60,9 @@ export function OmeZarrImageViewer(props: OmeZarrViewerContainerProps) {
     onLoadAllSlicesClicked,
     onAllSlicesLoaded,
     onLoadAllSlicesAborted,
+    autoLoadAllSlices: true,
   });
-
+  console.log("allSlicesLoaded: ", allSlicesLoaded);
   return (
     <div className={cns("w-full", "h-full", "relative", classNames?.root)}>
       <Renderer


### PR DESCRIPTION
### Summary
- Adds support for initializing the viewer at the middle Z slice via a new `shouldLoadMiddleZ` flag in `useOmeZarrViewer` and `OmeZarrImageViewer`.
- Adds `resolutionLevel` support for controlling which resolution to load in `OmeZarrImageSource`.
- Refactors `loadOmeroDefaultZ` to include a fallback and console warning if the metadata field is missing.
- Cleans up excessive `console.debug` and `console.log` statements in `ImageSeriesLayer` and related hooks to reduce log noise.
- Consolidates state updates for `zIndex` using `useEffect`.

### Related Issue
Closes #<issue-number>

### Tests & Checks
checked embrella/ example app
