### PR TITLE
Use canvas.clientWidth instead of idetik.width for scale-bar updates

### DIFF
--- a/packages/core/examples/image2d_from_omezarr5d_u16/scale_bar.ts
+++ b/packages/core/examples/image2d_from_omezarr5d_u16/scale_bar.ts
@@ -27,12 +27,12 @@ export class ScaleBar {
 
     const cameraWidthWorld =
       orthoCamera.transform.scale[0] * orthoCamera.viewportSize[0];
-    const unitPerCanvasPixel = cameraWidthWorld / idetik.width;
+    const unitPerCanvasPixel = cameraWidthWorld / idetik.canvas.clientWidth;
 
     // The use of clientWidth assumes that the lineDiv has no padding,
     // which is true in this example. If similar code is used elsewhere,
     // the lack of padding should be asserted and or enforced.
-    const lineWidth = this.lineDiv_.clientWidth * window.devicePixelRatio;
+    const lineWidth = this.lineDiv_.clientWidth;
     const lineWidthWorld = lineWidth * unitPerCanvasPixel;
 
     this.textDiv_.textContent = `${lineWidthWorld.toFixed(2)} ${this.unit_}`;

--- a/packages/core/examples/image2d_from_omezarr5d_u16/scale_bar.ts
+++ b/packages/core/examples/image2d_from_omezarr5d_u16/scale_bar.ts
@@ -32,8 +32,7 @@ export class ScaleBar {
     // The use of clientWidth assumes that the lineDiv has no padding,
     // which is true in this example. If similar code is used elsewhere,
     // the lack of padding should be asserted and or enforced.
-    const lineWidth = this.lineDiv_.clientWidth;
-    const lineWidthWorld = lineWidth * unitPerCanvasPixel;
+    const lineWidthWorld = this.lineDiv_.clientWidth * unitPerCanvasPixel;
 
     this.textDiv_.textContent = `${lineWidthWorld.toFixed(2)} ${this.unit_}`;
   }

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/components/ScaleBar/ScaleBar.tsx
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/components/ScaleBar/ScaleBar.tsx
@@ -95,13 +95,12 @@ class ScaleBarOverlay {
 
     const cameraWidthWorld =
       orthoCamera.transform.scale[0] * orthoCamera.viewportSize[0];
-    const unitPerCanvasPixel = cameraWidthWorld / idetik.width;
+    const unitPerCanvasPixel = cameraWidthWorld / idetik.canvas.clientWidth;
 
     // The use of clientWidth assumes that containerDiv has no padding,
     // which is true in this case. If similar code is used elsewhere,
     // the lack of padding should be asserted and or enforced.
-    const containerWidth = containerDiv.clientWidth * window.devicePixelRatio;
-    const containerWidthWorld = containerWidth * unitPerCanvasPixel;
+    const containerWidthWorld = containerDiv.clientWidth * unitPerCanvasPixel;
 
     if (containerWidthWorld !== this.containerWidthWorld_) {
       this.containerWidthWorld_ = containerWidthWorld;


### PR DESCRIPTION
### Summary
This fixes an issue with the reported physical length of the scale bar when switching between displays with different DPIs (see #306) by using `idetik.canvas.clientWidth` instead of `idetik.width` and `window.devicePixelRatio` to handle the scale-bar length calculations.

Using the CSS width rather than the canvas buffer width is conceptually simpler, and is also immune to Safari's partial support for `window.devicePixelRatio`.

### Related Issue
Closes #306 

### Tests & Checks
I manually tested the scale bar example and the React component example with the setup described in #306. The bug is present without these changes and not present after. After these changes, I verified that the reported physical length of a single pixel and the whole image is as expected based on the image metadata.
