### PR TITLE
Add general overlays to Idetik with scalebar and FPS overlay examples

### DIFF
--- a/packages/core/examples/chunk_streaming/fps_overlay.ts
+++ b/packages/core/examples/chunk_streaming/fps_overlay.ts
@@ -1,0 +1,31 @@
+type FpsOverlayProps = {
+  textDiv: HTMLDivElement;
+};
+
+export class FpsOverlay {
+  textDiv_: HTMLDivElement;
+  msSinceLastUpdate_: number = 0;
+  lastTimestamp_?: DOMHighResTimeStamp;
+
+  constructor(props: FpsOverlayProps) {
+    this.textDiv_ = props.textDiv;
+  }
+
+  public update(_idetik: unknown, timestamp?: DOMHighResTimeStamp): void {
+    if (timestamp === undefined) {
+      return;
+    }
+    if (this.lastTimestamp_ === undefined) {
+      this.lastTimestamp_ = timestamp;
+      return;
+    }
+    const elapsedMs = timestamp - this.lastTimestamp_;
+    this.lastTimestamp_ = timestamp;
+    if (this.msSinceLastUpdate_ < 1000) {
+      this.msSinceLastUpdate_ += elapsedMs;
+      return;
+    }
+    this.textDiv_.textContent = `FPS: ${(1000 / elapsedMs).toFixed(0)}`;
+    this.msSinceLastUpdate_ = 0;
+  }
+}

--- a/packages/core/examples/chunk_streaming/fps_overlay.ts
+++ b/packages/core/examples/chunk_streaming/fps_overlay.ts
@@ -4,7 +4,7 @@ type FpsOverlayProps = {
 
 export class FpsOverlay {
   textDiv_: HTMLDivElement;
-  msSinceLastUpdate_: number = 0;
+  msSinceLastUpdate_ = 0;
   lastTimestamp_?: DOMHighResTimeStamp;
 
   constructor(props: FpsOverlayProps) {

--- a/packages/core/examples/chunk_streaming/index.html
+++ b/packages/core/examples/chunk_streaming/index.html
@@ -17,10 +17,22 @@
         width: 100%;
         height: 100%;
       }
+      #fps-text {
+        position: absolute;
+        top: 1em;
+        left: 1em;
+        width: 10%;
+        margin: 1em;
+        padding: 1em;
+        color: white;
+        background-color: rgba(0, 0, 0, 0.5);
+        user-select: none;
+      }
     </style>
   </head>
   <body>
     <canvas id="canvas"></canvas>
+    <div id="fps-text">FPS: unknown</div>
     <script type="module" src="./main.ts"></script>
   </body>
 </html>

--- a/packages/core/examples/chunk_streaming/main.ts
+++ b/packages/core/examples/chunk_streaming/main.ts
@@ -7,6 +7,7 @@ import {
   Region,
 } from "@";
 import { PanZoomControls } from "@/objects/cameras/controls";
+import { FpsOverlay } from "./fps_overlay";
 
 const url =
   "https://public.czbiohub.org/royerlab/zebrahub/imaging/single-objective/ZSNS001.ome.zarr/";
@@ -29,10 +30,14 @@ const channelProps = [{ contrastLimits: [0, 255] as [number, number] }];
 const imageLayer = new ImageLayer({ source, region, channelProps });
 const axesLayer = new AxesLayer({ length: 1500, width: 0.01 });
 const camera = new OrthographicCamera(left, right, top, bottom);
+const fpsOverlay = new FpsOverlay({
+  textDiv: document.querySelector<HTMLDivElement>("#fps-text")!,
+});
 
 new Idetik({
   canvas: document.querySelector<HTMLCanvasElement>("#canvas")!,
   camera,
   controls: new PanZoomControls(camera, camera.position),
   layers: [imageLayer, axesLayer],
+  overlays: [fpsOverlay],
 }).start();

--- a/packages/core/examples/image2d_from_omezarr5d_u16/index.html
+++ b/packages/core/examples/image2d_from_omezarr5d_u16/index.html
@@ -17,10 +17,38 @@
         width: 100%;
         height: 100%;
       }
