### PR TITLE
feat: Load only visible chunks based on view bounds

### DIFF
--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -131,8 +131,6 @@ export class ChunkManagerSource {
   }
 
   public async updateChunks(visibleBounds: Bounds) {
-    // TODO: map the LOD factor from the chunk manager to an available LOD in image space
-    // TODO: replace the following block with loading based on intersection tests
     if (this.hasVisibleBoundsChanged(visibleBounds)) {
       this.computeVisibleChunks(visibleBounds);
       this.lastVisibleBounds_ = {

--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -69,7 +69,7 @@ export class ChunkManagerSource {
           this.chunks_.push({
             state: "unloaded",
             lod,
-            visible: true, // TODO:(shlomnissan) should be set to false
+            visible: false,
             shape: {
               x: chunkWidth,
               y: chunkHeight,

--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -110,7 +110,9 @@ export class ChunkManagerSource {
   }
 
   public getVisibleChunks(): ImageChunk[] {
-    return this.chunks_[this.currentLOD_].filter((e) => e.visible);
+    const visibleChunks = this.chunks_[this.currentLOD_].filter((e) => e.visible);
+    const visibleAndReady = visibleChunks.filter((e) => e.state === "loaded");
+    return visibleAndReady;
   }
 
   public setLOD(lodFactor: number): void {
@@ -126,15 +128,59 @@ export class ChunkManagerSource {
     }
   }
 
-  public async updateChunks(_: Bounds) {
-    // TODO: map the LOD factor from the chunk manager to an available LOD in image space
-    // TODO: replace the following block with loading based on intersection tests
+  public async updateChunks(visibleBounds: Bounds) {
+    this.computeVisibleChunks(visibleBounds);
+
     for (const chunk of this.chunks_[this.currentLOD_]) {
-      if (chunk.state === "unloaded") {
+      if (chunk.visible && chunk.state === "unloaded") {
         chunk.state = "loading";
         this.loader_.loadChunkDataFromRegion(chunk, this.region_).then(() => {
           chunk.state = "loaded";
+        }).catch((error) => {
+          console.error(`Error loading chunk (${chunk.chunkIndex?.x},${chunk.chunkIndex?.y}): ${error}`);
+          chunk.state = "unloaded";
         });
+      }
+    }
+  }
+
+  private computeVisibleChunks(visibleBounds: Bounds): void {
+    const currentChunks = this.chunks_[this.currentLOD_];
+    if (currentChunks.length === 0) return;
+
+    // Get chunk size in virtual coordinates for current LOD
+    const firstChunk = currentChunks[0];
+    const chunkVirtualWidth = firstChunk.shape.x * firstChunk.scale.x;
+    const chunkVirtualHeight = firstChunk.shape.y * firstChunk.scale.y;
+
+    // Compute chunk index range using analytical approach
+    const chunkIndexX1 = Math.floor(visibleBounds.min[0] / chunkVirtualWidth);
+    const chunkIndexX2 = Math.floor(visibleBounds.max[0] / chunkVirtualWidth);
+    const chunkIndexY1 = Math.floor(visibleBounds.min[1] / chunkVirtualHeight);
+    const chunkIndexY2 = Math.floor(visibleBounds.max[1] / chunkVirtualHeight);
+
+    // Ensure min/max are in correct order
+    const minChunkIndexX = Math.min(chunkIndexX1, chunkIndexX2);
+    const maxChunkIndexX = Math.max(chunkIndexX1, chunkIndexX2);
+    const minChunkIndexY = Math.min(chunkIndexY1, chunkIndexY2);
+    const maxChunkIndexY = Math.max(chunkIndexY1, chunkIndexY2);
+
+    // Reset all chunks to not visible first
+    for (const chunk of currentChunks) {
+      chunk.visible = false;
+    }
+
+    // Set visible chunks based on index range
+    for (const chunk of currentChunks) {
+      if (!chunk.chunkIndex) continue;
+      const { x, y } = chunk.chunkIndex;
+      if (
+        x >= minChunkIndexX &&
+        x <= maxChunkIndexX &&
+        y >= minChunkIndexY &&
+        y <= maxChunkIndexY
+      ) {
+        chunk.visible = true;
       }
     }
   }

--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -157,41 +157,35 @@ export class ChunkManagerSource {
 
   private updateChunkVisibility(visibleBounds: Bounds): void {
     if (this.chunks_.length === 0) return;
-    const firstChunkAtLOD = this.chunks_.find(
-      (chunk) => chunk.lod === this.currentLOD_
-    );
-    if (!firstChunkAtLOD) return;
-    const chunkVirtualWidth = firstChunkAtLOD.shape.x * firstChunkAtLOD.scale.x;
-    const chunkVirtualHeight =
-      firstChunkAtLOD.shape.y * firstChunkAtLOD.scale.y;
 
-    const minChunkIndexX = Math.floor(visibleBounds.min[0] / chunkVirtualWidth);
-    const maxChunkIndexX = Math.ceil(visibleBounds.max[0] / chunkVirtualWidth);
-    const minChunkIndexY = Math.floor(
-      visibleBounds.min[1] / chunkVirtualHeight
-    );
-    const maxChunkIndexY = Math.ceil(visibleBounds.max[1] / chunkVirtualHeight);
-
-    // Reset visibility and set visible chunks based on index range in a single pass
     for (const chunk of this.chunks_) {
-      // exit early if chunks are not at the current LOD
-      if (chunk.lod !== this.currentLOD_) {
+      if (!chunk.chunkIndex) {
         chunk.visible = false;
         continue;
       }
 
-      chunk.visible = false;
-      if (chunk.chunkIndex) {
-        const { x, y } = chunk.chunkIndex;
-        if (
-          x >= minChunkIndexX &&
-          x <= maxChunkIndexX &&
-          y >= minChunkIndexY &&
-          y <= maxChunkIndexY
-        ) {
-          chunk.visible = true;
-        }
-      }
+      const chunkVirtualWidth = chunk.shape.x * chunk.scale.x;
+      const chunkVirtualHeight = chunk.shape.y * chunk.scale.y;
+
+      const minChunkIndexX = Math.floor(
+        visibleBounds.min[0] / chunkVirtualWidth
+      );
+      const maxChunkIndexX = Math.ceil(
+        visibleBounds.max[0] / chunkVirtualWidth
+      );
+      const minChunkIndexY = Math.floor(
+        visibleBounds.min[1] / chunkVirtualHeight
+      );
+      const maxChunkIndexY = Math.ceil(
+        visibleBounds.max[1] / chunkVirtualHeight
+      );
+
+      const { x, y } = chunk.chunkIndex;
+      chunk.visible =
+        x >= minChunkIndexX &&
+        x <= maxChunkIndexX &&
+        y >= minChunkIndexY &&
+        y <= maxChunkIndexY;
     }
   }
 

--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -173,22 +173,19 @@ export class ChunkManagerSource {
     const minChunkIndexY = Math.min(chunkIndexY1, chunkIndexY2);
     const maxChunkIndexY = Math.max(chunkIndexY1, chunkIndexY2);
 
-    // Reset all chunks to not visible first
+    // Reset visibility and set visible chunks based on index range in a single pass
     for (const chunk of this.chunks_) {
       chunk.visible = false;
-    }
-
-    // Set visible chunks based on index range
-    for (const chunk of this.chunks_) {
-      if (!chunk.chunkIndex) continue;
-      const { x, y } = chunk.chunkIndex;
-      if (
-        x >= minChunkIndexX &&
-        x <= maxChunkIndexX &&
-        y >= minChunkIndexY &&
-        y <= maxChunkIndexY
-      ) {
-        chunk.visible = true;
+      if (chunk.chunkIndex) {
+        const { x, y } = chunk.chunkIndex;
+        if (
+          x >= minChunkIndexX &&
+          x <= maxChunkIndexX &&
+          y >= minChunkIndexY &&
+          y <= maxChunkIndexY
+        ) {
+          chunk.visible = true;
+        }
       }
     }
   }

--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -8,6 +8,7 @@ import { Region } from "../data/region";
 import { Camera } from "../objects/cameras/camera";
 import { vec2, vec4, mat4 } from "gl-matrix";
 import { almostEqual } from "../utilities/almost_equal";
+import { Logger } from "../utilities/logger";
 
 type Bounds = { min: vec2; max: vec2 };
 
@@ -92,62 +93,53 @@ export class ChunkManagerSource {
     }
   }
 
-  /**
-   * Returns all chunks at the current LOD that are both visible and fully loaded.
-   * These are the chunks that are ready to be rendered in the current view.
-   */
-  public getVisibleChunks(): ImageChunk[] {
-    return this.chunks_.filter(
+  public getChunks(): ImageChunk[] {
+    const chunks = this.chunks_.filter(
       (chunk) =>
         chunk.lod === this.currentLOD_ &&
         chunk.visible &&
         chunk.state === "loaded"
     );
+    console.debug(chunks);
+    return chunks;
   }
 
-  /**
-   * Loads any currently visible chunks that are not yet loaded.
-   * Recomputes visibility if the visible bounds have changed since the last update.
-   *
-   * @param visibleBounds - The virtual-space bounding box of the current camera view.
-   */
-  public loadVisibleChunks(visibleBounds: Bounds) {
-    if (this.hasVisibleBoundsChanged(visibleBounds)) {
+  public loadVisibleChunks() {
+    for (const chunk of this.chunks_) {
+      this.processChunkData(chunk);
+    }
+  }
+
+  public update(lodFactor: number, visibleBounds: Bounds) {
+    this.setLOD(lodFactor);
+
+    if (visibleBounds !== this.lastVisibleBounds_) {
       this.updateChunkVisibility(visibleBounds);
       this.lastVisibleBounds_ = {
         min: vec2.clone(visibleBounds.min),
         max: vec2.clone(visibleBounds.max),
       };
     }
-    for (const chunk of this.chunks_) {
-      if (chunk.visible && chunk.state === "unloaded") {
-        chunk.state = "loading";
-        this.loader_
-          .loadChunkDataFromRegion(chunk, this.region_)
-          .then(() => {
-            chunk.state = "loaded";
-          })
-          .catch((error) => {
-            console.error(
-              `Error loading chunk (${chunk.chunkIndex?.x},${chunk.chunkIndex?.y}): ${error}`
-            );
-            chunk.state = "unloaded";
-          });
-      }
-    }
+
+    this.loadVisibleChunks();
   }
 
-  /**
-   * Updates the current level-of-detail (LOD) based on a continuous LOD factor,
-   * and recalculates chunk visibility for the given view bounds.
-   *
-   * @param lodFactor - A continuous value used to select the LOD level (higher = coarser).
-   * @param visibleBounds - The virtual-space bounds used to determine chunk visibility.
-   */
-  public refreshViewState(lodFactor: number, visibleBounds: Bounds) {
-    this.setLOD(lodFactor);
-    this.updateChunkVisibility(visibleBounds);
-    return this.loadVisibleChunks(visibleBounds);
+  private processChunkData(chunk: ImageChunk): void {
+    if (!chunk.visible || chunk.state !== "unloaded") return;
+
+    chunk.state = "loading";
+    this.loader_
+      .loadChunkDataFromRegion(chunk, this.region_)
+      .then(() => {
+        chunk.state = "loaded";
+      })
+      .catch((error) => {
+        Logger.error(
+          "ChunkManager",
+          `Error loading chunk (${chunk.chunkIndex?.x},${chunk.chunkIndex?.y}): ${error}`
+        );
+        chunk.state = "unloaded";
+      });
   }
 
   private setLOD(lodFactor: number): void {
@@ -218,19 +210,6 @@ export class ChunkManagerSource {
       }
     }
   }
-
-  private hasVisibleBoundsChanged(visibleBounds: Bounds): boolean {
-    if (!this.lastVisibleBounds_) {
-      return true;
-    }
-
-    return (
-      !almostEqual(visibleBounds.min[0], this.lastVisibleBounds_.min[0]) ||
-      !almostEqual(visibleBounds.min[1], this.lastVisibleBounds_.min[1]) ||
-      !almostEqual(visibleBounds.max[0], this.lastVisibleBounds_.max[0]) ||
-      !almostEqual(visibleBounds.max[1], this.lastVisibleBounds_.max[1])
-    );
-  }
 }
 
 export class ChunkManager {
@@ -254,7 +233,7 @@ export class ChunkManager {
     const lodFactor = Math.log2(1 / virtualUnitsPerScreenPixel);
 
     for (const [_, chunkManagerSource] of this.sources_) {
-      return chunkManagerSource.refreshViewState(lodFactor, visibleBounds);
+      chunkManagerSource.update(lodFactor, visibleBounds);
     }
   }
 

--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -202,11 +202,11 @@ export class ChunkManagerSource {
     const epsilon = 1e-6;
     return (
       Math.abs(visibleBounds.min[0] - this.lastVisibleBounds_.min[0]) >
-      epsilon ||
+        epsilon ||
       Math.abs(visibleBounds.min[1] - this.lastVisibleBounds_.min[1]) >
-      epsilon ||
+        epsilon ||
       Math.abs(visibleBounds.max[0] - this.lastVisibleBounds_.max[0]) >
-      epsilon ||
+        epsilon ||
       Math.abs(visibleBounds.max[1] - this.lastVisibleBounds_.max[1]) > epsilon
     );
   }

--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -195,6 +195,7 @@ export class ChunkManagerSource {
       return true;
     }
 
+    const EPSILON = 1e-6;
     return (
       Math.abs(visibleBounds.min[0] - this.lastVisibleBounds_.min[0]) >
         EPSILON ||

--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -110,7 +110,9 @@ export class ChunkManagerSource {
   }
 
   public getVisibleChunks(): ImageChunk[] {
-    const visibleChunks = this.chunks_[this.currentLOD_].filter((e) => e.visible);
+    const visibleChunks = this.chunks_[this.currentLOD_].filter(
+      (e) => e.visible
+    );
     const visibleAndReady = visibleChunks.filter((e) => e.state === "loaded");
     return visibleAndReady;
   }
@@ -134,12 +136,17 @@ export class ChunkManagerSource {
     for (const chunk of this.chunks_[this.currentLOD_]) {
       if (chunk.visible && chunk.state === "unloaded") {
         chunk.state = "loading";
-        this.loader_.loadChunkDataFromRegion(chunk, this.region_).then(() => {
-          chunk.state = "loaded";
-        }).catch((error) => {
-          console.error(`Error loading chunk (${chunk.chunkIndex?.x},${chunk.chunkIndex?.y}): ${error}`);
-          chunk.state = "unloaded";
-        });
+        this.loader_
+          .loadChunkDataFromRegion(chunk, this.region_)
+          .then(() => {
+            chunk.state = "loaded";
+          })
+          .catch((error) => {
+            console.error(
+              `Error loading chunk (${chunk.chunkIndex?.x},${chunk.chunkIndex?.y}): ${error}`
+            );
+            chunk.state = "unloaded";
+          });
       }
     }
   }

--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -195,15 +195,14 @@ export class ChunkManagerSource {
       return true;
     }
 
-    const epsilon = 1e-6;
     return (
       Math.abs(visibleBounds.min[0] - this.lastVisibleBounds_.min[0]) >
-        epsilon ||
+        EPSILON ||
       Math.abs(visibleBounds.min[1] - this.lastVisibleBounds_.min[1]) >
-        epsilon ||
+        EPSILON ||
       Math.abs(visibleBounds.max[0] - this.lastVisibleBounds_.max[0]) >
-        epsilon ||
-      Math.abs(visibleBounds.max[1] - this.lastVisibleBounds_.max[1]) > epsilon
+        EPSILON ||
+      Math.abs(visibleBounds.max[1] - this.lastVisibleBounds_.max[1]) > EPSILON
     );
   }
 }

--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -157,10 +157,9 @@ export class ChunkManagerSource {
   }
 
   private computeVisibleChunks(visibleBounds: Bounds): void {
-    const currentChunks = this.chunks_;
-    if (currentChunks.length === 0) return;
+    if (this.chunks_.length === 0) return;
 
-    const firstChunk = currentChunks[0];
+    const firstChunk = this.chunks_[0];
     const chunkVirtualWidth = firstChunk.shape.x * firstChunk.scale.x;
     const chunkVirtualHeight = firstChunk.shape.y * firstChunk.scale.y;
 
@@ -175,12 +174,12 @@ export class ChunkManagerSource {
     const maxChunkIndexY = Math.max(chunkIndexY1, chunkIndexY2);
 
     // Reset all chunks to not visible first
-    for (const chunk of currentChunks) {
+    for (const chunk of this.chunks_) {
       chunk.visible = false;
     }
 
     // Set visible chunks based on index range
-    for (const chunk of currentChunks) {
+    for (const chunk of this.chunks_) {
       if (!chunk.chunkIndex) continue;
       const { x, y } = chunk.chunkIndex;
       if (

--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -92,22 +92,10 @@ export class ChunkManagerSource {
     }
   }
 
-  private validateScaleRatios(xIdx: number, yIdx: number): void {
-    const availableScales = this.attrs_.map((attr) => attr.scale);
-    for (let i = 1; i < availableScales.length; i++) {
-      const prev = availableScales[i - 1];
-      const curr = availableScales[i];
-      const rx = curr[xIdx] / prev[xIdx];
-      const ry = curr[yIdx] / prev[yIdx];
-
-      if (!almostEqual(rx, 2) || !almostEqual(ry, 2)) {
-        throw new Error(
-          `Scales must be separated by factors of 2. Got ratio (${rx}, ${ry}) between scales ${prev} and ${curr}`
-        );
-      }
-    }
-  }
-
+  /**
+   * Returns all chunks at the current LOD that are both visible and fully loaded.
+   * These are the chunks that are ready to be rendered in the current view.
+   */
   public getVisibleChunks(): ImageChunk[] {
     return this.chunks_.filter(
       (chunk) =>
@@ -117,20 +105,13 @@ export class ChunkManagerSource {
     );
   }
 
-  public setLOD(lodFactor: number): void {
-    const maxLOD = this.attrs_.length - 1;
-    const targetLOD = Math.max(
-      0,
-      Math.min(maxLOD, Math.floor(maxLOD - lodFactor))
-    );
-
-    if (targetLOD !== this.currentLOD_) {
-      console.debug(`LOD changed from ${this.currentLOD_} to ${targetLOD}`);
-      this.currentLOD_ = targetLOD;
-    }
-  }
-
-  public async updateChunks(visibleBounds: Bounds) {
+  /**
+   * Loads any currently visible chunks that are not yet loaded.
+   * Recomputes visibility if the visible bounds have changed since the last update.
+   *
+   * @param visibleBounds - The virtual-space bounding box of the current camera view.
+   */
+  public updateChunks(visibleBounds: Bounds) {
     if (this.hasVisibleBoundsChanged(visibleBounds)) {
       this.updateVisibleChunks(visibleBounds);
       this.lastVisibleBounds_ = {
@@ -156,9 +137,34 @@ export class ChunkManagerSource {
     }
   }
 
+  /**
+   * Updates the current level-of-detail (LOD) based on a continuous LOD factor,
+   * and recalculates chunk visibility for the given view bounds.
+   *
+   * @param lodFactor - A continuous value used to select the LOD level (higher = coarser).
+   * @param visibleBounds - The virtual-space bounds used to determine chunk visibility.
+   */
+  public updateLODAndVisibility(lodFactor: number, visibleBounds: Bounds) {
+    this.setLOD(lodFactor);
+    this.updateVisibleChunks(visibleBounds);
+    return this.updateChunks(visibleBounds);
+  }
+
+  private setLOD(lodFactor: number): void {
+    const maxLOD = this.attrs_.length - 1;
+    const targetLOD = Math.max(
+      0,
+      Math.min(maxLOD, Math.floor(maxLOD - lodFactor))
+    );
+
+    if (targetLOD !== this.currentLOD_) {
+      console.debug(`LOD changed from ${this.currentLOD_} to ${targetLOD}`);
+      this.currentLOD_ = targetLOD;
+    }
+  }
+
   private updateVisibleChunks(visibleBounds: Bounds): void {
     if (this.chunks_.length === 0) return;
-
     const firstChunkAtLOD = this.chunks_.find(
       (chunk) => chunk.lod === this.currentLOD_
     );
@@ -176,6 +182,12 @@ export class ChunkManagerSource {
 
     // Reset visibility and set visible chunks based on index range in a single pass
     for (const chunk of this.chunks_) {
+      // exit early if chunks are not at the current LOD
+      if (chunk.lod !== this.currentLOD_) {
+        chunk.visible = false;
+        continue;
+      }
+
       chunk.visible = false;
       if (chunk.chunkIndex) {
         const { x, y } = chunk.chunkIndex;
@@ -187,6 +199,22 @@ export class ChunkManagerSource {
         ) {
           chunk.visible = true;
         }
+      }
+    }
+  }
+
+  private validateScaleRatios(xIdx: number, yIdx: number): void {
+    const availableScales = this.attrs_.map((attr) => attr.scale);
+    for (let i = 1; i < availableScales.length; i++) {
+      const prev = availableScales[i - 1];
+      const curr = availableScales[i];
+      const rx = curr[xIdx] / prev[xIdx];
+      const ry = curr[yIdx] / prev[yIdx];
+
+      if (!almostEqual(rx, 2) || !almostEqual(ry, 2)) {
+        throw new Error(
+          `Scales must be separated by factors of 2. Got ratio (${rx}, ${ry}) between scales ${prev} and ${curr}`
+        );
       }
     }
   }
@@ -226,8 +254,10 @@ export class ChunkManager {
     const lodFactor = Math.log2(1 / virtualUnitsPerScreenPixel);
 
     for (const [_, chunkManagerSource] of this.sources_) {
-      chunkManagerSource.setLOD(lodFactor);
-      chunkManagerSource.updateChunks(visibleBounds);
+      return chunkManagerSource.updateLODAndVisibility(
+        lodFactor,
+        visibleBounds
+      );
     }
   }
 

--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -111,9 +111,9 @@ export class ChunkManagerSource {
    *
    * @param visibleBounds - The virtual-space bounding box of the current camera view.
    */
-  public updateChunks(visibleBounds: Bounds) {
+  public loadVisibleChunks(visibleBounds: Bounds) {
     if (this.hasVisibleBoundsChanged(visibleBounds)) {
-      this.updateVisibleChunks(visibleBounds);
+      this.updateChunkVisibility(visibleBounds);
       this.lastVisibleBounds_ = {
         min: vec2.clone(visibleBounds.min),
         max: vec2.clone(visibleBounds.max),
@@ -144,10 +144,10 @@ export class ChunkManagerSource {
    * @param lodFactor - A continuous value used to select the LOD level (higher = coarser).
    * @param visibleBounds - The virtual-space bounds used to determine chunk visibility.
    */
-  public updateLODAndVisibility(lodFactor: number, visibleBounds: Bounds) {
+  public refreshViewState(lodFactor: number, visibleBounds: Bounds) {
     this.setLOD(lodFactor);
-    this.updateVisibleChunks(visibleBounds);
-    return this.updateChunks(visibleBounds);
+    this.updateChunkVisibility(visibleBounds);
+    return this.loadVisibleChunks(visibleBounds);
   }
 
   private setLOD(lodFactor: number): void {
@@ -163,7 +163,7 @@ export class ChunkManagerSource {
     }
   }
 
-  private updateVisibleChunks(visibleBounds: Bounds): void {
+  private updateChunkVisibility(visibleBounds: Bounds): void {
     if (this.chunks_.length === 0) return;
     const firstChunkAtLOD = this.chunks_.find(
       (chunk) => chunk.lod === this.currentLOD_
@@ -254,10 +254,7 @@ export class ChunkManager {
     const lodFactor = Math.log2(1 / virtualUnitsPerScreenPixel);
 
     for (const [_, chunkManagerSource] of this.sources_) {
-      return chunkManagerSource.updateLODAndVisibility(
-        lodFactor,
-        visibleBounds
-      );
+      return chunkManagerSource.refreshViewState(lodFactor, visibleBounds);
     }
   }
 

--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -94,14 +94,12 @@ export class ChunkManagerSource {
   }
 
   public getChunks(): ImageChunk[] {
-    const chunks = this.chunks_.filter(
+    return this.chunks_.filter(
       (chunk) =>
         chunk.lod === this.currentLOD_ &&
         chunk.visible &&
         chunk.state === "loaded"
     );
-    console.debug(chunks);
-    return chunks;
   }
 
   public loadVisibleChunks() {
@@ -156,7 +154,13 @@ export class ChunkManagerSource {
   }
 
   private updateChunkVisibility(visibleBounds: Bounds): void {
-    if (this.chunks_.length === 0) return;
+    if (this.chunks_.length === 0) {
+      Logger.warn(
+        "ChunkManager",
+        "updateChunkVisibility called with no chunks initialized"
+      );
+      return;
+    }
 
     for (const chunk of this.chunks_) {
       if (!chunk.chunkIndex) {

--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -159,9 +159,10 @@ export class ChunkManagerSource {
   private computeVisibleChunks(visibleBounds: Bounds): void {
     if (this.chunks_.length === 0) return;
 
-    const firstChunk = this.chunks_[0];
-    const chunkVirtualWidth = firstChunk.shape.x * firstChunk.scale.x;
-    const chunkVirtualHeight = firstChunk.shape.y * firstChunk.scale.y;
+    const firstChunkAtLOD = this.chunks_.find((chunk) => chunk.lod === this.currentLOD_);
+    if (!firstChunkAtLOD) return;
+    const chunkVirtualWidth = firstChunkAtLOD.shape.x * firstChunkAtLOD.scale.x;
+    const chunkVirtualHeight = firstChunkAtLOD.shape.y * firstChunkAtLOD.scale.y;
 
     const chunkIndexX1 = Math.floor(visibleBounds.min[0] / chunkVirtualWidth);
     const chunkIndexX2 = Math.floor(visibleBounds.max[0] / chunkVirtualWidth);
@@ -195,18 +196,15 @@ export class ChunkManagerSource {
       return true;
     }
 
-    const EPSILON = 1e-6;
     return (
-      Math.abs(visibleBounds.min[0] - this.lastVisibleBounds_.min[0]) >
-        EPSILON ||
-      Math.abs(visibleBounds.min[1] - this.lastVisibleBounds_.min[1]) >
-        EPSILON ||
-      Math.abs(visibleBounds.max[0] - this.lastVisibleBounds_.max[0]) >
-        EPSILON ||
-      Math.abs(visibleBounds.max[1] - this.lastVisibleBounds_.max[1]) > EPSILON
+      !almostEqual(visibleBounds.min[0], this.lastVisibleBounds_.min[0]) ||
+      !almostEqual(visibleBounds.min[1], this.lastVisibleBounds_.min[1]) ||
+      !almostEqual(visibleBounds.max[0], this.lastVisibleBounds_.max[0]) ||
+      !almostEqual(visibleBounds.max[1], this.lastVisibleBounds_.max[1])
     );
   }
 }
+
 
 export class ChunkManager {
   private readonly sources_ = new Map<ImageChunkSource, ChunkManagerSource>();

--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -132,7 +132,7 @@ export class ChunkManagerSource {
 
   public async updateChunks(visibleBounds: Bounds) {
     if (this.hasVisibleBoundsChanged(visibleBounds)) {
-      this.computeVisibleChunks(visibleBounds);
+      this.updateVisibleChunks(visibleBounds);
       this.lastVisibleBounds_ = {
         min: vec2.clone(visibleBounds.min),
         max: vec2.clone(visibleBounds.max),
@@ -156,23 +156,23 @@ export class ChunkManagerSource {
     }
   }
 
-  private computeVisibleChunks(visibleBounds: Bounds): void {
+  private updateVisibleChunks(visibleBounds: Bounds): void {
     if (this.chunks_.length === 0) return;
 
-    const firstChunkAtLOD = this.chunks_.find((chunk) => chunk.lod === this.currentLOD_);
+    const firstChunkAtLOD = this.chunks_.find(
+      (chunk) => chunk.lod === this.currentLOD_
+    );
     if (!firstChunkAtLOD) return;
     const chunkVirtualWidth = firstChunkAtLOD.shape.x * firstChunkAtLOD.scale.x;
-    const chunkVirtualHeight = firstChunkAtLOD.shape.y * firstChunkAtLOD.scale.y;
+    const chunkVirtualHeight =
+      firstChunkAtLOD.shape.y * firstChunkAtLOD.scale.y;
 
-    const chunkIndexX1 = Math.floor(visibleBounds.min[0] / chunkVirtualWidth);
-    const chunkIndexX2 = Math.ceil(visibleBounds.max[0] / chunkVirtualWidth);
-    const chunkIndexY1 = Math.floor(visibleBounds.min[1] / chunkVirtualHeight);
-    const chunkIndexY2 = Math.ceil(visibleBounds.max[1] / chunkVirtualHeight);
-
-    const minChunkIndexX = chunkIndexX1;
-    const maxChunkIndexX = chunkIndexX2;
-    const minChunkIndexY = chunkIndexY1;
-    const maxChunkIndexY = chunkIndexY2;
+    const minChunkIndexX = Math.floor(visibleBounds.min[0] / chunkVirtualWidth);
+    const maxChunkIndexX = Math.ceil(visibleBounds.max[0] / chunkVirtualWidth);
+    const minChunkIndexY = Math.floor(
+      visibleBounds.min[1] / chunkVirtualHeight
+    );
+    const maxChunkIndexY = Math.ceil(visibleBounds.max[1] / chunkVirtualHeight);
 
     // Reset visibility and set visible chunks based on index range in a single pass
     for (const chunk of this.chunks_) {
@@ -204,7 +204,6 @@ export class ChunkManagerSource {
     );
   }
 }
-
 
 export class ChunkManager {
   private readonly sources_ = new Map<ImageChunkSource, ChunkManagerSource>();

--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -165,14 +165,14 @@ export class ChunkManagerSource {
     const chunkVirtualHeight = firstChunkAtLOD.shape.y * firstChunkAtLOD.scale.y;
 
     const chunkIndexX1 = Math.floor(visibleBounds.min[0] / chunkVirtualWidth);
-    const chunkIndexX2 = Math.floor(visibleBounds.max[0] / chunkVirtualWidth);
+    const chunkIndexX2 = Math.ceil(visibleBounds.max[0] / chunkVirtualWidth);
     const chunkIndexY1 = Math.floor(visibleBounds.min[1] / chunkVirtualHeight);
-    const chunkIndexY2 = Math.floor(visibleBounds.max[1] / chunkVirtualHeight);
+    const chunkIndexY2 = Math.ceil(visibleBounds.max[1] / chunkVirtualHeight);
 
-    const minChunkIndexX = Math.min(chunkIndexX1, chunkIndexX2);
-    const maxChunkIndexX = Math.max(chunkIndexX1, chunkIndexX2);
-    const minChunkIndexY = Math.min(chunkIndexY1, chunkIndexY2);
-    const maxChunkIndexY = Math.max(chunkIndexY1, chunkIndexY2);
+    const minChunkIndexX = chunkIndexX1;
+    const maxChunkIndexX = chunkIndexX2;
+    const minChunkIndexY = chunkIndexY1;
+    const maxChunkIndexY = chunkIndexY2;
 
     // Reset visibility and set visible chunks based on index range in a single pass
     for (const chunk of this.chunks_) {
@@ -233,8 +233,8 @@ export class ChunkManager {
   }
 
   private computeVisibleBounds(camera: Camera): Bounds {
-    let topLeft = vec4.fromValues(-1.0, 1.0, 0.0, 1.0);
-    let bottomRight = vec4.fromValues(1.0, -1.0, 0.0, 1.0);
+    let topLeft = vec4.fromValues(-1.0, -1.0, 0.0, 1.0);
+    let bottomRight = vec4.fromValues(1.0, 1.0, 0.0, 1.0);
 
     const viewProjection = mat4.multiply(
       mat4.create(),

--- a/packages/core/src/layers/image_layer.ts
+++ b/packages/core/src/layers/image_layer.ts
@@ -87,7 +87,7 @@ export class ImageLayer extends Layer {
       }
     });
 
-    this.chunkManagerSource_.getVisibleChunks().forEach((chunk) => {
+    this.chunkManagerSource_.getChunks().forEach((chunk) => {
       if (chunk.state === "loaded" && !this.visibleChunks_.has(chunk)) {
         const image = this.createImage(chunk, this.channelProps);
         this.visibleChunks_.set(chunk, image);

--- a/packages/core/src/utilities/logger.ts
+++ b/packages/core/src/utilities/logger.ts
@@ -15,7 +15,12 @@ const Colors = {
 } satisfies Record<LogLevel, string>;
 
 // Add new module names here as needed to represent different parts of the application
-type Module = "WebGLRenderer" | "WebGLShaderProgram" | "Idetik" | "ImageLayer";
+type Module =
+  | "WebGLRenderer"
+  | "WebGLShaderProgram"
+  | "Idetik"
+  | "ImageLayer"
+  | "ChunkManager";
 
 export class Logger {
   private static logLevel_: LogLevel =


### PR DESCRIPTION
## Load only visible chunks based on view bounds

This PR introduces visibility culling to the chunk loading system. Instead of loading all chunks at the current LOD, we now compute which chunks intersect the visible view bounds and only load those.

###  Features

- **New `getVisibleChunks()` API**: Returns only chunks that are both `visible` and `loaded`, ready for rendering.
- **View-aware chunk loading**: `updateChunks()` now computes visibility using screen-projected bounds and loads only chunks that are in-view and currently `"unloaded"`.
- **Visibility invalidation optimization**: Adds `hasVisibleBoundsChanged()` to avoid recomputing visibility if the camera hasn't moved.
- **Error handling**: Gracefully catches chunk loading errors and resets chunk state to `"unloaded"`.

### Benefits

- Reduces memory and network load by only loading chunks the user can actually see.
- Avoids repeated visibility computation when the view is unchanged.

### Tests: 
verified chunk_streaming example is only loading the chunks within the current viewport