### PR TITLE
Inject Idetik context to individual layers

### DIFF
--- a/packages/core/examples/image2d_from_omezarr4d_hcs/main.ts
+++ b/packages/core/examples/image2d_from_omezarr4d_hcs/main.ts
@@ -53,7 +53,7 @@ const imageSelector = document.querySelector("#image") as HTMLSelectElement;
 
 const onImageChange = async () => {
   console.debug("onImageChange: ", imageSelector.value);
-  app.layerManager.layers.length = 0;
+  app.layerManager.removeAll();
   const imageUrl =
     plateUrl + "/" + wellSelector.value + "/" + imageSelector.value;
   const source = new OmeZarrImageSource(imageUrl, 0);
@@ -90,7 +90,7 @@ const onImageChange = async () => {
 
 const onWellChange = async () => {
   console.debug("onWellChange: ", wellSelector.value);
-  app.layerManager.layers.length = 0;
+  app.layerManager.removeAll();
   const path = wellSelector.value;
   const well = await loadOmeZarrWell(plateUrl, path);
   console.debug("well", well);

--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -1,0 +1,11 @@
+import { Camera } from "../objects/cameras/camera";
+
+export class ChunkManager {
+  public getVisibleChunks() {
+    // TODO: implement
+  }
+
+  public update(_camera: Camera, _bufferWidth: number, _bufferHeight: number) {
+    // TODO: implement
+  }
+}

--- a/packages/core/src/core/layer.ts
+++ b/packages/core/src/core/layer.ts
@@ -1,3 +1,4 @@
+import { IdetikContext } from "../idetik";
 import { RenderableObject } from "./renderable_object";
 import { clamp } from "../utilities/clamp";
 
@@ -25,9 +26,9 @@ export abstract class Layer {
   public blendMode: blendMode;
 
   constructor({
-    transparent: transparent = false,
+    transparent = false,
     opacity = 1.0,
-    blendMode: blendMode = "normal",
+    blendMode = "normal",
   }: LayerOptions = {}) {
     if (opacity < 0 || opacity > 1) {
       console.warn(
@@ -51,6 +52,12 @@ export abstract class Layer {
   }
 
   public abstract update(): void;
+
+  // TODO: Consider making this an abstract method once chunk manager
+  // integration is finalized. Most layers will likely need access to the chunk
+  // manager, but for now, we allow optional overrides to avoid requiring
+  // placeholder implementations.
+  public onAttached(_context: IdetikContext) {}
 
   public get objects() {
     return this.objects_;

--- a/packages/core/src/core/layer_manager.ts
+++ b/packages/core/src/core/layer_manager.ts
@@ -39,7 +39,11 @@ export class LayerManager {
     this.layers_.splice(index, 1);
   }
 
-  public get layers() {
+  public removeAll() {
+    this.layers_.length = 0;
+  }
+
+  public get layers(): readonly Layer[] {
     return this.layers_;
   }
 }

--- a/packages/core/src/core/layer_manager.ts
+++ b/packages/core/src/core/layer_manager.ts
@@ -1,7 +1,15 @@
 import { Layer } from "./layer";
+import { IdetikContext } from "../idetik";
 
 export class LayerManager {
-  private layers_: Layer[] = [];
+  private readonly layers_: Layer[] = [];
+
+  // TODO: Make this non-optional when react components use the Idetik Runtime
+  private readonly context_?: IdetikContext;
+
+  constructor(context?: IdetikContext) {
+    this.context_ = context;
+  }
 
   public partitionLayers(): {
     opaque: Layer[];
@@ -23,6 +31,9 @@ export class LayerManager {
 
   public add(layer: Layer) {
     this.layers_.push(layer);
+    if (this.context_) {
+      layer.onAttached(this.context_);
+    }
   }
   public remove(index: number) {
     this.layers_.splice(index, 1);

--- a/packages/core/src/idetik.ts
+++ b/packages/core/src/idetik.ts
@@ -4,6 +4,7 @@ import { LayerManager } from "./core/layer_manager";
 import { WebGLRenderer } from "./renderers/webgl_renderer";
 import { PanZoomControls } from "./objects/cameras/controls";
 import { Logger } from "./utilities/logger";
+import { ChunkManager } from "./core/chunk_manager";
 
 type IdetikParams = {
   canvasSelector: string;
@@ -12,16 +13,28 @@ type IdetikParams = {
   layers?: Layer[];
 };
 
+export type IdetikContext = {
+  chunkManager: ChunkManager;
+};
+
 export class Idetik {
   public layerManager: LayerManager;
   public camera: Camera;
 
+  private readonly context_: IdetikContext;
   private readonly renderer_: WebGLRenderer;
+  private readonly chunkManager_: ChunkManager;
 
   constructor(params: IdetikParams) {
     this.camera = params.camera;
-    this.layerManager = new LayerManager();
     this.renderer_ = new WebGLRenderer(params.canvasSelector);
+    this.chunkManager_ = new ChunkManager();
+
+    this.context_ = {
+      chunkManager: this.chunkManager_,
+    };
+
+    this.layerManager = new LayerManager(this.context_);
 
     if (params.controls) {
       // TODO: move controls to the idetik class
@@ -58,6 +71,11 @@ export class Idetik {
         );
         return;
       }
+      this.chunkManager_.update(
+        this.camera,
+        this.renderer_.width,
+        this.renderer_.height
+      );
       this.renderer_.render(this.layerManager, this.camera);
       requestAnimationFrame(render);
     };

--- a/packages/core/src/layers/image_layer.ts
+++ b/packages/core/src/layers/image_layer.ts
@@ -1,4 +1,5 @@
 import { Layer, LayerOptions } from "../core/layer";
+import { IdetikContext } from "../idetik";
 import { Region } from "../data/region";
 import { ImageChunk, ImageChunkSource } from "../data/image_chunk";
 import { ChannelProps } from "../objects/textures/channel";
@@ -33,6 +34,10 @@ export class ImageLayer extends Layer {
     this.source_ = source;
     this.region_ = region;
     this.channelProps_ = channelProps;
+  }
+
+  public onAttached(_context: IdetikContext): void {
+    // TODO: context.chunkManager.addSource(this.source_)
   }
 
   public update() {

--- a/packages/ultrack-prototype/frontend/components/Renderer.tsx
+++ b/packages/ultrack-prototype/frontend/components/Renderer.tsx
@@ -60,7 +60,7 @@ export default function Renderer({
     const onReady = () => {
       setPlaybackEnabled(true);
       // TODO: update the data on the layers instead of creating new ones
-      layerManager.layers.length = 0;
+      layerManager.removeAll();
       layerManager.add(imageSeriesLayer);
       layerManager.add(tracksLayer);
       const extent = tracksLayer.extent;


### PR DESCRIPTION
### Summary

This PR introduces an `IdetikContext` type, which currently holds a reference
to an empty `ChunkManager` class. The context is created during runtime
initialization and passed to the `LayerManager`, which then injects it into each
layer added to the scene.

The intent is for layers to use their `onAttached` hook to register new sources with the `ChunkManager` and potentially access visible chunks from it. The exact mechanism for interacting with the chunk manager is still open for discussion. One option is for each layer to retain a reference to the chunk manager or the context itself and request chunks via a method like `chunkManager.getVisibleChunks(source)`. Alternatively, the chunk manager could return a dedicated store instance for each source, which layers can then use directly.

### Tests & Checks

- All tests and checks are passing.