+      #scale-bar-box {
+        display: flex;
+        flex-direction: column;
+        position: absolute;
+        bottom: 1em;
+        left: 1em;
+        width: 15%;
+        margin: 1em;
+        padding: 1em;
+        gap: 0.5em;
+        align-items: start;
+        justify-content: center;
+        background-color: rgba(0, 0, 0, 0.5);
+        user-select: none;
+      }
+      #scale-bar-text {
+        color: white;
+        text-align: start;
+      }
+      #scale-bar-line {
+        width: 100%;
+        height: 1em;
+        background-color: white;
+      }
     </style>
   </head>
   <body>
     <canvas id="canvas"></canvas>
+    <div id="scale-bar-box">
+      <div id="scale-bar-text"></div>
+      <div id="scale-bar-line"></div>
+    </div>
     <script type="module" src="./main.ts"></script>
   </body>
 </html>

--- a/packages/core/examples/image2d_from_omezarr5d_u16/main.ts
+++ b/packages/core/examples/image2d_from_omezarr5d_u16/main.ts
@@ -7,6 +7,7 @@ import {
 } from "@";
 import { AxesLayer } from "@/layers/axes_layer";
 import { PanZoomControls } from "@/objects/cameras/controls";
+import { ScaleBar } from "./scale_bar";
 
 const url =
   "https://public.czbiohub.org/royerlab/zebrahub/imaging/single-objective/ZSNS001.ome.zarr/";
@@ -29,10 +30,16 @@ const channelProps = [{ contrastLimits: [0, 255] as [number, number] }];
 const layer = new ImageLayer({ source, region, channelProps });
 const axes = new AxesLayer({ length: 2000, width: 0.01 });
 const camera = new OrthographicCamera(left, right, top, bottom);
+const scaleBar = new ScaleBar({
+  textDiv: document.querySelector<HTMLDivElement>("#scale-bar-text")!,
+  lineDiv: document.querySelector<HTMLDivElement>("#scale-bar-line")!,
+  unit: "μm",
+});
 
 new Idetik({
   canvas: document.querySelector<HTMLCanvasElement>("canvas")!,
   camera,
   controls: new PanZoomControls(camera, camera.position),
   layers: [layer, axes],
+  overlays: [scaleBar],
 }).start();

--- a/packages/core/examples/image2d_from_omezarr5d_u16/scale_bar.ts
+++ b/packages/core/examples/image2d_from_omezarr5d_u16/scale_bar.ts
@@ -1,0 +1,40 @@
+import { Idetik, OrthographicCamera } from "@";
+
+type ScaleBarProps = {
+  textDiv: HTMLDivElement;
+  lineDiv: HTMLDivElement;
+  unit?: string;
+};
+
+export class ScaleBar {
+  private textDiv_: HTMLDivElement;
+  private lineDiv_: HTMLDivElement;
+  private unit_: string;
+
+  constructor(props: ScaleBarProps) {
+    this.textDiv_ = props.textDiv;
+    this.lineDiv_ = props.lineDiv;
+    this.unit_ = props.unit ?? "";
+  }
+
+  public update(idetik: Idetik, _timestamp?: DOMHighResTimeStamp): void {
+    const camera = idetik.camera;
+    if (camera.type !== "OrthographicCamera") {
+      console.error("ScaleBar can only be used with OrthographicCamera");
+      return;
+    }
+    const orthoCamera = camera as OrthographicCamera;
+
+    const cameraWidthWorld =
+      orthoCamera.transform.scale[0] * orthoCamera.viewportSize[0];
+    const unitPerCanvasPixel = cameraWidthWorld / idetik.width;
+
+    // The use of clientWidth assumes that the barDiv has no padding,
+    // which is true in this example. If similar code is used elsewhere,
+    // the lack of padding should be asserted and or enforced.
+    const barWidth = this.lineDiv_.clientWidth * window.devicePixelRatio;
+    const barWidthWorld = barWidth * unitPerCanvasPixel;
+
+    this.textDiv_.textContent = `${barWidthWorld.toFixed(2)} ${this.unit_}`;
+  }
+}

