### PR TITLE
(Stacked) Render wireframes on top of meshes [1/2]

### DIFF
--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -148,7 +148,10 @@ export class ChunkManagerSource {
     );
 
     if (targetLOD !== this.currentLOD_) {
-      console.debug(`LOD changed from ${this.currentLOD_} to ${targetLOD}`);
+      Logger.debug(
+        "ChunkManager",
+        `LOD changed from ${this.currentLOD_} to ${targetLOD}`
+      );
       this.currentLOD_ = targetLOD;
     }
   }

--- a/packages/core/src/core/geometry.ts
+++ b/packages/core/src/core/geometry.ts
@@ -1,4 +1,5 @@
 import { Node } from "./node";
+import { Logger } from "../utilities/logger";
 
 type GeometryAttributeType =
   | "position"
@@ -32,14 +33,16 @@ type GeometryAttribute = {
 };
 
 export class Geometry extends Node {
+  private readonly attributes_: GeometryAttribute[];
   protected vertexData_: Float32Array;
   protected indexData_: Uint32Array;
-  private readonly attributes_: GeometryAttribute[];
+  private wireframeIndexData_: Uint32Array;
 
   constructor(vertexData: number[] = [], indexData: number[] = []) {
     super();
     this.vertexData_ = new Float32Array(vertexData);
     this.indexData_ = new Uint32Array(indexData);
+    this.wireframeIndexData_ = new Uint32Array();
     this.attributes_ = [];
   }
 
@@ -54,7 +57,7 @@ export class Geometry extends Node {
   public get stride() {
     return (
       this.attributes_.reduce((acc, curr) => {
-        return (acc += curr.itemSize);
+        return acc + curr.itemSize;
       }, 0) * Float32Array.BYTES_PER_ELEMENT
     );
   }
@@ -67,11 +70,59 @@ export class Geometry extends Node {
     return this.indexData_;
   }
 
+  public get wireframeIndexData() {
+    return this.wireframeIndexData_;
+  }
+
   public get attributes() {
     return this.attributes_;
   }
 
   public get type() {
     return "Geometry";
+  }
+
+  public generateWireframeIndexData() {
+    const indexData = this.indexData_;
+
+    if (indexData.length === 0) {
+      Logger.warn(
+        "Geometry",
+        "Wireframe generation error: only indexed geometries are supported"
+      );
+      return;
+    }
+
+    if (indexData.length % 3 !== 0) {
+      Logger.warn("Geometry", "Wireframe generation error: non-triangle data");
+      return;
+    }
+
+    const edgeSet = new Set<string>();
+    const wireframeIndices: number[] = [];
+    const addEdge = (a: number, b: number) => {
+      // Normalize edge order and use a set to deduplicate,
+      // since shared edges between triangles would otherwise
+      // be added multiple times.
+      const i0 = Math.min(a, b);
+      const i1 = Math.max(a, b);
+      const key = `${i0},${i1}`;
+      if (!edgeSet.has(key)) {
+        edgeSet.add(key);
+        wireframeIndices.push(i0, i1);
+      }
+    };
+
+    for (let i = 0; i < indexData.length; i += 3) {
+      const i0 = indexData[i];
+      const i1 = indexData[i + 1];
+      const i2 = indexData[i + 2];
+
+      addEdge(i0, i1);
+      addEdge(i1, i2);
+      addEdge(i2, i0);
+    }
+
+    this.wireframeIndexData_ = new Uint32Array(wireframeIndices);
   }
 }

--- a/packages/core/src/core/geometry.ts
+++ b/packages/core/src/core/geometry.ts
@@ -98,7 +98,7 @@ export class Geometry extends Node {
       return;
     }
 
-    const edgeSet = new Set<string>();
+    const edgeSet = new Set<{ i0: number; i1: number }>();
     const wireframeIndices: number[] = [];
     const addEdge = (a: number, b: number) => {
       // Normalize edge order and use a set to deduplicate,
@@ -106,9 +106,8 @@ export class Geometry extends Node {
       // be added multiple times.
       const i0 = Math.min(a, b);
       const i1 = Math.max(a, b);
-      const key = `${i0},${i1}`;
-      if (!edgeSet.has(key)) {
-        edgeSet.add(key);
+      if (!edgeSet.has({ i0, i1 })) {
+        edgeSet.add({ i0, i1 });
         wireframeIndices.push(i0, i1);
       }
     };

--- a/packages/core/src/core/renderable_object.ts
+++ b/packages/core/src/core/renderable_object.ts
@@ -13,7 +13,7 @@ export abstract class RenderableObject extends Node {
   private geometry_ = new Geometry();
   private programName_: Shader | null = null;
   private primitive_: Primitive = "triangles";
-  private wireframeOnShaded_ = false;
+  private wireframeEnabled_ = false;
 
   public addTexture(texture: Texture) {
     this.textures_.push(texture);
@@ -33,15 +33,15 @@ export abstract class RenderableObject extends Node {
 
   public set geometry(geometry: Geometry) {
     this.geometry_ = geometry;
-    if (this.wireframeOnShaded_) {
-      this.generateWireframeIndicesIfNeeded(true);
+    if (this.wireframeEnabled_) {
+      this.generateWireframeIndicesIfNeeded();
     }
   }
 
   public set wireframeOnShaded(enabled: boolean) {
-    this.wireframeOnShaded_ = enabled;
-    if (this.wireframeOnShaded_) {
-      this.generateWireframeIndicesIfNeeded(false);
+    this.wireframeEnabled_ = enabled;
+    if (this.wireframeEnabled_) {
+      this.generateWireframeIndicesIfNeeded();
     }
   }
 
@@ -64,10 +64,10 @@ export abstract class RenderableObject extends Node {
     this.primitive_ = primitive;
   }
 
-  private generateWireframeIndicesIfNeeded(forced: boolean) {
+  private generateWireframeIndicesIfNeeded() {
     const hasIndexData = this.geometry_.indexData.length > 0;
     const hasWireframeIndexData = this.geometry_.wireframeIndexData.length > 0;
-    if (hasIndexData && (!hasWireframeIndexData || forced)) {
+    if (hasIndexData && !hasWireframeIndexData) {
       this.geometry_.generateWireframeIndexData();
     }
   }

--- a/packages/core/src/core/renderable_object.ts
+++ b/packages/core/src/core/renderable_object.ts
@@ -8,11 +8,12 @@ import { Shader } from "../renderers/shaders";
 export type Primitive = "triangles" | "points";
 
 export abstract class RenderableObject extends Node {
+  private readonly textures_: Texture[] = [];
+  private readonly transform_ = new TrsTransform();
   private geometry_ = new Geometry();
-  private textures_: Texture[] = [];
-  private transform_ = new TrsTransform();
   private programName_: Shader | null = null;
   private primitive_: Primitive = "triangles";
+  private wireframeOnShaded_ = false;
 
   public addTexture(texture: Texture) {
     this.textures_.push(texture);
@@ -32,6 +33,16 @@ export abstract class RenderableObject extends Node {
 
   public set geometry(geometry: Geometry) {
     this.geometry_ = geometry;
+    if (this.wireframeOnShaded_) {
+      this.generateWireframeIndicesIfNeeded(true);
+    }
+  }
+
+  public set wireframeOnShaded(enabled: boolean) {
+    this.wireframeOnShaded_ = enabled;
+    if (this.wireframeOnShaded_) {
+      this.generateWireframeIndicesIfNeeded(false);
+    }
   }
 
   public get programName(): Shader {
@@ -51,6 +62,14 @@ export abstract class RenderableObject extends Node {
 
   protected set primitive(primitive: Primitive) {
     this.primitive_ = primitive;
+  }
+
+  private generateWireframeIndicesIfNeeded(forced: boolean) {
+    const hasIndexData = this.geometry_.indexData.length > 0;
+    const hasWireframeIndexData = this.geometry_.wireframeIndexData.length > 0;
+    if (hasIndexData && (!hasWireframeIndexData || forced)) {
+      this.geometry_.generateWireframeIndexData();
+    }
   }
 
   /**

--- a/packages/core/src/renderers/webgl_renderer.ts
+++ b/packages/core/src/renderers/webgl_renderer.ts
@@ -10,7 +10,7 @@ import { Layer } from "../core/layer";
 import { LayerManager } from "../core/layer_manager";
 import { Camera } from "../objects/cameras/camera";
 import { WebGLState } from "./WebGLState";
-import { Primitive } from "../core/renderable_object";
+import { Primitive, RenderableObject } from "../core/renderable_object";
 
 import { mat4 } from "gl-matrix";
 
@@ -52,16 +52,6 @@ export class WebGLRenderer extends Renderer {
     this.state_ = new WebGLState(this.gl);
   }
 
-  private renderLayer(layer: Layer) {
-    // Set blending mode once per layer
-    if (layer.transparent) {
-      this.state_.setBlendingMode(layer.blendMode);
-    } else {
-      this.state_.setBlendingMode("none");
-    }
-    layer.objects.forEach((_, i) => this.renderObject(layer, i));
-  }
-
   public render(layerManager: LayerManager, camera: Camera) {
     this.clear();
     this.activeCamera = camera;
@@ -85,59 +75,22 @@ export class WebGLRenderer extends Renderer {
     this.state_.setDepthMask(true);
   }
 
+  private renderLayer(layer: Layer) {
+    this.state_.setBlendingMode(layer.transparent ? layer.blendMode : "none");
+    layer.objects.forEach((_, i) => this.renderObject(layer, i));
+  }
+
   protected renderObject(layer: Layer, objectIndex: number) {
     const object = layer.objects[objectIndex];
-    const program = this.getShaderProgram(object.programName).use();
-
-    const modelView = mat4.multiply(
-      mat4.create(),
-      this.activeCamera.viewMatrix,
-      object.transform.matrix
-    );
-    const projection = mat4.multiply(
-      mat4.create(),
-      axisDirection,
-      this.activeCamera.projectionMatrix
-    );
-    const resolution = [this.canvas.width, this.canvas.height];
-
-    const objectUniforms = object.getUniforms();
-    for (const uniformName of program.uniformNames) {
-      switch (uniformName) {
-        // Set common uniforms with renderer data
-        case "ModelView":
-          program.setUniform(uniformName, modelView);
-          break;
-        case "Projection":
-          program.setUniform(uniformName, projection);
-          break;
-        case "Resolution":
-          program.setUniform(uniformName, resolution);
-          break;
-        case "u_opacity":
-          program.setUniform(uniformName, layer.opacity);
-          break;
-        default:
-          // Get uniforms from the renderable object
-          if (uniformName in objectUniforms) {
-            program.setUniform(uniformName, objectUniforms[uniformName]);
-          }
-      }
-    }
-
     this.bindings_.bindObject(object);
-
     object.textures.forEach((texture) => {
       this.textures_.bindTexture(texture);
     });
 
-    const primitive = this.getShaderPrimitive(object.primitive);
-    const index = object.geometry.indexData;
-    if (index.length) {
-      this.gl.drawElements(primitive, index.length, this.gl.UNSIGNED_INT, 0);
-    } else {
-      this.gl.drawArrays(primitive, 0, object.geometry.vertexCount);
-    }
+    const program = this.getShaderProgram(object.programName).use();
+    this.drawObject(layer, object, program);
+
+    // TODO: If "wireframe on shaded" call draw object with different parameters
   }
 
   protected resize(width: number, height: number) {
@@ -165,7 +118,55 @@ export class WebGLRenderer extends Renderer {
     return this.shaders_.get(type)!;
   }
 
-  private getShaderPrimitive(type: Primitive) {
+  private drawObject(
+    layer: Layer,
+    object: RenderableObject,
+    program: WebGLShaderProgram
+  ) {
+    const modelView = mat4.multiply(
+      mat4.create(),
+      this.activeCamera.viewMatrix,
+      object.transform.matrix
+    );
+    const projection = mat4.multiply(
+      mat4.create(),
+      axisDirection,
+      this.activeCamera.projectionMatrix
+    );
+    const resolution = [this.canvas.width, this.canvas.height];
+
+    const objectUniforms = object.getUniforms();
+    for (const uniformName of program.uniformNames) {
+      switch (uniformName) {
+        case "ModelView":
+          program.setUniform(uniformName, modelView);
+          break;
+        case "Projection":
+          program.setUniform(uniformName, projection);
+          break;
+        case "Resolution":
+          program.setUniform(uniformName, resolution);
+          break;
+        case "u_opacity":
+          program.setUniform(uniformName, layer.opacity);
+          break;
+        default:
+          if (uniformName in objectUniforms) {
+            program.setUniform(uniformName, objectUniforms[uniformName]);
+          }
+      }
+    }
+
+    const primitive = this.getGLPrimitve(object.primitive);
+    const index = object.geometry.indexData;
+    if (index.length) {
+      this.gl.drawElements(primitive, index.length, this.gl.UNSIGNED_INT, 0);
+    } else {
+      this.gl.drawArrays(primitive, 0, object.geometry.vertexCount);
+    }
+  }
+
+  private getGLPrimitve(type: Primitive) {
     switch (type) {
       case "points":
         return this.gl.POINTS;

--- a/packages/core/src/renderers/webgl_renderer.ts
+++ b/packages/core/src/renderers/webgl_renderer.ts
@@ -93,31 +93,6 @@ export class WebGLRenderer extends Renderer {
     // TODO: If "wireframe on shaded" call draw object with different parameters
   }
 
-  protected resize(width: number, height: number) {
-    this.gl.viewport(0, 0, width, height);
-  }
-
-  protected clear() {
-    this.gl.clearColor(...this.backgroundColor.rgba);
-    this.gl.clear(this.gl.COLOR_BUFFER_BIT | this.gl.DEPTH_BUFFER_BIT);
-    this.state_.setDepthTesting(true);
-    this.gl.depthFunc(this.gl.LEQUAL);
-  }
-
-  private getShaderProgram(type: Shader) {
-    if (!this.shaders_.has(type)) {
-      this.shaders_.set(
-        type,
-        new WebGLShaderProgram(
-          this.gl,
-          shaderCode[type].vertex,
-          shaderCode[type].fragment
-        )
-      );
-    }
-    return this.shaders_.get(type)!;
-  }
-
   private drawObject(
     layer: Layer,
     object: RenderableObject,
@@ -177,6 +152,31 @@ export class WebGLRenderer extends Renderer {
         throw new Error(`Unknown Primitive type: ${exhaustiveCheck}`);
       }
     }
+  }
+
+  protected resize(width: number, height: number) {
+    this.gl.viewport(0, 0, width, height);
+  }
+
+  protected clear() {
+    this.gl.clearColor(...this.backgroundColor.rgba);
+    this.gl.clear(this.gl.COLOR_BUFFER_BIT | this.gl.DEPTH_BUFFER_BIT);
+    this.state_.setDepthTesting(true);
+    this.gl.depthFunc(this.gl.LEQUAL);
+  }
+
+  private getShaderProgram(type: Shader) {
+    if (!this.shaders_.has(type)) {
+      this.shaders_.set(
+        type,
+        new WebGLShaderProgram(
+          this.gl,
+          shaderCode[type].vertex,
+          shaderCode[type].fragment
+        )
+      );
+    }
+    return this.shaders_.get(type)!;
   }
 
   private get gl() {

--- a/packages/core/src/utilities/logger.ts
+++ b/packages/core/src/utilities/logger.ts
@@ -16,11 +16,12 @@ const Colors = {
 
 // Add new module names here as needed to represent different parts of the application
 type Module =
-  | "WebGLRenderer"
-  | "WebGLShaderProgram"
+  | "ChunkManager"
+  | "Geometry"
   | "Idetik"
   | "ImageLayer"
-  | "ChunkManager"
+  | "WebGLRenderer"
+  | "WebGLShaderProgram"
   | "WebGLTexture";
 
 export class Logger {


### PR DESCRIPTION
### Summary

This PR introduces initial support for rendering wireframes over shaded
geometry. It adds on-demand generation of wireframe index data when a
renderable object is set to wireframe-on-shaded mode, and refactors the WebGL
renderer by extracting the draw call logic into a separate method. This lays
the groundwork for rendering the same object twice — once for the shaded mesh
and once for the wireframe overlay with different rendering parameters.

**Next steps (in a follow-up PR)**
- Add wireframe-specific VAO and EBO support in `WebGLBuffers`
- Introduce a flat-colored shader for wireframes
- Complete the integration in the `WebGLRenderer` logic

### Related Issue
Related issue: https://github.com/chanzuckerberg/idetik/issues/47 (close in the next PR)

### Tests & Checks
- All checks have passed
- Verified manually that all examples are working as expected