### PR TITLE
Add an Idetik runtime object

### DIFF
--- a/packages/core/examples/image_stack_from_omezarr3d_f32/main.ts
+++ b/packages/core/examples/image_stack_from_omezarr3d_f32/main.ts
@@ -1,20 +1,16 @@
 import {
-  LayerManager,
   LayerState,
+  Idetik,
   ImageSeriesLayer,
   OmeZarrImageSource,
   OrthographicCamera,
   Region,
-  WebGLRenderer,
   ChannelProps,
 } from "@";
 import { PanZoomControls } from "@/objects/cameras/controls";
 
 const url =
   "https://files.cryoetdataportal.cziscience.com/10444/24apr23a_Position_12/Reconstructions/VoxelSpacing4.990/Tomograms/100/24apr23a_Position_12.zarr";
-const layerManager = new LayerManager();
-const renderer = new WebGLRenderer("#canvas");
-const camera = new OrthographicCamera(0, 128, 0, 128);
 
 // Source is 3D with axes (z, y, x), so we provide an interval in z
 const source = new OmeZarrImageSource(url);
@@ -47,11 +43,10 @@ const layer = new ImageSeriesLayer({
   seriesDimensionName: zDimName,
   channelProps,
 });
+
 layer.addStateChangeCallback((newState: LayerState) => {
   stateEl!.textContent = newState;
 });
-
-layerManager.add(layer);
 
 const zSlider = document.querySelector<HTMLInputElement>("#z-slider")!;
 const zIndexEl = document.querySelector<HTMLSpanElement>("#z-index")!;
@@ -75,10 +70,18 @@ zSlider.addEventListener("input", (event) => {
   }, 20);
 });
 
+const camera = new OrthographicCamera(0, 128, 0, 128);
+const app = new Idetik({
+  canvasSelector: "canvas",
+  camera,
+  layers: [layer],
+}).start();
+
+layer.setIndex(zSlider.valueAsNumber);
 const setCameraFrame = (newState: LayerState) => {
   if (newState === "ready" && layer.extent !== undefined) {
     camera.setFrame(0, layer.extent.x, 0, layer.extent.y);
-    renderer.setControls(new PanZoomControls(camera, camera.position));
+    app.setControls(new PanZoomControls(camera, camera.position));
     camera.update();
     // remove the callback to only set the camera frame once
     layer.removeStateChangeCallback(setCameraFrame);
@@ -96,11 +99,6 @@ loadAllButton.addEventListener("click", () => {
   }
 });
 
-function animate() {
-  renderer.render(layerManager, camera);
-  requestAnimationFrame(animate);
-}
-
 async function preloadAllSlices() {
   console.log("loading all slices");
   loadAllButton.disabled = true;
@@ -116,5 +114,3 @@ async function setLayerIndex(index: number) {
     zIndexEl!.textContent = `${index}`;
   }
 }
-
-animate();

--- a/packages/core/src/idetik.ts
+++ b/packages/core/src/idetik.ts
@@ -1,0 +1,50 @@
+import { Camera } from "./objects/cameras/camera";
+import { Layer } from "./core/layer";
+import { LayerManager } from "./core/layer_manager";
+import { WebGLRenderer } from "./renderers/webgl_renderer";
+import { PanZoomControls } from "./objects/cameras/controls";
+
+type IdetikParams = {
+  canvasSelector: string;
+  camera: Camera;
+  controls?: PanZoomControls;
+  layers?: Layer[];
+};
+
+export class Idetik {
+  public layerManager: LayerManager;
+  public camera: Camera;
+
+  private readonly renderer_: WebGLRenderer;
+
+  constructor(params: IdetikParams) {
+    this.camera = params.camera;
+    this.layerManager = new LayerManager();
+    this.renderer_ = new WebGLRenderer(params.canvasSelector);
+
+    if (params.controls) {
+      // TODO: move controls to the idetik class
+      this.renderer_.setControls(params.controls);
+    }
+
+    if (params.layers) {
+      for (const layer of params.layers) {
+        this.layerManager.add(layer);
+      }
+    }
+  }
+
+  // TODO: this should be modified once the controls are moved to the idetik class
+  public setControls(controls: PanZoomControls) {
+    this.renderer_.setControls(controls);
+  }
+
+  public start() {
+    const render = () => {
+      this.renderer_.render(this.layerManager, this.camera);
+      requestAnimationFrame(render);
+    };
+    render();
+    return this;
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,6 @@
-export { WebGLRenderer } from "./renderers/webgl_renderer";
+export { Idetik } from "./idetik";
 
+export { WebGLRenderer } from "./renderers/webgl_renderer";
 export { OrthographicCamera } from "./objects/cameras/orthographic_camera";
 export { PerspectiveCamera } from "./objects/cameras/perspective_camera";
 export { NullControls, PanZoomControls } from "./objects/cameras/controls";


### PR DESCRIPTION
### Summary

This PR introduces the `Idetik` runtime object as a centralized entry point for
application initialization and control. It encapsulates core systems including
the camera, controls, renderer, and layer manager, and provides lifecycle
methods (currently just `start()`) for managing the rendering loop. This
abstraction simplifies setup, improves separation of concerns, and lays the
groundwork for future systems like a chunk manager and state serialization.

Key benefits:
- Cleaner and more modular app initialization
- Centralized lifecycle and system management
- Easier to extend with new runtime components

### Next Steps

- Convert all examples to use the new runtime
- Refactor camera controls
  - Move camera controls up to the `Idetik` object.
  - Update the controls logic to use a transform.

### Tests & Checks

- All tests pass
- Integrate to an example for manual verification
