### PR TITLE
refactor: core changes for react refactoring

### DIFF
--- a/packages/core/examples/chunk_streaming/main.ts
+++ b/packages/core/examples/chunk_streaming/main.ts
@@ -31,7 +31,7 @@ const axesLayer = new AxesLayer({ length: 1500, width: 0.01 });
 const camera = new OrthographicCamera(left, right, top, bottom);
 
 new Idetik({
-  canvasSelector: "canvas",
+  canvas: document.querySelector<HTMLCanvasElement>("#canvas")!,
   camera,
   controls: new PanZoomControls(camera, camera.position),
   layers: [imageLayer, axesLayer],

--- a/packages/core/examples/image2d_from_omezarr4d_hcs/main.ts
+++ b/packages/core/examples/image2d_from_omezarr4d_hcs/main.ts
@@ -81,7 +81,7 @@ const onImageChange = async () => {
   });
   app.layerManager.add(newLayer);
   newLayer.addStateChangeCallback((state) => {
-    if (state === "ready" && newLayer?.extent) {
+    if (state === "ready" && newLayer.extent) {
       camera.setFrame(0, newLayer.extent.x, 0, newLayer.extent.y);
       camera.update();
       controls.panTarget = camera.position;

--- a/packages/core/examples/image2d_from_omezarr4d_hcs/main.ts
+++ b/packages/core/examples/image2d_from_omezarr4d_hcs/main.ts
@@ -41,8 +41,6 @@ const app = new Idetik({
   controls,
 }).start();
 
-let currentLayer: ImageLayer | undefined;
-
 const region: Region = [
   { dimension: "T", index: { type: "point", value: 0 } },
   { dimension: "C", index: { type: "interval", start: 1, stop: 3 } },
@@ -55,9 +53,7 @@ const imageSelector = document.querySelector("#image") as HTMLSelectElement;
 
 const onImageChange = async () => {
   console.debug("onImageChange: ", imageSelector.value);
-  if (currentLayer) {
-    app.layerManager.remove(currentLayer);
-  }
+  app.layerManager.removeAll();
   const imageUrl =
     plateUrl + "/" + wellSelector.value + "/" + imageSelector.value;
   const source = new OmeZarrImageSource(imageUrl);
@@ -74,7 +70,7 @@ const onImageChange = async () => {
     [omeroChannels[1].window.start, omeroChannels[1].window.end],
     [omeroChannels[2].window.start, omeroChannels[2].window.end],
   ];
-  currentLayer = new ImageLayer({
+  const newLayer = new ImageLayer({
     source,
     region,
     channelProps: [
@@ -83,10 +79,10 @@ const onImageChange = async () => {
     ],
     lod: 0,
   });
-  app.layerManager.add(currentLayer);
-  currentLayer.addStateChangeCallback((state) => {
-    if (state === "ready" && currentLayer?.extent) {
-      camera.setFrame(0, currentLayer.extent.x, 0, currentLayer.extent.y);
+  app.layerManager.add(newLayer);
+  newLayer.addStateChangeCallback((state) => {
+    if (state === "ready" && newLayer?.extent) {
+      camera.setFrame(0, newLayer.extent.x, 0, newLayer.extent.y);
       camera.update();
       controls.panTarget = camera.position;
     }
@@ -95,9 +91,7 @@ const onImageChange = async () => {
 
 const onWellChange = async () => {
   console.debug("onWellChange: ", wellSelector.value);
-  if (currentLayer) {
-    app.layerManager.remove(currentLayer);
-  }
+  app.layerManager.removeAll();
   const path = wellSelector.value;
   const well = await loadOmeZarrWell(plateUrl, path);
   console.debug("well", well);

--- a/packages/core/examples/image2d_from_omezarr4d_hcs/main.ts
+++ b/packages/core/examples/image2d_from_omezarr4d_hcs/main.ts
@@ -36,10 +36,12 @@ wellPaths.forEach((path) => {
 const camera = new OrthographicCamera(0, 840, 0, 360);
 const controls = new PanZoomControls(camera, camera.position);
 const app = new Idetik({
-  canvasSelector: "canvas",
+  canvas: document.querySelector<HTMLCanvasElement>("canvas")!,
   camera,
   controls,
 }).start();
+
+let currentLayer: ImageLayer | undefined;
 
 const region: Region = [
   { dimension: "T", index: { type: "point", value: 0 } },
@@ -53,7 +55,9 @@ const imageSelector = document.querySelector("#image") as HTMLSelectElement;
 
 const onImageChange = async () => {
   console.debug("onImageChange: ", imageSelector.value);
-  app.layerManager.removeAll();
+  if (currentLayer) {
+    app.layerManager.remove(currentLayer);
+  }
   const imageUrl =
     plateUrl + "/" + wellSelector.value + "/" + imageSelector.value;
   const source = new OmeZarrImageSource(imageUrl);
@@ -70,7 +74,7 @@ const onImageChange = async () => {
     [omeroChannels[1].window.start, omeroChannels[1].window.end],
     [omeroChannels[2].window.start, omeroChannels[2].window.end],
   ];
-  const layer = new ImageLayer({
+  currentLayer = new ImageLayer({
     source,
     region,
     channelProps: [
@@ -79,10 +83,10 @@ const onImageChange = async () => {
     ],
     lod: 0,
   });
-  app.layerManager.add(layer);
-  layer.addStateChangeCallback((state) => {
-    if (state === "ready" && layer.extent) {
-      camera.setFrame(0, layer.extent.x, 0, layer.extent.y);
+  app.layerManager.add(currentLayer);
+  currentLayer.addStateChangeCallback((state) => {
+    if (state === "ready" && currentLayer?.extent) {
+      camera.setFrame(0, currentLayer.extent.x, 0, currentLayer.extent.y);
       camera.update();
       controls.panTarget = camera.position;
     }
@@ -91,7 +95,9 @@ const onImageChange = async () => {
 
 const onWellChange = async () => {
   console.debug("onWellChange: ", wellSelector.value);
-  app.layerManager.removeAll();
+  if (currentLayer) {
+    app.layerManager.remove(currentLayer);
+  }
   const path = wellSelector.value;
   const well = await loadOmeZarrWell(plateUrl, path);
   console.debug("well", well);

--- a/packages/core/examples/image2d_from_omezarr5d_u16/main.ts
+++ b/packages/core/examples/image2d_from_omezarr5d_u16/main.ts
@@ -31,7 +31,7 @@ const axes = new AxesLayer({ length: 2000, width: 0.01 });
 const camera = new OrthographicCamera(left, right, top, bottom);
 
 new Idetik({
-  canvasSelector: "canvas",
+  canvas: document.querySelector<HTMLCanvasElement>("canvas")!,
   camera,
   controls: new PanZoomControls(camera, camera.position),
   layers: [layer, axes],

--- a/packages/core/examples/image2d_from_omezarr5d_u8/main.ts
+++ b/packages/core/examples/image2d_from_omezarr5d_u8/main.ts
@@ -40,7 +40,7 @@ const orthoCamControls = new PanZoomControls(orthoCam);
 const perspectiveCamControls = new PanZoomControls(perspectiveCam);
 
 const app = new Idetik({
-  canvasSelector: "canvas",
+  canvas: document.querySelector<HTMLCanvasElement>("canvas")!,
   camera: perspectiveCam,
   controls: perspectiveCamControls,
   layers: [layer, axes],

--- a/packages/core/examples/image_series_from_omezarr5d_u8/main.ts
+++ b/packages/core/examples/image_series_from_omezarr5d_u8/main.ts
@@ -62,7 +62,7 @@ layer.setIndex(slider.valueAsNumber - timeInterval.start);
 layer.preloadSeries();
 
 new Idetik({
-  canvasSelector: "canvas",
+  canvas: document.querySelector<HTMLCanvasElement>("canvas")!,
   camera: new OrthographicCamera(0, 1920, 0, 1440),
   layers: [layer],
 }).start();

--- a/packages/core/examples/image_stack_from_omezarr3d_f32/main.ts
+++ b/packages/core/examples/image_stack_from_omezarr3d_f32/main.ts
@@ -76,7 +76,7 @@ zSlider.addEventListener("input", (event) => {
 
 const camera = new OrthographicCamera(0, 128, 0, 128);
 const app = new Idetik({
-  canvasSelector: "canvas",
+  canvas: document.querySelector<HTMLCanvasElement>("canvas")!,
   camera,
   layers: [layer],
 }).start();

--- a/packages/core/examples/layer_blending/main.ts
+++ b/packages/core/examples/layer_blending/main.ts
@@ -113,7 +113,7 @@ overlayLayer.preloadSeries();
 
 const camera = new OrthographicCamera(0, 1920, 0, 1440);
 new Idetik({
-  canvasSelector: "canvas",
+  canvas: document.querySelector<HTMLCanvasElement>("canvas")!,
   camera,
   layers: [layer, overlayLayer],
 }).start();

--- a/packages/core/examples/points/main.ts
+++ b/packages/core/examples/points/main.ts
@@ -57,7 +57,7 @@ const virusLikeLocations = await fetchPositionsFromNDJson(virusLikeUrl);
 type Marker = "circle" | "square" | "triangle";
 
 class Particles extends Layer {
-  public type = "Particles";
+  public readonly type = "Particles";
   private readonly points_: vec3[] = [];
   private readonly color_: Color;
   private readonly markerIndex_: number = 0;
@@ -215,9 +215,8 @@ const imageLayer = new ImageSeriesLayer({
 });
 
 const camera = new OrthographicCamera(0, 1024, 0, 1024, -10000, 10000);
-const canvas = document.querySelector<HTMLCanvasElement>("canvas")!;
 const app = new Idetik({
-  canvas,
+  canvas: document.querySelector<HTMLCanvasElement>("canvas")!,
   camera,
   layers: [imageLayer],
 }).start();

--- a/packages/core/examples/points/main.ts
+++ b/packages/core/examples/points/main.ts
@@ -57,6 +57,7 @@ const virusLikeLocations = await fetchPositionsFromNDJson(virusLikeUrl);
 type Marker = "circle" | "square" | "triangle";
 
 class Particles extends Layer {
+  public type = "Particles";
   private readonly points_: vec3[] = [];
   private readonly color_: Color;
   private readonly markerIndex_: number = 0;
@@ -214,8 +215,9 @@ const imageLayer = new ImageSeriesLayer({
 });
 
 const camera = new OrthographicCamera(0, 1024, 0, 1024, -10000, 10000);
+const canvas = document.querySelector<HTMLCanvasElement>("canvas")!;
 const app = new Idetik({
-  canvasSelector: "canvas",
+  canvas,
   camera,
   layers: [imageLayer],
 }).start();

--- a/packages/core/examples/projected_lines/main.ts
+++ b/packages/core/examples/projected_lines/main.ts
@@ -20,7 +20,7 @@ const layer = new ProjectedLineLayer([
 ]);
 
 new Idetik({
-  canvasSelector: "canvas",
+  canvas: document.querySelector<HTMLCanvasElement>("canvas")!,
   camera: new PerspectiveCamera({ fov: 60 }),
   layers: [layer],
 }).start();

--- a/packages/core/examples/tracks/main.ts
+++ b/packages/core/examples/tracks/main.ts
@@ -116,8 +116,9 @@ const { xMin: left, xMax: right, yMin: top, yMax: bottom } = lineLayer.extent;
 const camera = new OrthographicCamera(left, right, top, bottom);
 camera.zoom(0.5);
 
+const canvas = document.querySelector<HTMLCanvasElement>("canvas")!;
 new Idetik({
-  canvasSelector: "canvas",
+  canvas,
   camera,
   controls: new PanZoomControls(camera, camera.position),
   layers: [imageSeriesLayer, lineLayer],

--- a/packages/core/examples/tracks/main.ts
+++ b/packages/core/examples/tracks/main.ts
@@ -116,9 +116,8 @@ const { xMin: left, xMax: right, yMin: top, yMax: bottom } = lineLayer.extent;
 const camera = new OrthographicCamera(left, right, top, bottom);
 camera.zoom(0.5);
 
-const canvas = document.querySelector<HTMLCanvasElement>("canvas")!;
 new Idetik({
-  canvas,
+  canvas: document.querySelector<HTMLCanvasElement>("canvas")!,
   camera,
   controls: new PanZoomControls(camera, camera.position),
   layers: [imageSeriesLayer, lineLayer],

--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -3,7 +3,7 @@ import {
   ImageChunkLoader,
   ImageChunkSource,
   LoaderAttributes,
-} from "@/data/image_chunk";
+} from "../data/image_chunk";
 import { Region } from "../data/region";
 import { Camera } from "../objects/cameras/camera";
 import { vec2, vec4, mat4 } from "gl-matrix";

--- a/packages/core/src/core/layer.ts
+++ b/packages/core/src/core/layer.ts
@@ -21,6 +21,8 @@ export interface LayerOptions {
 }
 
 export abstract class Layer {
+  public abstract readonly type: string;
+
   private objects_: RenderableObject[] = [];
   private state_: LayerState = "initialized";
   private readonly callbacks_: StateChangeCallback[] = [];

--- a/packages/core/src/core/layer_manager.ts
+++ b/packages/core/src/core/layer_manager.ts
@@ -3,6 +3,8 @@ import { IdetikContext } from "../idetik";
 
 export class LayerManager {
   private readonly layers_: Layer[] = [];
+  private layersSnapshot_: Layer[] | null = null;
+  private callbacks_: Array<() => void> = [];
 
   // TODO: Make this non-optional when react components use the Idetik Runtime
   private readonly context_?: IdetikContext;
@@ -34,16 +36,58 @@ export class LayerManager {
     if (this.context_) {
       layer.onAttached(this.context_);
     }
+    this.notifyLayersChanged();
   }
-  public remove(index: number) {
+
+  public remove(layer: Layer) {
+    const index = this.layers_.indexOf(layer);
+    if (index === -1) {
+      throw new Error(`Layer to remove not found: ${layer}`);
+    }
     this.layers_.splice(index, 1);
+    this.notifyLayersChanged();
+  }
+
+  public removeByIndex(index: number) {
+    this.layers_.splice(index, 1);
+    this.notifyLayersChanged();
   }
 
   public removeAll() {
     this.layers_.length = 0;
+    this.notifyLayersChanged();
   }
 
   public get layers(): readonly Layer[] {
     return this.layers_;
+  }
+
+  private notifyLayersChanged(): void {
+    this.layersSnapshot_ = null;
+    for (const callback of this.callbacks_) {
+      callback();
+    }
+  }
+
+  addCallback = (callback: () => void): (() => void) => {
+    this.callbacks_.push(callback);
+    return () => {
+      this.removeCallback(callback);
+    };
+  };
+
+  public removeCallback(callback: () => void): void {
+    const index = this.callbacks_.indexOf(callback);
+    if (index === undefined) {
+      throw new Error(`Callback to remove not found: ${callback}`);
+    }
+    this.callbacks_.splice(index, 1);
+  }
+
+  public getSnapshot(): Layer[] {
+    if (this.layersSnapshot_ === null) {
+      this.layersSnapshot_ = [...this.layers_];
+    }
+    return this.layersSnapshot_;
   }
 }

--- a/packages/core/src/core/layer_manager.ts
+++ b/packages/core/src/core/layer_manager.ts
@@ -2,8 +2,7 @@ import { Layer } from "./layer";
 import { IdetikContext } from "../idetik";
 
 export class LayerManager {
-  private readonly layers_: Layer[] = [];
-  private layersSnapshot_: Layer[] | null = null;
+  private layers_: ReadonlyArray<Layer> = [];
   private callbacks_: Array<() => void> = [];
 
   // TODO: Make this non-optional when react components use the Idetik Runtime
@@ -32,7 +31,7 @@ export class LayerManager {
   }
 
   public add(layer: Layer) {
-    this.layers_.push(layer);
+    this.layers_ = [...this.layers_, layer];
     if (this.context_) {
       layer.onAttached(this.context_);
     }
@@ -44,17 +43,16 @@ export class LayerManager {
     if (index === -1) {
       throw new Error(`Layer to remove not found: ${layer}`);
     }
-    this.layers_.splice(index, 1);
-    this.notifyLayersChanged();
+    this.removeByIndex(index);
   }
 
   public removeByIndex(index: number) {
-    this.layers_.splice(index, 1);
+    this.layers_ = this.layers_.filter((_, i) => i !== index);
     this.notifyLayersChanged();
   }
 
   public removeAll() {
-    this.layers_.length = 0;
+    this.layers_ = [];
     this.notifyLayersChanged();
   }
 
@@ -63,31 +61,23 @@ export class LayerManager {
   }
 
   private notifyLayersChanged(): void {
-    this.layersSnapshot_ = null;
     for (const callback of this.callbacks_) {
       callback();
     }
   }
 
-  addCallback = (callback: () => void): (() => void) => {
+  public addLayersChangeCallback(callback: () => void): () => void {
     this.callbacks_.push(callback);
     return () => {
-      this.removeCallback(callback);
+      this.removeLayersChangeCallback(callback);
     };
-  };
+  }
 
-  public removeCallback(callback: () => void): void {
+  public removeLayersChangeCallback(callback: () => void): void {
     const index = this.callbacks_.indexOf(callback);
     if (index === undefined) {
       throw new Error(`Callback to remove not found: ${callback}`);
     }
     this.callbacks_.splice(index, 1);
-  }
-
-  public getSnapshot(): Layer[] {
-    if (this.layersSnapshot_ === null) {
-      this.layersSnapshot_ = [...this.layers_];
-    }
-    return this.layersSnapshot_;
   }
 }

--- a/packages/core/src/core/renderer.ts
+++ b/packages/core/src/core/renderer.ts
@@ -18,9 +18,6 @@ export abstract class Renderer {
   protected abstract renderObject(layer: Layer, objectIndex: number): void;
   protected abstract clear(): void;
 
-  protected beginTransparentPass(): void {}
-  protected endTransparentPass(): void {}
-
   constructor(canvas: HTMLCanvasElement) {
     this.canvas_ = canvas;
     this.updateRendererSize();

--- a/packages/core/src/core/renderer.ts
+++ b/packages/core/src/core/renderer.ts
@@ -18,11 +18,11 @@ export abstract class Renderer {
   protected abstract renderObject(layer: Layer, objectIndex: number): void;
   protected abstract clear(): void;
 
-  constructor(selector: string) {
-    this.canvas_ = document.querySelector<HTMLCanvasElement>(selector);
-    if (!this.canvas_) {
-      throw new Error(`Canvas element not found for selector "${selector}"`);
-    }
+  protected beginTransparentPass(): void {}
+  protected endTransparentPass(): void {}
+
+  constructor(canvas: HTMLCanvasElement) {
+    this.canvas_ = canvas;
     this.updateRendererSize();
     window.addEventListener("resize", () => {
       this.updateRendererSize();

--- a/packages/core/src/idetik.ts
+++ b/packages/core/src/idetik.ts
@@ -39,7 +39,7 @@ export class Idetik {
 
     this.camera = params.camera;
     const canvas =
-      params.canvas ||
+      params.canvas ??
       document.querySelector<HTMLCanvasElement>(params.canvasSelector!);
     if (!canvas) {
       throw new Error(`Canvas not found: ${params.canvasSelector}`);
@@ -79,7 +79,7 @@ export class Idetik {
     this.renderer_.setControls(controls);
   }
 
-  // TODO: this can be moved directly to this calss, but will need access to (and possibly expose)
+  // TODO: this can be moved directly to this class, but will need access to (and possibly expose)
   // the canvas element
   // let's do it at the same time `setControls` is moved to this class
   public clientToClip(position: vec2, depth: number = 0): vec3 {

--- a/packages/core/src/idetik.ts
+++ b/packages/core/src/idetik.ts
@@ -5,6 +5,7 @@ import { WebGLRenderer } from "./renderers/webgl_renderer";
 import { CameraControls } from "./objects/cameras/controls";
 import { Logger } from "./utilities/logger";
 import { ChunkManager } from "./core/chunk_manager";
+import { vec2, vec3 } from "gl-matrix";
 
 type IdetikParams = {
   canvas?: HTMLCanvasElement;
@@ -21,8 +22,9 @@ export type IdetikContext = {
 export class Idetik {
   public layerManager: LayerManager;
   public camera: Camera;
-  public readonly renderer_: WebGLRenderer;
+  public readonly canvas: HTMLCanvasElement;
 
+  private readonly renderer_: WebGLRenderer;
   private readonly context_: IdetikContext;
   private readonly chunkManager_: ChunkManager;
   private lastAnimationId_?: number;
@@ -42,6 +44,7 @@ export class Idetik {
     if (!canvas) {
       throw new Error(`Canvas not found: ${params.canvasSelector}`);
     }
+    this.canvas = canvas;
     this.renderer_ = new WebGLRenderer(canvas);
     this.chunkManager_ = new ChunkManager();
 
@@ -74,6 +77,13 @@ export class Idetik {
   // TODO: this should be modified once the controls are moved to the idetik class
   public setControls(controls: CameraControls) {
     this.renderer_.setControls(controls);
+  }
+
+  // TODO: this can be moved directly to this calss, but will need access to (and possibly expose)
+  // the canvas element
+  // let's do it at the same time `setControls` is moved to this class
+  public clientToClip(position: vec2, depth: number = 0): vec3 {
+    return this.renderer_.clientToClip(position, depth);
   }
 
   public start() {

--- a/packages/core/src/idetik.ts
+++ b/packages/core/src/idetik.ts
@@ -34,9 +34,11 @@ export class Idetik {
     if (params.canvas && params.canvasSelector) {
       throw new Error("Cannot provide both canvas and canvasSelector");
     }
-    
+
     this.camera = params.camera;
-    const canvas = params.canvas || document.querySelector<HTMLCanvasElement>(params.canvasSelector!);
+    const canvas =
+      params.canvas ||
+      document.querySelector<HTMLCanvasElement>(params.canvasSelector!);
     if (!canvas) {
       throw new Error(`Canvas not found: ${params.canvasSelector}`);
     }

--- a/packages/core/src/idetik.ts
+++ b/packages/core/src/idetik.ts
@@ -7,7 +7,8 @@ import { Logger } from "./utilities/logger";
 import { ChunkManager } from "./core/chunk_manager";
 
 type IdetikParams = {
-  canvasSelector: string;
+  canvas?: HTMLCanvasElement;
+  canvasSelector?: string;
   camera: Camera;
   controls?: CameraControls;
   layers?: Layer[];
@@ -20,15 +21,26 @@ export type IdetikContext = {
 export class Idetik {
   public layerManager: LayerManager;
   public camera: Camera;
+  public readonly renderer_: WebGLRenderer;
 
   private readonly context_: IdetikContext;
-  private readonly renderer_: WebGLRenderer;
   private readonly chunkManager_: ChunkManager;
   private lastAnimationId_?: number;
 
   constructor(params: IdetikParams) {
+    if (!params.canvas && !params.canvasSelector) {
+      throw new Error("Either canvas or canvasSelector must be provided");
+    }
+    if (params.canvas && params.canvasSelector) {
+      throw new Error("Cannot provide both canvas and canvasSelector");
+    }
+    
     this.camera = params.camera;
-    this.renderer_ = new WebGLRenderer(params.canvasSelector);
+    const canvas = params.canvas || document.querySelector<HTMLCanvasElement>(params.canvasSelector!);
+    if (!canvas) {
+      throw new Error(`Canvas not found: ${params.canvasSelector}`);
+    }
+    this.renderer_ = new WebGLRenderer(canvas);
     this.chunkManager_ = new ChunkManager();
 
     this.context_ = {

--- a/packages/core/src/layers/axes_layer.ts
+++ b/packages/core/src/layers/axes_layer.ts
@@ -3,6 +3,8 @@ import { ProjectedLineGeometry } from "../objects/geometry/projected_line_geomet
 import { ProjectedLine } from "../objects/renderable/projected_line";
 
 export class AxesLayer extends Layer {
+  public readonly type = "AxesLayer";
+
   constructor(params: { length: number; width: number }) {
     super();
     const { length, width } = params;

--- a/packages/core/src/layers/image_layer.ts
+++ b/packages/core/src/layers/image_layer.ts
@@ -17,6 +17,8 @@ export type ImageLayerProps = LayerOptions & {
 
 // Loads data from an image source into renderable objects.
 export class ImageLayer extends Layer {
+  public readonly type = "ImageLayer";
+
   private readonly source_: ImageChunkSource;
   // TODO: remove this when region is passed through to update.
   // https://github.com/chanzuckerberg/idetik/issues/33

--- a/packages/core/src/layers/image_series_layer.ts
+++ b/packages/core/src/layers/image_series_layer.ts
@@ -37,6 +37,8 @@ type SetIndexResult = {
 
 // Loads 2D+z image data (Z-stack) from an image source into renderable objects.
 export class ImageSeriesLayer extends Layer {
+  public readonly type = "ImageSeriesLayer";
+
   private readonly source_: ImageChunkSource;
   private readonly region_: Region;
   private readonly seriesDimensionName_: string;

--- a/packages/core/src/layers/projected_line_layer.ts
+++ b/packages/core/src/layers/projected_line_layer.ts
@@ -10,6 +10,8 @@ type LineParameters = {
 };
 
 export class ProjectedLineLayer extends Layer {
+  public readonly type = "ProjectedLineLayer";
+
   private paths_: vec3[][] = [];
 
   constructor(lines: LineParameters[] = []) {

--- a/packages/core/src/layers/tracks_layer.ts
+++ b/packages/core/src/layers/tracks_layer.ts
@@ -12,6 +12,8 @@ type TrackParameters = {
 };
 
 export class TracksLayer extends Layer {
+  public readonly type = "TracksLayer";
+
   private tracks_: TrackParameters[] = [];
 
   constructor(tracks: TrackParameters[] = []) {

--- a/packages/core/src/objects/cameras/camera.ts
+++ b/packages/core/src/objects/cameras/camera.ts
@@ -5,7 +5,6 @@ export abstract class Camera extends RenderableObject {
   protected projectionMatrix_ = mat4.create();
   protected near_ = 0;
   protected far_ = 0;
-  protected zoom_ = 1;
 
   protected abstract updateProjectionMatrix(): void;
 

--- a/packages/core/src/renderers/webgl_renderer.ts
+++ b/packages/core/src/renderers/webgl_renderer.ts
@@ -33,8 +33,8 @@ export class WebGLRenderer extends Renderer {
   private readonly textures_: WebGLTextures;
   private readonly state_: WebGLState;
 
-  constructor(selector: string) {
-    super(selector);
+  constructor(canvas: HTMLCanvasElement) {
+    super(canvas);
 
     this.gl_ = this.canvas.getContext("webgl2", { depth: true });
     if (!this.gl_) {

--- a/packages/core/test/idetik.test.ts
+++ b/packages/core/test/idetik.test.ts
@@ -1,0 +1,89 @@
+import { expect, test, vi } from "vitest";
+import { Idetik } from "@/idetik";
+import { OrthographicCamera } from "@/objects/cameras/orthographic_camera";
+
+test("Runtime constructor throws error when neither canvas nor canvasSelector provided", () => {
+  const camera = new OrthographicCamera(0, 128, 0, 128);
+
+  expect(() => {
+    new Idetik({ camera });
+  }).toThrow("Either canvas or canvasSelector must be provided");
+});
+
+test("Runtime constructor throws error when both canvas and canvasSelector provided", () => {
+  const canvas = document.createElement("canvas");
+  const camera = new OrthographicCamera(0, 128, 0, 128);
+
+  expect(() => {
+    new Idetik({
+      canvas,
+      canvasSelector: "#canvas",
+      camera,
+    });
+  }).toThrow("Cannot provide both canvas and canvasSelector");
+});
+
+test("Runtime constructor throws error when canvas not found with selector", () => {
+  const camera = new OrthographicCamera(0, 128, 0, 128);
+
+  expect(() => {
+    new Idetik({
+      canvasSelector: "#non-existent-canvas",
+      camera,
+    });
+  }).toThrow("Canvas not found: #non-existent-canvas");
+});
+
+test("Runtime initializes with canvas element", () => {
+  const canvas = document.createElement("canvas");
+  const camera = new OrthographicCamera(0, 128, 0, 128);
+
+  const idetik = new Idetik({ canvas, camera });
+
+  expect(idetik.canvas).toBe(canvas);
+  expect(idetik.camera).toBe(camera);
+  expect(idetik.layerManager).toBeDefined();
+});
+
+test("Runtime initializes with canvas selector", () => {
+  const canvas = document.createElement("canvas");
+  canvas.id = "test-canvas";
+  document.body.appendChild(canvas);
+
+  const camera = new OrthographicCamera(0, 128, 0, 128);
+
+  const idetik = new Idetik({
+    canvasSelector: "#test-canvas",
+    camera,
+  });
+
+  expect(idetik.canvas).toBe(canvas);
+  expect(idetik.camera).toBe(camera);
+  expect(idetik.layerManager).toBeDefined();
+
+  document.body.removeChild(canvas);
+});
+
+test("Runtime start/stop controls the animation loop", () => {
+  const canvas = document.createElement("canvas");
+  const camera = new OrthographicCamera(0, 128, 0, 128);
+  const idetik = new Idetik({ canvas, camera });
+
+  const rafSpy = vi.spyOn(window, "requestAnimationFrame");
+  idetik.start();
+  expect(rafSpy).toHaveBeenCalled();
+
+  const cancelRafSpy = vi.spyOn(window, "cancelAnimationFrame");
+  idetik.stop();
+  expect(cancelRafSpy).toHaveBeenCalled();
+});
+
+test("Width and height properties return (scaled) canvas shape", () => {
+  const devicePixelRatio = window.devicePixelRatio;
+  const canvas = document.createElement("canvas");
+  const camera = new OrthographicCamera(0, 128, 0, 128);
+  const idetik = new Idetik({ canvas, camera });
+
+  expect(idetik.width).toBe(canvas.clientWidth * devicePixelRatio);
+  expect(idetik.height).toBe(canvas.clientHeight * devicePixelRatio);
+});

--- a/packages/core/test/layer.test.ts
+++ b/packages/core/test/layer.test.ts
@@ -3,7 +3,7 @@ import { expect, test, vi } from "vitest";
 import { Layer } from "@";
 
 class TestLayer extends Layer {
-  public type = "TestLayer";
+  public readonly type = "TestLayer";
 
   public update() {}
 

--- a/packages/core/test/layer.test.ts
+++ b/packages/core/test/layer.test.ts
@@ -3,6 +3,8 @@ import { expect, test, vi } from "vitest";
 import { Layer } from "@";
 
 class TestLayer extends Layer {
+  public type = "TestLayer";
+
   public update() {}
 
   public setStateReady() {

--- a/packages/core/test/webgl_renderer.test.ts
+++ b/packages/core/test/webgl_renderer.test.ts
@@ -4,18 +4,14 @@ import { WebGLRenderer } from "@";
 
 test("Instantiate WebGLRenderer", () => {
   document.body.innerHTML = '<canvas id="canvas"></canvas>';
-  const renderer = new WebGLRenderer("#canvas");
+  const canvas = document.querySelector<HTMLCanvasElement>("#canvas")!;
+  const renderer = new WebGLRenderer(canvas);
   expect(renderer).toBeDefined();
-});
-
-test("Instantiate WebGLRenderer with invalid selector", () => {
-  document.body.innerHTML = "";
-  expect(() => new WebGLRenderer("#canvas")).toThrowError();
 });
 
 test("Instantiate WebGLRenderer with no WebGL context", () => {
   document.body.innerHTML = '<canvas id="canvas"></canvas>';
   const canvas = document.querySelector<HTMLCanvasElement>("#canvas")!;
   canvas.getContext = () => null;
-  expect(() => new WebGLRenderer("#canvas")).toThrowError();
+  expect(() => new WebGLRenderer(canvas)).toThrowError();
 });

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -55,6 +55,7 @@
   },
   "peerDependencies": {
     "@czi-sds/components": "^22.3.0",
+    "@idetik/core": "^0.0.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   }

--- a/packages/react/src/components/hooks/useOmeZarrImageViewer.ts
+++ b/packages/react/src/components/hooks/useOmeZarrImageViewer.ts
@@ -17,7 +17,7 @@ import {
   getGrayscaleChannelProp,
   defaultGreyscaleChannel,
 } from "../viewers/OmeZarrImageViewer/utils";
-import { useIdetik } from ".";
+import { useIdetik } from "./useIdetik";
 
 export interface OmeZarrImageViewerProps {
   sourceUrl: string;
@@ -185,7 +185,7 @@ export function useOmeZarrViewer({
 
     return () => {
       shouldSetLayer = false;
-      idetik?.layerManager.remove(0);
+      idetik?.layerManager.removeByIndex(0);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps -- Deps that trigger layer creation.
   }, [source, sourceUrl, region, seriesDimensionName, shouldAutoLoadAllSlices]);

--- a/packages/ultrack-prototype/frontend/components/Renderer.tsx
+++ b/packages/ultrack-prototype/frontend/components/Renderer.tsx
@@ -53,18 +53,10 @@ export default function Renderer({
     lastTaskId.current = task.taskId;
     const { tracksLayer, imageSeriesLayer } = task.layers();
     setImageSeriesLayer((prevLayer: ImageSeriesLayer | null) => {
-      if (prevLayer !== null) {
-        prevLayer.close();
-        layerManager.remove(prevLayer);
-      }
+      prevLayer?.close();
       return imageSeriesLayer;
     });
-    setTracksLayer((prevLayer: TracksLayer | null) => {
-      if (prevLayer !== null) {
-        layerManager.remove(prevLayer);
-      }
-      return tracksLayer;
-    });
+    setTracksLayer(tracksLayer);
     const onReady = () => {
       setPlaybackEnabled(true);
       // TODO: update the data on the layers instead of creating new ones

--- a/packages/ultrack-prototype/frontend/components/Renderer.tsx
+++ b/packages/ultrack-prototype/frontend/components/Renderer.tsx
@@ -53,10 +53,18 @@ export default function Renderer({
     lastTaskId.current = task.taskId;
     const { tracksLayer, imageSeriesLayer } = task.layers();
     setImageSeriesLayer((prevLayer: ImageSeriesLayer | null) => {
-      if (prevLayer !== null) prevLayer.close();
+      if (prevLayer !== null) {
+        prevLayer.close();
+        layerManager.remove(prevLayer);
+      }
       return imageSeriesLayer;
     });
-    setTracksLayer(tracksLayer);
+    setTracksLayer((prevLayer: TracksLayer | null) => {
+      if (prevLayer !== null) {
+        layerManager.remove(prevLayer);
+      }
+      return tracksLayer;
+    });
     const onReady = () => {
       setPlaybackEnabled(true);
       // TODO: update the data on the layers instead of creating new ones
@@ -78,7 +86,9 @@ export default function Renderer({
       }
     };
     imageSeriesLayer.addStateChangeCallback(onStateChange);
-    return () => imageSeriesLayer.removeStateChangeCallback(onStateChange);
+    return () => {
+      imageSeriesLayer.removeStateChangeCallback(onStateChange);
+    };
   }, [task, setPlaybackEnabled]);
 
   // Use the mount-effect so that the renderer can find the corresponding
@@ -86,7 +96,8 @@ export default function Renderer({
   useEffect(() => {
     console.debug("Renderer::mount");
     let lastRequestId = 0;
-    const renderer = new WebGLRenderer(`#${canvasId}`);
+    const canvas = document.querySelector<HTMLCanvasElement>(`#${canvasId}`)!;
+    const renderer = new WebGLRenderer(canvas);
     renderer.setControls(controls);
     function animate() {
       renderer.render(layerManager, camera);


### PR DESCRIPTION
### Summary
This PR refactors the core `Idetik` class to accept an `HTMLCanvasElement` directly instead of a canvas selector string, while maintaining backward compatibility during a transition period. This works better for React integration because the canvas element may not be available at the time of component initialization, so when using the context we don't have to rely as much on mount effects, forward refs, or prop drilling. I also think it's a more direct/intuitive interface in general.

This provides a cleaner, more direct API while maintaining backward compatibility and simplifies some of the work on React integration slated for a future PR.

- *Core API Change*: Modified `IdetikParams` to accept both `canvas?: HTMLCanvasElement` and
  `canvasSelector?: string` with validation to ensure exactly one is provided
  - **Note**: This change is temporarily backward compatible, because the current react context expects it and is hard to detangle.
- *Idetik Runtime*: Expose `canvas` as public readonly property on the runtime object so applications (CryoLens) can directly register event listeners on it. Also provide access to `clientToClip` through the runtime (implemented on the `Renderer` at the moment because it holds the canvas ref). This is also probably temporary and could be replaced by Layers registering interactions or adding "resources" that can register interactions.
- *WebGL Renderer*: Updated to consistently use `HTMLCanvasElement` internally
  - **Note - breaking change**: users should be using the `Idetik` runtime object anyway, but if not they will need to update to pass a canvas element instead of a selector to the `WebGLRenderer`
- *Examples Updated*: All core examples now use `document.querySelector<HTMLCanvasElement>()` pattern
- *React Integration*: Minimal changes to maintain compatibility - fixed circular dependency in hooks
- *Ultrack Updates*: Updated to use canvas element instead of selector string
- *Package Dependencies*: Updated React package to properly declare `@idetik/core` as peer dependency

**LayerManager Changes**
New Layer Management Methods:
- Added `remove(layer: Layer)` - removes a specific layer instance (safer than index-based removal, and more convenient when you have a layer reference in React)
  - **Note - breaking change**: existing usage of `remove` with the layer index need to be updated to pass the layer, or use `removeByIndex(index: number)` if you need the old behavior

React Integration Support:
- Added `addLayersChangeCallback`, `removeLayersChangeCallback` for subscribing to layer changes with `useSyncExternalStore`
- This follows the pattern established in `ImageSeriesLayer` for synchronizing react state with Idetik state

**Layer Type Property**

Added Abstract readonly `type` property. This is a small change, but it helps in a few ways and
follows the pattern we've already established in the codebase:
- Better debugging - you can easily identify layer types in dev tools
- Enables type-safe layer filtering and management in React components
- Supports future features like layer-specific UI controls
- Makes layer serialization/deserialization possible

### Testing
I tested the examples, the demo apps in `@idetik/react`, and the ultrack prototype
The refactor is tested by the CryoLens example as well, which is using my [WIP refactor branch](https://github.com/chanzuckerberg/idetik/tree/aganders3/react-refactor-ideas), which this code is extracted from.