### PR TITLE
(small) Make camera param in runtime obj non-optional

### DIFF
--- a/packages/core/examples/projected_lines/main.ts
+++ b/packages/core/examples/projected_lines/main.ts
@@ -19,17 +19,11 @@ const layer = new ProjectedLineLayer([
   { path: helixB, color: [0.0, 0.7, 0.0], width: 0.02 },
 ]);
 
-const app = new Idetik({
+new Idetik({
   canvasSelector: "canvas",
+  camera: new PerspectiveCamera({ fov: 60 }),
   layers: [layer],
-});
-
-app.camera = new PerspectiveCamera({
-  fov: 60,
-  aspectRatio: app.width / app.height,
-});
-
-app.start();
+}).start();
 
 function generateHelix(params: {
   radius: number;

--- a/packages/core/src/idetik.ts
+++ b/packages/core/src/idetik.ts
@@ -7,19 +7,19 @@ import { Logger } from "./utilities/logger";
 
 type IdetikParams = {
   canvasSelector: string;
-  camera?: Camera;
+  camera: Camera;
   controls?: PanZoomControls;
   layers?: Layer[];
 };
 
 export class Idetik {
   public layerManager: LayerManager;
-  public camera?: Camera;
+  public camera: Camera;
 
   private readonly renderer_: WebGLRenderer;
 
   constructor(params: IdetikParams) {
-    this.camera = params.camera || undefined;
+    this.camera = params.camera;
     this.layerManager = new LayerManager();
     this.renderer_ = new WebGLRenderer(params.canvasSelector);
 

--- a/packages/core/src/objects/cameras/perspective_camera.ts
+++ b/packages/core/src/objects/cameras/perspective_camera.ts
@@ -13,7 +13,7 @@ type PerspectiveCameraOptions = {
 };
 
 export class PerspectiveCamera extends Camera {
-  private fov_: number;
+  private readonly fov_: number;
   private aspectRatio_: number;
 
   constructor(options: PerspectiveCameraOptions = {}) {


### PR DESCRIPTION
### Summary

This PR updates the Idetik runtime object constructor to require a
camera parameter, making it no longer optional.

### Tests & Checks

- All tests are passing.
- Manual verification.
