### PR TITLE
feat: implement LOD selection and scale-aware image loading

### DIFF
--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -89,7 +89,7 @@ export class ChunkManagerSource {
   ): number {
     // Get the actual visible bounds to determine virtual width
     const viewExtent = this.calculateVisibleBounds(camera);
-    const virtualWidth = viewExtent.worldWidth;
+    const virtualWidth = viewExtent.virtualWidth;
     const virtualUnitsPerScreenPixel = virtualWidth / bufferWidth;
 
     const numLods = availableScales.length;
@@ -104,8 +104,8 @@ export class ChunkManagerSource {
 
   // Calculate the visible bounds in virtual space.
   private calculateVisibleBounds(camera: Camera): {
-    worldWidth: number;
-    worldHeight: number;
+    virtualWidth: number;
+    virtualHeight: number;
   } {
     // Screen space corners (normalized device coordinates: -1 to +1)
     const topLeftNDC = vec4.fromValues(-1, 1, 0, 1);
@@ -119,7 +119,7 @@ export class ChunkManagerSource {
     );
     const invViewProjection = mat4.invert(mat4.create(), viewProjection);
 
-    // Transform to world space
+    // Transform to virtual space
     const topLeftWorld = vec4.transformMat4(
       vec4.create(),
       topLeftNDC,
@@ -131,10 +131,10 @@ export class ChunkManagerSource {
       invViewProjection
     );
 
-    const worldWidth = Math.abs(bottomRightWorld[0] - topLeftWorld[0]);
-    const worldHeight = Math.abs(topLeftWorld[1] - bottomRightWorld[1]);
+    const virtualWidth = Math.abs(bottomRightWorld[0] - topLeftWorld[0]);
+    const virtualHeight = Math.abs(topLeftWorld[1] - bottomRightWorld[1]);
 
-    return { worldWidth, worldHeight };
+    return { virtualWidth, virtualHeight };
   }
 }
 

--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -79,61 +79,20 @@ export class ChunkManagerSource {
   public computeLOD(
     camera: Camera,
     bufferWidth: number, // screen/canvas width in pixels
-    bufferHeight: number, // screen/canvas height in pixels
     availableScales: number[][] // scale factors per LOD, where each scale is [c, z, y, x]
   ): number {
-
-    // Calculate world-space dimensions of the current visible view
+    // Get the actual visible bounds to determine virtual width
     const viewExtent = this.calculateVisibleBounds(camera);
+    const virtualWidth = viewExtent.worldWidth;
 
-    // Calculate desired screen resolution: pixels per world unit
-    // i.e., how many screen pixels span one unit of virtual space (zoom-dependent)
-    const desiredResolutionX = bufferWidth / viewExtent.worldWidth;
-    const desiredResolutionY = bufferHeight / viewExtent.worldHeight;
+    const virtualUnitsPerScreenPixel = virtualWidth / bufferWidth;
 
-    // Choose the higher resolution between X and Y (higher pixels per unit) to avoid aliasing
-    const desiredResolution = Math.max(desiredResolutionX, desiredResolutionY);
+    const numLods = availableScales.length;
+    const lodShift = numLods - 1;
+    const lodF = lodShift + Math.log2(1 / virtualUnitsPerScreenPixel);
 
-    // Select the LOD with resolution closest to what's needed - prefer higher resolution over lower resolution
-    let bestScaleIndex = 0;
-    let bestResolutionMatch = Infinity;
-
-    for (let i = 0; i < availableScales.length; i++) {
-      const scale = availableScales[i];
-
-      // Assume last two dimensions are spatial (y, x) — scale = world units per texel
-      const scaleX = scale[scale.length - 1];
-      const scaleY = scale[scale.length - 2];
-
-      // Convert resolution to texels per world unit
-      // Higher = more detail; lower = coarser
-      // Less than 1 texel per world unit = undersampling → aliasing risk
-      const resolutionX = 1.0 / scaleX;
-      const resolutionY = 1.0 / scaleY;
-      const resolution = Math.min(resolutionX, resolutionY); // Conservative estimate
-
-      const resolutionRatio = resolution / desiredResolution;
-
-      // Scoring:
-      // - If ratio >= 1.0 → oversampling → mildly penalize
-      // - If ratio < 1.0 → undersampling → penalize more strongly
-      let score: number;
-      if (resolutionRatio >= 1.0) {
-        // Resolution is higher than desired - score based on how much excess detail
-        score = resolutionRatio;
-      } else {
-        // Resolution is lower than desired - penalize but not too harshly
-        // Use 1/ratio so that the higher resolution ( that's closer to desired) gets better score
-        score = 1.0 / resolutionRatio;
-      }
-
-      if (score < bestResolutionMatch) {
-        bestResolutionMatch = score;
-        bestScaleIndex = i;
-      }
-    }
-
-    return bestScaleIndex;
+    const maxLod = numLods - 1;
+    return Math.max(0, Math.min(maxLod, Math.floor(lodF)));
   }
 
   // Calculate the visible bounds in virtual space.

--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -33,15 +33,10 @@ export class ChunkManagerSource {
       return undefined;
     }
 
-    console.log('Loading chunk with LOD:', this.currentLOD_, 'Region:', this.region_);
-    console.log('Available attributes:', this.attributes_);
-
     try {
       return await this.loader_.loadChunk(this.region_, this.currentLOD_);
     } catch (error) {
       console.warn("Failed to reload with new scale:", error);
-      console.warn("Current LOD:", this.currentLOD_);
-      console.warn("Attributes length:", this.attributes_.length);
       return undefined;
     }
   }
@@ -51,7 +46,6 @@ export class ChunkManagerSource {
     let lodResult: number;
 
     if (availableScales.length === 0) {
-      console.warn("No scales available, using default LOD 0");
       lodResult = 0; // Use first LOD level when no scales available
       if (firstPass) {
         this.currentLOD_ = lodResult;
@@ -92,14 +86,12 @@ export class ChunkManagerSource {
 
     // Check for invalid values
     if (!isFinite(virtualWidth) || virtualWidth <= 0 || !isFinite(bufferWidth) || bufferWidth <= 0) {
-      console.warn('Invalid dimensions for LOD calculation:', { virtualWidth, bufferWidth });
       return 0; // Default to highest resolution
     }
 
     const virtualUnitsPerScreenPixel = virtualWidth / bufferWidth;
 
     if (!isFinite(virtualUnitsPerScreenPixel) || virtualUnitsPerScreenPixel <= 0) {
-      console.warn('Invalid virtualUnitsPerScreenPixel:', virtualUnitsPerScreenPixel);
       return 0;
     }
 
@@ -167,12 +159,10 @@ export class ChunkManager {
   public async addSource(source: ImageChunkSource) {
     let existing = this.sources_.get(source);
     if (!existing) {
-      console.log("adding sourceq", source);
       const loader = await source.open();
       const attrs = await loader.loadAttributes();
       existing = new ChunkManagerSource(loader, attrs);
       this.sources_.set(source, existing);
-      console.log("added source", source);
     }
     return existing;
   }

--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -33,27 +33,32 @@ export class ChunkManagerSource {
       return undefined;
     }
 
+    console.log('Loading chunk with LOD:', this.currentLOD_, 'Region:', this.region_);
+    console.log('Available attributes:', this.attributes_);
+
     try {
       return await this.loader_.loadChunk(this.region_, this.currentLOD_);
     } catch (error) {
       console.warn("Failed to reload with new scale:", error);
+      console.warn("Current LOD:", this.currentLOD_);
+      console.warn("Attributes length:", this.attributes_.length);
       return undefined;
     }
   }
 
-  public async updateLOD(camera: Camera, bufferWidth: number, bufferHeight: number, firstPass: boolean = false): Promise<ImageChunk | undefined> {
+  public async updateLOD(camera: Camera, bufferWidth: number, firstPass: boolean = false): Promise<ImageChunk | undefined> {
     const availableScales = this.attributes_.map(attr => attr.scale);
     let lodResult: number;
+
     if (availableScales.length === 0) {
-      console.warn("No scales available");
-      lodResult = this.attributes_.length - 1;
+      console.warn("No scales available, using default LOD 0");
+      lodResult = 0; // Use first LOD level when no scales available
       if (firstPass) {
-        // if first pass, set the current LOD to the default and load the chunk
         this.currentLOD_ = lodResult;
         return await this.load();
       }
     } else {
-      lodResult = this.computeLOD(camera, bufferWidth, bufferHeight, availableScales);
+      lodResult = this.computeLOD(camera, bufferWidth, availableScales);
     }
 
     const lodChanged = lodResult !== this.currentLOD_;
@@ -85,14 +90,27 @@ export class ChunkManagerSource {
     const viewExtent = this.calculateVisibleBounds(camera);
     const virtualWidth = viewExtent.worldWidth;
 
+    // Check for invalid values
+    if (!isFinite(virtualWidth) || virtualWidth <= 0 || !isFinite(bufferWidth) || bufferWidth <= 0) {
+      console.warn('Invalid dimensions for LOD calculation:', { virtualWidth, bufferWidth });
+      return 0; // Default to highest resolution
+    }
+
     const virtualUnitsPerScreenPixel = virtualWidth / bufferWidth;
+
+    if (!isFinite(virtualUnitsPerScreenPixel) || virtualUnitsPerScreenPixel <= 0) {
+      console.warn('Invalid virtualUnitsPerScreenPixel:', virtualUnitsPerScreenPixel);
+      return 0;
+    }
 
     const numLods = availableScales.length;
     const lodShift = numLods - 1;
-    const lodF = lodShift + Math.log2(1 / virtualUnitsPerScreenPixel);
+    const lodF = lodShift - Math.log2(1 / virtualUnitsPerScreenPixel);
 
     const maxLod = numLods - 1;
-    return Math.max(0, Math.min(maxLod, Math.floor(lodF)));
+    const result = Math.max(0, Math.min(maxLod, Math.floor(lodF)));
+
+    return result;
   }
 
   // Calculate the visible bounds in virtual space.
@@ -159,10 +177,10 @@ export class ChunkManager {
     return existing;
   }
 
-  public async update(camera: Camera, bufferWidth: number, bufferHeight: number) {
+  public async update(camera: Camera, bufferWidth: number) {
     // const visibleBounds = this.computeVisibleBounds(camera);
     for (const source of this.sources_.values()) {
-      await source.updateLOD(camera, bufferWidth, bufferHeight);
+      await source.updateLOD(camera, bufferWidth);
     }
   }
 

--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -67,7 +67,7 @@ export class ChunkManagerSource {
     return [chunk];
   }
 
-  public async updateLOD(camera: Camera, bufferWidth: number, bufferHeight: number): Promise<ImageChunk | undefined> {
+  public async loadChunk(camera: Camera, bufferWidth: number, bufferHeight: number): Promise<ImageChunk | undefined> {
     const availableScales = this.attributes_.map(attr => attr.scale);
     const lodResult = this.computeLOD(camera, bufferWidth, bufferHeight, availableScales);
 
@@ -226,12 +226,10 @@ export class ChunkManager {
     return existing;
   }
 
-  public async update(camera: Camera, region: Region, bufferWidth: number, bufferHeight: number) {
+  public async update(camera: Camera, bufferWidth: number, bufferHeight: number) {
     // const visibleBounds = this.computeVisibleBounds(camera);
-    // Note: ChunkManager doesn't know about regions, so layers will call updateLOD directly
-    // This is left here for future use when we implement proper chunk management
     for (const source of this.sources_.values()) {
-      await source.updateLOD(camera, bufferWidth, bufferHeight, region);
+      await source.loadChunk(camera, bufferWidth, bufferHeight);
     }
   }
 

--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -21,7 +21,7 @@ export class ChunkManagerSource {
   constructor(loader: ImageChunkLoader, attributes: LoaderAttributes[]) {
     this.loader_ = loader;
     this.attributes_ = attributes;
-    this.currentLOD_ = this.attributes_.length - 1;
+    this.currentLOD_ = this.attributes_.length - 1; // default to lowest res
   }
 
   public setRegion(region: Region) {
@@ -30,74 +30,66 @@ export class ChunkManagerSource {
 
   public async load(): Promise<ImageChunk | undefined> {
     if (!this.region_) {
-      return;
+      return undefined;
     }
 
-    try {
-      const chunks = await this.getVisibleChunks();
-      return chunks[0]; // Return first (and only) chunk
-    } catch (error) {
-      console.warn("Failed to load chunk:", error);
-      return;
-    }
+    await this.loadChunk();
+    const chunks = this.getVisibleChunks();
+    return chunks[0];
   }
 
   public async updateLOD(
     camera: Camera,
-    bufferWidth: number,
-    firstPass: boolean = false
+    bufferWidth: number
   ): Promise<ImageChunk | undefined> {
     const availableScales = this.attributes_.map((attr) => attr.scale);
-    let lodResult: number;
-
+    
     if (availableScales.length === 0) {
-      lodResult = 0; // Use first LOD level when no scales available
-      if (firstPass) {
-        this.currentLOD_ = lodResult;
-        return await this.load();
-      }
-    } else {
-      lodResult = this.computeLOD(camera, bufferWidth, availableScales);
-    }
-
-    const lodChanged = lodResult !== this.currentLOD_;
-
-    if (lodChanged || firstPass) {
-      if (lodChanged) {
-        const oldLOD = this.currentLOD_ ?? "none";
-        console.log(`LOD changed from ${oldLOD} to ${lodResult}`);
-      }
-      this.currentLOD_ = lodResult;
+      // No scales available, just ensure chunk is loaded at current LOD
       return await this.load();
     }
+
+    const lodResult = this.computeLOD(camera, bufferWidth, availableScales);
+    const lodChanged = lodResult !== this.currentLOD_;
+
+    if (lodChanged) {
+      console.log(`LOD changed from ${this.currentLOD_} to ${lodResult}`);
+      this.currentLOD_ = lodResult;
+    }
+
+    return await this.load();
   }
 
-  public async getVisibleChunks(): Promise<ImageChunk[]> {
+  public getVisibleChunks(): ImageChunk[] {
     if (!this.region_) {
       return [];
     }
+    return this.chunks_[this.currentLOD_] || [];
+  }
 
-    // Check if we already have the chunk cached for current LOD
+  public async loadChunk(): Promise<void> {
+    if (!this.region_) {
+      return;
+    }
+
+    // Check if already cached
     if (this.chunks_[this.currentLOD_]?.length > 0) {
-      return this.chunks_[this.currentLOD_];
+      return;
     }
 
     try {
-      // Cache the loaded chunk
       const chunk = await this.loader_.loadChunk(
         this.region_,
         this.currentLOD_
       );
       this.chunks_[this.currentLOD_] = [chunk];
-      return this.chunks_[this.currentLOD_];
     } catch (error) {
       // Throttle error logging to prevent console spam in render loop
       const now = Date.now();
       if (now - this.lastErrorTime_ > this.ERROR_THROTTLE_MS_) {
-        console.warn("Failed to load chunk in getVisibleChunks:", error);
+        console.warn("Failed to load chunk:", error);
         this.lastErrorTime_ = now;
       }
-      return [];
     }
   }
 

--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -89,25 +89,7 @@ export class ChunkManagerSource {
     // Get the actual visible bounds to determine virtual width
     const viewExtent = this.calculateVisibleBounds(camera);
     const virtualWidth = viewExtent.worldWidth;
-
-    // Check for invalid values
-    if (
-      !isFinite(virtualWidth) ||
-      virtualWidth <= 0 ||
-      !isFinite(bufferWidth) ||
-      bufferWidth <= 0
-    ) {
-      return 0; // Default to highest resolution
-    }
-
     const virtualUnitsPerScreenPixel = virtualWidth / bufferWidth;
-
-    if (
-      !isFinite(virtualUnitsPerScreenPixel) ||
-      virtualUnitsPerScreenPixel <= 0
-    ) {
-      return 0;
-    }
 
     const numLods = availableScales.length;
     const lodShift = numLods - 1;

--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -6,14 +6,6 @@ import {
 } from "@/data/image_chunk";
 import { Region } from "@/data/region";
 
-export interface LODResult {
-  // Optimal scale index to use (0 = highest resolution)
-  scaleIndex: number;
-  // Effective resolution in pixels per world unit
-  resolution: number;
-  // Scale factor for this level (world units per pixel)
-  scaleFactor: number;
-}
 
 import { Camera } from "../objects/cameras/camera";
 import { vec2, vec4, mat4 } from "gl-matrix";
@@ -24,7 +16,7 @@ export class ChunkManagerSource {
   private readonly loader_: ImageChunkLoader;
   private readonly attributes_: LoaderAttributes[];
   private region_?: Region;
-  private currentLOD_?: LODResult;
+  private currentLOD_?: { scaleIndex: number; resolution: number };
 
   constructor(loader: ImageChunkLoader, attributes: LoaderAttributes[]) {
     this.loader_ = loader;
@@ -59,7 +51,7 @@ export class ChunkManagerSource {
     if (lodChanged || firstPass) {
       if (lodChanged) {
         const oldLOD = this.currentLOD_?.scaleIndex ?? 'none';
-        console.log(`LOD changed from ${oldLOD} to ${lodResult.scaleIndex} (resolution: ${lodResult.resolution.toFixed(2)}, scale factor: ${lodResult.scaleFactor.toFixed(4)})`);
+        console.log(`LOD changed from ${oldLOD} to ${lodResult.scaleIndex} (resolution: ${lodResult.resolution.toFixed(2)}`);
       }
       this.currentLOD_ = lodResult;
       return await this.load();
@@ -79,18 +71,13 @@ export class ChunkManagerSource {
     bufferWidth: number, // screen/canvas width in pixels
     bufferHeight: number, // screen/canvas height in pixels
     availableScales: number[][] // scale factors per LOD, where each scale is [c, z, y, x]
-  ): LODResult {
-    // console.log("computeLOD", availableScales);
+  ): { scaleIndex: number; resolution: number } {
     if (availableScales.length === 0) {
       throw new Error("No scales available");
     }
 
     // Calculate world-space dimensions of the current visible view
-    const viewExtent = this.calculateViewExtent(
-      camera,
-      bufferWidth,
-      bufferHeight
-    );
+    const viewExtent = this.calculateViewExtent(camera);
 
     // Calculate desired screen resolution: pixels per world unit
     // i.e., how many screen pixels span one unit of virtual space (zoom-dependent)
@@ -143,20 +130,16 @@ export class ChunkManagerSource {
     const scaleX = selectedScale[selectedScale.length - 1];
     const scaleY = selectedScale[selectedScale.length - 2];
     const effectiveResolution = Math.min(1.0 / scaleX, 1.0 / scaleY);
-    const effectiveScaleFactor = Math.max(scaleX, scaleY);
 
     return {
       scaleIndex: bestScaleIndex,
       resolution: effectiveResolution,
-      scaleFactor: effectiveScaleFactor,
     };
   }
 
   // Calculate the world space extent (width/height) currently visible in the camera view.
   private calculateViewExtent(
     camera: Camera,
-    _bufferWidth: number, // screen width
-    _bufferHeight: number // screen height
   ): { worldWidth: number; worldHeight: number } {
     // Screen space corners (normalized device coordinates: -1 to +1)
     const topLeft = camera.clipToWorld([-1, 1, 0]); // camera space to world space

--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -1,5 +1,14 @@
 import { Camera } from "../objects/cameras/camera";
 
+export interface LODResult {
+  /** Optimal scale index to use (0 = highest resolution) */
+  scaleIndex: number;
+  /** Effective resolution in pixels per world unit */
+  resolution: number;
+  /** Scale factor for this level (physical units per pixel) */
+  scaleFactor: number;
+}
+
 export class ChunkManager {
   public getVisibleChunks() {
     // TODO: implement
@@ -7,5 +16,123 @@ export class ChunkManager {
 
   public update(_camera: Camera, _bufferWidth: number, _bufferHeight: number) {
     // TODO: implement
+  }
+
+  /**
+   * Compute the optimal Level of Detail (LOD) scale index based on camera view and screen resolution.
+   *
+   * The algorithm selects the scale level where approximately one data pixel maps to one screen pixel,
+   * providing optimal visual quality without wasting bandwidth on imperceptible detail.
+   *
+   * @param camera - Current camera providing the view transformation
+   * @param bufferWidth - Screen/canvas width in pixels
+   * @param bufferHeight - Screen/canvas height in pixels
+   * @param availableScales - Array of scale factors for each LOD level, where scales[0] is highest resolution
+   * @param currentPosition - World position being viewed (defaults to camera center)
+   * @returns LODResult with optimal scale index and resolution info
+   */
+  public computeLOD(
+    camera: Camera,
+    bufferWidth: number, // screen width
+    bufferHeight: number, // screen height
+    availableScales: number[][],
+    _currentPosition?: [number, number]
+  ): LODResult {
+    if (availableScales.length === 0) {
+      throw new Error("No scales available");
+    }
+
+    // Use camera center if no position specified
+    // Future enhancement: could use _currentPosition for view-dependent LOD calculation
+
+    // Calculate world space dimensions of the current view
+    const viewExtent = this.calculateViewExtent(camera, bufferWidth, bufferHeight);
+
+    // Calculate desired resolution: pixels per world unit
+    // This represents how many screen pixels we want per world space unit
+    const desiredResolutionX = bufferWidth / viewExtent.worldWidth;
+    const desiredResolutionY = bufferHeight / viewExtent.worldHeight;
+
+    // Use the more restrictive resolution (higher value = more detail needed)
+    const desiredResolution = Math.max(desiredResolutionX, desiredResolutionY);
+
+    // Find the scale that best matches our desired resolution
+    let bestScaleIndex = 0;
+    let bestResolutionMatch = Infinity;
+
+    for (let i = 0; i < availableScales.length; i++) {
+      const scale = availableScales[i];
+
+      // Assume last two dimensions are X and Y (spatial dimensions)
+      const scaleX = scale[scale.length - 1]; // X scale factor (world units per pixel)
+      const scaleY = scale[scale.length - 2]; // Y scale factor (world units per pixel)
+
+      // Convert to resolution: pixels per world unit
+      const resolutionX = 1.0 / scaleX; // pixels/texel per world unit in X
+      const resolutionY = 1.0 / scaleY; // pixels/texel per world unit in Y
+      const resolution = Math.min(resolutionX, resolutionY); // Conservative estimate
+
+      // Find scale that provides resolution closest to (but not less than) desired
+      // Prefer slightly higher resolution over lower resolution
+      const resolutionRatio = resolution / desiredResolution;
+
+      // Score: prefer resolutions >= desired, but be reasonable about lower resolutions
+      let score: number;
+      if (resolutionRatio >= 1.0) {
+        // Resolution is higher than desired - score based on how much excess detail
+        score = resolutionRatio;
+      } else {
+        // Resolution is lower than desired - penalize but not too harshly
+        // Use 1/ratio so higher resolution (closer to desired) gets better score
+        score = 1.0 / resolutionRatio;
+      }
+
+      if (score < bestResolutionMatch) {
+        bestResolutionMatch = score;
+        bestScaleIndex = i;
+      }
+    }
+
+    const selectedScale = availableScales[bestScaleIndex];
+    const scaleX = selectedScale[selectedScale.length - 1];
+    const scaleY = selectedScale[selectedScale.length - 2];
+    const effectiveResolution = Math.min(1.0 / scaleX, 1.0 / scaleY);
+    const effectiveScaleFactor = Math.max(scaleX, scaleY);
+
+    return {
+      scaleIndex: bestScaleIndex,
+      resolution: effectiveResolution,
+      scaleFactor: effectiveScaleFactor,
+    };
+  }
+
+  /**
+   * Calculate the world space extent (width/height) currently visible in the camera view.
+   */
+  private calculateViewExtent(
+    camera: Camera,
+    _bufferWidth: number, // screen width
+    _bufferHeight: number // screen height
+  ): { worldWidth: number; worldHeight: number } { // virtual world space extent
+    // Convert screen corners to world coordinates to determine view extent
+
+    // Screen space corners (normalized device coordinates: -1 to +1)
+    const topLeft = camera.clipToWorld([-1, 1, 0]); // camera space to world space
+    const topRight = camera.clipToWorld([1, 1, 0]);
+    const bottomLeft = camera.clipToWorld([-1, -1, 0]);
+    const bottomRight = camera.clipToWorld([1, -1, 0]);
+
+    // Calculate world space dimensions
+    const worldWidth = Math.max(
+      Math.abs(topRight[0] - topLeft[0]),
+      Math.abs(bottomRight[0] - bottomLeft[0])
+    );
+
+    const worldHeight = Math.max(
+      Math.abs(topLeft[1] - bottomLeft[1]),
+      Math.abs(topRight[1] - bottomRight[1])
+    );
+
+    return { worldWidth, worldHeight };
   }
 }

--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -28,25 +28,13 @@ export class ChunkManagerSource {
     this.region_ = region;
   }
 
-  public async load(): Promise<ImageChunk | undefined> {
-    if (!this.region_) {
-      return undefined;
-    }
-
-    await this.loadChunk();
-    const chunks = this.getVisibleChunks();
-    return chunks[0];
-  }
-
-  public async updateLOD(
-    camera: Camera,
-    bufferWidth: number
-  ): Promise<ImageChunk | undefined> {
+  public async updateLOD(camera: Camera, bufferWidth: number) {
     const availableScales = this.attributes_.map((attr) => attr.scale);
-    
+
     if (availableScales.length === 0) {
       // No scales available, just ensure chunk is loaded at current LOD
-      return await this.load();
+      await this.loadChunk();
+      return;
     }
 
     const lodResult = this.computeLOD(camera, bufferWidth, availableScales);
@@ -57,7 +45,7 @@ export class ChunkManagerSource {
       this.currentLOD_ = lodResult;
     }
 
-    return await this.load();
+    await this.loadChunk();
   }
 
   public getVisibleChunks(): ImageChunk[] {

--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -5,7 +5,7 @@ export interface LODResult {
   scaleIndex: number;
   // Effective resolution in pixels per world unit
   resolution: number;
-  // Scale factor for this level (physical units per pixel)
+  // Scale factor for this level (world units per pixel)
   scaleFactor: number;
 }
 

--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -16,11 +16,12 @@ export class ChunkManagerSource {
   private readonly loader_: ImageChunkLoader;
   private readonly attributes_: LoaderAttributes[];
   private region_?: Region;
-  private currentLOD_?: { scaleIndex: number; resolution: number };
+  private currentLOD_: number;
 
   constructor(loader: ImageChunkLoader, attributes: LoaderAttributes[]) {
     this.loader_ = loader;
     this.attributes_ = attributes;
+    this.currentLOD_ = this.attributes_.length - 1;
   }
 
   public setRegion(region: Region) {
@@ -31,11 +32,9 @@ export class ChunkManagerSource {
     if (!this.region_) {
       return undefined;
     }
-    // Use computed LOD if available; otherwise default to lowest resolution
-    const lod = this.currentLOD_?.scaleIndex ?? this.attributes_.length - 1;
 
     try {
-      return await this.loader_.loadChunk(this.region_, lod);
+      return await this.loader_.loadChunk(this.region_, this.currentLOD_);
     } catch (error) {
       console.warn("Failed to reload with new scale:", error);
       return undefined;
@@ -44,14 +43,25 @@ export class ChunkManagerSource {
 
   public async updateLOD(camera: Camera, bufferWidth: number, bufferHeight: number, firstPass: boolean = false): Promise<ImageChunk | undefined> {
     const availableScales = this.attributes_.map(attr => attr.scale);
-    const lodResult = this.computeLOD(camera, bufferWidth, bufferHeight, availableScales);
+    let lodResult: number;
+    if (availableScales.length === 0) {
+      console.warn("No scales available");
+      lodResult = this.attributes_.length - 1;
+      if (firstPass) {
+        // if first pass, set the current LOD to the default and load the chunk
+        this.currentLOD_ = lodResult;
+        return await this.load();
+      }
+    } else {
+      lodResult = this.computeLOD(camera, bufferWidth, bufferHeight, availableScales);
+    }
 
-    const lodChanged = !this.currentLOD_ || lodResult.scaleIndex !== this.currentLOD_.scaleIndex;
+    const lodChanged = lodResult !== this.currentLOD_;
 
     if (lodChanged || firstPass) {
       if (lodChanged) {
-        const oldLOD = this.currentLOD_?.scaleIndex ?? 'none';
-        console.log(`LOD changed from ${oldLOD} to ${lodResult.scaleIndex} (resolution: ${lodResult.resolution.toFixed(2)}`);
+        const oldLOD = this.currentLOD_ ?? 'none';
+        console.log(`LOD changed from ${oldLOD} to ${lodResult}`);
       }
       this.currentLOD_ = lodResult;
       return await this.load();
@@ -59,10 +69,10 @@ export class ChunkManagerSource {
   }
 
   public async getVisibleChunks(): Promise<ImageChunk[]> {
-    if (!this.region_ || !this.currentLOD_) {
+    if (!this.region_) {
       return [];
     }
-    const chunk = await this.loader_.loadChunk(this.region_, this.currentLOD_.scaleIndex);
+    const chunk = await this.loader_.loadChunk(this.region_, this.currentLOD_);
     return [chunk];
   }
 
@@ -71,13 +81,10 @@ export class ChunkManagerSource {
     bufferWidth: number, // screen/canvas width in pixels
     bufferHeight: number, // screen/canvas height in pixels
     availableScales: number[][] // scale factors per LOD, where each scale is [c, z, y, x]
-  ): { scaleIndex: number; resolution: number } {
-    if (availableScales.length === 0) {
-      throw new Error("No scales available");
-    }
+  ): number {
 
     // Calculate world-space dimensions of the current visible view
-    const viewExtent = this.calculateViewExtent(camera);
+    const viewExtent = this.calculateVisibleBounds(camera);
 
     // Calculate desired screen resolution: pixels per world unit
     // i.e., how many screen pixels span one unit of virtual space (zoom-dependent)
@@ -126,37 +133,31 @@ export class ChunkManagerSource {
       }
     }
 
-    const selectedScale = availableScales[bestScaleIndex];
-    const scaleX = selectedScale[selectedScale.length - 1];
-    const scaleY = selectedScale[selectedScale.length - 2];
-    const effectiveResolution = Math.min(1.0 / scaleX, 1.0 / scaleY);
-
-    return {
-      scaleIndex: bestScaleIndex,
-      resolution: effectiveResolution,
-    };
+    return bestScaleIndex;
   }
 
-  // Calculate the world space extent (width/height) currently visible in the camera view.
-  private calculateViewExtent(
+  // Calculate the visible bounds in virtual space.
+  private calculateVisibleBounds(
     camera: Camera,
   ): { worldWidth: number; worldHeight: number } {
     // Screen space corners (normalized device coordinates: -1 to +1)
-    const topLeft = camera.clipToWorld([-1, 1, 0]); // camera space to world space
-    const topRight = camera.clipToWorld([1, 1, 0]);
-    const bottomLeft = camera.clipToWorld([-1, -1, 0]);
-    const bottomRight = camera.clipToWorld([1, -1, 0]);
+    const topLeftNDC = vec4.fromValues(-1, 1, 0, 1);
+    const bottomRightNDC = vec4.fromValues(1, -1, 0, 1);
 
-    // Calculate world space dimensions
-    const worldWidth = Math.max(
-      Math.abs(topRight[0] - topLeft[0]),
-      Math.abs(bottomRight[0] - bottomLeft[0])
+    // Compute inverse view-projection matrix once
+    const viewProjection = mat4.multiply(
+      mat4.create(),
+      camera.projectionMatrix,
+      camera.viewMatrix
     );
+    const invViewProjection = mat4.invert(mat4.create(), viewProjection);
 
-    const worldHeight = Math.max(
-      Math.abs(topLeft[1] - bottomLeft[1]),
-      Math.abs(topRight[1] - bottomRight[1])
-    );
+    // Transform to world space
+    const topLeftWorld = vec4.transformMat4(vec4.create(), topLeftNDC, invViewProjection);
+    const bottomRightWorld = vec4.transformMat4(vec4.create(), bottomRightNDC, invViewProjection);
+
+    const worldWidth = Math.abs(bottomRightWorld[0] - topLeftWorld[0]);
+    const worldHeight = Math.abs(topLeftWorld[1] - bottomRightWorld[1]);
 
     return { worldWidth, worldHeight };
   }

--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -11,6 +11,7 @@ import { vec4, mat4 } from "gl-matrix";
 
 export class ChunkManagerSource {
   private readonly loader_: ImageChunkLoader;
+  private readonly chunks_: ImageChunk[][] = [];
   private readonly attributes_: LoaderAttributes[];
   private region_?: Region;
   private currentLOD_: number;
@@ -75,12 +76,19 @@ export class ChunkManagerSource {
       return [];
     }
 
+    // Check if we already have the chunk cached for current LOD
+    if (this.chunks_[this.currentLOD_]?.length > 0) {
+      return this.chunks_[this.currentLOD_];
+    }
+
     try {
+      // Cache the loaded chunk
       const chunk = await this.loader_.loadChunk(
         this.region_,
         this.currentLOD_
       );
-      return [chunk];
+      this.chunks_[this.currentLOD_] = [chunk];
+      return this.chunks_[this.currentLOD_];
     } catch (error) {
       // Throttle error logging to prevent console spam in render loop
       const now = Date.now();

--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -39,17 +39,8 @@ export class ChunkManagerSource {
     if (!this.region_) {
       return undefined;
     }
-
     // Use computed LOD if available; otherwise default to lowest resolution
     const lod = this.currentLOD_?.scaleIndex ?? this.attributes_.length - 1;
-
-    return await this.loader_.loadChunk(this.region_, lod);
-  }
-
-  public async reloadWithScale(lod: number): Promise<ImageChunk | undefined> {
-    if (!this.region_) {
-      return undefined;
-    }
 
     try {
       return await this.loader_.loadChunk(this.region_, lod);
@@ -59,15 +50,7 @@ export class ChunkManagerSource {
     }
   }
 
-  public async getVisibleChunks(): Promise<ImageChunk[]> {
-    if (!this.region_ || !this.currentLOD_) {
-      return [];
-    }
-    const chunk = await this.loader_.loadChunk(this.region_, this.currentLOD_.scaleIndex);
-    return [chunk];
-  }
-
-  public async loadChunk(camera: Camera, bufferWidth: number, bufferHeight: number): Promise<ImageChunk | undefined> {
+  public async updateLOD(camera: Camera, bufferWidth: number, bufferHeight: number): Promise<ImageChunk | undefined> {
     const availableScales = this.attributes_.map(attr => attr.scale);
     const lodResult = this.computeLOD(camera, bufferWidth, bufferHeight, availableScales);
 
@@ -77,11 +60,20 @@ export class ChunkManagerSource {
       const oldLOD = this.currentLOD_?.scaleIndex ?? 'none';
       console.log(`LOD changed from ${oldLOD} to ${lodResult.scaleIndex} (resolution: ${lodResult.resolution.toFixed(2)}, scale factor: ${lodResult.scaleFactor.toFixed(4)})`);
       this.currentLOD_ = lodResult;
-      return await this.reloadWithScale(lodResult.scaleIndex);
+      return await this.load();
     }
 
     this.currentLOD_ = lodResult;
+    // return await this.load();
     return undefined;
+  }
+
+  public async getVisibleChunks(): Promise<ImageChunk[]> {
+    if (!this.region_ || !this.currentLOD_) {
+      return [];
+    }
+    const chunk = await this.loader_.loadChunk(this.region_, this.currentLOD_.scaleIndex);
+    return [chunk];
   }
 
   public computeLOD(
@@ -229,7 +221,7 @@ export class ChunkManager {
   public async update(camera: Camera, bufferWidth: number, bufferHeight: number) {
     // const visibleBounds = this.computeVisibleBounds(camera);
     for (const source of this.sources_.values()) {
-      await source.loadChunk(camera, bufferWidth, bufferHeight);
+      await source.updateLOD(camera, bufferWidth, bufferHeight);
     }
   }
 

--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -1,11 +1,11 @@
 import { Camera } from "../objects/cameras/camera";
 
 export interface LODResult {
-  /** Optimal scale index to use (0 = highest resolution) */
+  // Optimal scale index to use (0 = highest resolution)
   scaleIndex: number;
-  /** Effective resolution in pixels per world unit */
+  // Effective resolution in pixels per world unit
   resolution: number;
-  /** Scale factor for this level (physical units per pixel) */
+  // Scale factor for this level (physical units per pixel)
   scaleFactor: number;
 }
 
@@ -18,72 +18,61 @@ export class ChunkManager {
     // TODO: implement
   }
 
-  /**
-   * Compute the optimal Level of Detail (LOD) scale index based on camera view and screen resolution.
-   *
-   * The algorithm selects the scale level where approximately one data pixel maps to one screen pixel,
-   * providing optimal visual quality without wasting bandwidth on imperceptible detail.
-   *
-   * @param camera - Current camera providing the view transformation
-   * @param bufferWidth - Screen/canvas width in pixels
-   * @param bufferHeight - Screen/canvas height in pixels
-   * @param availableScales - Array of scale factors for each LOD level, where scales[0] is highest resolution
-   * @param currentPosition - World position being viewed (defaults to camera center)
-   * @returns LODResult with optimal scale index and resolution info
-   */
   public computeLOD(
     camera: Camera,
-    bufferWidth: number, // screen width
-    bufferHeight: number, // screen height
-    availableScales: number[][],
-    _currentPosition?: [number, number]
+    bufferWidth: number, // screen/canvas width in pixels
+    bufferHeight: number, // screen/canvas height in pixels
+    availableScales: number[][] // scale factors per LOD, where each scale is [c, z, y, x]
   ): LODResult {
     if (availableScales.length === 0) {
       throw new Error("No scales available");
     }
 
-    // Use camera center if no position specified
-    // Future enhancement: could use _currentPosition for view-dependent LOD calculation
+    // Calculate world-space dimensions of the current visible view
+    const viewExtent = this.calculateViewExtent(
+      camera,
+      bufferWidth,
+      bufferHeight
+    );
 
-    // Calculate world space dimensions of the current view
-    const viewExtent = this.calculateViewExtent(camera, bufferWidth, bufferHeight);
-
-    // Calculate desired resolution: pixels per world unit
-    // This represents how many screen pixels we want per world space unit
+    // Calculate desired screen resolution: pixels per world unit
+    // i.e., how many screen pixels span one unit of virtual space (zoom-dependent)
     const desiredResolutionX = bufferWidth / viewExtent.worldWidth;
     const desiredResolutionY = bufferHeight / viewExtent.worldHeight;
 
-    // Use the more restrictive resolution (higher value = more detail needed)
+    // Choose the higher resolution between X and Y (higher pixels per unit) to avoid aliasing
     const desiredResolution = Math.max(desiredResolutionX, desiredResolutionY);
 
-    // Find the scale that best matches our desired resolution
+    // Select the LOD with resolution closest to what's needed - prefer higher resolution over lower resolution
     let bestScaleIndex = 0;
     let bestResolutionMatch = Infinity;
 
     for (let i = 0; i < availableScales.length; i++) {
       const scale = availableScales[i];
 
-      // Assume last two dimensions are X and Y (spatial dimensions)
-      const scaleX = scale[scale.length - 1]; // X scale factor (world units per pixel)
-      const scaleY = scale[scale.length - 2]; // Y scale factor (world units per pixel)
+      // Assume last two dimensions are spatial (y, x) — scale = world units per texel
+      const scaleX = scale[scale.length - 1];
+      const scaleY = scale[scale.length - 2];
 
-      // Convert to resolution: pixels per world unit
-      const resolutionX = 1.0 / scaleX; // pixels/texel per world unit in X
-      const resolutionY = 1.0 / scaleY; // pixels/texel per world unit in Y
+      // Convert resolution to texels per world unit
+      // Higher = more detail; lower = coarser
+      // Less than 1 texel per world unit = undersampling → aliasing risk
+      const resolutionX = 1.0 / scaleX;
+      const resolutionY = 1.0 / scaleY;
       const resolution = Math.min(resolutionX, resolutionY); // Conservative estimate
 
-      // Find scale that provides resolution closest to (but not less than) desired
-      // Prefer slightly higher resolution over lower resolution
       const resolutionRatio = resolution / desiredResolution;
 
-      // Score: prefer resolutions >= desired, but be reasonable about lower resolutions
+      // Scoring:
+      // - If ratio >= 1.0 → oversampling → mildly penalize
+      // - If ratio < 1.0 → undersampling → penalize more strongly
       let score: number;
       if (resolutionRatio >= 1.0) {
         // Resolution is higher than desired - score based on how much excess detail
         score = resolutionRatio;
       } else {
         // Resolution is lower than desired - penalize but not too harshly
-        // Use 1/ratio so higher resolution (closer to desired) gets better score
+        // Use 1/ratio so that the higher resolution ( that's closer to desired) gets better score
         score = 1.0 / resolutionRatio;
       }
 
@@ -113,7 +102,8 @@ export class ChunkManager {
     camera: Camera,
     _bufferWidth: number, // screen width
     _bufferHeight: number // screen height
-  ): { worldWidth: number; worldHeight: number } { // virtual world space extent
+  ): { worldWidth: number; worldHeight: number } {
+    // virtual world space extent
     // Convert screen corners to world coordinates to determine view extent
 
     // Screen space corners (normalized device coordinates: -1 to +1)

--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -6,17 +6,16 @@ import {
 } from "@/data/image_chunk";
 import { Region } from "@/data/region";
 
-
 import { Camera } from "../objects/cameras/camera";
-import { vec2, vec4, mat4 } from "gl-matrix";
-
-type Bounds = { min: vec2; max: vec2 };
+import { vec4, mat4 } from "gl-matrix";
 
 export class ChunkManagerSource {
   private readonly loader_: ImageChunkLoader;
   private readonly attributes_: LoaderAttributes[];
   private region_?: Region;
   private currentLOD_: number;
+  private lastErrorTime_ = 0;
+  private readonly ERROR_THROTTLE_MS_ = 5000; // Only log errors every 5 seconds
 
   constructor(loader: ImageChunkLoader, attributes: LoaderAttributes[]) {
     this.loader_ = loader;
@@ -41,8 +40,12 @@ export class ChunkManagerSource {
     }
   }
 
-  public async updateLOD(camera: Camera, bufferWidth: number, firstPass: boolean = false): Promise<ImageChunk | undefined> {
-    const availableScales = this.attributes_.map(attr => attr.scale);
+  public async updateLOD(
+    camera: Camera,
+    bufferWidth: number,
+    firstPass: boolean = false
+  ): Promise<ImageChunk | undefined> {
+    const availableScales = this.attributes_.map((attr) => attr.scale);
     let lodResult: number;
 
     if (availableScales.length === 0) {
@@ -59,7 +62,7 @@ export class ChunkManagerSource {
 
     if (lodChanged || firstPass) {
       if (lodChanged) {
-        const oldLOD = this.currentLOD_ ?? 'none';
+        const oldLOD = this.currentLOD_ ?? "none";
         console.log(`LOD changed from ${oldLOD} to ${lodResult}`);
       }
       this.currentLOD_ = lodResult;
@@ -71,8 +74,22 @@ export class ChunkManagerSource {
     if (!this.region_) {
       return [];
     }
-    const chunk = await this.loader_.loadChunk(this.region_, this.currentLOD_);
-    return [chunk];
+
+    try {
+      const chunk = await this.loader_.loadChunk(
+        this.region_,
+        this.currentLOD_
+      );
+      return [chunk];
+    } catch (error) {
+      // Throttle error logging to prevent console spam in render loop
+      const now = Date.now();
+      if (now - this.lastErrorTime_ > this.ERROR_THROTTLE_MS_) {
+        console.warn("Failed to load chunk in getVisibleChunks:", error);
+        this.lastErrorTime_ = now;
+      }
+      return [];
+    }
   }
 
   public computeLOD(
@@ -85,13 +102,21 @@ export class ChunkManagerSource {
     const virtualWidth = viewExtent.worldWidth;
 
     // Check for invalid values
-    if (!isFinite(virtualWidth) || virtualWidth <= 0 || !isFinite(bufferWidth) || bufferWidth <= 0) {
+    if (
+      !isFinite(virtualWidth) ||
+      virtualWidth <= 0 ||
+      !isFinite(bufferWidth) ||
+      bufferWidth <= 0
+    ) {
       return 0; // Default to highest resolution
     }
 
     const virtualUnitsPerScreenPixel = virtualWidth / bufferWidth;
 
-    if (!isFinite(virtualUnitsPerScreenPixel) || virtualUnitsPerScreenPixel <= 0) {
+    if (
+      !isFinite(virtualUnitsPerScreenPixel) ||
+      virtualUnitsPerScreenPixel <= 0
+    ) {
       return 0;
     }
 
@@ -106,9 +131,10 @@ export class ChunkManagerSource {
   }
 
   // Calculate the visible bounds in virtual space.
-  private calculateVisibleBounds(
-    camera: Camera,
-  ): { worldWidth: number; worldHeight: number } {
+  private calculateVisibleBounds(camera: Camera): {
+    worldWidth: number;
+    worldHeight: number;
+  } {
     // Screen space corners (normalized device coordinates: -1 to +1)
     const topLeftNDC = vec4.fromValues(-1, 1, 0, 1);
     const bottomRightNDC = vec4.fromValues(1, -1, 0, 1);
@@ -122,39 +148,26 @@ export class ChunkManagerSource {
     const invViewProjection = mat4.invert(mat4.create(), viewProjection);
 
     // Transform to world space
-    const topLeftWorld = vec4.transformMat4(vec4.create(), topLeftNDC, invViewProjection);
-    const bottomRightWorld = vec4.transformMat4(vec4.create(), bottomRightNDC, invViewProjection);
+    const topLeftWorld = vec4.transformMat4(
+      vec4.create(),
+      topLeftNDC,
+      invViewProjection
+    );
+    const bottomRightWorld = vec4.transformMat4(
+      vec4.create(),
+      bottomRightNDC,
+      invViewProjection
+    );
 
     const worldWidth = Math.abs(bottomRightWorld[0] - topLeftWorld[0]);
     const worldHeight = Math.abs(topLeftWorld[1] - bottomRightWorld[1]);
 
     return { worldWidth, worldHeight };
   }
-
 }
 
 export class ChunkManager {
   private readonly sources_ = new Map<ImageChunkSource, ChunkManagerSource>();
-
-  public computeVisibleBounds(camera: Camera): Bounds {
-    let topLeft = vec4.fromValues(-1.0, 1.0, 0.0, 1.0);
-    let bottomRight = vec4.fromValues(1.0, -1.0, 0.0, 1.0);
-
-    const viewProjection = mat4.multiply(
-      mat4.create(),
-      camera.projectionMatrix,
-      camera.viewMatrix
-    );
-
-    const inv = mat4.invert(mat4.create(), viewProjection);
-    topLeft = vec4.transformMat4(vec4.create(), topLeft, inv);
-    bottomRight = vec4.transformMat4(vec4.create(), bottomRight, inv);
-
-    return {
-      min: vec2.fromValues(topLeft[0], topLeft[1]),
-      max: vec2.fromValues(bottomRight[0], bottomRight[1]),
-    };
-  }
 
   public async addSource(source: ImageChunkSource) {
     let existing = this.sources_.get(source);
@@ -168,10 +181,8 @@ export class ChunkManager {
   }
 
   public async update(camera: Camera, bufferWidth: number) {
-    // const visibleBounds = this.computeVisibleBounds(camera);
     for (const source of this.sources_.values()) {
       await source.updateLOD(camera, bufferWidth);
     }
   }
-
 }

--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -92,7 +92,7 @@ export class ChunkManagerSource {
     }
   }
 
-  public computeLOD(
+  private computeLOD(
     camera: Camera,
     bufferWidth: number, // screen/canvas width in pixels
     availableScales: number[][] // scale factors per LOD, where each scale is [c, z, y, x]

--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -30,14 +30,15 @@ export class ChunkManagerSource {
 
   public async load(): Promise<ImageChunk | undefined> {
     if (!this.region_) {
-      return undefined;
+      return;
     }
 
     try {
-      return await this.loader_.loadChunk(this.region_, this.currentLOD_);
+      const chunks = await this.getVisibleChunks();
+      return chunks[0]; // Return first (and only) chunk
     } catch (error) {
-      console.warn("Failed to reload with new scale:", error);
-      return undefined;
+      console.warn("Failed to load chunk:", error);
+      return;
     }
   }
 

--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -32,9 +32,11 @@ export class ChunkManagerSource {
     const availableScales = this.attributes_.map((attr) => attr.scale);
 
     if (availableScales.length === 0) {
-      // No scales available, just ensure chunk is loaded at current LOD
-      await this.loadChunk();
-      return;
+      if (this.currentLOD_ !== this.attributes_.length - 1) {
+        // No scales available, just ensure chunk is loaded at current LOD
+        await this.loadChunk();
+        return;
+      }
     }
 
     const lodResult = this.computeLOD(camera, bufferWidth, availableScales);
@@ -43,9 +45,8 @@ export class ChunkManagerSource {
     if (lodChanged) {
       console.log(`LOD changed from ${this.currentLOD_} to ${lodResult}`);
       this.currentLOD_ = lodResult;
+      await this.loadChunk();
     }
-
-    await this.loadChunk();
   }
 
   public getVisibleChunks(): ImageChunk[] {

--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -4,6 +4,7 @@ import {
   ImageChunkSource,
   LoaderAttributes,
 } from "@/data/image_chunk";
+import { Region } from "@/data/region";
 
 export interface LODResult {
   // Optimal scale index to use (0 = highest resolution)
@@ -20,68 +21,67 @@ import { vec2, vec4, mat4 } from "gl-matrix";
 type Bounds = { min: vec2; max: vec2 };
 
 export class ChunkManagerSource {
-  // @ts-expect-error unused for now
-  private readonly chunks_: ImageChunk[][] = [];
-  // @ts-expect-error unused for now
-  private readonly loader_;
+  private readonly loader_: ImageChunkLoader;
+  private readonly attributes_: LoaderAttributes[];
+  private region_?: Region;
+  private currentLOD_?: LODResult;
 
-  constructor(loader: ImageChunkLoader, _: LoaderAttributes[]) {
+  constructor(loader: ImageChunkLoader, attributes: LoaderAttributes[]) {
     this.loader_ = loader;
-
-    // TODO: create chunks for each LOD without loading data
+    this.attributes_ = attributes;
   }
 
-  public getVisibleChunks(): ImageChunk[] {
-    return [];
+  public setRegion(region: Region) {
+    this.region_ = region;
   }
 
-  public updateChunks(_: Bounds) {
-    // TODO: intersection test, set visibility and load data
-  }
-}
-
-export class ChunkManager {
-  private readonly sources_ = new Map<ImageChunkSource, ChunkManagerSource>();
-
-  public async addSource(source: ImageChunkSource) {
-    let existing = this.sources_.get(source);
-    if (!existing) {
-      const loader = await source.open();
-      const attrs = await loader.loadAttributes();
-      existing = new ChunkManagerSource(loader, attrs);
-      this.sources_.set(source, existing);
+  public async load(): Promise<ImageChunk | undefined> {
+    if (!this.region_) {
+      return undefined;
     }
-    return existing;
+
+    // Use computed LOD if available; otherwise default to lowest resolution
+    const lod = this.currentLOD_?.scaleIndex ?? this.attributes_.length - 1;
+
+    return await this.loader_.loadChunk(this.region_, lod);
   }
 
-  public update(camera: Camera, _bufferWidth: number, _bufferHeight: number) {
-    const visibleBounds = this.computeVisibleBounds(camera);
+  public async reloadWithScale(lod: number): Promise<ImageChunk | undefined> {
+    if (!this.region_) {
+      return undefined;
+    }
 
-    // TODO: compute LOD assuming the index is not image-based
-
-    for (const [_, chunkManagerSource] of this.sources_) {
-      chunkManagerSource.updateChunks(visibleBounds);
+    try {
+      return await this.loader_.loadChunk(this.region_, lod);
+    } catch (error) {
+      console.warn("Failed to reload with new scale:", error);
+      return undefined;
     }
   }
 
-  private computeVisibleBounds(camera: Camera): Bounds {
-    let topLeft = vec4.fromValues(-1.0, 1.0, 0.0, 1.0);
-    let bottomRight = vec4.fromValues(1.0, -1.0, 0.0, 1.0);
+  public async getVisibleChunks(): Promise<ImageChunk[]> {
+    if (!this.region_ || !this.currentLOD_) {
+      return [];
+    }
+    const chunk = await this.loader_.loadChunk(this.region_, this.currentLOD_.scaleIndex);
+    return [chunk];
+  }
 
-    const viewProjection = mat4.multiply(
-      mat4.create(),
-      camera.projectionMatrix,
-      camera.viewMatrix
-    );
+  public async updateLOD(camera: Camera, bufferWidth: number, bufferHeight: number): Promise<ImageChunk | undefined> {
+    const availableScales = this.attributes_.map(attr => attr.scale);
+    const lodResult = this.computeLOD(camera, bufferWidth, bufferHeight, availableScales);
 
-    const inv = mat4.invert(mat4.create(), viewProjection);
-    topLeft = vec4.transformMat4(vec4.create(), topLeft, inv);
-    bottomRight = vec4.transformMat4(vec4.create(), bottomRight, inv);
+    const lodChanged = !this.currentLOD_ || lodResult.scaleIndex !== this.currentLOD_.scaleIndex;
 
-    return {
-      min: vec2.fromValues(topLeft[0], topLeft[1]),
-      max: vec2.fromValues(bottomRight[0], bottomRight[1]),
-    };
+    if (lodChanged) {
+      const oldLOD = this.currentLOD_?.scaleIndex ?? 'none';
+      console.log(`LOD changed from ${oldLOD} to ${lodResult.scaleIndex} (resolution: ${lodResult.resolution.toFixed(2)}, scale factor: ${lodResult.scaleFactor.toFixed(4)})`);
+      this.currentLOD_ = lodResult;
+      return await this.reloadWithScale(lodResult.scaleIndex);
+    }
+
+    this.currentLOD_ = lodResult;
+    return undefined;
   }
 
   public computeLOD(
@@ -90,6 +90,7 @@ export class ChunkManager {
     bufferHeight: number, // screen/canvas height in pixels
     availableScales: number[][] // scale factors per LOD, where each scale is [c, z, y, x]
   ): LODResult {
+    // console.log("computeLOD", availableScales);
     if (availableScales.length === 0) {
       throw new Error("No scales available");
     }
@@ -186,4 +187,52 @@ export class ChunkManager {
 
     return { worldWidth, worldHeight };
   }
+
+}
+
+export class ChunkManager {
+  private readonly sources_ = new Map<ImageChunkSource, ChunkManagerSource>();
+
+  public computeVisibleBounds(camera: Camera): Bounds {
+    let topLeft = vec4.fromValues(-1.0, 1.0, 0.0, 1.0);
+    let bottomRight = vec4.fromValues(1.0, -1.0, 0.0, 1.0);
+
+    const viewProjection = mat4.multiply(
+      mat4.create(),
+      camera.projectionMatrix,
+      camera.viewMatrix
+    );
+
+    const inv = mat4.invert(mat4.create(), viewProjection);
+    topLeft = vec4.transformMat4(vec4.create(), topLeft, inv);
+    bottomRight = vec4.transformMat4(vec4.create(), bottomRight, inv);
+
+    return {
+      min: vec2.fromValues(topLeft[0], topLeft[1]),
+      max: vec2.fromValues(bottomRight[0], bottomRight[1]),
+    };
+  }
+
+  public async addSource(source: ImageChunkSource) {
+    let existing = this.sources_.get(source);
+    if (!existing) {
+      console.log("adding sourceq", source);
+      const loader = await source.open();
+      const attrs = await loader.loadAttributes();
+      existing = new ChunkManagerSource(loader, attrs);
+      this.sources_.set(source, existing);
+      console.log("added source", source);
+    }
+    return existing;
+  }
+
+  public async update(camera: Camera, region: Region, bufferWidth: number, bufferHeight: number) {
+    // const visibleBounds = this.computeVisibleBounds(camera);
+    // Note: ChunkManager doesn't know about regions, so layers will call updateLOD directly
+    // This is left here for future use when we implement proper chunk management
+    for (const source of this.sources_.values()) {
+      await source.updateLOD(camera, bufferWidth, bufferHeight, region);
+    }
+  }
+
 }

--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -50,22 +50,20 @@ export class ChunkManagerSource {
     }
   }
 
-  public async updateLOD(camera: Camera, bufferWidth: number, bufferHeight: number): Promise<ImageChunk | undefined> {
+  public async updateLOD(camera: Camera, bufferWidth: number, bufferHeight: number, firstPass: boolean = false): Promise<ImageChunk | undefined> {
     const availableScales = this.attributes_.map(attr => attr.scale);
     const lodResult = this.computeLOD(camera, bufferWidth, bufferHeight, availableScales);
 
     const lodChanged = !this.currentLOD_ || lodResult.scaleIndex !== this.currentLOD_.scaleIndex;
 
-    if (lodChanged) {
-      const oldLOD = this.currentLOD_?.scaleIndex ?? 'none';
-      console.log(`LOD changed from ${oldLOD} to ${lodResult.scaleIndex} (resolution: ${lodResult.resolution.toFixed(2)}, scale factor: ${lodResult.scaleFactor.toFixed(4)})`);
+    if (lodChanged || firstPass) {
+      if (lodChanged) {
+        const oldLOD = this.currentLOD_?.scaleIndex ?? 'none';
+        console.log(`LOD changed from ${oldLOD} to ${lodResult.scaleIndex} (resolution: ${lodResult.resolution.toFixed(2)}, scale factor: ${lodResult.scaleFactor.toFixed(4)})`);
+      }
       this.currentLOD_ = lodResult;
       return await this.load();
     }
-
-    this.currentLOD_ = lodResult;
-    // return await this.load();
-    return undefined;
   }
 
   public async getVisibleChunks(): Promise<ImageChunk[]> {

--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -95,17 +95,12 @@ export class ChunkManager {
     };
   }
 
-  /**
-   * Calculate the world space extent (width/height) currently visible in the camera view.
-   */
+  // Calculate the world space extent (width/height) currently visible in the camera view.
   private calculateViewExtent(
     camera: Camera,
     _bufferWidth: number, // screen width
     _bufferHeight: number // screen height
   ): { worldWidth: number; worldHeight: number } {
-    // virtual world space extent
-    // Convert screen corners to world coordinates to determine view extent
-
     // Screen space corners (normalized device coordinates: -1 to +1)
     const topLeft = camera.clipToWorld([-1, 1, 0]); // camera space to world space
     const topRight = camera.clipToWorld([1, 1, 0]);

--- a/packages/core/src/data/image_chunk.ts
+++ b/packages/core/src/data/image_chunk.ts
@@ -49,7 +49,7 @@ export type ImageChunkSource = {
 export type LoaderAttributes = {
   dimensionNames: string[];
   shape: readonly number[];
-  scale: readonly number[];
+  scale: number[];
 };
 
 export type ImageChunkLoader = {

--- a/packages/core/src/idetik.ts
+++ b/packages/core/src/idetik.ts
@@ -71,10 +71,7 @@ export class Idetik {
         );
         return;
       }
-      this.chunkManager_.update(
-        this.camera,
-        this.renderer_.width
-      );
+      this.chunkManager_.update(this.camera, this.renderer_.width);
       this.renderer_.render(this.layerManager, this.camera);
       requestAnimationFrame(render);
     };

--- a/packages/core/src/idetik.ts
+++ b/packages/core/src/idetik.ts
@@ -5,6 +5,7 @@ import { WebGLRenderer } from "./renderers/webgl_renderer";
 import { PanZoomControls } from "./objects/cameras/controls";
 import { Logger } from "./utilities/logger";
 import { ChunkManager } from "./core/chunk_manager";
+import { Region } from "./data/region";
 
 type IdetikParams = {
   canvasSelector: string;
@@ -15,8 +16,8 @@ type IdetikParams = {
 
 export type IdetikContext = {
   chunkManager: ChunkManager;
-  getCamera: () => Camera;
-  getViewport: () => { width: number; height: number };
+  camera: Camera;
+  viewport: { width: number; height: number };
 };
 
 export class Idetik {
@@ -34,11 +35,8 @@ export class Idetik {
 
     this.context_ = {
       chunkManager: this.chunkManager_,
-      getCamera: () => this.camera,
-      getViewport: () => ({
-        width: this.renderer_.width,
-        height: this.renderer_.height,
-      }),
+      camera: this.camera,
+      viewport: { width: this.renderer_.width, height: this.renderer_.height },
     };
 
     this.layerManager = new LayerManager(this.context_);
@@ -68,7 +66,7 @@ export class Idetik {
     this.renderer_.setControls(controls);
   }
 
-  public start() {
+  public start(region: Region) {
     Logger.info("Idetik", "Idetik runtime started");
     const render = () => {
       if (!this.camera) {
@@ -80,6 +78,7 @@ export class Idetik {
       }
       this.chunkManager_.update(
         this.camera,
+        region,
         this.renderer_.width,
         this.renderer_.height
       );

--- a/packages/core/src/idetik.ts
+++ b/packages/core/src/idetik.ts
@@ -5,7 +5,6 @@ import { WebGLRenderer } from "./renderers/webgl_renderer";
 import { PanZoomControls } from "./objects/cameras/controls";
 import { Logger } from "./utilities/logger";
 import { ChunkManager } from "./core/chunk_manager";
-import { Region } from "./data/region";
 
 type IdetikParams = {
   canvasSelector: string;
@@ -66,7 +65,7 @@ export class Idetik {
     this.renderer_.setControls(controls);
   }
 
-  public start(region: Region) {
+  public start() {
     Logger.info("Idetik", "Idetik runtime started");
     const render = () => {
       if (!this.camera) {
@@ -78,7 +77,6 @@ export class Idetik {
       }
       this.chunkManager_.update(
         this.camera,
-        region,
         this.renderer_.width,
         this.renderer_.height
       );

--- a/packages/core/src/idetik.ts
+++ b/packages/core/src/idetik.ts
@@ -35,7 +35,10 @@ export class Idetik {
     this.context_ = {
       chunkManager: this.chunkManager_,
       getCamera: () => this.camera,
-      getViewport: () => ({ width: this.renderer_.width, height: this.renderer_.height }),
+      getViewport: () => ({
+        width: this.renderer_.width,
+        height: this.renderer_.height,
+      }),
     };
 
     this.layerManager = new LayerManager(this.context_);

--- a/packages/core/src/idetik.ts
+++ b/packages/core/src/idetik.ts
@@ -15,8 +15,6 @@ type IdetikParams = {
 
 export type IdetikContext = {
   chunkManager: ChunkManager;
-  camera: Camera;
-  viewport: { width: number; height: number };
 };
 
 export class Idetik {
@@ -34,8 +32,6 @@ export class Idetik {
 
     this.context_ = {
       chunkManager: this.chunkManager_,
-      camera: this.camera,
-      viewport: { width: this.renderer_.width, height: this.renderer_.height },
     };
 
     this.layerManager = new LayerManager(this.context_);
@@ -77,8 +73,7 @@ export class Idetik {
       }
       this.chunkManager_.update(
         this.camera,
-        this.renderer_.width,
-        this.renderer_.height
+        this.renderer_.width
       );
       this.renderer_.render(this.layerManager, this.camera);
       requestAnimationFrame(render);

--- a/packages/core/src/idetik.ts
+++ b/packages/core/src/idetik.ts
@@ -15,6 +15,8 @@ type IdetikParams = {
 
 export type IdetikContext = {
   chunkManager: ChunkManager;
+  getCamera: () => Camera;
+  getViewport: () => { width: number; height: number };
 };
 
 export class Idetik {
@@ -32,6 +34,8 @@ export class Idetik {
 
     this.context_ = {
       chunkManager: this.chunkManager_,
+      getCamera: () => this.camera,
+      getViewport: () => ({ width: this.renderer_.width, height: this.renderer_.height }),
     };
 
     this.layerManager = new LayerManager(this.context_);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,6 +9,8 @@ export type { CameraControls } from "./objects/cameras/controls";
 export { Layer } from "./core/layer";
 export type { LayerState } from "./core/layer";
 export { LayerManager } from "./core/layer_manager";
+export { ChunkManager } from "./core/chunk_manager";
+export type { LODResult } from "./core/chunk_manager";
 
 export { AxesLayer } from "./layers/axes_layer";
 export { ProjectedLineLayer } from "./layers/projected_line_layer";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -10,7 +10,6 @@ export { Layer } from "./core/layer";
 export type { LayerState } from "./core/layer";
 export { LayerManager } from "./core/layer_manager";
 export { ChunkManager } from "./core/chunk_manager";
-export type { LODResult } from "./core/chunk_manager";
 
 export { AxesLayer } from "./layers/axes_layer";
 export { ProjectedLineLayer } from "./layers/projected_line_layer";

--- a/packages/core/src/layers/image_layer_xyz.ts
+++ b/packages/core/src/layers/image_layer_xyz.ts
@@ -35,7 +35,7 @@ export class ImageLayerXYZ extends Layer {
     this.channelProps_ = channelProps;
   }
 
-  public async onAttached(context: IdetikContext): Promise<void> {
+  public async onAttached(context: IdetikContext) {
     this.chunkManagerSource_ = await context.chunkManager.addSource(
       this.source_
     );

--- a/packages/core/src/layers/image_layer_xyz.ts
+++ b/packages/core/src/layers/image_layer_xyz.ts
@@ -21,7 +21,6 @@ export class ImageLayerXYZ extends Layer {
   private channelProps_?: ChannelProps[];
   private image_?: ImageRenderable;
   private extent_?: { x: number; y: number };
-  private context_?: IdetikContext;
 
   constructor({
     source,
@@ -37,7 +36,6 @@ export class ImageLayerXYZ extends Layer {
   }
 
   public async onAttached(context: IdetikContext): Promise<void> {
-    this.context_ = context;
     this.chunkManagerSource_ = await context.chunkManager.addSource(
       this.source_
     );

--- a/packages/core/src/layers/image_layer_xyz.ts
+++ b/packages/core/src/layers/image_layer_xyz.ts
@@ -1,18 +1,12 @@
 import { Layer, LayerOptions } from "../core/layer";
 import { IdetikContext } from "../idetik";
 import { Region } from "../data/region";
-import {
-  ImageChunk,
-  ImageChunkLoader,
-  ImageChunkSource,
-  LoaderAttributes,
-} from "../data/image_chunk";
+import { ImageChunk, ImageChunkSource } from "../data/image_chunk";
 import { ChunkManagerSource } from "../core/chunk_manager";
 import { ChannelProps } from "../objects/textures/channel";
 import { ImageRenderable } from "../objects/renderable/image_renderable";
 import { Texture2DArray } from "../objects/textures/texture_2d_array";
 import { PlaneGeometry } from "../objects/geometry/plane_geometry";
-import { LODResult } from "../core/chunk_manager";
 
 export type ImageLayerProps = LayerOptions & {
   source: ImageChunkSource;
@@ -28,9 +22,6 @@ export class ImageLayerXYZ extends Layer {
   private image_?: ImageRenderable;
   private extent_?: { x: number; y: number };
   private context_?: IdetikContext;
-  private currentLOD_?: LODResult;
-  private attributes_: LoaderAttributes[] | undefined;
-  private loader_: ImageChunkLoader | undefined;
 
   constructor({
     source,
@@ -45,52 +36,74 @@ export class ImageLayerXYZ extends Layer {
     this.channelProps_ = channelProps;
   }
 
-  private async ensureLoader(): Promise<ImageChunkLoader> {
-    if (!this.loader_) {
-      this.loader_ = await this.source_.open();
-    }
-    return this.loader_;
-  }
-
-  private async ensureAttributes(): Promise<LoaderAttributes[]> {
-    if (!this.attributes_) {
-      const loader = await this.ensureLoader();
-      this.attributes_ = await loader.loadAttributes();
-    }
-    return this.attributes_;
-  }
-
   public async onAttached(context: IdetikContext): Promise<void> {
-    // TODO: context.chunkManager.addSource(this.source_)
+    console.log("onAttached");
     this.context_ = context;
-    await this.ensureLoader(); // preload loader early
-    await this.ensureAttributes(); // preload attributes early
     this.chunkManagerSource_ = await context.chunkManager.addSource(
       this.source_
     );
+    this.chunkManagerSource_.setRegion(this.region_);
   }
 
-  public update() {
-    if (!this.chunkManagerSource_) return;
-
-    const chunks = this.chunkManagerSource_.getVisibleChunks();
-    chunks.forEach((_) => {
-      // TODO: create image renderable for visible chunks if needed
-    });
+  public async update() {
+    if (!this.chunkManagerSource_ || !this.context_) return;
 
     switch (this.state) {
       case "initialized":
-        this.load(this.region_);
+        await this.load();
         break;
       case "loading":
         break;
       case "ready":
-        this.updateLOD();
+        await this.updateLOD();
         break;
       default: {
         const exhaustiveCheck: never = this.state;
         throw new Error(`Unhandled LayerState case: ${exhaustiveCheck}`);
       }
+    }
+  }
+
+  private async load() {
+    if (!this.chunkManagerSource_) return;
+
+    this.setState("loading");
+    const chunk = await this.chunkManagerSource_.load();
+
+    if (chunk) {
+      this.extent_ = {
+        x: chunk.shape.x * chunk.scale.x,
+        y: chunk.shape.y * chunk.scale.y,
+      };
+
+      this.image_ = this.createImage(chunk);
+      this.addObject(this.image_);
+    }
+
+    this.setState("ready");
+  }
+
+  private async updateLOD() {
+    if (!this.chunkManagerSource_ || !this.context_) return;
+
+    const camera = this.context_.camera;
+    const viewport = this.context_.viewport;
+
+    const newChunk = await this.chunkManagerSource_.updateLOD(
+      camera,
+      viewport.width,
+      viewport.height
+    );
+
+    if (newChunk) {
+      this.extent_ = {
+        x: newChunk.shape.x * newChunk.scale.x,
+        y: newChunk.shape.y * newChunk.scale.y,
+      };
+
+      this.clearObjects();
+      this.image_ = this.createImage(newChunk);
+      this.addObject(this.image_);
     }
   }
 
@@ -103,41 +116,13 @@ export class ImageLayerXYZ extends Layer {
     this.image_?.setChannelProps(channelProps);
   }
 
-  private async load(region: Region) {
-    if (this.state !== "initialized") {
-      throw new Error(`Trying to load chunks more than once.`);
-    }
-    this.setState("loading");
-    const loader = await this.ensureLoader();
-
-    const attributes = await this.ensureAttributes();
-    // Use computed LOD if available; otherwise default to lowest resolution
-    const lod = this.currentLOD_?.scaleIndex ?? attributes.length - 1;
-
-    const chunk = await loader.loadChunk(region, lod);
-
-    this.extent_ = {
-      x: chunk.shape.x * chunk.scale.x,
-      y: chunk.shape.y * chunk.scale.y,
-    };
-
-    this.image_ = this.createImage(chunk, this.channelProps_);
-    this.addObject(this.image_);
-
-    this.setState("ready");
-  }
-
-  public get extent(): { x: number; y: number } | undefined {
-    return this.extent_;
-  }
-
-  private createImage(chunk: ImageChunk, channelProps?: ChannelProps[]) {
+  private createImage(chunk: ImageChunk): ImageRenderable {
     const geometry = new PlaneGeometry(chunk.shape.x, chunk.shape.y, 1, 1);
 
     const image = new ImageRenderable(
       geometry,
       Texture2DArray.createWithImageChunk(chunk),
-      channelProps
+      this.channelProps_
     );
 
     image.transform.setScale([chunk.scale.x, chunk.scale.y, 1]);
@@ -145,59 +130,7 @@ export class ImageLayerXYZ extends Layer {
     return image;
   }
 
-  private async updateLOD() {
-    if (!this.context_) {
-      return;
-    }
-
-    try {
-      const camera = this.context_.getCamera();
-      const viewport = this.context_.getViewport();
-      const attributes = await this.ensureAttributes();
-      const availableScales = attributes.map((attr) => attr.scale);
-
-      const lodResult = this.context_.chunkManager.computeLOD(
-        camera,
-        viewport.width,
-        viewport.height,
-        availableScales
-      );
-
-      if (
-        !this.currentLOD_ ||
-        lodResult.scaleIndex !== this.currentLOD_.scaleIndex
-      ) {
-        this.currentLOD_ = lodResult;
-        this.reloadWithScale(lodResult.scaleIndex);
-      }
-    } catch (error) {
-      console.warn("Failed to compute LOD:", error);
-    }
-  }
-
-  private async reloadWithScale(lod: number) {
-    if (!this.image_) {
-      return;
-    }
-
-    try {
-      const loader = await this.ensureLoader();
-      const chunk = await loader.loadChunk(this.region_, lod);
-
-      this.extent_ = {
-        x: chunk.shape.x * chunk.scale.x,
-        y: chunk.shape.y * chunk.scale.y,
-      };
-
-      this.clearObjects();
-      this.image_ = this.createImage(chunk, this.channelProps_);
-      this.addObject(this.image_);
-    } catch (error) {
-      console.warn("Failed to reload with new scale:", error);
-    }
-  }
-
-  public get currentLOD(): LODResult | undefined {
-    return this.currentLOD_;
+  public get extent(): { x: number; y: number } | undefined {
+    return this.extent_;
   }
 }

--- a/packages/core/src/layers/image_layer_xyz.ts
+++ b/packages/core/src/layers/image_layer_xyz.ts
@@ -89,7 +89,7 @@ export class ImageLayerXYZ extends Layer {
     const camera = this.context_.camera;
     const viewport = this.context_.viewport;
 
-    const newChunk = await this.chunkManagerSource_.loadChunk(
+    const newChunk = await this.chunkManagerSource_.updateLOD(
       camera,
       viewport.width,
       viewport.height

--- a/packages/core/src/layers/image_layer_xyz.ts
+++ b/packages/core/src/layers/image_layer_xyz.ts
@@ -50,12 +50,12 @@ export class ImageLayerXYZ extends Layer {
 
     switch (this.state) {
       case "initialized":
-        await this.load();
+        await this.updateImage();
         break;
       case "loading":
         break;
       case "ready":
-        await this.loadChunk();
+        await this.updateImage();
         break;
       default: {
         const exhaustiveCheck: never = this.state;
@@ -64,27 +64,14 @@ export class ImageLayerXYZ extends Layer {
     }
   }
 
-  private async load() {
-    if (!this.chunkManagerSource_) return;
-
-    this.setState("loading");
-    const chunk = await this.chunkManagerSource_.load();
-
-    if (chunk) {
-      this.extent_ = {
-        x: chunk.shape.x * chunk.scale.x,
-        y: chunk.shape.y * chunk.scale.y,
-      };
-
-      this.image_ = this.createImage(chunk);
-      this.addObject(this.image_);
-    }
-
-    this.setState("ready");
-  }
-
-  private async loadChunk() {
+  private async updateImage() {
     if (!this.chunkManagerSource_ || !this.context_) return;
+
+    const firstPass = this.state === "initialized";
+    
+    if (firstPass) {
+      this.setState("loading");
+    }
 
     const camera = this.context_.camera;
     const viewport = this.context_.viewport;
@@ -92,19 +79,31 @@ export class ImageLayerXYZ extends Layer {
     const newChunk = await this.chunkManagerSource_.updateLOD(
       camera,
       viewport.width,
-      viewport.height
+      viewport.height,
+      firstPass
     );
 
     if (newChunk) {
-      this.extent_ = {
-        x: newChunk.shape.x * newChunk.scale.x,
-        y: newChunk.shape.y * newChunk.scale.y,
-      };
-
-      this.clearObjects();
-      this.image_ = this.createImage(newChunk);
-      this.addObject(this.image_);
+      this.processChunk(newChunk, !firstPass);
     }
+
+    if (firstPass) {
+      this.setState("ready");
+    }
+  }
+
+  private processChunk(chunk: ImageChunk, shouldClear: boolean) {
+    this.extent_ = {
+      x: chunk.shape.x * chunk.scale.x,
+      y: chunk.shape.y * chunk.scale.y,
+    };
+
+    if (shouldClear) {
+      this.clearObjects();
+    }
+
+    this.image_ = this.createImage(chunk);
+    this.addObject(this.image_);
   }
 
   public get channelProps(): ChannelProps[] | undefined {

--- a/packages/core/src/layers/image_layer_xyz.ts
+++ b/packages/core/src/layers/image_layer_xyz.ts
@@ -37,7 +37,6 @@ export class ImageLayerXYZ extends Layer {
   }
 
   public async onAttached(context: IdetikContext): Promise<void> {
-    console.log("onAttached");
     this.context_ = context;
     this.chunkManagerSource_ = await context.chunkManager.addSource(
       this.source_

--- a/packages/core/src/layers/image_layer_xyz.ts
+++ b/packages/core/src/layers/image_layer_xyz.ts
@@ -55,7 +55,7 @@ export class ImageLayerXYZ extends Layer {
       case "loading":
         break;
       case "ready":
-        await this.updateLOD();
+        await this.loadChunk();
         break;
       default: {
         const exhaustiveCheck: never = this.state;
@@ -83,13 +83,13 @@ export class ImageLayerXYZ extends Layer {
     this.setState("ready");
   }
 
-  private async updateLOD() {
+  private async loadChunk() {
     if (!this.chunkManagerSource_ || !this.context_) return;
 
     const camera = this.context_.camera;
     const viewport = this.context_.viewport;
 
-    const newChunk = await this.chunkManagerSource_.updateLOD(
+    const newChunk = await this.chunkManagerSource_.loadChunk(
       camera,
       viewport.width,
       viewport.height

--- a/packages/core/src/layers/image_layer_xyz.ts
+++ b/packages/core/src/layers/image_layer_xyz.ts
@@ -47,12 +47,10 @@ export class ImageLayerXYZ extends Layer {
 
     switch (this.state) {
       case "initialized":
+      case "ready":
         await this.updateChunks();
         break;
       case "loading":
-        break;
-      case "ready":
-        await this.updateChunks();
         break;
       default: {
         const exhaustiveCheck: never = this.state;
@@ -64,32 +62,27 @@ export class ImageLayerXYZ extends Layer {
   private async updateChunks() {
     if (!this.chunkManagerSource_) return;
 
-    const isInitialLoad = this.state === "initialized";
-
-    if (isInitialLoad) {
+    if (this.state === "initialized") {
       this.setState("loading");
     }
 
-    const chunks = await this.chunkManagerSource_.getVisibleChunks();
+    await this.chunkManagerSource_.loadChunk();
+    const chunks = this.chunkManagerSource_.getVisibleChunks();
 
     if (chunks.length > 0) {
-      this.processChunk(chunks[0], !isInitialLoad);
+      this.processChunk(chunks[0]);
     }
 
-    if (isInitialLoad) {
-      this.setState("ready");
-    }
+    this.setState("ready");
   }
 
-  private processChunk(chunk: ImageChunk, shouldClear: boolean) {
+  private processChunk(chunk: ImageChunk) {
     this.extent_ = {
       x: chunk.shape.x * chunk.scale.x,
       y: chunk.shape.y * chunk.scale.y,
     };
 
-    if (shouldClear) {
-      this.clearObjects();
-    }
+    this.clearObjects();
 
     this.image_ = this.createImage(chunk);
     this.addObject(this.image_);

--- a/packages/core/src/layers/image_layer_xyz.ts
+++ b/packages/core/src/layers/image_layer_xyz.ts
@@ -46,16 +46,16 @@ export class ImageLayerXYZ extends Layer {
   }
 
   public async update() {
-    if (!this.chunkManagerSource_ || !this.context_) return;
+    if (!this.chunkManagerSource_) return;
 
     switch (this.state) {
       case "initialized":
-        await this.updateImage();
+        await this.updateChunks();
         break;
       case "loading":
         break;
       case "ready":
-        await this.updateImage();
+        await this.updateChunks();
         break;
       default: {
         const exhaustiveCheck: never = this.state;
@@ -64,29 +64,22 @@ export class ImageLayerXYZ extends Layer {
     }
   }
 
-  private async updateImage() {
-    if (!this.chunkManagerSource_ || !this.context_) return;
+  private async updateChunks() {
+    if (!this.chunkManagerSource_) return;
 
-    const firstPass = this.state === "initialized";
+    const isInitialLoad = this.state === "initialized";
 
-    if (firstPass) {
+    if (isInitialLoad) {
       this.setState("loading");
     }
 
-    const camera = this.context_.camera;
-    const viewport = this.context_.viewport;
+    const chunks = await this.chunkManagerSource_.getVisibleChunks();
 
-    const newChunk = await this.chunkManagerSource_.updateLOD(
-      camera,
-      viewport.width,
-      firstPass
-    );
-
-    if (newChunk) {
-      this.processChunk(newChunk, !firstPass);
+    if (chunks.length > 0) {
+      this.processChunk(chunks[0], !isInitialLoad);
     }
 
-    if (firstPass) {
+    if (isInitialLoad) {
       this.setState("ready");
     }
   }

--- a/packages/core/src/layers/image_layer_xyz.ts
+++ b/packages/core/src/layers/image_layer_xyz.ts
@@ -1,7 +1,11 @@
 import { Layer, LayerOptions } from "../core/layer";
 import { IdetikContext } from "../idetik";
 import { Region } from "../data/region";
-import { ImageChunk, ImageChunkSource, ImageChunkLoader } from "../data/image_chunk";
+import {
+  ImageChunk,
+  ImageChunkSource,
+  ImageChunkLoader,
+} from "../data/image_chunk";
 import { ChannelProps } from "../objects/textures/channel";
 import { ImageRenderable } from "../objects/renderable/image_renderable";
 import { Texture2DArray } from "../objects/textures/texture_2d_array";
@@ -109,9 +113,12 @@ export class ImageLayerXYZ extends Layer {
 
   private async loadAvailableScales(loader: ImageChunkLoader) {
     if (loader instanceof OmeZarrImageLoader) {
+      // TODO: Support multiple multiscales (pyramids) per image.
+      // Currently assumes multiscales[0] is the only pyramid, which is typical for most datasets.
+      // In future, we could expose a way to select which pyramid to use. (e.g. a dropdown?)
       const image = loader.metadata_.multiscales[0];
-      this.availableScales_ = image.datasets.map(dataset =>
-        dataset.coordinateTransformations[0].scale
+      this.availableScales_ = image.datasets.map(
+        (dataset) => dataset.coordinateTransformations[0].scale
       );
     } else {
       const attributes = await loader.loadAttributes();
@@ -134,13 +141,16 @@ export class ImageLayerXYZ extends Layer {
         viewport.height,
         this.availableScales_
       );
-      
-      if (!this.currentLOD_ || lodResult.scaleIndex !== this.currentLOD_.scaleIndex) {
+
+      if (
+        !this.currentLOD_ ||
+        lodResult.scaleIndex !== this.currentLOD_.scaleIndex
+      ) {
         this.currentLOD_ = lodResult;
         this.reloadWithScale(lodResult.scaleIndex);
       }
     } catch (error) {
-      console.warn('Failed to compute LOD:', error);
+      console.warn("Failed to compute LOD:", error);
     }
   }
 
@@ -166,7 +176,7 @@ export class ImageLayerXYZ extends Layer {
       this.image_ = this.createImage(chunk, this.channelProps_);
       this.addObject(this.image_);
     } catch (error) {
-      console.warn('Failed to reload with new scale:', error);
+      console.warn("Failed to reload with new scale:", error);
     }
   }
 

--- a/packages/core/src/layers/image_layer_xyz.ts
+++ b/packages/core/src/layers/image_layer_xyz.ts
@@ -66,14 +66,15 @@ export class ImageLayerXYZ extends Layer {
       this.setState("loading");
     }
 
-    await this.chunkManagerSource_.loadChunk();
     const chunks = this.chunkManagerSource_.getVisibleChunks();
 
     if (chunks.length > 0) {
       this.processChunk(chunks[0]);
     }
 
-    this.setState("ready");
+    if (this.state === "loading") {
+      this.setState("ready");
+    }
   }
 
   private processChunk(chunk: ImageChunk) {

--- a/packages/core/src/layers/image_layer_xyz.ts
+++ b/packages/core/src/layers/image_layer_xyz.ts
@@ -68,7 +68,7 @@ export class ImageLayerXYZ extends Layer {
     if (!this.chunkManagerSource_ || !this.context_) return;
 
     const firstPass = this.state === "initialized";
-    
+
     if (firstPass) {
       this.setState("loading");
     }
@@ -79,7 +79,6 @@ export class ImageLayerXYZ extends Layer {
     const newChunk = await this.chunkManagerSource_.updateLOD(
       camera,
       viewport.width,
-      viewport.height,
       firstPass
     );
 

--- a/packages/core/src/layers/image_layer_xyz.ts
+++ b/packages/core/src/layers/image_layer_xyz.ts
@@ -43,6 +43,7 @@ export class ImageLayerXYZ extends Layer {
   }
 
   public onAttached(context: IdetikContext): void {
+    // TODO: context.chunkManager.addSource(this.source_)
     this.context_ = context;
   }
 

--- a/packages/core/src/layers/image_layer_xyz.ts
+++ b/packages/core/src/layers/image_layer_xyz.ts
@@ -3,15 +3,15 @@ import { IdetikContext } from "../idetik";
 import { Region } from "../data/region";
 import {
   ImageChunk,
-  ImageChunkSource,
   ImageChunkLoader,
+  ImageChunkSource,
+  LoaderAttributes,
 } from "../data/image_chunk";
 import { ChannelProps } from "../objects/textures/channel";
 import { ImageRenderable } from "../objects/renderable/image_renderable";
 import { Texture2DArray } from "../objects/textures/texture_2d_array";
 import { PlaneGeometry } from "../objects/geometry/plane_geometry";
 import { LODResult } from "../core/chunk_manager";
-import { OmeZarrImageLoader } from "../data/ome_zarr_image_loader";
 
 export type ImageLayerProps = LayerOptions & {
   source: ImageChunkSource;
@@ -26,31 +26,43 @@ export class ImageLayerXYZ extends Layer {
   private image_?: ImageRenderable;
   private extent_?: { x: number; y: number };
   private context_?: IdetikContext;
-  private availableScales_?: number[][];
   private currentLOD_?: LODResult;
-
-  // TODO:(shlomnissan) Remove this parameter—LOD will be computed
-  // dynamically by the chunk manager.
-  private readonly lod_?: number;
+  private attributes_: LoaderAttributes[] | undefined;
+  private loader_: ImageChunkLoader | undefined;
 
   constructor({
     source,
     region,
     channelProps,
-    lod,
     ...layerOptions
   }: ImageLayerProps) {
     super(layerOptions);
     this.setState("initialized");
     this.source_ = source;
     this.region_ = region;
-    this.lod_ = lod;
     this.channelProps_ = channelProps;
   }
 
-  public onAttached(context: IdetikContext): void {
+  private async ensureLoader(): Promise<ImageChunkLoader> {
+    if (!this.loader_) {
+      this.loader_ = await this.source_.open();
+    }
+    return this.loader_;
+  }
+
+  private async ensureAttributes(): Promise<LoaderAttributes[]> {
+    if (!this.attributes_) {
+      const loader = await this.ensureLoader();
+      this.attributes_ = await loader.loadAttributes();
+    }
+    return this.attributes_;
+  }
+
+  public async onAttached(context: IdetikContext): Promise<void> {
     // TODO: context.chunkManager.addSource(this.source_)
     this.context_ = context;
+    await this.ensureLoader(); // preload loader early
+    await this.ensureAttributes(); // preload attributes early
   }
 
   public update() {
@@ -84,13 +96,11 @@ export class ImageLayerXYZ extends Layer {
       throw new Error(`Trying to load chunks more than once.`);
     }
     this.setState("loading");
-    const loader = await this.source_.open();
-    
-    // await this.loadAvailableScales(loader);
-    // const chunk = await loader.loadChunk(region);
+    const loader = await this.ensureLoader();
 
-    const attributes = await loader.loadAttributes();
-    const lod = this.lod_ ?? attributes.length - 1;
+    const attributes = await this.ensureAttributes();
+    // Use computed LOD if available; otherwise default to lowest resolution
+    const lod = this.currentLOD_?.scaleIndex ?? attributes.length - 1;
 
     const chunk = await loader.loadChunk(region, lod);
 
@@ -123,35 +133,22 @@ export class ImageLayerXYZ extends Layer {
     return image;
   }
 
-  private async loadAvailableScales(loader: ImageChunkLoader) {
-    if (loader instanceof OmeZarrImageLoader) {
-      // TODO: Support multiple multiscales (pyramids) per image.
-      // Currently assumes multiscales[0] is the only pyramid, which is typical for most datasets.
-      // In future, we could expose a way to select which pyramid to use. (e.g. a dropdown?)
-      const image = loader.metadata_.multiscales[0];
-      this.availableScales_ = image.datasets.map(
-        (dataset) => dataset.coordinateTransformations[0].scale
-      );
-    } else {
-      const attributes = await loader.loadAttributes();
-      this.availableScales_ = [Array.from(attributes.scale)];
-    }
-  }
-
-  private updateLOD() {
-    if (!this.context_ || !this.availableScales_) {
+  private async updateLOD() {
+    if (!this.context_) {
       return;
     }
 
     try {
       const camera = this.context_.getCamera();
       const viewport = this.context_.getViewport();
+      const attributes = await this.ensureAttributes();
+      const availableScales = attributes.map((attr) => attr.scale);
 
       const lodResult = this.context_.chunkManager.computeLOD(
         camera,
         viewport.width,
         viewport.height,
-        this.availableScales_
+        availableScales
       );
 
       if (
@@ -166,18 +163,14 @@ export class ImageLayerXYZ extends Layer {
     }
   }
 
-  private async reloadWithScale(scaleIndex: number) {
+  private async reloadWithScale(lod: number) {
     if (!this.image_) {
       return;
     }
 
     try {
-      const loader = await this.source_.open();
-      if (loader instanceof OmeZarrImageLoader) {
-        loader.scaleIndex_ = scaleIndex;
-      }
-
-      const chunk = await loader.loadChunk(this.region_);
+      const loader = await this.ensureLoader();
+      const chunk = await loader.loadChunk(this.region_, lod);
 
       this.extent_ = {
         x: chunk.shape.x * chunk.scale.x,

--- a/packages/core/src/layers/image_layer_xyz.ts
+++ b/packages/core/src/layers/image_layer_xyz.ts
@@ -1,11 +1,13 @@
 import { Layer, LayerOptions } from "../core/layer";
 import { IdetikContext } from "../idetik";
 import { Region } from "../data/region";
-import { ImageChunk, ImageChunkSource } from "../data/image_chunk";
+import { ImageChunk, ImageChunkSource, ImageChunkLoader } from "../data/image_chunk";
 import { ChannelProps } from "../objects/textures/channel";
 import { ImageRenderable } from "../objects/renderable/image_renderable";
 import { Texture2DArray } from "../objects/textures/texture_2d_array";
 import { PlaneGeometry } from "../objects/geometry/plane_geometry";
+import { LODResult } from "../core/chunk_manager";
+import { OmeZarrImageLoader } from "../data/ome_zarr_image_loader";
 
 export type ImageLayerProps = LayerOptions & {
   source: ImageChunkSource;
@@ -19,6 +21,9 @@ export class ImageLayerXYZ extends Layer {
   private channelProps_?: ChannelProps[];
   private image_?: ImageRenderable;
   private extent_?: { x: number; y: number };
+  private context_?: IdetikContext;
+  private availableScales_?: number[][];
+  private currentLOD_?: LODResult;
 
   constructor({
     source,
@@ -33,8 +38,8 @@ export class ImageLayerXYZ extends Layer {
     this.channelProps_ = channelProps;
   }
 
-  public onAttached(_context: IdetikContext): void {
-    // TODO: context.chunkManager.addSource(this.source_)
+  public onAttached(context: IdetikContext): void {
+    this.context_ = context;
   }
 
   public update() {
@@ -43,7 +48,9 @@ export class ImageLayerXYZ extends Layer {
         this.load(this.region_);
         break;
       case "loading":
+        break;
       case "ready":
+        this.updateLOD();
         break;
       default: {
         const exhaustiveCheck: never = this.state;
@@ -67,6 +74,9 @@ export class ImageLayerXYZ extends Layer {
     }
     this.setState("loading");
     const loader = await this.source_.open();
+
+    await this.loadAvailableScales(loader);
+
     const chunk = await loader.loadChunk(region);
     this.extent_ = {
       x: chunk.shape.x * chunk.scale.x,
@@ -95,5 +105,72 @@ export class ImageLayerXYZ extends Layer {
     image.transform.setScale([chunk.scale.x, chunk.scale.y, 1]);
     image.transform.setTranslation([chunk.offset.x, chunk.offset.y, 0]);
     return image;
+  }
+
+  private async loadAvailableScales(loader: ImageChunkLoader) {
+    if (loader instanceof OmeZarrImageLoader) {
+      const image = loader.metadata_.multiscales[0];
+      this.availableScales_ = image.datasets.map(dataset =>
+        dataset.coordinateTransformations[0].scale
+      );
+    } else {
+      const attributes = await loader.loadAttributes();
+      this.availableScales_ = [Array.from(attributes.scale)];
+    }
+  }
+
+  private updateLOD() {
+    if (!this.context_ || !this.availableScales_) {
+      return;
+    }
+
+    try {
+      const camera = this.context_.getCamera();
+      const viewport = this.context_.getViewport();
+
+      const lodResult = this.context_.chunkManager.computeLOD(
+        camera,
+        viewport.width,
+        viewport.height,
+        this.availableScales_
+      );
+      
+      if (!this.currentLOD_ || lodResult.scaleIndex !== this.currentLOD_.scaleIndex) {
+        this.currentLOD_ = lodResult;
+        this.reloadWithScale(lodResult.scaleIndex);
+      }
+    } catch (error) {
+      console.warn('Failed to compute LOD:', error);
+    }
+  }
+
+  private async reloadWithScale(scaleIndex: number) {
+    if (!this.image_) {
+      return;
+    }
+
+    try {
+      const loader = await this.source_.open();
+      if (loader instanceof OmeZarrImageLoader) {
+        loader.scaleIndex_ = scaleIndex;
+      }
+
+      const chunk = await loader.loadChunk(this.region_);
+
+      this.extent_ = {
+        x: chunk.shape.x * chunk.scale.x,
+        y: chunk.shape.y * chunk.scale.y,
+      };
+
+      this.clearObjects();
+      this.image_ = this.createImage(chunk, this.channelProps_);
+      this.addObject(this.image_);
+    } catch (error) {
+      console.warn('Failed to reload with new scale:', error);
+    }
+  }
+
+  public get currentLOD(): LODResult | undefined {
+    return this.currentLOD_;
   }
 }


### PR DESCRIPTION
### Summary

This PR adds support for resolution-dependent Level of Detail (LOD) selection and dynamic image reloading in the image layer system. The viewer now computes the optimal scale index for the current zoom level and screen resolution, and reloads the image from the appropriate scale level.

### Key Changes

- Added `computeLOD()` to `ChunkManager`, which calculates the best scale index based on pixels per world unit vs texels per world unit, using a soft scoring function that penalizes undersampling.
- Implemented `loadAvailableScales()` in `ImageLayerXYZ` to extract scale metadata from NGFF multiscales or fallback loaders.
- Connected LOD computation to runtime context via `getCamera()` and `getViewport()`.
- Introduced `updateLOD()` and `reloadWithScale()` to selectively reload chunks at a new LOD only when needed.
- Ensured initial and runtime LOD transitions are efficient and avoid unnecessary reloading.
- Added error handling for loader fallbacks and scale index validation.


### Tests & Checks
checked that LOD was properly returned in chunk_streaming example