### PR TITLE
[fix] Pass through prop for `shouldAutoLoadAllSlices`

### DIFF
--- a/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
@@ -42,6 +42,7 @@ export function OmeZarrImageViewer(props: OmeZarrViewerContainerProps) {
     onAllSlicesLoaded,
     onLoadAllSlicesAborted,
     resolutionLevel,
+    shouldAutoLoadAllSlices,
     shouldLoadMiddleZ,
   } = props;
 
@@ -65,7 +66,7 @@ export function OmeZarrImageViewer(props: OmeZarrViewerContainerProps) {
     onAllSlicesLoaded,
     onLoadAllSlicesAborted,
     resolutionLevel,
-    shouldAutoLoadAllSlices: true,
+    shouldAutoLoadAllSlices,
     shouldLoadMiddleZ,
   });
   // Compute zIndex for display


### PR DESCRIPTION
### Summary
This passes through the `shouldAutoLoadAllSlices` prop, which was added in #258 but ends up hard-coded to `true`.

@phoenixAja @bchu1 please take a look when updating, in case this affects the CZII HITL app.

### Related Issue
[See bug discussion in Slack](https://chanzuckerbergteam.slack.com/archives/C08JLLH6QKT/p1748551049926779)

### Tests & Checks
Tested manually in react example app
