### PR TITLE
(ONE LINE) Disable antialiasing to eliminate artifacts

### DIFF
--- a/packages/core/src/renderers/webgl_renderer.ts
+++ b/packages/core/src/renderers/webgl_renderer.ts
@@ -36,7 +36,10 @@ export class WebGLRenderer extends Renderer {
   constructor(canvas: HTMLCanvasElement) {
     super(canvas);
 
-    this.gl_ = this.canvas.getContext("webgl2", { depth: true });
+    this.gl_ = this.canvas.getContext("webgl2", {
+      depth: true,
+      antialias: false,
+    });
     if (!this.gl_) {
       throw new Error(`Failed to initialize WebGL2 context`);
     }


### PR DESCRIPTION
### Summary

This PR disables antialiasing to avoid artifacts along tile edges. WebGL
enables multisample antialiasing (MSAA) by default, which is typically used
to smooth jagged edges. However, in tile-based rendering, MSAA can cause
visible seams or blending artifacts between tiles, as seen in our application.

Disabling MSAA is a common practice in precise scientific or technical
visualizations where pixel accuracy is more important than edge smoothing.
In our case, turning off MSAA resolves the artifacts observed in the chunked
data example.

One important note: MSAA cannot be toggled at runtime. If we ever need to
support selective antialiasing, we may need to introduce framebuffer-based
rendering with explicit control over sampling.

This change does not fix all visual issues. If linear filtering is enabled,
we still expect artifacts around tile edges due to texture interpolation.

https://en.wikipedia.org/wiki/Multisample_anti-aliasing

### Related Issue
N/A

### Tests & Checks
- Visual verification (see screenshots in full size)
- All checks have passed.

| Antialiasing enabled | Antialiasing disabled |
|----------|----------|
| ![Screenshot 2025-07-08 at 2 12 58 PM](https://github.com/user-attachments/assets/49c96c83-bacc-4e9d-9a2e-90b0716fdcc7) | ![Screenshot 2025-07-08 at 2 12 40 PM](https://github.com/user-attachments/assets/a026fac3-e01b-4314-86ab-203121225bee)  |



