### PR TITLE
Add resource disposal and refactor buffers/textures

### DIFF
--- a/packages/core/src/core/geometry.ts
+++ b/packages/core/src/core/geometry.ts
@@ -12,6 +12,19 @@ type GeometryAttributeType =
   | "size"
   | "marker";
 
+export const GeometryAttributeIndex: Record<GeometryAttributeType, number> = {
+  position: 0,
+  normal: 1,
+  uv: 2,
+  next_position: 3,
+  previous_position: 4,
+  direction: 5,
+  path_proportion: 6,
+  color: 7,
+  size: 8,
+  marker: 9,
+};
+
 type GeometryAttribute = {
   type: GeometryAttributeType;
   itemSize: number;
@@ -21,7 +34,7 @@ type GeometryAttribute = {
 export class Geometry extends Node {
   protected vertexData_: Float32Array;
   protected indexData_: Uint32Array;
-  private attributes_: GeometryAttribute[];
+  private readonly attributes_: GeometryAttribute[];
 
   constructor(vertexData: number[] = [], indexData: number[] = []) {
     super();

--- a/packages/core/src/renderers/webgl_buffers.ts
+++ b/packages/core/src/renderers/webgl_buffers.ts
@@ -1,69 +1,81 @@
 import { RenderableObject } from "../core/renderable_object";
+import { GeometryAttributeIndex } from "../core/geometry";
+
+type BufferHandles = {
+  vao: WebGLVertexArrayObject;
+  vbo: WebGLBuffer;
+  ebo?: WebGLBuffer;
+};
 
 export class WebGLBuffers {
   private readonly gl_: WebGL2RenderingContext;
-  private VAOs_: Map<string, WebGLVertexArrayObject> = new Map();
-  private currentVAO_: WebGLVertexArrayObject = 0;
+  private readonly buffers_: Map<RenderableObject, BufferHandles> = new Map();
+  private currentObject_: RenderableObject | null = null;
 
   constructor(gl: WebGL2RenderingContext) {
     this.gl_ = gl;
   }
 
-  public bind(object: RenderableObject) {
-    const uuid = object.geometry.uuid;
+  public bindObject(object: RenderableObject) {
+    if (this.alreadyActive(object)) return;
 
-    if (this.alreadyActive(uuid)) return;
-
-    let objectVAO = this.VAOs_.get(uuid) || null;
-    if (!objectVAO) {
-      objectVAO = this.createVAO();
+    if (!this.buffers_.has(object)) {
+      this.generateBuffers(object);
     }
 
-    this.gl_.bindVertexArray(objectVAO);
-    if (!this.VAOs_.has(uuid)) {
-      this.createBuffers(object);
-      this.VAOs_.set(uuid, objectVAO);
+    const buffers = this.buffers_.get(object);
+    if (!buffers) {
+      throw new Error("Failed to retrieve buffer handles for object");
     }
 
-    this.currentVAO_ = objectVAO!;
+    this.gl_.bindVertexArray(buffers.vao);
+    this.currentObject_ = object;
   }
 
-  private alreadyActive(uuid: string) {
-    if (this.currentVAO_ !== 0) {
-      return this.VAOs_.get(uuid) === this.currentVAO_;
+  public disposeObject(object: RenderableObject) {
+    const buffers = this.buffers_.get(object);
+    if (!buffers) return;
+
+    this.gl_.deleteVertexArray(buffers.vao);
+    this.gl_.deleteBuffer(buffers.vbo);
+
+    if (buffers.ebo) this.gl_.deleteBuffer(buffers.ebo);
+
+    this.buffers_.delete(object);
+    if (this.currentObject_ === object) {
+      this.currentObject_ = null;
     }
-    return false;
   }
 
-  private createVAO() {
+  public disposeAll() {
+    for (const object of this.buffers_.keys()) {
+      this.disposeObject(object);
+    }
+  }
+
+  private alreadyActive(object: RenderableObject) {
+    return this.currentObject_ === object;
+  }
+
+  private generateBuffers(object: RenderableObject) {
     const vao = this.gl_.createVertexArray();
     if (!vao) {
-      throw new Error(`Unable to generate a vertex array object name`);
+      throw new Error("Failed to create vertex array object (VAO)");
     }
-    return vao;
-  }
 
-  private createBuffers(object: RenderableObject) {
-    const buffer = this.gl_.createBuffer();
-    const { vertexData, indexData, attributes, stride } = object.geometry;
+    this.gl_.bindVertexArray(vao);
 
-    const bufferType = this.gl_.ARRAY_BUFFER;
-    this.gl_.bindBuffer(bufferType, buffer);
-    this.gl_.bufferData(bufferType, vertexData, this.gl_.STATIC_DRAW);
+    const { vertexData } = object.geometry;
+    const vboType = this.gl_.ARRAY_BUFFER;
+    const vbo = this.gl_.createBuffer();
+    if (!vbo) throw new Error("Failed to create vertex buffer (VBO)");
 
+    this.gl_.bindBuffer(vboType, vbo);
+    this.gl_.bufferData(vboType, vertexData, this.gl_.STATIC_DRAW);
+
+    const { attributes, stride } = object.geometry;
     attributes.forEach((attr) => {
-      let idx = -1;
-      if (attr.type === "position") idx = 0;
-      if (attr.type === "normal") idx = 1;
-      if (attr.type === "uv") idx = 2;
-      if (attr.type == "previous_position") idx = 3;
-      if (attr.type == "next_position") idx = 4;
-      if (attr.type == "direction") idx = 5;
-      if (attr.type == "path_proportion") idx = 6;
-      if (attr.type == "color") idx = 7;
-      if (attr.type == "size") idx = 8;
-      if (attr.type == "marker") idx = 9;
-
+      const idx = GeometryAttributeIndex[attr.type];
       this.gl_.vertexAttribPointer(
         idx,
         attr.itemSize,
@@ -75,14 +87,20 @@ export class WebGLBuffers {
       this.gl_.enableVertexAttribArray(idx);
     });
 
+    const buffers: BufferHandles = { vao, vbo };
+
+    const { indexData } = object.geometry;
     if (indexData.length) {
-      const indexBuffer = this.gl_.createBuffer();
-      this.gl_.bindBuffer(this.gl_.ELEMENT_ARRAY_BUFFER, indexBuffer);
-      this.gl_.bufferData(
-        this.gl_.ELEMENT_ARRAY_BUFFER,
-        indexData,
-        this.gl_.STATIC_DRAW
-      );
+      const eboType = this.gl_.ELEMENT_ARRAY_BUFFER;
+      const ebo = this.gl_.createBuffer();
+      if (!ebo) throw new Error("Failed to create index buffer (EBO)");
+
+      this.gl_.bindBuffer(eboType, ebo);
+      this.gl_.bufferData(eboType, indexData, this.gl_.STATIC_DRAW);
+      buffers.ebo = ebo;
     }
+
+    this.buffers_.set(object, buffers);
+    this.gl_.bindVertexArray(null);
   }
 }

--- a/packages/core/src/renderers/webgl_renderer.ts
+++ b/packages/core/src/renderers/webgl_renderer.ts
@@ -125,10 +125,10 @@ export class WebGLRenderer extends Renderer {
       }
     }
 
-    this.bindings_.bind(object);
+    this.bindings_.bindObject(object);
 
     object.textures.forEach((texture) => {
-      this.textures_.bind(texture);
+      this.textures_.bindTexture(texture);
     });
 
     const primitive = this.getShaderPrimitive(object.primitive);

--- a/packages/core/src/renderers/webgl_textures.ts
+++ b/packages/core/src/renderers/webgl_textures.ts
@@ -1,3 +1,4 @@
+import { Logger } from "../utilities/logger";
 import {
   Texture,
   TextureFilter,
@@ -9,136 +10,137 @@ import {
 import { Texture2D } from "../objects/textures/texture_2d";
 import { Texture2DArray } from "../objects/textures/texture_2d_array";
 
+type TextureFormatInfo = {
+  internalFormat: number;
+  format: number;
+  type: number;
+};
+
 export class WebGLTextures {
   private readonly gl_: WebGL2RenderingContext;
-  private readonly textures_: Map<string, WebGLTexture> = new Map();
-  private currentTexture_: WebGLTexture = 0;
+  private readonly textures_: Map<Texture, WebGLTexture> = new Map();
+  private currentTexture_: Texture | null = null;
 
   constructor(gl: WebGL2RenderingContext) {
     this.gl_ = gl;
   }
 
-  public bind(texture: Texture) {
-    if (this.alreadyActive(texture.uuid) && !texture.needsUpdate) return;
+  public bindTexture(texture: Texture) {
+    if (this.alreadyActive(texture)) return;
 
-    let textureId = this.textures_.get(texture.uuid) || null;
+    const textureType = this.getTextureType(texture);
+    const info = this.getDataFormatInfo(texture.dataFormat, texture.dataType);
+
+    if (!this.textures_.has(texture)) {
+      this.generateTexture(texture, info, textureType);
+    }
+
+    const textureId = this.textures_.get(texture);
     if (!textureId) {
-      textureId = this.createTexture();
+      throw new Error("Failed to retrieve texture ID");
     }
 
-    this.gl_.bindTexture(this.getGLTextureType(texture), textureId);
-    if (!this.textures_.has(texture.uuid)) {
-      this.allocateTextureStorage(texture);
-      this.textures_.set(texture.uuid, textureId);
-    }
-
+    this.gl_.bindTexture(textureType, textureId);
     if (texture.needsUpdate && texture.data !== null) {
-      // Currently, we don't support mipmaps, so we always update the base level (0).
-      const mipmapLevel = 0;
-
-      // The offsets are always set to zero because we are replacing the entire data set.
-      const offset = { x: 0, y: 0, z: 0 };
-
-      this.configureTextureParameters(texture);
-      this.uploadTextureSubData(texture, mipmapLevel, offset);
+      this.configureTextureParameters(texture, textureType);
+      this.uploadTextureData(texture, info, textureType);
       texture.needsUpdate = false;
     }
 
-    this.currentTexture_ = textureId;
+    this.currentTexture_ = texture;
   }
 
-  private alreadyActive(uuid: string) {
-    if (this.currentTexture_ !== 0) {
-      return this.textures_.get(uuid) === this.currentTexture_;
+  public disposeTexture(texture: Texture) {
+    const id = this.textures_.get(texture);
+    if (id) {
+      this.gl_.deleteTexture(id);
+      this.textures_.delete(texture);
+      if (this.currentTexture_ === texture) {
+        this.currentTexture_ = null;
+      }
     }
-    return false;
   }
 
-  private createTexture() {
-    const texture = this.gl_.createTexture();
-    if (!texture) {
-      throw new Error(`Unable to generate a texture name`);
+  public disposeAll() {
+    for (const texture of this.textures_.keys()) {
+      this.disposeTexture(texture);
     }
-    return texture;
   }
 
-  private configureTextureParameters(texture: Texture) {
-    const gl = this.gl_;
-
-    gl.pixelStorei(gl.UNPACK_ALIGNMENT, texture.unpackAlignment);
-    gl.pixelStorei(gl.UNPACK_ROW_LENGTH, texture.unpackRowLength);
-
-    gl.texParameteri(
-      this.getGLTextureType(texture),
-      gl.TEXTURE_MIN_FILTER,
-      this.getGLFilter(texture.minFilter, texture.dataFormat, texture.dataType)
-    );
-
-    gl.texParameteri(
-      this.getGLTextureType(texture),
-      gl.TEXTURE_MAG_FILTER,
-      this.getGLFilter(texture.maxFilter, texture.dataFormat, texture.dataType)
-    );
-
-    gl.texParameteri(
-      this.getGLTextureType(texture),
-      gl.TEXTURE_WRAP_S,
-      this.getGLWrapMode(texture.wrapS)
-    );
-
-    gl.texParameteri(
-      this.getGLTextureType(texture),
-      gl.TEXTURE_WRAP_T,
-      this.getGLWrapMode(texture.wrapT)
-    );
-
-    gl.texParameteri(
-      this.getGLTextureType(texture),
-      gl.TEXTURE_WRAP_R,
-      this.getGLWrapMode(texture.wrapR)
-    );
+  private alreadyActive(texture: Texture) {
+    return this.currentTexture_ === texture && !texture.needsUpdate;
   }
 
-  private allocateTextureStorage(texture: Texture) {
+  private generateTexture(
+    texture: Texture,
+    info: TextureFormatInfo,
+    type: number
+  ) {
+    const textureId = this.gl_.createTexture();
+    if (!textureId) throw new Error("Failed to create texture");
+
+    this.gl_.bindTexture(type, textureId);
+
     if (this.isTexture2D(texture)) {
       this.gl_.texStorage2D(
-        this.getGLTextureType(texture),
+        type,
         texture.mipmapLevels,
-        this.getGLInternalFormat(texture.dataFormat, texture.dataType),
+        info.internalFormat,
         texture.width,
         texture.height
       );
     } else if (this.isTexture2DArray(texture)) {
       this.gl_.texStorage3D(
-        this.getGLTextureType(texture),
+        type,
         texture.mipmapLevels,
-        this.getGLInternalFormat(texture.dataFormat, texture.dataType),
+        info.internalFormat,
         texture.width,
         texture.height,
         texture.depth
       );
     } else {
-      throw new Error(
-        "Attempting to allocate storage for an unsupported texture type"
-      );
+      throw new Error(`Unknown texture type ${texture.type}`);
     }
+
+    this.textures_.set(texture, textureId);
+    this.gl_.bindTexture(type, null);
   }
 
-  private uploadTextureSubData(
+  private configureTextureParameters(texture: Texture, type: number) {
+    const gl = this.gl_;
+    const minFilter = this.getFilter(texture.minFilter, texture);
+    const maxFilter = this.getFilter(texture.maxFilter, texture);
+
+    gl.pixelStorei(gl.UNPACK_ALIGNMENT, texture.unpackAlignment);
+    gl.pixelStorei(gl.UNPACK_ROW_LENGTH, texture.unpackRowLength);
+    gl.texParameteri(type, gl.TEXTURE_MIN_FILTER, minFilter);
+    gl.texParameteri(type, gl.TEXTURE_MAG_FILTER, maxFilter);
+    gl.texParameteri(type, gl.TEXTURE_WRAP_S, this.getWrapMode(texture.wrapS));
+    gl.texParameteri(type, gl.TEXTURE_WRAP_T, this.getWrapMode(texture.wrapT));
+    gl.texParameteri(type, gl.TEXTURE_WRAP_R, this.getWrapMode(texture.wrapR));
+  }
+
+  private uploadTextureData(
     texture: Texture,
-    mipmapLevel: number,
-    offset: { x: number; y: number; z: number }
+    info: TextureFormatInfo,
+    type: number
   ) {
+    // Only base level (0) is updated; mipmaps are not supported.
+    const mipmapLevel = 0;
+
+    // Zero offsets because entire dataset is overwritten.
+    const offset = { x: 0, y: 0, z: 0 };
+
     if (this.isTexture2D(texture)) {
       this.gl_.texSubImage2D(
-        this.getGLTextureType(texture),
+        type,
         mipmapLevel,
         offset.x,
         offset.y,
         texture.width,
         texture.height,
-        this.getGLFormat(texture.dataFormat, texture.dataType),
-        this.getGLType(texture.dataType),
+        info.format,
+        info.type,
         // This function has multiple overloads. We are temporarily casting it to
         // ArrayBufferView to ensure the correct overload is called. Once we
         // consolidate Texture2D and DataTexture2D, we can remove this cast.
@@ -147,7 +149,7 @@ export class WebGLTextures {
       );
     } else if (this.isTexture2DArray(texture)) {
       this.gl_.texSubImage3D(
-        this.getGLTextureType(texture),
+        type,
         mipmapLevel,
         offset.x,
         offset.y,
@@ -155,8 +157,8 @@ export class WebGLTextures {
         texture.width,
         texture.height,
         texture.depth,
-        this.getGLFormat(texture.dataFormat, texture.dataType),
-        this.getGLType(texture.dataType),
+        info.format,
+        info.type,
         texture.data as ArrayBufferView
       );
     } else {
@@ -166,86 +168,85 @@ export class WebGLTextures {
     }
   }
 
-  private getGLTextureType(texture: Texture) {
-    if (this.isTexture2D(texture)) {
-      return this.gl_.TEXTURE_2D;
-    } else if (this.isTexture2DArray(texture)) {
-      return this.gl_.TEXTURE_2D_ARRAY;
-    } else {
-      throw new Error(`Unknown texture type ${texture.type}`);
-    }
-  }
-
-  private getGLFilter(
-    filter: TextureFilter,
-    format: TextureDataFormat,
-    type: TextureDataType
-  ) {
-    if (format == "scalar" && type != "float" && filter != "nearest") {
-      console.warn(
+  private getFilter(filter: TextureFilter, texture: Texture) {
+    const { dataFormat, dataType } = texture;
+    if (
+      dataFormat === "scalar" &&
+      dataType !== "float" &&
+      filter !== "nearest"
+    ) {
+      Logger.warn(
+        "WebGLTexture",
         "Integer values are not filterable. Using gl.NEAREST instead."
       );
       return this.gl_.NEAREST;
     }
-
+    // prettier-ignore
     switch (filter) {
-      case "nearest":
-        return this.gl_.NEAREST;
-      case "linear":
-        return this.gl_.LINEAR;
+      case "nearest": return this.gl_.NEAREST;
+      case "linear": return this.gl_.LINEAR;
+      default: throw new Error(`Unsupported texture filter: ${filter}`);
     }
   }
 
-  private getGLWrapMode(mode: TextureWrapMode) {
+  private getTextureType(texture: Texture) {
+    if (this.isTexture2D(texture)) return this.gl_.TEXTURE_2D;
+    if (this.isTexture2DArray(texture)) return this.gl_.TEXTURE_2D_ARRAY;
+    throw new Error(`Unknown texture type ${texture.type}`);
+  }
+
+  private getWrapMode(mode: TextureWrapMode) {
+    // prettier-ignore
     switch (mode) {
-      case "repeat":
-        return this.gl_.REPEAT;
-      case "clamp_to_edge":
-        return this.gl_.CLAMP_TO_EDGE;
+      case "repeat": return this.gl_.REPEAT;
+      case "clamp_to_edge": return this.gl_.CLAMP_TO_EDGE;
+      default: throw new Error(`Unsupported wrap mode: ${mode}`);
     }
   }
 
-  private getGLType(type: TextureDataType) {
-    switch (type) {
-      case "unsigned_byte":
-        return this.gl_.UNSIGNED_BYTE;
-      case "unsigned_short":
-        return this.gl_.UNSIGNED_SHORT;
-      case "float":
-        return this.gl_.FLOAT;
-    }
-  }
-
-  private getGLFormat(format: TextureDataFormat, type: TextureDataType) {
-    switch (format) {
-      case "rgb":
-        return this.gl_.RGB;
-      case "rgba":
-        return this.gl_.RGBA;
-      case "scalar":
-        if (type === "float") return this.gl_.RED;
-        return this.gl_.RED_INTEGER;
-    }
-  }
-
-  private getGLInternalFormat(
+  private getDataFormatInfo(
     format: TextureDataFormat,
     type: TextureDataType
-  ) {
+  ): TextureFormatInfo {
     if (format === "rgba" && type === "unsigned_byte") {
-      return this.gl_.RGBA8;
-    } else if (format === "rgb" && type === "unsigned_byte") {
-      return this.gl_.RGB8;
-    } else if (format === "scalar" && type === "unsigned_byte") {
-      return this.gl_.R8UI;
-    } else if (format === "scalar" && type === "unsigned_short") {
-      return this.gl_.R16UI;
-    } else if (format === "scalar" && type === "float") {
-      return this.gl_.R32F;
+      return {
+        internalFormat: this.gl_.RGBA8,
+        format: this.gl_.RGBA,
+        type: this.gl_.UNSIGNED_BYTE,
+      };
     }
-    throw Error(
-      `Unsupported data format and type combination ${format}/${type}`
-    );
+    if (format === "rgb" && type === "unsigned_byte") {
+      return {
+        internalFormat: this.gl_.RGB8,
+        format: this.gl_.RGB,
+        type: this.gl_.UNSIGNED_BYTE,
+      };
+    }
+    if (format === "scalar") {
+      switch (type) {
+        case "unsigned_byte":
+          return {
+            internalFormat: this.gl_.R8UI,
+            format: this.gl_.RED_INTEGER,
+            type: this.gl_.UNSIGNED_BYTE,
+          };
+        case "unsigned_short":
+          return {
+            internalFormat: this.gl_.R16UI,
+            format: this.gl_.RED_INTEGER,
+            type: this.gl_.UNSIGNED_SHORT,
+          };
+        case "float":
+          return {
+            internalFormat: this.gl_.R32F,
+            format: this.gl_.RED,
+            type: this.gl_.FLOAT,
+          };
+        default:
+          throw new Error(`Unsupported scalar type: ${type}`);
+      }
+    }
+    throw new Error(`Unsupported format/type: ${format}/${type}`);
   }
 
   private isTexture2D(texture: Texture): texture is Texture2D {
@@ -253,6 +254,6 @@ export class WebGLTextures {
   }
 
   private isTexture2DArray(texture: Texture): texture is Texture2DArray {
-    return (texture as Texture2DArray).type === "Texture2DArray";
+    return texture.type === "Texture2DArray";
   }
 }

--- a/packages/core/src/utilities/logger.ts
+++ b/packages/core/src/utilities/logger.ts
@@ -20,7 +20,8 @@ type Module =
   | "WebGLShaderProgram"
   | "Idetik"
   | "ImageLayer"
-  | "ChunkManager";
+  | "ChunkManager"
+  | "WebGLTexture";
 
 export class Logger {
   private static logLevel_: LogLevel =


### PR DESCRIPTION
### Summary

This PR refactors both `WebGLBuffers` and `WebGLTextures` to support upcoming work
on GPU resource lifetime management. It introduces `dispose()` and `disposeAll()`
methods to both classes for explicit resource cleanup.

**WebGLBuffers**
The primary change involves structuring buffer-related GPU handles (vao, vbo, ebo)
into a unified object. This simplifies resource tracking and disposal beyond basic
map cleanup. It will also help when adding wireframe index buffers.

**WebGLTextures**
The main improvements include eliminating repeated calls to common utility methods
(e.g., texture format/type lookups) and reorganizing logic to improve readability
and reduce duplication.

### ⚠️ Note
It may be easier to review by reading through the full files instead of diffing individual changes.

### Related Issue
Closes #41 

### Tests & Checks
- Manual verification
- All checks have passed
