### PR TITLE
(Stacked) Render wireframes on top of meshes [2/2]

### DIFF
--- a/packages/core/src/core/renderable_object.ts
+++ b/packages/core/src/core/renderable_object.ts
@@ -5,15 +5,15 @@ import { TrsTransform } from "../core/transforms";
 
 import { Shader } from "../renderers/shaders";
 
-export type Primitive = "triangles" | "points";
+export type Primitive = "triangles" | "points" | "lines";
 
 export abstract class RenderableObject extends Node {
+  public wireframeEnabled = false;
   private readonly textures_: Texture[] = [];
   private readonly transform_ = new TrsTransform();
   private geometry_ = new Geometry();
   private programName_: Shader | null = null;
   private primitive_: Primitive = "triangles";
-  private wireframeEnabled_ = false;
 
   public addTexture(texture: Texture) {
     this.textures_.push(texture);
@@ -33,16 +33,6 @@ export abstract class RenderableObject extends Node {
 
   public set geometry(geometry: Geometry) {
     this.geometry_ = geometry;
-    if (this.wireframeEnabled_) {
-      this.generateWireframeIndicesIfNeeded();
-    }
-  }
-
-  public set wireframeOnShaded(enabled: boolean) {
-    this.wireframeEnabled_ = enabled;
-    if (this.wireframeEnabled_) {
-      this.generateWireframeIndicesIfNeeded();
-    }
   }
 
   public get programName(): Shader {
@@ -62,14 +52,6 @@ export abstract class RenderableObject extends Node {
 
   protected set primitive(primitive: Primitive) {
     this.primitive_ = primitive;
-  }
-
-  private generateWireframeIndicesIfNeeded() {
-    const hasIndexData = this.geometry_.indexData.length > 0;
-    const hasWireframeIndexData = this.geometry_.wireframeIndexData.length > 0;
-    if (hasIndexData && !hasWireframeIndexData) {
-      this.geometry_.generateWireframeIndexData();
-    }
   }
 
   /**

--- a/packages/core/src/renderers/shaders/index.ts
+++ b/packages/core/src/renderers/shaders/index.ts
@@ -7,10 +7,13 @@ import uintImageFragmentShader from "./uint_image_frag.glsl";
 import uintImageArrayFragmentShader from "./uint_image_array_frag.glsl";
 import pointsVertexShader from "./points_vert.glsl";
 import pointsFragmentShader from "./points_frag.glsl";
+import wireframeVertexShader from "./wireframe_vert.glsl";
+import wireframeFragmentShader from "./wireframe_frag.glsl";
 
 export type Shader =
   | "projectedLine"
   | "points"
+  | "wireframe"
   | "floatImage"
   | "floatImageArray"
   | "uintImage"
@@ -25,6 +28,10 @@ export const shaderCode: Record<Shader, { vertex: string; fragment: string }> =
     points: {
       vertex: pointsVertexShader,
       fragment: pointsFragmentShader,
+    },
+    wireframe: {
+      vertex: wireframeVertexShader,
+      fragment: wireframeFragmentShader,
     },
     // TODO: consolidate image shaders
     floatImage: {

--- a/packages/core/src/renderers/shaders/wireframe_frag.glsl
+++ b/packages/core/src/renderers/shaders/wireframe_frag.glsl
@@ -1,0 +1,11 @@
+#version 300 es
+
+precision mediump float;
+
+layout (location = 0) out vec4 fragColor;
+
+uniform float u_opacity;
+
+void main() {
+    fragColor = vec4(1.0, 1.0, 1.0, u_opacity);
+}

--- a/packages/core/src/renderers/shaders/wireframe_vert.glsl
+++ b/packages/core/src/renderers/shaders/wireframe_vert.glsl
@@ -1,0 +1,11 @@
+#version 300 es
+
+layout (location = 0) in vec3 inPosition;
+layout (location = 1) in vec3 inNormal;
+
+uniform mat4 Projection;
+uniform mat4 ModelView;
+
+void main() {
+    gl_Position = Projection * ModelView * vec4(inPosition, 1.0);
+}

--- a/packages/core/src/renderers/webgl_buffers.ts
+++ b/packages/core/src/renderers/webgl_buffers.ts
@@ -5,31 +5,47 @@ type BufferHandles = {
   vao: WebGLVertexArrayObject;
   vbo: WebGLBuffer;
   ebo?: WebGLBuffer;
+  wireframeVao?: WebGLVertexArrayObject;
+  wireframeEbo?: WebGLBuffer;
 };
+
+type IndexType = "triangles" | "lines";
 
 export class WebGLBuffers {
   private readonly gl_: WebGL2RenderingContext;
   private readonly buffers_: Map<RenderableObject, BufferHandles> = new Map();
-  private currentObject_: RenderableObject | null = null;
+  private currentVao_: WebGLVertexArrayObject | null = null;
 
   constructor(gl: WebGL2RenderingContext) {
     this.gl_ = gl;
   }
 
-  public bindObject(object: RenderableObject) {
-    if (this.alreadyActive(object)) return;
-
-    if (!this.buffers_.has(object)) {
-      this.generateBuffers(object);
+  public bindObject(
+    object: RenderableObject,
+    indexType: IndexType = "triangles"
+  ) {
+    let buffers = this.buffers_.get(object);
+    if (buffers) {
+      const vao = indexType === "lines" ? buffers.wireframeVao : buffers.vao;
+      if (this.alreadyActive(vao)) return;
     }
 
-    const buffers = this.buffers_.get(object);
     if (!buffers) {
-      throw new Error("Failed to retrieve buffer handles for object");
+      this.generateBuffers(object);
+      buffers = this.buffers_.get(object);
+      if (!buffers) {
+        throw new Error("Failed to retrieve buffer handles for object");
+      }
     }
 
-    this.gl_.bindVertexArray(buffers.vao);
-    this.currentObject_ = object;
+    if (indexType !== "lines") {
+      this.gl_.bindVertexArray(buffers.vao);
+      this.currentVao_ = buffers.vao;
+    } else {
+      const vao = buffers.wireframeVao || this.generateWireframeBuffers(object);
+      this.gl_.bindVertexArray(vao);
+      this.currentVao_ = vao;
+    }
   }
 
   public disposeObject(object: RenderableObject) {
@@ -39,11 +55,17 @@ export class WebGLBuffers {
     this.gl_.deleteVertexArray(buffers.vao);
     this.gl_.deleteBuffer(buffers.vbo);
 
+    if (buffers.wireframeVao) this.gl_.deleteVertexArray(buffers.wireframeVao);
     if (buffers.ebo) this.gl_.deleteBuffer(buffers.ebo);
+    if (buffers.wireframeEbo) this.gl_.deleteBuffer(buffers.wireframeEbo);
 
     this.buffers_.delete(object);
-    if (this.currentObject_ === object) {
-      this.currentObject_ = null;
+
+    if (
+      this.currentVao_ === buffers.vao ||
+      this.currentVao_ === buffers.wireframeVao
+    ) {
+      this.currentVao_ = null;
     }
   }
 
@@ -53,26 +75,79 @@ export class WebGLBuffers {
     }
   }
 
-  private alreadyActive(object: RenderableObject) {
-    return this.currentObject_ === object;
+  private alreadyActive(vao?: WebGLVertexArrayObject) {
+    return vao && this.currentVao_ === vao;
   }
 
   private generateBuffers(object: RenderableObject) {
-    const vao = this.gl_.createVertexArray();
-    if (!vao) {
-      throw new Error("Failed to create vertex array object (VAO)");
-    }
-
+    const vao = this.createVertexArray();
     this.gl_.bindVertexArray(vao);
 
     const { vertexData } = object.geometry;
-    const vboType = this.gl_.ARRAY_BUFFER;
-    const vbo = this.gl_.createBuffer();
-    if (!vbo) throw new Error("Failed to create vertex buffer (VBO)");
 
+    const vbo = this.gl_.createBuffer();
+    if (!vbo) throw new Error("Failed to create vertex buffer object");
+
+    const vboType = this.gl_.ARRAY_BUFFER;
     this.gl_.bindBuffer(vboType, vbo);
     this.gl_.bufferData(vboType, vertexData, this.gl_.STATIC_DRAW);
+    this.setupVertexAttributes(object);
 
+    const buffers: BufferHandles = { vao, vbo };
+
+    const { indexData } = object.geometry;
+    if (indexData.length) {
+      const ebo = this.gl_.createBuffer();
+      if (!ebo) throw new Error("Failed to create element buffer object");
+
+      const eboType = this.gl_.ELEMENT_ARRAY_BUFFER;
+      this.gl_.bindBuffer(eboType, ebo);
+      this.gl_.bufferData(eboType, indexData, this.gl_.STATIC_DRAW);
+      buffers.ebo = ebo;
+    }
+
+    this.buffers_.set(object, buffers);
+    this.gl_.bindVertexArray(null);
+  }
+
+  private generateWireframeBuffers(object: RenderableObject) {
+    const existingBuffers = this.buffers_.get(object);
+    if (!existingBuffers) {
+      throw new Error("Failed to generate wireframe buffers");
+    }
+
+    const vao = this.createVertexArray();
+    this.gl_.bindVertexArray(vao);
+    this.gl_.bindBuffer(this.gl_.ARRAY_BUFFER, existingBuffers.vbo);
+    this.setupVertexAttributes(object);
+
+    const geometry = object.geometry;
+    if (geometry.wireframeIndexData.length === 0) {
+      geometry.generateWireframeIndexData();
+    }
+
+    const ebo = this.gl_.createBuffer();
+    if (!ebo) throw new Error("Failed to create an element buffer object");
+
+    const eboType = this.gl_.ELEMENT_ARRAY_BUFFER;
+    const { wireframeIndexData } = geometry;
+    this.gl_.bindBuffer(eboType, ebo);
+    this.gl_.bufferData(eboType, wireframeIndexData, this.gl_.STATIC_DRAW);
+
+    existingBuffers.wireframeVao = vao;
+    existingBuffers.wireframeEbo = ebo;
+    this.gl_.bindVertexArray(null);
+
+    return vao;
+  }
+
+  private createVertexArray() {
+    const vao = this.gl_.createVertexArray();
+    if (!vao) throw new Error("Failed to create vertex array object");
+    return vao;
+  }
+
+  private setupVertexAttributes(object: RenderableObject) {
     const { attributes, stride } = object.geometry;
     attributes.forEach((attr) => {
       const idx = GeometryAttributeIndex[attr.type];
@@ -86,21 +161,5 @@ export class WebGLBuffers {
       );
       this.gl_.enableVertexAttribArray(idx);
     });
-
-    const buffers: BufferHandles = { vao, vbo };
-
-    const { indexData } = object.geometry;
-    if (indexData.length) {
-      const eboType = this.gl_.ELEMENT_ARRAY_BUFFER;
-      const ebo = this.gl_.createBuffer();
-      if (!ebo) throw new Error("Failed to create index buffer (EBO)");
-
-      this.gl_.bindBuffer(eboType, ebo);
-      this.gl_.bufferData(eboType, indexData, this.gl_.STATIC_DRAW);
-      buffers.ebo = ebo;
-    }
-
-    this.buffers_.set(object, buffers);
-    this.gl_.bindVertexArray(null);
   }
 }

--- a/packages/core/src/renderers/webgl_renderer.ts
+++ b/packages/core/src/renderers/webgl_renderer.ts
@@ -88,14 +88,19 @@ export class WebGLRenderer extends Renderer {
     });
 
     const program = this.getShaderProgram(object.programName).use();
-    this.drawObject(layer, object, program);
+    this.drawObject(layer, object, false, program);
 
-    // TODO: If "wireframe on shaded" call draw object with different parameters
+    if (object.wireframeEnabled) {
+      this.bindings_.bindObject(object, "lines");
+      const wireframeProgram = this.getShaderProgram("wireframe").use();
+      this.drawObject(layer, object, true, wireframeProgram);
+    }
   }
 
   private drawObject(
     layer: Layer,
     object: RenderableObject,
+    wireframe: boolean,
     program: WebGLShaderProgram
   ) {
     const modelView = mat4.multiply(
@@ -132,8 +137,13 @@ export class WebGLRenderer extends Renderer {
       }
     }
 
-    const primitive = this.getGLPrimitve(object.primitive);
-    const index = object.geometry.indexData;
+    let index = object.geometry.indexData;
+    let primitive = this.getGLPrimitve(object.primitive);
+    if (wireframe) {
+      index = object.geometry.wireframeIndexData;
+      primitive = this.getGLPrimitve("lines");
+    }
+
     if (index.length) {
       this.gl.drawElements(primitive, index.length, this.gl.UNSIGNED_INT, 0);
     } else {
@@ -147,6 +157,8 @@ export class WebGLRenderer extends Renderer {
         return this.gl.POINTS;
       case "triangles":
         return this.gl.TRIANGLES;
+      case "lines":
+        return this.gl.LINES;
       default: {
         const exhaustiveCheck: never = type;
         throw new Error(`Unknown Primitive type: ${exhaustiveCheck}`);


### PR DESCRIPTION
### Summary

This PR finalizes the wireframe-over-shaded-geometry feature. It introduces
dedicated VAO and EBO support for wireframes within WebGL buffers, adds a basic
passthrough shader for rendering flat colors, and completes the necessary
integration in `WebGLRenderer`.

**Next Steps**
I'm calling it done because the functionality is there, but I want to extend it in a follow-up:
- Implement layer-specific logic for displaying debug wireframes.
- Add color option for wireframes - for example, different wireframe colors may be desirable per LOD level.
- Apply polygon offset to ensure wireframes consistently render on top of shaded geometry.

### Related Issue
Closes #47 

### Tests & Checks
- Manually verified — see attached video.
- To enable wireframes, set `wireframeEnabled = true` on renderable objects.
- All existing examples render correctly with no regressions.
- All checks have passed.

https://github.com/user-attachments/assets/bad8dc00-4261-4d5f-bd3f-73b363eeaee4

