### PR TITLE
Add ChunkManagerSource and refactor

### DIFF
--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -1,11 +1,77 @@
-import { Camera } from "../objects/cameras/camera";
+import {
+  ImageChunk,
+  ImageChunkLoader,
+  ImageChunkSource,
+  LoaderAttributes,
+} from "@/data/image_chunk";
 
-export class ChunkManager {
-  public getVisibleChunks() {
-    // TODO: implement
+import { Camera } from "../objects/cameras/camera";
+import { vec2, vec4, mat4 } from "gl-matrix";
+
+type Bounds = { min: vec2; max: vec2 };
+
+export class ChunkManagerSource {
+  // @ts-expect-error unused for now
+  private readonly chunks_: ImageChunk[][] = [];
+  // @ts-expect-error unused for now
+  private readonly loader_;
+
+  constructor(loader: ImageChunkLoader, _: LoaderAttributes[]) {
+    this.loader_ = loader;
+
+    // TODO: create chunks for each LOD without loading data
   }
 
-  public update(_camera: Camera, _bufferWidth: number, _bufferHeight: number) {
-    // TODO: implement
+  public getVisibleChunks(): ImageChunk[] {
+    return [];
+  }
+
+  public updateChunks(_: Bounds) {
+    // TODO: intersection test, set visibility and load data
+  }
+}
+
+export class ChunkManager {
+  private readonly sources_ = new Map<ImageChunkSource, ChunkManagerSource>();
+
+  public async addSource(source: ImageChunkSource) {
+    let existing = this.sources_.get(source);
+    if (!existing) {
+      const loader = await source.open();
+      const attrs = await loader.loadAttributes();
+      existing = new ChunkManagerSource(loader, attrs);
+      this.sources_.set(source, existing);
+    }
+    return existing;
+  }
+
+  public update(camera: Camera, _bufferWidth: number, _bufferHeight: number) {
+    const visibleBounds = this.computeVisibleBounds(camera);
+
+    // TODO: compute LOD assuming the index is not image-based
+
+    for (const [_, chunkManagerSource] of this.sources_) {
+      chunkManagerSource.updateChunks(visibleBounds);
+    }
+  }
+
+  private computeVisibleBounds(camera: Camera): Bounds {
+    let topLeft = vec4.fromValues(-1.0, 1.0, 0.0, 1.0);
+    let bottomRight = vec4.fromValues(1.0, -1.0, 0.0, 1.0);
+
+    const viewProjection = mat4.multiply(
+      mat4.create(),
+      camera.projectionMatrix,
+      camera.viewMatrix
+    );
+
+    const inv = mat4.invert(mat4.create(), viewProjection);
+    topLeft = vec4.transformMat4(vec4.create(), topLeft, inv);
+    bottomRight = vec4.transformMat4(vec4.create(), bottomRight, inv);
+
+    return {
+      min: vec2.fromValues(topLeft[0], topLeft[1]),
+      max: vec2.fromValues(bottomRight[0], bottomRight[1]),
+    };
   }
 }

--- a/packages/core/src/core/layer.ts
+++ b/packages/core/src/core/layer.ts
@@ -57,7 +57,7 @@ export abstract class Layer {
   // integration is finalized. Most layers will likely need access to the chunk
   // manager, but for now, we allow optional overrides to avoid requiring
   // placeholder implementations.
-  public onAttached(_context: IdetikContext) {}
+  public async onAttached(_context: IdetikContext) {}
 
   public get objects() {
     return this.objects_;

--- a/packages/core/src/layers/image_layer_xyz.ts
+++ b/packages/core/src/layers/image_layer_xyz.ts
@@ -2,6 +2,7 @@ import { Layer, LayerOptions } from "../core/layer";
 import { IdetikContext } from "../idetik";
 import { Region } from "../data/region";
 import { ImageChunk, ImageChunkSource } from "../data/image_chunk";
+import { ChunkManagerSource } from "../core/chunk_manager";
 import { ChannelProps } from "../objects/textures/channel";
 import { ImageRenderable } from "../objects/renderable/image_renderable";
 import { Texture2DArray } from "../objects/textures/texture_2d_array";
@@ -16,6 +17,7 @@ export type ImageLayerProps = LayerOptions & {
 export class ImageLayerXYZ extends Layer {
   private readonly source_: ImageChunkSource;
   private readonly region_: Region;
+  private chunkManagerSource_?: ChunkManagerSource;
   private channelProps_?: ChannelProps[];
   private image_?: ImageRenderable;
   private extent_?: { x: number; y: number };
@@ -33,11 +35,20 @@ export class ImageLayerXYZ extends Layer {
     this.channelProps_ = channelProps;
   }
 
-  public onAttached(_context: IdetikContext): void {
-    // TODO: context.chunkManager.addSource(this.source_)
+  public async onAttached(context: IdetikContext) {
+    this.chunkManagerSource_ = await context.chunkManager.addSource(
+      this.source_
+    );
   }
 
   public update() {
+    if (!this.chunkManagerSource_) return;
+
+    const chunks = this.chunkManagerSource_.getVisibleChunks();
+    chunks.forEach((_) => {
+      // TODO: create image renderable for visible chunks if needed
+    });
+
     switch (this.state) {
       case "initialized":
         this.load(this.region_);

--- a/packages/core/src/objects/cameras/camera.ts
+++ b/packages/core/src/objects/cameras/camera.ts
@@ -21,6 +21,10 @@ export abstract class Camera extends RenderableObject {
     return this.projectionMatrix_;
   }
 
+  get viewMatrix() {
+    return this.transform.inverse;
+  }
+
   public abstract setAspectRatio(aspectRatio: number): void;
   public abstract zoom(factor: number): void;
 

--- a/packages/core/src/renderers/webgl_renderer.ts
+++ b/packages/core/src/renderers/webgl_renderer.ts
@@ -91,7 +91,7 @@ export class WebGLRenderer extends Renderer {
 
     const modelView = mat4.multiply(
       mat4.create(),
-      this.activeCamera.transform.inverse,
+      this.activeCamera.viewMatrix,
       object.transform.matrix
     );
     const projection = mat4.multiply(


### PR DESCRIPTION
### Summary

This PR introduces a `ChunkManagerSource` interface that allows layers to
interact with the chunk manager indirectly. It also adds placeholder
structures and comments to outline the intended chunk manager architecture
without fully implementing it, helping to unblock downstream development.

### Tests & Checks

- All checks have passed
- Verified the chunk streaming example is not broken
