### PR TITLE
Fix pan-zoom controls when leaving the canvas

### DIFF
--- a/packages/core/src/objects/cameras/controls.ts
+++ b/packages/core/src/objects/cameras/controls.ts
@@ -43,9 +43,9 @@ export class PanZoomControls implements CameraControls {
         (event: Event) => this.wheel(event as WheelEvent, clientToWorld),
       ],
       [
-        "mousedown",
+        "pointerdown",
         (event: Event) =>
-          this.mousedown(event as MouseEvent, target, clientToWorld),
+          this.pointerdown(event as PointerEvent, target, clientToWorld),
       ],
     ];
   }
@@ -66,17 +66,23 @@ export class PanZoomControls implements CameraControls {
     this.pan(deltaWorld);
   }
 
-  private mousedown(
-    event: MouseEvent,
+  private pointerdown(
+    event: PointerEvent,
     target: EventTarget,
     clientToWorld: ClientToWorld
   ) {
     const clientStart = vec2.fromValues(event.clientX, event.clientY);
     const worldStart = clientToWorld(clientStart, this.clipDepth);
+    const pointerId = event.pointerId;
 
-    const onMouseMove = (event: Event) => {
-      if (!(event instanceof MouseEvent)) {
-        throw new Error("Expected MouseEvent");
+    // capture the pointer to ensure we receive events even when outside the element
+    if (target instanceof Element) {
+      target.setPointerCapture(pointerId);
+    }
+
+    const onPointerMove = (event: Event) => {
+      if (!(event instanceof PointerEvent) || event.pointerId !== pointerId) {
+        return;
       }
       const clientPos = vec2.fromValues(event.clientX, event.clientY);
       const worldPos = clientToWorld(clientPos, this.clipDepth);
@@ -84,15 +90,22 @@ export class PanZoomControls implements CameraControls {
       this.pan(deltaWorld);
     };
 
-    const onMouseUp = () => {
-      target.removeEventListener("mousemove", onMouseMove);
-      target.removeEventListener("mouseup", onMouseUp);
-      target.removeEventListener("mouseleave", onMouseUp);
+    const onPointerUp = (event: Event) => {
+      if (!(event instanceof PointerEvent) || event.pointerId !== pointerId) {
+        return;
+      }
+      target.removeEventListener("pointermove", onPointerMove);
+      target.removeEventListener("pointerup", onPointerUp);
+      target.removeEventListener("pointercancel", onPointerUp);
+
+      if (target instanceof Element) {
+        target.releasePointerCapture(pointerId);
+      }
     };
 
-    target.addEventListener("mousemove", onMouseMove);
-    target.addEventListener("mouseup", onMouseUp);
-    target.addEventListener("mouseleave", onMouseUp);
+    target.addEventListener("pointermove", onPointerMove);
+    target.addEventListener("pointerup", onPointerUp);
+    target.addEventListener("pointercancel", onPointerUp);
   }
 
   private pan(deltaWorld: vec3) {

--- a/packages/core/src/objects/cameras/controls.ts
+++ b/packages/core/src/objects/cameras/controls.ts
@@ -87,12 +87,12 @@ export class PanZoomControls implements CameraControls {
     const onMouseUp = () => {
       target.removeEventListener("mousemove", onMouseMove);
       target.removeEventListener("mouseup", onMouseUp);
-      target.removeEventListener("mouseout", onMouseUp);
+      target.removeEventListener("mouseleave", onMouseUp);
     };
 
     target.addEventListener("mousemove", onMouseMove);
     target.addEventListener("mouseup", onMouseUp);
-    target.addEventListener("mouseout", onMouseUp);
+    target.addEventListener("mouseleave", onMouseUp);
   }
 
   private pan(deltaWorld: vec3) {

--- a/packages/core/src/objects/cameras/controls.ts
+++ b/packages/core/src/objects/cameras/controls.ts
@@ -87,10 +87,14 @@ export class PanZoomControls implements CameraControls {
     const onMouseUp = () => {
       target.removeEventListener("mousemove", onMouseMove);
       target.removeEventListener("mouseup", onMouseUp);
+      target.removeEventListener("mouseleave", onMouseUp);
+      target.removeEventListener("mouseout", onMouseUp);
     };
 
     target.addEventListener("mousemove", onMouseMove);
     target.addEventListener("mouseup", onMouseUp);
+    target.addEventListener("mouseleave", onMouseUp);
+    target.addEventListener("mouseout", onMouseUp);
   }
 
   private pan(deltaWorld: vec3) {

--- a/packages/core/src/objects/cameras/controls.ts
+++ b/packages/core/src/objects/cameras/controls.ts
@@ -87,13 +87,11 @@ export class PanZoomControls implements CameraControls {
     const onMouseUp = () => {
       target.removeEventListener("mousemove", onMouseMove);
       target.removeEventListener("mouseup", onMouseUp);
-      target.removeEventListener("mouseleave", onMouseUp);
       target.removeEventListener("mouseout", onMouseUp);
     };
 
     target.addEventListener("mousemove", onMouseMove);
     target.addEventListener("mouseup", onMouseUp);
-    target.addEventListener("mouseleave", onMouseUp);
     target.addEventListener("mouseout", onMouseUp);
   }
 


### PR DESCRIPTION
### Summary
In `PanZoomControls` this change now uses pointer events instead of mouse events and treats the `pointercancel` event in the same way as a `pointerup` event, which prevents the surprising and undesirable behavior described in #284. Another benefit of using pointer events is that we can capture and release the pointer event ID, which allows us to continue responding to pointer events when the pointer is down but strictly outside the target.

### Related Issue
Closes #284

### Tests & Checks
I manually tested an example with pan-zoom controls and the main React component.
