### PR TITLE
Remove "scale index" from OmeZarrImageLoader

### DIFF
--- a/packages/core/examples/image2d_from_omezarr4d_hcs/main.ts
+++ b/packages/core/examples/image2d_from_omezarr4d_hcs/main.ts
@@ -56,7 +56,7 @@ const onImageChange = async () => {
   app.layerManager.removeAll();
   const imageUrl =
     plateUrl + "/" + wellSelector.value + "/" + imageSelector.value;
-  const source = new OmeZarrImageSource(imageUrl, 0);
+  const source = new OmeZarrImageSource(imageUrl);
   const omeroDefaultZ = await loadOmeroDefaultZ(imageUrl);
   region[2] = {
     dimension: "Z",
@@ -77,6 +77,7 @@ const onImageChange = async () => {
       { color: [0, 1, 1], contrastLimits: contrastLimits[0] },
       { color: [1, 0, 1], contrastLimits: contrastLimits[1] },
     ],
+    lod: 0,
   });
   app.layerManager.add(layer);
   layer.addStateChangeCallback((state) => {

--- a/packages/core/examples/image_stack_from_omezarr3d_f32/main.ts
+++ b/packages/core/examples/image_stack_from_omezarr3d_f32/main.ts
@@ -17,12 +17,15 @@ const url =
 const source = new OmeZarrImageSource(url);
 const loader = await source.open();
 const attributes = await loader.loadAttributes();
+const lods = attributes.length;
+const attributesForLastLod = attributes[lods - 1];
+
 const zDimName = "z";
-const zAxisIndex = attributes.dimensionNames.findIndex(
+const zAxisIndex = attributesForLastLod.dimensionNames.findIndex(
   (dim) => dim === zDimName
 );
 const zMin = 0;
-const zMax = attributes.shape[zAxisIndex];
+const zMax = attributesForLastLod.shape[zAxisIndex];
 const region: Region = [
   { dimension: zDimName, index: { type: "full" } },
   { dimension: "x", index: { type: "full" } },

--- a/packages/core/examples/points/main.ts
+++ b/packages/core/examples/points/main.ts
@@ -189,12 +189,14 @@ virusLike.setDepth(INITIAL_Z_POSITION);
 const imageSource = new OmeZarrImageSource(imageUrl);
 const loader = await imageSource.open();
 const attributes = await loader.loadAttributes();
+const attributesForLastLod = attributes[attributes.length - 1];
+
 const zDimName = "z";
-const zAxisIndex = attributes.dimensionNames.findIndex(
+const zAxisIndex = attributesForLastLod.dimensionNames.findIndex(
   (dim) => dim === zDimName
 );
 const zMin = 0;
-const zMax = attributes.shape[zAxisIndex];
+const zMax = attributesForLastLod.shape[zAxisIndex];
 const zSlider = document.querySelector<HTMLInputElement>("#z-slider")!;
 zSlider.min = `${zMin}`;
 zSlider.max = `${zMax - 1}`;

--- a/packages/core/src/core/layer.ts
+++ b/packages/core/src/core/layer.ts
@@ -14,6 +14,10 @@ export interface LayerOptions {
   transparent?: boolean;
   opacity?: number;
   blendMode?: blendMode;
+
+  // TODO:(shlomnissan) Remove this parameter—LOD will be computed
+  // dynamically by the chunk manager.
+  lod?: number;
 }
 
 export abstract class Layer {

--- a/packages/core/src/data/image_chunk.ts
+++ b/packages/core/src/data/image_chunk.ts
@@ -53,6 +53,11 @@ export type LoaderAttributes = {
 };
 
 export type ImageChunkLoader = {
-  loadChunk(input: Region, scheduler?: PromiseScheduler): Promise<ImageChunk>;
-  loadAttributes(): Promise<LoaderAttributes>;
+  loadChunk(
+    input: Region,
+    lod: number,
+    scheduler?: PromiseScheduler
+  ): Promise<ImageChunk>;
+
+  loadAttributes(): Promise<LoaderAttributes[]>;
 };

--- a/packages/core/src/data/ome_zarr_image_loader.ts
+++ b/packages/core/src/data/ome_zarr_image_loader.ts
@@ -13,11 +13,19 @@ import { PromiseScheduler } from "./promise_scheduler";
 import { Image as OmeNgffImage } from "../data/ome_ngff/0.4/image";
 import { parseOmeNgffImage } from "../data/ome_zarr_hcs_metadata_loader";
 
+type ImageAttributes = {
+  image: OmeNgffImage["multiscales"][number];
+  dimensionNames: string[];
+  datasetPath: string;
+  scale: number[];
+  translation: number[];
+};
+
 // Implements the interface required for getting array chunks in zarrita:
 // https://github.com/manzt/zarrita.js/blob/c15c1a14e42a83516972368ac962ebdf56a6dcdb/packages/indexing/src/types.ts#L52
 export class PromiseQueue<T> {
-  private promises_: Array<() => Promise<T>> = [];
-  private scheduler_: PromiseScheduler;
+  private readonly promises_: Array<() => Promise<T>> = [];
+  private readonly scheduler_: PromiseScheduler;
 
   constructor(scheduler: PromiseScheduler) {
     this.scheduler_ = scheduler;
@@ -35,11 +43,11 @@ export class PromiseQueue<T> {
 // Loads chunks from a multiscale zarr image implementing OME-NGFF v0.4:
 // https://ngff.openmicroscopy.org/0.4/#image-layout
 export class OmeZarrImageLoader {
-  root_: zarr.Group<zarr.FetchStore>;
-  scaleIndex_: number;
-  metadata_: OmeNgffImage;
+  private readonly root_: zarr.Group<zarr.FetchStore>;
+  private readonly metadata_: OmeNgffImage;
+  private readonly lods_: number;
 
-  constructor(root: zarr.Group<zarr.FetchStore>, scaleIndex?: number) {
+  constructor(root: zarr.Group<zarr.FetchStore>) {
     this.root_ = root;
     this.metadata_ = parseOmeNgffImage(this.root_);
     if (this.metadata_.multiscales.length !== 1) {
@@ -48,28 +56,23 @@ export class OmeZarrImageLoader {
       );
     }
 
-    const numScales = this.metadata_.multiscales[0].datasets.length;
-    if (scaleIndex === undefined) {
-      // TODO: when undefined use the input to determine what level to load.
-      // That is, dynamically select the scale based on the size of the chunk
-      // to be loaded and how big it will be on screen.
-      // https://github.com/chanzuckerberg/idetik/issues/37
-      // default to the lowest resolution
-      this.scaleIndex_ = numScales - 1;
-    } else if (scaleIndex < 0) {
-      // allow reverse indexing with negative numbers
-      this.scaleIndex_ = Math.max(0, numScales + scaleIndex);
-    } else {
-      this.scaleIndex_ = Math.min(numScales - 1, scaleIndex);
-    }
+    this.lods_ = this.metadata_.multiscales[0].datasets.length;
   }
 
   async loadChunk(
     region: Region,
+    lod: number,
     scheduler?: PromiseScheduler
   ): Promise<ImageChunk> {
-    const { datasetPath, scale, translation } = this.getImageAttributes();
-    const indices = this.regionToIndices(region);
+    if (lod >= this.lods_) {
+      throw new Error(
+        `Invalid LOD index: ${lod}. Only ${this.lods_} lod(s) available`
+      );
+    }
+
+    const attributes = this.getImageAttributes()[lod];
+    const indices = this.regionToIndices(region, attributes);
+    const { datasetPath, scale, translation } = attributes;
 
     const array = await zarr.open.v2(this.root_.resolve(datasetPath), {
       kind: "array",
@@ -126,50 +129,51 @@ export class OmeZarrImageLoader {
     return chunk;
   }
 
-  private getImageAttributes(scaleIndex?: number): {
-    image: OmeNgffImage["multiscales"][number];
-    dimensionNames: string[];
-    datasetPath: string;
-    scale: number[];
-    translation: number[];
-  } {
-    const image = this.metadata_.multiscales[0];
-    const axes = image.axes;
-    const dimensionNames = image.axes.map((axis) => axis.name);
-    const dataset = image.datasets[scaleIndex ?? this.scaleIndex_];
-    const datasetPath = dataset.path;
-    const scale = dataset.coordinateTransformations[0].scale;
-    const translation =
-      dataset.coordinateTransformations.length === 2
-        ? dataset.coordinateTransformations[1].translation
-        : new Array(axes.length).fill(0);
-    return {
-      image,
-      dimensionNames,
-      datasetPath,
-      scale,
-      translation,
-    };
+  private getImageAttributes(): ImageAttributes[] {
+    const output: ImageAttributes[] = [];
+
+    for (let i = 0; i < this.lods_; ++i) {
+      const image = this.metadata_.multiscales[0];
+      const axes = image.axes;
+      const dimensionNames = image.axes.map((axis) => axis.name);
+      const dataset = image.datasets[i];
+      const datasetPath = dataset.path;
+      const scale = dataset.coordinateTransformations[0].scale;
+      const translation =
+        dataset.coordinateTransformations.length === 2
+          ? dataset.coordinateTransformations[1].translation
+          : new Array(axes.length).fill(0);
+
+      output.push({ image, dimensionNames, datasetPath, scale, translation });
+    }
+
+    return output;
   }
 
-  public async loadAttributes(): Promise<LoaderAttributes> {
-    const { dimensionNames, datasetPath, scale } = this.getImageAttributes();
-
-    const array = await zarr.open.v2(this.root_.resolve(datasetPath), {
-      kind: "array",
-      attrs: false,
-    });
-    const shape = array.shape;
-
-    return {
-      dimensionNames,
-      shape,
-      scale,
-    };
+  public async loadAttributes(): Promise<LoaderAttributes[]> {
+    return await Promise.all(
+      this.getImageAttributes().map(async (attr) => {
+        const zarrArray = await zarr.open.v2(
+          this.root_.resolve(attr.datasetPath),
+          {
+            kind: "array",
+            attrs: false,
+          }
+        );
+        return {
+          dimensionNames: attr.dimensionNames,
+          shape: zarrArray.shape,
+          scale: attr.scale,
+        };
+      })
+    );
   }
 
-  regionToIndices(region: Region): Array<Slice | number> {
-    const { dimensionNames, scale, translation } = this.getImageAttributes();
+  private regionToIndices(
+    region: Region,
+    attributes: ImageAttributes
+  ): Array<Slice | number> {
+    const { dimensionNames, scale, translation } = attributes;
 
     const indices: Array<Slice | number> = [];
     for (const [i, dimName] of dimensionNames.entries()) {

--- a/packages/core/src/data/ome_zarr_image_source.ts
+++ b/packages/core/src/data/ome_zarr_image_source.ts
@@ -3,17 +3,15 @@ import { OmeZarrImageLoader } from "../data/ome_zarr_image_loader";
 
 // Opens an OME-Zarr multiscale image from the URL of its Zarr group.
 export class OmeZarrImageSource {
-  private url_: string;
-  private scaleIndex_?: number;
+  private readonly url_: string;
 
-  constructor(url: string, scaleIndex?: number) {
+  constructor(url: string) {
     this.url_ = url;
-    this.scaleIndex_ = scaleIndex;
   }
 
   async open(): Promise<OmeZarrImageLoader> {
     const store = new zarr.FetchStore(this.url_);
     const root = await zarr.open.v2(store, { kind: "group" });
-    return new OmeZarrImageLoader(root, this.scaleIndex_);
+    return new OmeZarrImageLoader(root);
   }
 }

--- a/packages/core/src/layers/image_layer.ts
+++ b/packages/core/src/layers/image_layer.ts
@@ -22,16 +22,22 @@ export class ImageLayer extends Layer {
   private image_?: ImageRenderable;
   private extent_?: { x: number; y: number };
 
+  // TODO:(shlomnissan) Remove this parameter—LOD will be computed
+  // dynamically by the chunk manager.
+  private readonly lod_?: number;
+
   constructor({
     source,
     region,
     channelProps,
+    lod,
     ...layerOptions
   }: ImageLayerProps) {
     super(layerOptions);
     this.setState("initialized");
     this.source_ = source;
     this.region_ = region;
+    this.lod_ = lod;
     this.channelProps_ = channelProps;
   }
 
@@ -66,7 +72,10 @@ export class ImageLayer extends Layer {
     }
     this.setState("loading");
     const loader = await this.source_.open();
-    const chunk = await loader.loadChunk(region);
+    const attributes = await loader.loadAttributes();
+    const lod = this.lod_ ?? attributes.length - 1;
+
+    const chunk = await loader.loadChunk(region, lod);
     this.extent_ = {
       x: chunk.shape.x * chunk.scale.x,
       y: chunk.shape.y * chunk.scale.y,

--- a/packages/core/src/layers/image_layer_xyz.ts
+++ b/packages/core/src/layers/image_layer_xyz.ts
@@ -20,16 +20,22 @@ export class ImageLayerXYZ extends Layer {
   private image_?: ImageRenderable;
   private extent_?: { x: number; y: number };
 
+  // TODO:(shlomnissan) Remove this parameter—LOD will be computed
+  // dynamically by the chunk manager.
+  private readonly lod_?: number;
+
   constructor({
     source,
     region,
     channelProps,
+    lod,
     ...layerOptions
   }: ImageLayerProps) {
     super(layerOptions);
     this.setState("initialized");
     this.source_ = source;
     this.region_ = region;
+    this.lod_ = lod;
     this.channelProps_ = channelProps;
   }
 
@@ -67,7 +73,10 @@ export class ImageLayerXYZ extends Layer {
     }
     this.setState("loading");
     const loader = await this.source_.open();
-    const chunk = await loader.loadChunk(region);
+    const attributes = await loader.loadAttributes();
+    const lod = this.lod_ ?? attributes.length - 1;
+
+    const chunk = await loader.loadChunk(region, lod);
     this.extent_ = {
       x: chunk.shape.x * chunk.scale.x,
       y: chunk.shape.y * chunk.scale.y,

--- a/packages/core/src/layers/image_series_layer.ts
+++ b/packages/core/src/layers/image_series_layer.ts
@@ -43,27 +43,33 @@ export class ImageSeriesLayer extends Layer {
   private readonly seriesIndex_: Interval | Full;
   private readonly scheduler_: PromiseScheduler = new PromiseScheduler(16);
   private readonly initialChannelProps_?: ChannelProps[];
+  private readonly channelChangeCallbacks_: Array<() => void> = [];
   private loader_: ImageChunkLoader | null = null;
   private seriesAttributes_?: SeriesAttributes;
   private loadingToken_: LoadingToken | null = null;
   private texture_: Texture2DArray | null = null;
   private dataChunks_: ImageChunk[] = [];
   private channelProps_?: ChannelProps[];
-  private channelChangeCallbacks_: Array<() => void> = [];
   private image_?: ImageRenderable;
   private extent_?: { x: number; y: number };
+
+  // TODO:(shlomnissan) Remove this parameter—LOD will be computed
+  // dynamically by the chunk manager.
+  private readonly lod_?: number;
 
   constructor({
     source,
     region,
     seriesDimensionName,
     channelProps,
+    lod,
     ...layerOptions
   }: ImageSeriesLayerProps) {
     super(layerOptions);
     this.setState("initialized");
     this.source_ = source;
     this.region_ = region;
+    this.lod_ = lod;
     this.seriesDimensionName_ = seriesDimensionName;
     const seriesDimensionalIndex = region.find(
       (x) => x.dimension == seriesDimensionName
@@ -179,18 +185,21 @@ export class ImageSeriesLayer extends Layer {
       return this.seriesAttributes_;
     }
     const loader = await this.getLoader();
-
     const attributes = await loader.loadAttributes();
-    const seriesIndex = attributes.dimensionNames.findIndex(
+    const numScales = attributes.length;
+    const attributesForLastScale = attributes[numScales - 1];
+
+    const seriesIndex = attributesForLastScale.dimensionNames.findIndex(
       (dim) => dim === this.seriesDimensionName_
     );
     if (seriesIndex === -1) {
       throw new Error(
-        `Series dimension "${this.seriesDimensionName_}" not found in loader dimensions: ${attributes.dimensionNames}`
+        `Series dimension "${this.seriesDimensionName_}" not found in loader dimensions: ${attributesForLastScale.dimensionNames}`
       );
     }
-    const seriesDimScale = attributes.scale[seriesIndex];
-    const seriesMax = attributes.shape[seriesIndex] * seriesDimScale;
+    const seriesDimScale = attributesForLastScale.scale[seriesIndex];
+    const seriesMax =
+      attributesForLastScale.shape[seriesIndex] * seriesDimScale;
 
     const indexIsFull = this.seriesIndex_.type === "full";
     const seriesStart = indexIsFull ? 0 : this.seriesIndex_.start;
@@ -217,7 +226,6 @@ export class ImageSeriesLayer extends Layer {
         `Requested index ${index} is out of bounds [0, ${seriesAttributes.length - 1}]`
       );
     }
-    const loader = await this.getLoader();
 
     // replace the series region with a point region for the requested index
     const position = seriesAttributes.start + index * seriesAttributes.scale;
@@ -229,8 +237,11 @@ export class ImageSeriesLayer extends Layer {
       index: { type: "point", value: position },
     });
 
-    const chunk = await loader.loadChunk(pointRegion, this.scheduler_);
+    const loader = await this.getLoader();
+    const attributes = await loader.loadAttributes();
+    const lod = this.lod_ ?? attributes.length - 1;
 
+    const chunk = await loader.loadChunk(pointRegion, lod, this.scheduler_);
     this.dataChunks_[index] = chunk;
 
     if (token && !token.canceled) {

--- a/packages/react/src/components/hooks/useOmeZarrImageViewer.ts
+++ b/packages/react/src/components/hooks/useOmeZarrImageViewer.ts
@@ -27,7 +27,7 @@ interface UseOmeZarrViewerProps {
   onAllSlicesLoaded?: () => void;
   onLoadAllSlicesAborted?: () => void;
   fallbackContrastLimits?: [number, number];
-  resolutionLevel?: number;
+  lod?: number;
   shouldAutoLoadAllSlices?: boolean;
   shouldLoadMiddleZ?: boolean;
 }
@@ -42,7 +42,7 @@ export function useOmeZarrViewer({
   onAllSlicesLoaded,
   onLoadAllSlicesAborted,
   fallbackContrastLimits,
-  resolutionLevel = 0,
+  lod = 0,
   shouldAutoLoadAllSlices = false,
   shouldLoadMiddleZ = false,
 }: UseOmeZarrViewerProps) {
@@ -54,10 +54,10 @@ export function useOmeZarrViewer({
   const { idetik, setIdetik, setChannelControls } = useIdetik();
 
   useEffect(() => {
-    const newSource = new OmeZarrImageSource(sourceUrl, resolutionLevel);
+    const newSource = new OmeZarrImageSource(sourceUrl);
     setSource(newSource);
     setAllSlicesLoaded(false);
-  }, [sourceUrl, resolutionLevel]);
+  }, [sourceUrl, lod]);
 
   const zoomToFit = useCallback(
     (layer: ImageSeriesLayer): OrthographicCamera | void => {
@@ -100,6 +100,7 @@ export function useOmeZarrViewer({
           region,
           seriesDimensionName,
           channelProps,
+          lod,
         });
         layer.setIndex(
           Math.round(zValue * (zRange[1] - zRange[0]) + zRange[0])
@@ -175,14 +176,15 @@ export function useOmeZarrViewer({
         return;
       }
       const loader = await source.open();
-      const attrs = await loader.loadAttributes();
+      const attributes = await loader.loadAttributes();
+      const attributesForLOD = attributes[lod];
 
-      const zIdx = attrs.dimensionNames.findIndex(
+      const zIdx = attributesForLOD.dimensionNames.findIndex(
         (d: string) => d.toUpperCase() === seriesDimensionName.toUpperCase()
       );
 
       const min = 0;
-      const max = attrs.shape[zIdx] - 1;
+      const max = attributesForLOD.shape[zIdx] - 1;
 
       if (max - min <= 0) {
         setZRange([0, 0]);
@@ -199,7 +201,7 @@ export function useOmeZarrViewer({
 
       if (isFullZ) {
         if (shouldLoadMiddleZ) {
-          const zShape = attrs.shape[zIdx];
+          const zShape = attributesForLOD.shape[zIdx];
           initialZ = Math.floor(zShape / 2);
         } else {
           initialZ = await loadOmeroDefaultZ(sourceUrl);

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
@@ -63,7 +63,7 @@ export function OmeZarrImageViewer(props: OmeZarrViewerContainerProps) {
     onLoadAllSlicesClicked,
     onAllSlicesLoaded,
     onLoadAllSlicesAborted,
-    resolutionLevel,
+    lod: resolutionLevel,
     shouldAutoLoadAllSlices,
     shouldLoadMiddleZ,
   });


### PR DESCRIPTION
### Summary

This PR updates the image loader implementation by removing the internal
`scaleIndex` member, enabling support for loading chunks across multiple LODs
independently. This is change is needed for the upcoming chunk streaming
functionality, where the chunk manager may request chunks from multiple LODs
within the same store. Additionally, the term "scale" has been renamed to "lod"
where applicable, to reduce ambiguity with image scale factors.

**The driving change here is passing a required LOD index to** `ImageChunkLoader::loadChunk`.

**Note**: I added an lod parameter to individual layers as a temporary solution for selecting the level of detail. This will be removed once chunk streaming is fully implemented. At that point, we may introduce an lod clamping parameter at the top level, likely within OmeZarrImageSource, to centralize LOD selection logic.

### Tests & Checks
- Tests are passing.
- Verified by ensuring that all are working.
