### PR TITLE
feat: Dynamic LOD Computation for ChunkManager

### DIFF
--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -16,6 +16,8 @@ export class ChunkManagerSource {
   private readonly region_;
   private readonly attrs_: LoaderAttributes[];
   public currentLOD_: number = 0;
+  private readonly xIdx_: number;
+  private readonly yIdx_: number;
 
   constructor(
     loader: ImageChunkLoader,
@@ -26,6 +28,16 @@ export class ChunkManagerSource {
     this.region_ = region;
     this.attrs_ = attrs;
     this.currentLOD_ = 1;
+
+    this.xIdx_ = region.findIndex(
+      (entry) => entry.dimension.toLocaleLowerCase() === "x"
+    );
+    this.yIdx_ = region.findIndex(
+      (entry) => entry.dimension.toLocaleLowerCase() === "y"
+    );
+    if (this.xIdx_ === -1 || this.yIdx_ === -1) {
+      throw new Error("Missing required spatial axis x/y");
+    }
 
     // generate chunks for each LOD without loading data
     this.chunks_ = Array(this.attrs_.length)
@@ -91,8 +103,9 @@ export class ChunkManagerSource {
     for (let i = 1; i < availableScales.length; i++) {
       const prev = availableScales[i - 1];
       const curr = availableScales[i];
-      const rx = prev[0] / curr[0];
-      const ry = prev[1] / curr[1];
+      const rx = curr[this.xIdx_] / prev[this.xIdx_];
+      const ry = curr[this.yIdx_] / prev[this.yIdx_];
+
       if (Math.abs(rx - 2) > EPS || Math.abs(ry - 2) > EPS) {
         console.error(
           `Scale ratio between levels ${i - 1} and ${i} is (${rx}, ${ry}), expected (2.0, 2.0)`

--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -12,7 +12,7 @@ import { almostEqual } from "@/utilities/almost_equal";
 type Bounds = { min: vec2; max: vec2 };
 
 export class ChunkManagerSource {
-  private readonly chunks_: ImageChunk[][] = [];
+  private readonly chunks_: ImageChunk[][];
   private readonly loader_;
   private readonly region_;
   private readonly attrs_: LoaderAttributes[];
@@ -102,9 +102,6 @@ export class ChunkManagerSource {
       const ry = curr[yIdx] / prev[yIdx];
 
       if (!almostEqual(rx, 2) || !almostEqual(ry, 2)) {
-        console.error(
-          `Scale ratio between levels ${i - 1} and ${i} is (${rx}, ${ry}), expected (2.0, 2.0)`
-        );
         throw new Error(
           `Scales must be separated by factors of 2. Got ratio (${rx}, ${ry}) between scales ${prev} and ${curr}`
         );

--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -114,12 +114,9 @@ export class ChunkManagerSource {
     const virtualWidth = Math.abs(visibleBounds.max[0] - visibleBounds.min[0]);
     const virtualUnitsPerScreenPixel = virtualWidth / bufferWidth;
 
-    const numLods = availableScales.length;
-    const lodShift = numLods - 1;
-    const lodF = lodShift - Math.log2(1 / virtualUnitsPerScreenPixel);
-
-    const maxLod = numLods - 1;
-    const newLOD = Math.max(0, Math.min(maxLod, Math.floor(lodF)));
+    const maxLod = availableScales.length - 1;
+    const lodF = maxLod - Math.log2(1 / virtualUnitsPerScreenPixel);
+    const newLod = Math.max(0, Math.min(maxLod, Math.floor(lodF)));
 
     if (newLOD !== this.currentLOD_) {
       console.log(`LOD changed from ${this.currentLOD_} to ${newLOD}`);

--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -114,10 +114,8 @@ export class ChunkManagerSource {
   }
 
   public setLOD(lodFactor: number): void {
-    const numLods = this.attrs_.length;
-    const lodShift = numLods - 1;
-    const lodF = lodShift - lodFactor;
-    const newLOD = Math.max(0, Math.min(numLods - 1, Math.floor(lodF)));
+    const maxLOD = this.attrs_.length - 1;
+    const targetLOD = Math.max(0, Math.min(maxLOD, Math.floor(maxLOD - lodFactor)));
 
     if (newLOD !== this.currentLOD_) {
       console.debug(`LOD changed from ${this.currentLOD_} to ${newLOD}`);

--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -7,7 +7,7 @@ import {
 import { Region } from "../data/region";
 import { Camera } from "../objects/cameras/camera";
 import { vec2, vec4, mat4 } from "gl-matrix";
-import { almostEqual } from "@/utilities/almost_equal";
+import { almostEqual } from "../utilities/almost_equal";
 
 type Bounds = { min: vec2; max: vec2 };
 

--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -7,6 +7,7 @@ import {
 import { Region } from "../data/region";
 import { Camera } from "../objects/cameras/camera";
 import { vec2, vec4, mat4 } from "gl-matrix";
+import { almostEqual } from "@/utilities/almost_equal";
 
 type Bounds = { min: vec2; max: vec2 };
 
@@ -15,9 +16,10 @@ export class ChunkManagerSource {
   private readonly loader_;
   private readonly region_;
   private readonly attrs_: LoaderAttributes[];
-  public currentLOD_: number = 0;
+  private currentLOD_: number = 0;
   private readonly xIdx_: number;
   private readonly yIdx_: number;
+  private readonly channelIdx_: number;
 
   constructor(
     loader: ImageChunkLoader,
@@ -27,7 +29,7 @@ export class ChunkManagerSource {
     this.loader_ = loader;
     this.region_ = region;
     this.attrs_ = attrs;
-    this.currentLOD_ = 1;
+    this.currentLOD_ = 0;
 
     this.xIdx_ = region.findIndex(
       (entry) => entry.dimension.toLocaleLowerCase() === "x"
@@ -38,7 +40,14 @@ export class ChunkManagerSource {
     if (this.xIdx_ === -1 || this.yIdx_ === -1) {
       throw new Error("Missing required spatial axis x/y");
     }
-
+    let channelIdx = region.findIndex(
+      (entry) => entry.dimension.toLowerCase() === "c"
+    );
+    if (channelIdx === -1) {
+      channelIdx = 0;
+    }
+    this.validateScaleRatios(this.xIdx_, this.yIdx_);
+    this.channelIdx_ = channelIdx;
     // generate chunks for each LOD without loading data
     this.chunks_ = Array(this.attrs_.length)
       .fill(null)
@@ -53,7 +62,9 @@ export class ChunkManagerSource {
         this.attrs_[lod].shape[this.yIdx_] / chunkHeight
       );
       const channels =
-        this.attrs_[lod].shape.length === 3 ? this.attrs_[lod].shape[0] : 1;
+        this.attrs_[lod].shape.length === 3
+          ? this.attrs_[lod].shape[this.channelIdx_]
+          : 1;
       for (let x = 0; x < chunksX; ++x) {
         for (let y = 0; y < chunksY; ++y) {
           this.chunks_[lod].push({
@@ -82,25 +93,15 @@ export class ChunkManagerSource {
     }
   }
 
-  public getVisibleChunks(): ImageChunk[] {
-    return this.chunks_[this.currentLOD_].filter((e) => e.visible);
-  }
-
-  public computeLOD(
-    visibleBounds: Bounds,
-    bufferWidth: number // screen/canvas width in pixels
-  ): void {
+  private validateScaleRatios(xIdx: number, yIdx: number): void {
     const availableScales = this.attrs_.map((attr) => attr.scale);
-
-    // Assert that scales are separated by factors of 2
-    const EPS = 1e-6;
     for (let i = 1; i < availableScales.length; i++) {
       const prev = availableScales[i - 1];
       const curr = availableScales[i];
-      const rx = curr[this.xIdx_] / prev[this.xIdx_];
-      const ry = curr[this.yIdx_] / prev[this.yIdx_];
+      const rx = curr[xIdx] / prev[xIdx];
+      const ry = curr[yIdx] / prev[yIdx];
 
-      if (Math.abs(rx - 2) > EPS || Math.abs(ry - 2) > EPS) {
+      if (!almostEqual(rx, 2) || !almostEqual(ry, 2)) {
         console.error(
           `Scale ratio between levels ${i - 1} and ${i} is (${rx}, ${ry}), expected (2.0, 2.0)`
         );
@@ -109,20 +110,20 @@ export class ChunkManagerSource {
         );
       }
     }
+  }
 
-    // Calculate virtual width from visible bounds
-    const virtualWidth = Math.abs(visibleBounds.max[0] - visibleBounds.min[0]);
-    const virtualUnitsPerScreenPixel = virtualWidth / bufferWidth;
+  public getVisibleChunks(): ImageChunk[] {
+    return this.chunks_[this.currentLOD_].filter((e) => e.visible);
+  }
 
-    const numLods = availableScales.length;
+  public setLOD(lodFactor: number): void {
+    const numLods = this.attrs_.length;
     const lodShift = numLods - 1;
-    const lodF = lodShift - Math.log2(1 / virtualUnitsPerScreenPixel);
-
-    const maxLod = numLods - 1;
-    const newLOD = Math.max(0, Math.min(maxLod, Math.floor(lodF)));
+    const lodF = lodShift - lodFactor;
+    const newLOD = Math.max(0, Math.min(numLods - 1, Math.floor(lodF)));
 
     if (newLOD !== this.currentLOD_) {
-      console.log(`LOD changed from ${this.currentLOD_} to ${newLOD}`);
+      console.debug(`LOD changed from ${this.currentLOD_} to ${newLOD}`);
       this.currentLOD_ = newLOD;
     }
   }
@@ -157,11 +158,14 @@ export class ChunkManager {
 
   public update(camera: Camera, _bufferWidth: number, _bufferHeight: number) {
     const visibleBounds = this.computeVisibleBounds(camera);
+    const virtualWidth = Math.abs(visibleBounds.max[0] - visibleBounds.min[0]);
+    const virtualUnitsPerScreenPixel = virtualWidth / _bufferWidth;
+    const lodFactor = Math.log2(1 / virtualUnitsPerScreenPixel);
 
     // TODO: compute the LOD factor
 
     for (const [_, chunkManagerSource] of this.sources_) {
-      chunkManagerSource.computeLOD(visibleBounds, _bufferWidth);
+      chunkManagerSource.setLOD(lodFactor);
       chunkManagerSource.updateChunks(visibleBounds);
     }
   }

--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -44,20 +44,10 @@ export class ChunkManagerSource {
       .fill(null)
       .map(() => []);
     for (let lod = 0; lod < this.attrs_.length; ++lod) {
-      const xIdx = region.findIndex(
-        (entry) => entry.dimension.toLocaleLowerCase() === "x"
-      );
-      const yIdx = region.findIndex(
-        (entry) => entry.dimension.toLocaleLowerCase() === "y"
-      );
-      if (xIdx === -1 || yIdx === -1) {
-        throw new Error("Missing required spatial axis x/y");
-      }
-
-      const chunkWidth = this.attrs_[lod].chunks[xIdx];
-      const chunkHeight = this.attrs_[lod].chunks[yIdx];
-      const chunksX = Math.ceil(this.attrs_[lod].shape[xIdx] / chunkWidth);
-      const chunksY = Math.ceil(this.attrs_[lod].shape[yIdx] / chunkHeight);
+      const chunkWidth = this.attrs_[lod].chunks[this.xIdx_];
+      const chunkHeight = this.attrs_[lod].chunks[this.yIdx_];
+      const chunksX = Math.ceil(this.attrs_[lod].shape[this.xIdx_] / chunkWidth);
+      const chunksY = Math.ceil(this.attrs_[lod].shape[this.yIdx_] / chunkHeight);
       const channels =
         this.attrs_[lod].shape.length === 3 ? this.attrs_[lod].shape[0] : 1;
       for (let x = 0; x < chunksX; ++x) {
@@ -75,12 +65,12 @@ export class ChunkManagerSource {
             rowAlignmentBytes: 1,
             chunkIndex: { x, y },
             scale: {
-              x: this.attrs_[lod].scale[xIdx],
-              y: this.attrs_[lod].scale[yIdx],
+              x: this.attrs_[lod].scale[this.xIdx_],
+              y: this.attrs_[lod].scale[this.yIdx_],
             },
             offset: {
-              x: x * chunkWidth * this.attrs_[lod].scale[xIdx],
-              y: y * chunkHeight * this.attrs_[lod].scale[yIdx],
+              x: x * chunkWidth * this.attrs_[lod].scale[this.xIdx_],
+              y: y * chunkHeight * this.attrs_[lod].scale[this.yIdx_],
             },
           });
         }

--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -10,9 +10,6 @@ import { vec2, vec4, mat4 } from "gl-matrix";
 
 type Bounds = { min: vec2; max: vec2 };
 
-// temporary value. LOD will be computed dynamically
-// const curr_lod = 1;
-
 export class ChunkManagerSource {
   private readonly chunks_: ImageChunk[][] = [];
   private readonly loader_;
@@ -49,7 +46,8 @@ export class ChunkManagerSource {
       const chunkHeight = this.attrs_[lod].chunks[yIdx];
       const chunksX = Math.ceil(this.attrs_[lod].shape[xIdx] / chunkWidth);
       const chunksY = Math.ceil(this.attrs_[lod].shape[yIdx] / chunkHeight);
-      const channels = this.attrs_[lod].shape.length === 3 ? this.attrs_[lod].shape[0] : 1;
+      const channels =
+        this.attrs_[lod].shape.length === 3 ? this.attrs_[lod].shape[0] : 1;
       for (let x = 0; x < chunksX; ++x) {
         for (let y = 0; y < chunksY; ++y) {
           this.chunks_[lod].push({

--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -46,8 +46,12 @@ export class ChunkManagerSource {
     for (let lod = 0; lod < this.attrs_.length; ++lod) {
       const chunkWidth = this.attrs_[lod].chunks[this.xIdx_];
       const chunkHeight = this.attrs_[lod].chunks[this.yIdx_];
-      const chunksX = Math.ceil(this.attrs_[lod].shape[this.xIdx_] / chunkWidth);
-      const chunksY = Math.ceil(this.attrs_[lod].shape[this.yIdx_] / chunkHeight);
+      const chunksX = Math.ceil(
+        this.attrs_[lod].shape[this.xIdx_] / chunkWidth
+      );
+      const chunksY = Math.ceil(
+        this.attrs_[lod].shape[this.yIdx_] / chunkHeight
+      );
       const channels =
         this.attrs_[lod].shape.length === 3 ? this.attrs_[lod].shape[0] : 1;
       for (let x = 0; x < chunksX; ++x) {

--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -86,6 +86,23 @@ export class ChunkManagerSource {
   ): void {
     const availableScales = this.attrs_.map((attr) => attr.scale);
 
+    // Assert that scales are separated by factors of 2
+    const EPS = 1e-6;
+    for (let i = 1; i < availableScales.length; i++) {
+      const prev = availableScales[i - 1];
+      const curr = availableScales[i];
+      const rx = prev[0] / curr[0];
+      const ry = prev[1] / curr[1];
+      if (Math.abs(rx - 2) > EPS || Math.abs(ry - 2) > EPS) {
+        console.error(
+          `Scale ratio between levels ${i - 1} and ${i} is (${rx}, ${ry}), expected (2.0, 2.0)`
+        );
+        throw new Error(
+          `Scales must be separated by factors of 2. Got ratio (${rx}, ${ry}) between scales ${prev} and ${curr}`
+        );
+      }
+    }
+
     // Calculate virtual width from visible bounds
     const virtualWidth = Math.abs(visibleBounds.max[0] - visibleBounds.min[0]);
     const virtualUnitsPerScreenPixel = virtualWidth / bufferWidth;

--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -155,8 +155,6 @@ export class ChunkManager {
   public update(camera: Camera, _bufferWidth: number, _bufferHeight: number) {
     const visibleBounds = this.computeVisibleBounds(camera);
 
-    // TODO: compute the LOD factor
-
     for (const [_, chunkManagerSource] of this.sources_) {
       chunkManagerSource.computeLOD(visibleBounds, _bufferWidth);
       chunkManagerSource.updateChunks(visibleBounds);

--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -11,12 +11,14 @@ import { vec2, vec4, mat4 } from "gl-matrix";
 type Bounds = { min: vec2; max: vec2 };
 
 // temporary value. LOD will be computed dynamically
-const curr_lod = 1;
+// const curr_lod = 1;
 
 export class ChunkManagerSource {
   private readonly chunks_: ImageChunk[][] = [];
   private readonly loader_;
   private readonly region_;
+  private readonly attrs_: LoaderAttributes[];
+  public currentLOD_: number = 0;
 
   constructor(
     loader: ImageChunkLoader,
@@ -25,12 +27,14 @@ export class ChunkManagerSource {
   ) {
     this.loader_ = loader;
     this.region_ = region;
+    this.attrs_ = attrs;
+    this.currentLOD_ = 1;
 
     // generate chunks for each LOD without loading data
-    this.chunks_ = Array(attrs.length)
+    this.chunks_ = Array(this.attrs_.length)
       .fill(null)
       .map(() => []);
-    for (let lod = 0; lod < attrs.length; ++lod) {
+    for (let lod = 0; lod < this.attrs_.length; ++lod) {
       const xIdx = region.findIndex(
         (entry) => entry.dimension.toLocaleLowerCase() === "x"
       );
@@ -41,11 +45,11 @@ export class ChunkManagerSource {
         throw new Error("Missing required spatial axis x/y");
       }
 
-      const chunkWidth = attrs[lod].chunks[xIdx];
-      const chunkHeight = attrs[lod].chunks[yIdx];
-      const chunksX = Math.ceil(attrs[lod].shape[xIdx] / chunkWidth);
-      const chunksY = Math.ceil(attrs[lod].shape[yIdx] / chunkHeight);
-      const channels = attrs[lod].shape.length === 3 ? attrs[lod].shape[0] : 1;
+      const chunkWidth = this.attrs_[lod].chunks[xIdx];
+      const chunkHeight = this.attrs_[lod].chunks[yIdx];
+      const chunksX = Math.ceil(this.attrs_[lod].shape[xIdx] / chunkWidth);
+      const chunksY = Math.ceil(this.attrs_[lod].shape[yIdx] / chunkHeight);
+      const channels = this.attrs_[lod].shape.length === 3 ? this.attrs_[lod].shape[0] : 1;
       for (let x = 0; x < chunksX; ++x) {
         for (let y = 0; y < chunksY; ++y) {
           this.chunks_[lod].push({
@@ -61,12 +65,12 @@ export class ChunkManagerSource {
             rowAlignmentBytes: 1,
             chunkIndex: { x, y },
             scale: {
-              x: attrs[lod].scale[xIdx],
-              y: attrs[lod].scale[yIdx],
+              x: this.attrs_[lod].scale[xIdx],
+              y: this.attrs_[lod].scale[yIdx],
             },
             offset: {
-              x: x * chunkWidth * attrs[lod].scale[xIdx],
-              y: y * chunkHeight * attrs[lod].scale[yIdx],
+              x: x * chunkWidth * this.attrs_[lod].scale[xIdx],
+              y: y * chunkHeight * this.attrs_[lod].scale[yIdx],
             },
           });
         }
@@ -75,13 +79,36 @@ export class ChunkManagerSource {
   }
 
   public getVisibleChunks(): ImageChunk[] {
-    return this.chunks_[curr_lod].filter((e) => e.visible);
+    return this.chunks_[this.currentLOD_].filter((e) => e.visible);
+  }
+
+  public computeLOD(
+    visibleBounds: Bounds,
+    bufferWidth: number // screen/canvas width in pixels
+  ): void {
+    const availableScales = this.attrs_.map((attr) => attr.scale);
+
+    // Calculate virtual width from visible bounds
+    const virtualWidth = Math.abs(visibleBounds.max[0] - visibleBounds.min[0]);
+    const virtualUnitsPerScreenPixel = virtualWidth / bufferWidth;
+
+    const numLods = availableScales.length;
+    const lodShift = numLods - 1;
+    const lodF = lodShift - Math.log2(1 / virtualUnitsPerScreenPixel);
+
+    const maxLod = numLods - 1;
+    const newLOD = Math.max(0, Math.min(maxLod, Math.floor(lodF)));
+
+    if (newLOD !== this.currentLOD_) {
+      console.log(`LOD changed from ${this.currentLOD_} to ${newLOD}`);
+      this.currentLOD_ = newLOD;
+    }
   }
 
   public async updateChunks(_: Bounds) {
     // TODO: map the LOD factor from the chunk manager to an available LOD in image space
     // TODO: replace the following block with loading based on intersection tests
-    for (const chunk of this.chunks_[curr_lod]) {
+    for (const chunk of this.chunks_[this.currentLOD_]) {
       if (chunk.state === "unloaded") {
         chunk.state = "loading";
         this.loader_.loadChunkDataFromRegion(chunk, this.region_).then(() => {
@@ -112,6 +139,7 @@ export class ChunkManager {
     // TODO: compute the LOD factor
 
     for (const [_, chunkManagerSource] of this.sources_) {
+      chunkManagerSource.computeLOD(visibleBounds, _bufferWidth);
       chunkManagerSource.updateChunks(visibleBounds);
     }
   }

--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -40,13 +40,13 @@ export class ChunkManagerSource {
     if (this.xIdx_ === -1 || this.yIdx_ === -1) {
       throw new Error("Missing required spatial axis x/y");
     }
+    this.validateScaleRatios(this.xIdx_, this.yIdx_);
     let channelIdx = region.findIndex(
       (entry) => entry.dimension.toLowerCase() === "c"
     );
     if (channelIdx === -1) {
       channelIdx = 0;
     }
-    this.validateScaleRatios(this.xIdx_, this.yIdx_);
     this.channelIdx_ = channelIdx;
     // generate chunks for each LOD without loading data
     this.chunks_ = Array(this.attrs_.length)
@@ -115,11 +115,14 @@ export class ChunkManagerSource {
 
   public setLOD(lodFactor: number): void {
     const maxLOD = this.attrs_.length - 1;
-    const targetLOD = Math.max(0, Math.min(maxLOD, Math.floor(maxLOD - lodFactor)));
+    const targetLOD = Math.max(
+      0,
+      Math.min(maxLOD, Math.floor(maxLOD - lodFactor))
+    );
 
-    if (newLOD !== this.currentLOD_) {
-      console.debug(`LOD changed from ${this.currentLOD_} to ${newLOD}`);
-      this.currentLOD_ = newLOD;
+    if (targetLOD !== this.currentLOD_) {
+      console.debug(`LOD changed from ${this.currentLOD_} to ${targetLOD}`);
+      this.currentLOD_ = targetLOD;
     }
   }
 

--- a/packages/core/src/layers/image_layer.ts
+++ b/packages/core/src/layers/image_layer.ts
@@ -29,20 +29,17 @@ export class ImageLayer extends Layer {
   private visibleChunks_: Map<ImageChunk, ImageRenderable> = new Map();
 
   // TODO:(shlomnissan) Remove this parameter when chunk manager is used by default
-  private readonly lod_?: number;
 
   constructor({
     source,
     region,
     channelProps,
-    lod,
     ...layerOptions
   }: ImageLayerProps) {
     super(layerOptions);
     this.setState("initialized");
     this.source_ = source;
     this.region_ = region;
-    this.lod_ = lod;
     this.channelProps_ = channelProps;
 
     const x = region.find((r) => r.dimension.toLowerCase() === "x");
@@ -132,7 +129,7 @@ export class ImageLayer extends Layer {
     this.setState("loading");
     const loader = await this.source_.open();
     const attributes = await loader.loadAttributes();
-    const lod = this.lod_ ?? attributes.length - 1;
+    const lod = this.chunkManagerSource_?.currentLOD_ ?? attributes.length - 1;
 
     const chunk = await loader.loadRegion(region, lod);
     this.extent_ = {

--- a/packages/core/src/layers/image_layer.ts
+++ b/packages/core/src/layers/image_layer.ts
@@ -27,6 +27,7 @@ export class ImageLayer extends Layer {
   private image_?: ImageRenderable;
   private extent_?: { x: number; y: number };
   private visibleChunks_: Map<ImageChunk, ImageRenderable> = new Map();
+  private readonly lod_?: number;
 
   // TODO:(shlomnissan) Remove this parameter when chunk manager is used by default
 
@@ -34,6 +35,7 @@ export class ImageLayer extends Layer {
     source,
     region,
     channelProps,
+    lod,
     ...layerOptions
   }: ImageLayerProps) {
     super(layerOptions);
@@ -41,6 +43,7 @@ export class ImageLayer extends Layer {
     this.source_ = source;
     this.region_ = region;
     this.channelProps_ = channelProps;
+    this.lod_ = lod;
 
     const x = region.find((r) => r.dimension.toLowerCase() === "x");
     const y = region.find((r) => r.dimension.toLowerCase() === "y");
@@ -129,7 +132,7 @@ export class ImageLayer extends Layer {
     this.setState("loading");
     const loader = await this.source_.open();
     const attributes = await loader.loadAttributes();
-    const lod = this.chunkManagerSource_?.currentLOD_ ?? attributes.length - 1;
+    const lod = this.lod_ ?? attributes.length - 1;
 
     const chunk = await loader.loadRegion(region, lod);
     this.extent_ = {

--- a/packages/core/src/utilities/almost_equal.ts
+++ b/packages/core/src/utilities/almost_equal.ts
@@ -1,0 +1,3 @@
+export function almostEqual(a: number, b: number, epsilon = 1e-6): boolean {
+  return Math.abs(a - b) <= epsilon;
+}


### PR DESCRIPTION
This PR replaces the previously hardcoded curr_lod constant with logic that dynamically computes the appropriate level of detail (LOD) based on the current view bounds and screen resolution.

The ChunkManagerSource now uses the visible virtual width and the buffer (canvas) width to calculate a screen-space resolution ratio, from which it derives the most suitable LOD. This allows the system to adaptively select a coarser or finer LOD as the user zooms in and out, setting the stage for progressive loading and improved performance at scale.

LOD computation happens during ChunkManager.update, prior to triggering chunk updates.