### PR TITLE
Add chunk streaming example sandbox

### DIFF
--- a/packages/core/examples/chunk_streaming/index.html
+++ b/packages/core/examples/chunk_streaming/index.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Web Viewer</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        display: flex;
+        width: 100%;
+        height: 100%;
+      }
+      canvas {
+        width: 100%;
+        height: 100%;
+      }
+    </style>
+  </head>
+  <body>
+    <canvas id="canvas"></canvas>
+    <script type="module" src="./main.ts"></script>
+  </body>
+</html>

--- a/packages/core/examples/chunk_streaming/main.ts
+++ b/packages/core/examples/chunk_streaming/main.ts
@@ -1,0 +1,36 @@
+import {
+  Idetik,
+  ImageLayerXYZ,
+  OmeZarrImageSource,
+  OrthographicCamera,
+  Region,
+} from "@";
+import { PanZoomControls } from "@/objects/cameras/controls";
+
+const url =
+  "https://public.czbiohub.org/royerlab/zebrahub/imaging/single-objective/ZSNS001.ome.zarr/";
+const left = 150;
+const right = 950;
+const top = 100;
+const bottom = 900;
+
+// Source is 5D, so provide indices at 3 dimensions to project to 2D.
+// Also specify a subregion in x and y to exercise that part of the API.
+const source = new OmeZarrImageSource(url);
+const region: Region = [
+  { dimension: "t", index: { type: "point", value: 400 } },
+  { dimension: "c", index: { type: "point", value: 0 } },
+  { dimension: "z", index: { type: "point", value: 300 } },
+  { dimension: "y", index: { type: "interval", start: top, stop: bottom } },
+  { dimension: "x", index: { type: "interval", start: left, stop: right } },
+];
+const channelProps = [{ contrastLimits: [0, 255] as [number, number] }];
+const layer = new ImageLayerXYZ({ source, region, channelProps });
+const camera = new OrthographicCamera(left, right, top, bottom);
+
+new Idetik({
+  canvasSelector: "canvas",
+  camera,
+  controls: new PanZoomControls(camera, camera.position),
+  layers: [layer],
+}).start();

--- a/packages/core/examples/index.html
+++ b/packages/core/examples/index.html
@@ -49,6 +49,9 @@
           >2D Image from 5D OMEZarr with uint16 data</a
         >
       </li>
+      <li>
+        <a href="/chunk_streaming/index.html">Chunk Streaming</a>
+      </li>
       <li><a href="/projected_lines/index.html">Projected Lines</a></li>
       <li><a href="/tracks/index.html">Tracks on Image</a></li>
       <li><a href="/layer_blending/index.html">Layer Blending</a></li>

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,6 +14,7 @@ export { AxesLayer } from "./layers/axes_layer";
 export { ProjectedLineLayer } from "./layers/projected_line_layer";
 export { TracksLayer } from "./layers/tracks_layer";
 export { ImageLayer } from "./layers/image_layer";
+export { ImageLayerXYZ } from "./layers/image_layer_xyz";
 export { ImageSeriesLayer } from "./layers/image_series_layer";
 export { OmeZarrImageSource } from "./data/ome_zarr_image_source";
 

--- a/packages/core/src/layers/image_layer_xyz.ts
+++ b/packages/core/src/layers/image_layer_xyz.ts
@@ -1,4 +1,5 @@
 import { Layer, LayerOptions } from "../core/layer";
+import { IdetikContext } from "../idetik";
 import { Region } from "../data/region";
 import { ImageChunk, ImageChunkSource } from "../data/image_chunk";
 import { ChannelProps } from "../objects/textures/channel";
@@ -12,11 +13,8 @@ export type ImageLayerProps = LayerOptions & {
   channelProps?: ChannelProps[];
 };
 
-// Loads data from an image source into renderable objects.
-export class ImageLayer extends Layer {
+export class ImageLayerXYZ extends Layer {
   private readonly source_: ImageChunkSource;
-  // TODO: remove this when region is passed through to update.
-  // https://github.com/chanzuckerberg/idetik/issues/33
   private readonly region_: Region;
   private channelProps_?: ChannelProps[];
   private image_?: ImageRenderable;
@@ -35,6 +33,10 @@ export class ImageLayer extends Layer {
     this.channelProps_ = channelProps;
   }
 
+  public onAttached(_context: IdetikContext): void {
+    // TODO: context.chunkManager.addSource(this.source_)
+  }
+
   public update() {
     switch (this.state) {
       case "initialized":
@@ -51,7 +53,6 @@ export class ImageLayer extends Layer {
   }
 
   public get channelProps(): ChannelProps[] | undefined {
-    // TODO: should this return Channel[] instead of ChannelProps[]?
     return this.channelProps_;
   }
 
@@ -78,8 +79,6 @@ export class ImageLayer extends Layer {
     this.setState("ready");
   }
 
-  // TODO: we probably want something like this, but it should be unified across layers
-  // see TracksLayer for another example
   public get extent(): { x: number; y: number } | undefined {
     return this.extent_;
   }


### PR DESCRIPTION
### Summary

This PR introduces a new example demonstrating image loading via chunk
streaming. It also includes a sandboxed copy of `ImageLayer`, which we’ll
use to prototype chunk streaming support—such as integrating with the chunk
manager and generating per-tile image renderables. This isolated setup allows
us to iterate on chunk streaming features safely without impacting existing
examples or functionality.

### Tests & Checks
- All tests are passing