--- a/packages/core/examples/image2d_from_omezarr5d_u16/scale_bar.ts
+++ b/packages/core/examples/image2d_from_omezarr5d_u16/scale_bar.ts
@@ -29,12 +29,12 @@ export class ScaleBar {
       orthoCamera.transform.scale[0] * orthoCamera.viewportSize[0];
     const unitPerCanvasPixel = cameraWidthWorld / idetik.width;
 
-    // The use of clientWidth assumes that the barDiv has no padding,
+    // The use of clientWidth assumes that the lineDiv has no padding,
     // which is true in this example. If similar code is used elsewhere,
     // the lack of padding should be asserted and or enforced.
-    const barWidth = this.lineDiv_.clientWidth * window.devicePixelRatio;
-    const barWidthWorld = barWidth * unitPerCanvasPixel;
+    const lineWidth = this.lineDiv_.clientWidth * window.devicePixelRatio;
+    const lineWidthWorld = lineWidth * unitPerCanvasPixel;
 
-    this.textDiv_.textContent = `${barWidthWorld.toFixed(2)} ${this.unit_}`;
+    this.textDiv_.textContent = `${lineWidthWorld.toFixed(2)} ${this.unit_}`;
   }
 }

--- a/packages/core/src/core/overlay.ts
+++ b/packages/core/src/core/overlay.ts
@@ -1,5 +1,0 @@
-import { Idetik } from "../idetik";
-
-export type Overlay = {
-  update(idetik: Idetik, timestamp?: DOMHighResTimeStamp): void;
-};

--- a/packages/core/src/core/overlay.ts
+++ b/packages/core/src/core/overlay.ts
@@ -1,0 +1,5 @@
+import { Idetik } from "../idetik";
+
+export type Overlay = {
+  update(idetik: Idetik, timestamp?: DOMHighResTimeStamp): void;
+};

--- a/packages/core/src/idetik.ts
+++ b/packages/core/src/idetik.ts
@@ -1,6 +1,7 @@
 import { Camera } from "./objects/cameras/camera";
 import { Layer } from "./core/layer";
 import { LayerManager } from "./core/layer_manager";
+import { Overlay } from "./core/overlay";
 import { WebGLRenderer } from "./renderers/webgl_renderer";
 import { CameraControls } from "./objects/cameras/controls";
 import { Logger } from "./utilities/logger";
