### PR TITLE
feat: Refactor React components to use new Idetik object

### DIFF
--- a/packages/core/src/core/layer_manager.ts
+++ b/packages/core/src/core/layer_manager.ts
@@ -24,6 +24,9 @@ export class LayerManager {
   public add(layer: Layer) {
     this.layers_.push(layer);
   }
+  public remove(index: number) {
+    this.layers_.splice(index, 1);
+  }
 
   public get layers() {
     return this.layers_;

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.1",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite -m production",
     "compile": "tsc",
     "build": "vite build && tsc && rollup -c rollup.config.js",
     "format": "prettier --write './**/*.{ts,tsx,html,json}'",

--- a/packages/react/src/components/App.tsx
+++ b/packages/react/src/components/App.tsx
@@ -77,7 +77,7 @@ export default function App() {
         seriesDimensionName="Z"
         allSlicesSizeEstimate="250 MB"
         classNames={{
-          root: "bg-dark-sds-color-primitive-gray-100",
+          root: "bg-dark-sds-color-primitive-gray-100 flex-auto min-h-0",
         }}
         onLayerCreated={handleLayerCreated}
         onFirstSliceLoaded={handleFirstSliceLoaded}
@@ -90,9 +90,9 @@ export default function App() {
       </div>
       <input
         type="button"
-        value="Switch Image"
+        value="Next Image"
         onClick={() => setImageIndex((imageIndex + 1) % imagePaths.length)}
-        className="h-12"
+        className="h-12 shrink-0 basis-[50px]"
       />
     </div>
   );

--- a/packages/react/src/components/Main.tsx
+++ b/packages/react/src/components/Main.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+// import React from "react";
 import { createRoot } from "react-dom/client";
 import cns from "classnames";
 
@@ -9,9 +9,7 @@ const domNode = document.getElementById("app")!;
 const root = createRoot(domNode);
 
 root.render(
-  <React.StrictMode>
-    <div className={cns("font-sds-body")}>
-      <AppWithProviders />
-    </div>
-  </React.StrictMode>
+  <div className={cns("font-sds-body")}>
+    <AppWithProviders />
+  </div>
 );

--- a/packages/react/src/components/hooks/useIdetik.ts
+++ b/packages/react/src/components/hooks/useIdetik.ts
@@ -1,4 +1,4 @@
-import { ChannelProps, ImageSeriesLayer } from "@idetik/core";
+import { ChannelProps, Idetik } from "@idetik/core";
 import { createContext, useContext } from "react";
 
 export interface ChannelControl {
@@ -6,33 +6,24 @@ export interface ChannelControl {
   contrastRange: [number, number];
 }
 
-export type IdetikContextValue =
+export type IdetikContextValue = (
   | {
       isInitialized: true;
-      imageSeriesLayer: ImageSeriesLayer; // Only defined when isInitialized.
-      channels: ChannelProps[];
-      channelControls: ChannelControl[]; // Same order as channels.
-      setImageSeriesLayer: React.Dispatch<
-        React.SetStateAction<ImageSeriesLayer | undefined>
-      >;
-      clearImageSeriesLayer: () => void;
-      setChannelControls: React.Dispatch<
-        React.SetStateAction<Array<ChannelControl>>
-      >;
+      idetik: Idetik;
     }
   | {
       isInitialized: false;
-      imageSeriesLayer: undefined;
-      channels: ChannelProps[];
-      channelControls: ChannelControl[];
-      setImageSeriesLayer: React.Dispatch<
-        React.SetStateAction<ImageSeriesLayer | undefined>
-      >;
-      clearImageSeriesLayer: () => void;
-      setChannelControls: React.Dispatch<
-        React.SetStateAction<Array<ChannelControl>>
-      >;
-    };
+      idetik: undefined;
+    }
+) & {
+  channels: ChannelProps[];
+  channelControls: ChannelControl[]; // Same order as channels.
+  setIdetik: React.Dispatch<React.SetStateAction<Idetik | undefined>>;
+  clear: () => void;
+  setChannelControls: React.Dispatch<
+    React.SetStateAction<Array<ChannelControl>>
+  >;
+};
 
 export const IdetikContext = createContext<IdetikContextValue | undefined>(
   undefined

--- a/packages/react/src/components/hooks/useIdetik.ts
+++ b/packages/react/src/components/hooks/useIdetik.ts
@@ -19,7 +19,6 @@ export type IdetikContextValue = (
   channels: ChannelProps[];
   channelControls: ChannelControl[]; // Same order as channels.
   setIdetik: React.Dispatch<React.SetStateAction<Idetik | undefined>>;
-  clear: () => void;
   setChannelControls: React.Dispatch<
     React.SetStateAction<Array<ChannelControl>>
   >;

--- a/packages/react/src/components/hooks/useIdetik.ts
+++ b/packages/react/src/components/hooks/useIdetik.ts
@@ -16,6 +16,7 @@ export type IdetikContextValue = (
       idetik: undefined;
     }
 ) & {
+  // TODO: Refactor into 1 array that lives in each layer.
   channels: ChannelProps[];
   channelControls: ChannelControl[]; // Same order as channels.
   setIdetik: React.Dispatch<React.SetStateAction<Idetik | undefined>>;

--- a/packages/react/src/components/hooks/useIdetik.ts
+++ b/packages/react/src/components/hooks/useIdetik.ts
@@ -19,7 +19,7 @@ export type IdetikContextValue = (
   // TODO: Refactor into 1 array that lives in each layer.
   channels: ChannelProps[];
   channelControls: ChannelControl[]; // Same order as channels.
-  setIdetik: React.Dispatch<React.SetStateAction<Idetik | undefined>>;
+  setIdetik: (idetik: Idetik) => void;
   setChannelControls: React.Dispatch<
     React.SetStateAction<Array<ChannelControl>>
   >;

--- a/packages/react/src/components/hooks/useIdetik.ts
+++ b/packages/react/src/components/hooks/useIdetik.ts
@@ -19,6 +19,7 @@ export type IdetikContextValue = (
   // TODO: Refactor into 1 array that lives in each layer.
   channels: ChannelProps[];
   channelControls: ChannelControl[]; // Same order as channels.
+  // TODO: Remove need to integrator to set Idetik.
   setIdetik: (idetik: Idetik) => void;
   setChannelControls: React.Dispatch<
     React.SetStateAction<Array<ChannelControl>>

--- a/packages/react/src/components/hooks/useOmeZarrImageViewer.ts
+++ b/packages/react/src/components/hooks/useOmeZarrImageViewer.ts
@@ -51,7 +51,7 @@ export function useOmeZarrViewer({
   const [zValue, setZValue] = useState(0.5);
   const [loading, setLoading] = useState(true);
   const [allSlicesLoaded, setAllSlicesLoaded] = useState(false);
-  const { idetik, setIdetik, clear, setChannelControls } = useIdetik();
+  const { idetik, setIdetik, setChannelControls } = useIdetik();
 
   useEffect(() => {
     const newSource = new OmeZarrImageSource(sourceUrl, resolutionLevel);
@@ -120,7 +120,6 @@ export function useOmeZarrViewer({
                 })
               );
             } else {
-              idetik.layerManager.remove(0);
               idetik.layerManager.add(layer);
             }
             setLoading(false);
@@ -162,7 +161,7 @@ export function useOmeZarrViewer({
 
     return () => {
       shouldSetLayer = false;
-      clear();
+      idetik?.layerManager.remove(0);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps -- Deps that trigger layer creation.
   }, [source, sourceUrl, region, seriesDimensionName, shouldAutoLoadAllSlices]);

--- a/packages/react/src/components/hooks/useOmeZarrImageViewer.ts
+++ b/packages/react/src/components/hooks/useOmeZarrImageViewer.ts
@@ -53,13 +53,6 @@ export function useOmeZarrViewer({
   const [allSlicesLoaded, setAllSlicesLoaded] = useState(false);
   const { idetik, setIdetik, clear, setChannelControls } = useIdetik();
 
-  const zIndex = Math.round(zValue * (zRange[1] - zRange[0]) + zRange[0]);
-  useEffect(() => {
-    if (idetik !== undefined) {
-      (idetik.layerManager.layers[0] as ImageSeriesLayer)?.setIndex(zIndex);
-    }
-  }, [idetik, zIndex]);
-
   useEffect(() => {
     const newSource = new OmeZarrImageSource(sourceUrl, resolutionLevel);
     setSource(newSource);
@@ -108,6 +101,9 @@ export function useOmeZarrViewer({
           seriesDimensionName,
           channelProps,
         });
+        layer.setIndex(
+          Math.round(zValue * (zRange[1] - zRange[0]) + zRange[0])
+        );
 
         onLayerCreated?.();
 

--- a/packages/react/src/components/hooks/useOmeZarrImageViewer.ts
+++ b/packages/react/src/components/hooks/useOmeZarrImageViewer.ts
@@ -1,12 +1,12 @@
 import { useState, useEffect, useCallback } from "react";
 import {
-  LayerManager,
   OmeZarrImageSource,
   OrthographicCamera,
   ImageSeriesLayer,
   Region,
   loadOmeroChannels,
   loadOmeroDefaultZ,
+  Idetik,
 } from "@idetik/core";
 
 import {
@@ -47,30 +47,18 @@ export function useOmeZarrViewer({
   shouldLoadMiddleZ = false,
 }: UseOmeZarrViewerProps) {
   const [source, setSource] = useState<OmeZarrImageSource | null>(null);
-  const [layerManager, setLayerManager] = useState(() => new LayerManager());
-  const [camera, setCamera] = useState<OrthographicCamera | null>(null);
-  const [imageLayer, setImageLayer] = useState<ImageSeriesLayer | null>(null);
   const [zRange, setZRange] = useState<[number, number]>([0, 0]);
   const [zValue, setZValue] = useState(0.5);
   const [loading, setLoading] = useState(true);
   const [allSlicesLoaded, setAllSlicesLoaded] = useState(false);
-  const { setImageSeriesLayer, clearImageSeriesLayer, setChannelControls } =
-    useIdetik();
+  const { idetik, setIdetik, clear, setChannelControls } = useIdetik();
 
   const zIndex = Math.round(zValue * (zRange[1] - zRange[0]) + zRange[0]);
   useEffect(() => {
-    if (imageLayer) {
-      imageLayer.setIndex(zIndex);
+    if (idetik !== undefined) {
+      (idetik.layerManager.layers[0] as ImageSeriesLayer)?.setIndex(zIndex);
     }
-  }, [imageLayer, zIndex]);
-
-  useEffect(() => {
-    if (imageLayer) {
-      const newManager = new LayerManager();
-      newManager.add(imageLayer);
-      setLayerManager(newManager);
-    }
-  }, [imageLayer]);
+  }, [idetik, zIndex]);
 
   useEffect(() => {
     const newSource = new OmeZarrImageSource(sourceUrl, resolutionLevel);
@@ -78,14 +66,20 @@ export function useOmeZarrViewer({
     setAllSlicesLoaded(false);
   }, [sourceUrl, resolutionLevel]);
 
-  const zoomToFit = useCallback((layer: ImageSeriesLayer) => {
-    if (layer.extent) {
-      const cam = new OrthographicCamera(0, layer.extent.x, 0, layer.extent.y);
-      setCamera(cam);
-      return true;
-    }
-    return false;
-  }, []);
+  const zoomToFit = useCallback(
+    (layer: ImageSeriesLayer): OrthographicCamera | void => {
+      if (layer.extent) {
+        const cam = new OrthographicCamera(
+          0,
+          layer.extent.x,
+          0,
+          layer.extent.y
+        );
+        return cam;
+      }
+    },
+    []
+  );
 
   // Create Image Layer
   useEffect(() => {
@@ -119,7 +113,8 @@ export function useOmeZarrViewer({
 
         const onFirstLoad = async () => {
           if (!shouldSetLayer || !layer) return;
-          if (zoomToFit(layer)) {
+          const camera = zoomToFit(layer);
+          if (camera !== undefined) {
             setLoading(false);
             onFirstSliceLoaded?.();
             layer.removeStateChangeCallback(onFirstLoad);
@@ -138,21 +133,25 @@ export function useOmeZarrViewer({
                 setLoading(false);
               }
             }
+            if (shouldSetLayer) {
+              setIdetik(
+                new Idetik({
+                  canvasSelector: "#renderer",
+                  camera,
+                  layers: [layer],
+                })
+              );
+              setChannelControls(
+                omeroToChannelControls(
+                  omeroChannels,
+                  defaultGreyscaleChannel(fallbackContrastLimits)
+                )
+              );
+            }
           }
         };
 
         layer.addStateChangeCallback(onFirstLoad);
-
-        if (shouldSetLayer) {
-          setImageLayer(layer);
-          setImageSeriesLayer(layer);
-          setChannelControls(
-            omeroToChannelControls(
-              omeroChannels,
-              defaultGreyscaleChannel(fallbackContrastLimits)
-            )
-          );
-        }
       } catch (err) {
         console.error("[Viewer] Failed to load OMERO metadata:", err);
       }
@@ -162,9 +161,7 @@ export function useOmeZarrViewer({
 
     return () => {
       shouldSetLayer = false;
-      layer?.close();
-      setImageLayer(null);
-      clearImageSeriesLayer();
+      clear();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps -- Deps that trigger layer creation.
   }, [source, sourceUrl, region, seriesDimensionName, shouldAutoLoadAllSlices]);
@@ -240,11 +237,12 @@ export function useOmeZarrViewer({
       setZRange([min, max]);
     };
     fetchZRange();
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- Dependencies that affect z range.
   }, [source, seriesDimensionName, sourceUrl, shouldLoadMiddleZ]);
 
   // Update imageLayer's index on Z change
   useEffect(() => {
-    if (!imageLayer) return;
+    if (!idetik) return;
     let didSetLoadingTrue = false;
 
     const updateIndex = async () => {
@@ -256,7 +254,9 @@ export function useOmeZarrViewer({
       try {
         // Compute zIndex from zValue and zRange
         const zIndex = Math.round(zValue * (zRange[1] - zRange[0]) + zRange[0]);
-        await imageLayer.setIndex(zIndex);
+        await (idetik.layerManager.layers[0] as ImageSeriesLayer)?.setIndex(
+          zIndex
+        );
       } catch (err) {
         console.debug("Z index load aborted", err);
       } finally {
@@ -268,14 +268,16 @@ export function useOmeZarrViewer({
     };
 
     updateIndex();
-  }, [zValue, zRange, imageLayer]);
+  }, [idetik, zValue, zRange]);
 
   const loadAllSlicesCallback = useCallback(async () => {
-    if (!imageLayer) return;
+    if (!idetik) return;
     onLoadAllSlicesClicked?.();
     setLoading(true);
     try {
-      await imageLayer.preloadSeries();
+      await (
+        idetik.layerManager.layers[0] as ImageSeriesLayer
+      )?.preloadSeries();
     } catch (err) {
       console.info("load all slices failed or was aborted", err);
       onLoadAllSlicesAborted?.();
@@ -286,15 +288,13 @@ export function useOmeZarrViewer({
     onAllSlicesLoaded?.();
     setAllSlicesLoaded(true);
   }, [
-    imageLayer,
+    idetik,
     onLoadAllSlicesClicked,
     onAllSlicesLoaded,
     onLoadAllSlicesAborted,
   ]);
 
   return {
-    layerManager,
-    camera,
     zRange,
     zValue,
     setZValue,

--- a/packages/react/src/components/hooks/useOmeZarrImageViewer.ts
+++ b/packages/react/src/components/hooks/useOmeZarrImageViewer.ts
@@ -111,6 +111,15 @@ export function useOmeZarrViewer({
           if (!shouldSetLayer || !layer) return;
           const camera = zoomToFit(layer);
           if (camera !== undefined) {
+            if (idetik === undefined) {
+              setIdetik(
+                new Idetik({
+                  canvasSelector: "#renderer",
+                  camera,
+                  layers: [layer],
+                })
+              );
+            }
             setLoading(false);
             onFirstSliceLoaded?.();
             layer.removeStateChangeCallback(onFirstLoad);
@@ -130,13 +139,6 @@ export function useOmeZarrViewer({
               }
             }
             if (shouldSetLayer) {
-              setIdetik(
-                new Idetik({
-                  canvasSelector: "#renderer",
-                  camera,
-                  layers: [layer],
-                })
-              );
               setChannelControls(
                 omeroToChannelControls(
                   omeroChannels,

--- a/packages/react/src/components/hooks/useOmeZarrImageViewer.ts
+++ b/packages/react/src/components/hooks/useOmeZarrImageViewer.ts
@@ -110,6 +110,7 @@ export function useOmeZarrViewer({
         const onFirstLoad = async () => {
           if (!shouldSetLayer || !layer) return;
           const camera = zoomToFit(layer);
+          // TODO: Make camera type not possible to be undefined.
           if (camera !== undefined) {
             if (idetik === undefined) {
               setIdetik(

--- a/packages/react/src/components/hooks/useOmeZarrImageViewer.ts
+++ b/packages/react/src/components/hooks/useOmeZarrImageViewer.ts
@@ -119,6 +119,9 @@ export function useOmeZarrViewer({
                   layers: [layer],
                 })
               );
+            } else {
+              idetik.layerManager.remove(0);
+              idetik.layerManager.add(layer);
             }
             setLoading(false);
             onFirstSliceLoaded?.();

--- a/packages/react/src/components/providers/IdetikProvider.tsx
+++ b/packages/react/src/components/providers/IdetikProvider.tsx
@@ -13,8 +13,9 @@ import {
   IdetikContextValue,
 } from "../hooks/useIdetik";
 
-// The return value of the getSnapshot argument to useSyncExternalStore() must be memoized to
-// prevent infinite rerenders.
+// When the layer is not initialized yet, we can't instantiate a new (unstable) [] every render b/c
+// it will cause useSyncExternalStore() to re-render, resulting in another [] instance, which will
+// cause React to re-render again, resulting in an infinite loop.
 const EMPTY_ARRAY: never[] = [];
 
 /** Global Idetik state provider that you must wrap your application in. */

--- a/packages/react/src/components/providers/IdetikProvider.tsx
+++ b/packages/react/src/components/providers/IdetikProvider.tsx
@@ -3,7 +3,6 @@
 import { Idetik, ImageSeriesLayer } from "@idetik/core";
 import {
   PropsWithChildren,
-  useCallback,
   useMemo,
   useState,
   useSyncExternalStore,
@@ -20,27 +19,19 @@ const EMPTY_ARRAY: never[] = [];
 
 /** Global Idetik state provider that you must wrap your application in. */
 export const IdetikProvider = ({ children }: PropsWithChildren) => {
-  const getImageSeriesLayer = (): ImageSeriesLayer | undefined =>
-    idetik?.layerManager.layers[0] as ImageSeriesLayer;
-
-  // GLOBAL STATE:
   const [idetik, setIdetik] = useState<Idetik | undefined>(undefined);
+  const imageSeriesLayer = idetik?.layerManager.layers[0] as
+    | ImageSeriesLayer
+    | undefined;
   const channels = useSyncExternalStore(
-    getImageSeriesLayer()?.addChannelChangeCallback ?? (() => () => {}),
-    () => getImageSeriesLayer()?.channelProps ?? EMPTY_ARRAY,
+    imageSeriesLayer?.addChannelChangeCallback ?? (() => () => {}),
+    () => imageSeriesLayer?.channelProps ?? EMPTY_ARRAY,
     () => EMPTY_ARRAY // Doesn't render anything on SSR
   );
   const [channelControls, setChannelControls] = useState<Array<ChannelControl>>(
     []
   );
 
-  // MEMOIZED CALLBACKS:
-  const clear = useCallback(() => {
-    getImageSeriesLayer()?.close();
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- idetik is the only real dependency.
-  }, [idetik]);
-
-  // CONTEXT VALUE:
   const contextValue = useMemo<IdetikContextValue>(
     () =>
       idetik !== undefined
@@ -50,7 +41,6 @@ export const IdetikProvider = ({ children }: PropsWithChildren) => {
             channels,
             channelControls,
             setIdetik,
-            clear,
             setChannelControls,
           }
         : {
@@ -58,10 +48,9 @@ export const IdetikProvider = ({ children }: PropsWithChildren) => {
             channels,
             channelControls,
             setIdetik,
-            clear,
             setChannelControls,
           },
-    [channels, idetik, channelControls, clear]
+    [channels, idetik, channelControls]
   );
 
   return (

--- a/packages/react/src/components/providers/IdetikProvider.tsx
+++ b/packages/react/src/components/providers/IdetikProvider.tsx
@@ -37,7 +37,6 @@ export const IdetikProvider = ({ children }: PropsWithChildren) => {
   // MEMOIZED CALLBACKS:
   const clear = useCallback(() => {
     getImageSeriesLayer()?.close();
-    setIdetik(undefined);
     // eslint-disable-next-line react-hooks/exhaustive-deps -- idetik is the only real dependency.
   }, [idetik]);
 

--- a/packages/react/src/components/providers/IdetikProvider.tsx
+++ b/packages/react/src/components/providers/IdetikProvider.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ImageSeriesLayer } from "@idetik/core";
+import { Idetik, ImageSeriesLayer } from "@idetik/core";
 import {
   PropsWithChildren,
   useCallback,
@@ -14,54 +14,55 @@ import {
   IdetikContextValue,
 } from "../hooks/useIdetik";
 
-// The return value of the getSnapshot() argument to useSyncExternalStore() must be memoized to
+// The return value of the getSnapshot argument to useSyncExternalStore() must be memoized to
 // prevent infinite rerenders.
 const EMPTY_ARRAY: never[] = [];
 
 /** Global Idetik state provider that you must wrap your application in. */
 export const IdetikProvider = ({ children }: PropsWithChildren) => {
-  // Global state:
-  const [imageSeriesLayer, setImageSeriesLayer] = useState<
-    ImageSeriesLayer | undefined
-  >(undefined);
+  const getImageSeriesLayer = (): ImageSeriesLayer | undefined =>
+    idetik?.layerManager.layers[0] as ImageSeriesLayer;
+
+  // GLOBAL STATE:
+  const [idetik, setIdetik] = useState<Idetik | undefined>(undefined);
   const channels = useSyncExternalStore(
-    imageSeriesLayer?.addChannelChangeCallback ?? (() => () => {}),
-    () => imageSeriesLayer?.channelProps ?? EMPTY_ARRAY,
+    getImageSeriesLayer()?.addChannelChangeCallback ?? (() => () => {}),
+    () => getImageSeriesLayer()?.channelProps ?? EMPTY_ARRAY,
     () => EMPTY_ARRAY // Doesn't render anything on SSR
   );
   const [channelControls, setChannelControls] = useState<Array<ChannelControl>>(
     []
   );
 
-  // Memoized callbacks:
-  const clearImageSeriesLayer = useCallback(() => {
-    imageSeriesLayer?.close();
-    setImageSeriesLayer(undefined);
-  }, [imageSeriesLayer, setImageSeriesLayer]);
+  // MEMOIZED CALLBACKS:
+  const clear = useCallback(() => {
+    getImageSeriesLayer()?.close();
+    setIdetik(undefined);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- idetik is the only real dependency.
+  }, [idetik]);
 
-  // Context value:
+  // CONTEXT VALUE:
   const contextValue = useMemo<IdetikContextValue>(
     () =>
-      imageSeriesLayer !== undefined
+      idetik !== undefined
         ? {
             isInitialized: true,
-            imageSeriesLayer,
+            idetik,
             channels,
             channelControls,
-            setImageSeriesLayer,
-            clearImageSeriesLayer,
+            setIdetik,
+            clear,
             setChannelControls,
           }
         : {
             isInitialized: false,
-            imageSeriesLayer: undefined,
             channels,
             channelControls,
+            setIdetik,
+            clear,
             setChannelControls,
-            clearImageSeriesLayer,
-            setImageSeriesLayer,
           },
-    [channels, imageSeriesLayer, channelControls, clearImageSeriesLayer]
+    [channels, idetik, channelControls, clear]
   );
 
   return (

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
@@ -47,8 +47,6 @@ export function OmeZarrImageViewer(props: OmeZarrViewerContainerProps) {
   } = props;
 
   const {
-    layerManager,
-    camera,
     zRange,
     zValue,
     setZValue,
@@ -73,11 +71,7 @@ export function OmeZarrImageViewer(props: OmeZarrViewerContainerProps) {
   const zIndex = Math.round(zValue * (zRange[1] - zRange[0]) + zRange[0]);
   return (
     <div className={cns("w-full", "h-full", "relative", classNames?.root)}>
-      <Renderer
-        layerManager={layerManager}
-        camera={camera}
-        cameraControls="panzoom"
-      />
+      <Renderer cameraControls="panzoom" />
       <div
         className={cns(
           "absolute",

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/components/ChannelControlsList/ChannelControlsList.tsx
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/components/ChannelControlsList/ChannelControlsList.tsx
@@ -6,7 +6,7 @@ import {
 } from "@czi-sds/components";
 import cns from "classnames";
 import { ChannelControl } from "./components/ChannelControl";
-import { ChannelProps, ColorLike } from "@idetik/core";
+import { ChannelProps, ColorLike, ImageSeriesLayer } from "@idetik/core";
 import { useIdetik } from "../../../../hooks";
 
 export interface ChannelControlsListProps {
@@ -16,8 +16,7 @@ export interface ChannelControlsListProps {
 }
 
 export function ChannelControlsList({ classNames }: ChannelControlsListProps) {
-  const { isInitialized, imageSeriesLayer, channels, channelControls } =
-    useIdetik();
+  const { idetik, isInitialized, channels, channelControls } = useIdetik();
 
   const updateChannel = (
     index: number,
@@ -35,7 +34,9 @@ export function ChannelControlsList({ classNames }: ChannelControlsListProps) {
       ...channels[index],
       ...updates,
     };
-    imageSeriesLayer.setChannelProps(updatedChannels);
+    (idetik.layerManager.layers[0] as ImageSeriesLayer)?.setChannelProps(
+      updatedChannels
+    );
   };
 
   if (!isInitialized) {
@@ -130,7 +131,9 @@ export function ChannelControlsList({ classNames }: ChannelControlsListProps) {
               // Force dark mode styles on hover
               className="text-white hover:!text-white hover:!bg-dark-sds-color-semantic-base-fill-hover"
               onClick={() => {
-                imageSeriesLayer.resetChannelProps();
+                (
+                  idetik.layerManager.layers[0] as ImageSeriesLayer
+                ).resetChannelProps();
               }}
             >
               Reset channels

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/components/Renderer/Renderer.tsx
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/components/Renderer/Renderer.tsx
@@ -1,40 +1,39 @@
 import { useEffect, useRef } from "react";
 import {
-  LayerManager,
-  OrthographicCamera,
   CameraControls,
   PanZoomControls,
   NullControls,
   WebGLRenderer,
 } from "@idetik/core";
+import { useIdetik } from "components/hooks";
 
 type ControlType = "panzoom" | "none";
 
 interface RendererProps {
-  layerManager: LayerManager;
-  camera: OrthographicCamera | null;
   cameraControls?: ControlType;
   canvasId?: string;
 }
 
 export function Renderer({
-  layerManager,
-  camera,
   cameraControls = "panzoom",
   canvasId = "renderer",
 }: RendererProps) {
   const renderer = useRef<WebGLRenderer | null>(null);
   const controls = useRef<CameraControls>(new NullControls());
+  const { idetik } = useIdetik();
 
   useEffect(() => {
     console.debug("Renderer::setControls");
-    if (camera && cameraControls === "panzoom") {
-      controls.current = new PanZoomControls(camera, camera.position);
+    if (idetik?.camera && cameraControls === "panzoom") {
+      controls.current = new PanZoomControls(
+        idetik.camera,
+        idetik.camera.position
+      );
     } else {
       controls.current = new NullControls();
     }
     renderer.current?.setControls(controls.current);
-  }, [camera, cameraControls]);
+  }, [idetik, cameraControls]);
 
   // Use the mount-effect so that the renderer can find the corresponding
   // element by its ID.
@@ -47,10 +46,10 @@ export function Renderer({
       renderer.current.setControls(controls.current);
     }
     function animate() {
-      if (!camera) {
+      if (!idetik?.camera) {
         return;
       }
-      renderer.current?.render(layerManager, camera);
+      renderer.current?.render(idetik.layerManager, idetik.camera);
       lastRequestId = requestAnimationFrame(animate);
     }
     animate();
@@ -60,7 +59,7 @@ export function Renderer({
         cancelAnimationFrame(lastRequestId);
       }
     };
-  }, [canvasId, camera, layerManager]);
+  }, [idetik, canvasId]);
 
   return <canvas id={canvasId} style={{ width: "100%", height: "100%" }} />;
 }


### PR DESCRIPTION
 - Fixes some styling on the demo page.
 - Completes refactoring of all redundant state into the global context.
 - Makes `<Renderer>` directly depend on the global context.
 - I'm not very happy with the typecasts required to deal with the `Layer[]`, but how we want to address that is a separate issue.