### PR TITLE
(Small) Move the primitive attribute to geometry

### DIFF
--- a/packages/core/src/core/geometry.ts
+++ b/packages/core/src/core/geometry.ts
@@ -1,6 +1,8 @@
 import { Node } from "./node";
 import { Logger } from "../utilities/logger";
 
+export type Primitive = "triangles" | "points";
+
 type GeometryAttributeType =
   | "position"
   | "normal"
@@ -33,6 +35,8 @@ type GeometryAttribute = {
 };
 
 export class Geometry extends Node {
+  public primitive: Primitive = "triangles";
+
   private readonly attributes_: GeometryAttribute[];
   protected vertexData_: Float32Array;
   protected indexData_: Uint32Array;

--- a/packages/core/src/core/geometry.ts
+++ b/packages/core/src/core/geometry.ts
@@ -35,17 +35,21 @@ type GeometryAttribute = {
 };
 
 export class Geometry extends Node {
-  public primitive: Primitive = "triangles";
-
   private readonly attributes_: GeometryAttribute[];
+  private readonly primitive_: Primitive;
   protected vertexData_: Float32Array;
   protected indexData_: Uint32Array;
   private wireframeIndexData_: Uint32Array;
 
-  constructor(vertexData: number[] = [], indexData: number[] = []) {
+  constructor(
+    vertexData: number[] = [],
+    indexData: number[] = [],
+    primitive: Primitive = "triangles"
+  ) {
     super();
     this.vertexData_ = new Float32Array(vertexData);
     this.indexData_ = new Uint32Array(indexData);
+    this.primitive_ = primitive;
     this.wireframeIndexData_ = new Uint32Array();
     this.attributes_ = [];
   }
@@ -64,6 +68,10 @@ export class Geometry extends Node {
         return acc + curr.itemSize;
       }, 0) * Float32Array.BYTES_PER_ELEMENT
     );
+  }
+
+  public get primitive() {
+    return this.primitive_;
   }
 
   public get vertexData() {

--- a/packages/core/src/core/renderable_object.ts
+++ b/packages/core/src/core/renderable_object.ts
@@ -5,14 +5,11 @@ import { TrsTransform } from "../core/transforms";
 
 import { Shader } from "../renderers/shaders";
 
-export type Primitive = "triangles" | "points";
-
 export abstract class RenderableObject extends Node {
   private readonly textures_: Texture[] = [];
   private readonly transform_ = new TrsTransform();
   private geometry_ = new Geometry();
   private programName_: Shader | null = null;
-  private primitive_: Primitive = "triangles";
   private wireframeEnabled_ = false;
 
   public addTexture(texture: Texture) {
@@ -54,14 +51,6 @@ export abstract class RenderableObject extends Node {
 
   protected set programName(programName: Shader) {
     this.programName_ = programName;
-  }
-
-  public get primitive(): Primitive {
-    return this.primitive_;
-  }
-
-  protected set primitive(primitive: Primitive) {
-    this.primitive_ = primitive;
   }
 
   private generateWireframeIndicesIfNeeded() {

--- a/packages/core/src/objects/renderable/points.ts
+++ b/packages/core/src/objects/renderable/points.ts
@@ -19,7 +19,6 @@ export class Points extends RenderableObject {
   constructor(points: PointProperties[], markerAtlas: Texture2DArray) {
     super();
     this.programName = "points";
-    this.primitive = "points";
     this.atlas_ = markerAtlas;
 
     points.forEach((point) => {
@@ -63,6 +62,8 @@ export class Points extends RenderableObject {
       itemSize: 1,
       offset: geometry.stride,
     });
+
+    geometry.primitive = "points";
 
     this.geometry = geometry;
     this.addTexture(this.atlas_);

--- a/packages/core/src/objects/renderable/points.ts
+++ b/packages/core/src/objects/renderable/points.ts
@@ -40,7 +40,7 @@ export class Points extends RenderableObject {
       point.size,
       point.markerIndex,
     ]);
-    const geometry = new Geometry(vertexData);
+    const geometry = new Geometry(vertexData, [], "points");
 
     geometry.addAttribute({
       type: "position",
@@ -62,8 +62,6 @@ export class Points extends RenderableObject {
       itemSize: 1,
       offset: geometry.stride,
     });
-
-    geometry.primitive = "points";
 
     this.geometry = geometry;
     this.addTexture(this.atlas_);

--- a/packages/core/src/renderers/webgl_renderer.ts
+++ b/packages/core/src/renderers/webgl_renderer.ts
@@ -10,7 +10,8 @@ import { Layer } from "../core/layer";
 import { LayerManager } from "../core/layer_manager";
 import { Camera } from "../objects/cameras/camera";
 import { WebGLState } from "./WebGLState";
-import { Primitive, RenderableObject } from "../core/renderable_object";
+import { RenderableObject } from "../core/renderable_object";
+import { Primitive } from "../core/geometry";
 
 import { mat4 } from "gl-matrix";
 
@@ -135,7 +136,7 @@ export class WebGLRenderer extends Renderer {
       }
     }
 
-    const primitive = this.getGLPrimitve(object.primitive);
+    const primitive = this.getGLPrimitve(object.geometry.primitive);
     const index = object.geometry.indexData;
     if (index.length) {
       this.gl.drawElements(primitive, index.length, this.gl.UNSIGNED_INT, 0);


### PR DESCRIPTION
### Summary

This PR moves the primitive property from the renderable object base  
class to the geometry class. The primitive type is tightly coupled with
the geometry, so relocating it improves clarity and structure.  

This change also simplifies downstream work, such as wireframe  
rendering and supporting multiple geometries per renderable object.

### Related Issue
N/A

### Tests & Checks
- All checks have passed
- Manual verification of existing examples