@@ -13,6 +14,7 @@ type IdetikParams = {
   camera: Camera;
   controls?: CameraControls;
   layers?: Layer[];
+  overlays?: Overlay[];
 };
 
 export type IdetikContext = {
@@ -23,6 +25,7 @@ export class Idetik {
   public layerManager: LayerManager;
   public camera: Camera;
   public readonly canvas: HTMLCanvasElement;
+  public overlays?: Overlay[];
 
   private readonly renderer_: WebGLRenderer;
   private readonly context_: IdetikContext;
@@ -64,6 +67,8 @@ export class Idetik {
         this.layerManager.add(layer);
       }
     }
+
+    this.overlays = params.overlays ?? [];
   }
 
   public get width() {
@@ -88,7 +93,7 @@ export class Idetik {
 
   public start() {
     Logger.info("Idetik", "Idetik runtime started");
-    const render = () => {
+    const render = (timestamp?: DOMHighResTimeStamp) => {
       if (!this.camera) {
         Logger.warn(
           "Idetik",
@@ -102,6 +107,9 @@ export class Idetik {
         this.renderer_.height
       );
       this.renderer_.render(this.layerManager, this.camera);
+      for (const overlay of this.overlays ?? []) {
+        overlay.update(this, timestamp);
+      }
       this.lastAnimationId_ = requestAnimationFrame(render);
     };
     render();

--- a/packages/core/src/idetik.ts
+++ b/packages/core/src/idetik.ts
@@ -1,12 +1,15 @@
 import { Camera } from "./objects/cameras/camera";
 import { Layer } from "./core/layer";
 import { LayerManager } from "./core/layer_manager";
-import { Overlay } from "./core/overlay";
 import { WebGLRenderer } from "./renderers/webgl_renderer";
 import { CameraControls } from "./objects/cameras/controls";
 import { Logger } from "./utilities/logger";
 import { ChunkManager } from "./core/chunk_manager";
 import { vec2, vec3 } from "gl-matrix";
+
+type Overlay = {
+  update(idetik: Idetik, timestamp?: DOMHighResTimeStamp): void;
+};
 
 type IdetikParams = {
   canvas?: HTMLCanvasElement;

--- a/packages/core/src/idetik.ts
+++ b/packages/core/src/idetik.ts
@@ -25,7 +25,7 @@ export class Idetik {
   public layerManager: LayerManager;
   public camera: Camera;
   public readonly canvas: HTMLCanvasElement;
-  public overlays?: Overlay[];
+  public readonly overlays: Overlay[];
 
   private readonly renderer_: WebGLRenderer;
   private readonly context_: IdetikContext;
@@ -107,7 +107,7 @@ export class Idetik {
         this.renderer_.height
       );
       this.renderer_.render(this.layerManager, this.camera);
-      for (const overlay of this.overlays ?? []) {
+      for (const overlay of this.overlays) {
         overlay.update(this, timestamp);
       }
       this.lastAnimationId_ = requestAnimationFrame(render);

--- a/packages/core/src/objects/cameras/orthographic_camera.ts
+++ b/packages/core/src/objects/cameras/orthographic_camera.ts
@@ -10,6 +10,7 @@ export class OrthographicCamera extends Camera {
   private width_: number = DEFAULT_WIDTH;
   private height_: number = DEFAULT_HEIGHT;
   private viewportAspectRatio_: number = DEFAULT_ASPECT_RATIO;
+  private viewportSize_: [number, number] = [DEFAULT_WIDTH, DEFAULT_HEIGHT];
 
   constructor(
     left: number,
@@ -24,6 +25,10 @@ export class OrthographicCamera extends Camera {
     this.far_ = far;
     this.setFrame(left, right, bottom, top);
     this.updateProjectionMatrix();
+  }
+
+  public get viewportSize() {
+    return this.viewportSize_;
   }
 
   public setAspectRatio(aspectRatio: number) {
@@ -72,6 +77,7 @@ export class OrthographicCamera extends Camera {
     } else {
       viewportHalfHeight *= frameAspectRatio / this.viewportAspectRatio_;
     }
+    this.viewportSize_ = [2 * viewportHalfWidth, 2 * viewportHalfHeight];
     // Center the camera frame in the padded viewport frame.
     mat4.ortho(
       this.projectionMatrix_,


### PR DESCRIPTION
### Summary
This adds a general concept of overlays to Idetik. Overlays are updated at the end of an Idetik render pass. This allows applications that use Idetik to update content they are responsible for in-sync with the Idetik render loop.

One example of an overlay that we need to support soon is a scale-bar. These changes introduce a simple scale-bar in the OME-Zarr u16 example to show one way how that can be done. [Another branch that builds on this](https://github.com/chanzuckerberg/idetik/compare/andy-sweet/scalebar-overlay...andy-sweet/scalebar-overlay-react?expand=1) shows how Idetik's React component can do that.

These changes also introduce a crude frames-per-second (FPS) overlay as a different example that uses the render call's newly added timestamp.

The main downside of this approach is that it allows users of the Idetik runtime to run arbitrary code in the Idetik render loop, which could have significant performance implications.

### Related Issue
Related to #191

### Tests & Checks
I manually tested the examples where I added overlays to check for expected behavior (e.g. the overall scale of the image).
