### PR TITLE
Use idetik name instead of imaging-active-learning

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ provided script in `ultrack-prototype/run-full-stack.slurm`:
 ```shell
 ❯ ssh $USER@login01.czbiohub.org
 ❯ # ...you will need to confirm login using Duo 2FA
-❯ cd src/idetik# or whatever your local path to the repo
+❯ cd src/idetik  # or whatever your local path to the repo
 ❯ sbatch ./ultrack-prototype/run-full-stack.slurm
 Submitted batch job 1234567  # job ID will be unique
 ❯ squeue --user $USER

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ provided script in `ultrack-prototype/run-full-stack.slurm`:
 ```shell
 ❯ ssh $USER@login01.czbiohub.org
 ❯ # ...you will need to confirm login using Duo 2FA
-❯ cd src/imaging-active-learning  # or whatever your local path to the repo
+❯ cd src/idetik# or whatever your local path to the repo
 ❯ sbatch ./ultrack-prototype/run-full-stack.slurm
 Submitted batch job 1234567  # job ID will be unique
 ❯ squeue --user $USER

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "imaging-active-learning",
+  "name": "idetik",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/packages/core/src/data/image_chunk.ts
+++ b/packages/core/src/data/image_chunk.ts
@@ -21,7 +21,7 @@ export function isImageChunkData(value: unknown): value is ImageChunkData {
 
 // One 2D chunk of n-dimensional image data.
 // TODO: include the region of this chunk.
-// https://github.com/chanzuckerberg/imaging-active-learning/issues/34
+// https://github.com/chanzuckerberg/idetik/issues/34
 export type ImageChunk = {
   data: ImageChunkData;
   shape: {

--- a/packages/core/src/data/ome_zarr_image_loader.ts
+++ b/packages/core/src/data/ome_zarr_image_loader.ts
@@ -53,7 +53,7 @@ export class OmeZarrImageLoader {
       // TODO: when undefined use the input to determine what level to load.
       // That is, dynamically select the scale based on the size of the chunk
       // to be loaded and how big it will be on screen.
-      // https://github.com/chanzuckerberg/imaging-active-learning/issues/37
+      // https://github.com/chanzuckerberg/idetik/issues/37
       // default to the lowest resolution
       this.scaleIndex_ = numScales - 1;
     } else if (scaleIndex < 0) {

--- a/packages/core/src/data/region.ts
+++ b/packages/core/src/data/region.ts
@@ -18,7 +18,7 @@ export type Index = Point | Interval | Full;
 
 // An index for a specific dimension or axis in a region.
 // TODO: add a unit for the index value(s).
-// https://github.com/chanzuckerberg/imaging-active-learning/issues/36
+// https://github.com/chanzuckerberg/idetik/issues/36
 export type DimensionalIndex = {
   dimension: string;
   index: Index;

--- a/packages/core/src/layers/image_layer.ts
+++ b/packages/core/src/layers/image_layer.ts
@@ -16,7 +16,7 @@ export type ImageLayerProps = LayerOptions & {
 export class ImageLayer extends Layer {
   private readonly source_: ImageChunkSource;
   // TODO: remove this when region is passed through to update.
-  // https://github.com/chanzuckerberg/imaging-active-learning/issues/33
+  // https://github.com/chanzuckerberg/idetik/issues/33
   private readonly region_: Region;
   private channelProps_?: ChannelProps[];
   private image_?: ImageRenderable;


### PR DESCRIPTION
### Summary
This replaces a few instances of the old repo / top-level package name (imaging-active-learning) with the new name (idetik). Given that GitHub handles the rename pretty gracefully (i.e. by redirecting), most of these aren't strictly needed but clean things up for newcomers.
