### PR TITLE
(Stacked) Render wireframes on top of meshes [2/2]

### DIFF
--- a/packages/core/src/core/geometry.ts
+++ b/packages/core/src/core/geometry.ts
@@ -1,7 +1,6 @@
 import { Node } from "./node";
-import { Logger } from "../utilities/logger";
 
-export type Primitive = "triangles" | "points";
+export type Primitive = "triangles" | "points" | "lines";
 
 type GeometryAttributeType =
   | "position"
@@ -35,11 +34,10 @@ type GeometryAttribute = {
 };
 
 export class Geometry extends Node {
-  private readonly attributes_: GeometryAttribute[];
-  private readonly primitive_: Primitive;
+  protected primitive_: Primitive;
+  protected attributes_: GeometryAttribute[];
   protected vertexData_: Float32Array;
   protected indexData_: Uint32Array;
-  private wireframeIndexData_: Uint32Array;
 
   constructor(
     vertexData: number[] = [],
@@ -50,7 +48,6 @@ export class Geometry extends Node {
     this.vertexData_ = new Float32Array(vertexData);
     this.indexData_ = new Uint32Array(indexData);
     this.primitive_ = primitive;
-    this.wireframeIndexData_ = new Uint32Array();
     this.attributes_ = [];
   }
 
@@ -82,58 +79,11 @@ export class Geometry extends Node {
     return this.indexData_;
   }
 
-  public get wireframeIndexData() {
-    return this.wireframeIndexData_;
-  }
-
   public get attributes() {
     return this.attributes_;
   }
 
   public get type() {
     return "Geometry";
-  }
-
-  public generateWireframeIndexData() {
-    const indexData = this.indexData_;
-
-    if (indexData.length === 0) {
-      Logger.warn(
-        "Geometry",
-        "Wireframe generation error: only indexed geometries are supported"
-      );
-      return;
-    }
-
-    if (indexData.length % 3 !== 0) {
-      Logger.warn("Geometry", "Wireframe generation error: non-triangle data");
-      return;
-    }
-
-    const edgeSet = new Set<{ i0: number; i1: number }>();
-    const wireframeIndices: number[] = [];
-    const addEdge = (a: number, b: number) => {
-      // Normalize edge order and use a set to deduplicate,
-      // since shared edges between triangles would otherwise
-      // be added multiple times.
-      const i0 = Math.min(a, b);
-      const i1 = Math.max(a, b);
-      if (!edgeSet.has({ i0, i1 })) {
-        edgeSet.add({ i0, i1 });
-        wireframeIndices.push(i0, i1);
-      }
-    };
-
-    for (let i = 0; i < indexData.length; i += 3) {
-      const i0 = indexData[i];
-      const i1 = indexData[i + 1];
-      const i2 = indexData[i + 2];
-
-      addEdge(i0, i1);
-      addEdge(i1, i2);
-      addEdge(i2, i0);
-    }
-
-    this.wireframeIndexData_ = new Uint32Array(wireframeIndices);
   }
 }

--- a/packages/core/src/core/renderable_object.ts
+++ b/packages/core/src/core/renderable_object.ts
@@ -1,16 +1,18 @@
 import { Node } from "../core/node";
 import { Geometry } from "../core/geometry";
+import { WireframeGeometry } from "../core/wireframe_geometry";
 import { Texture } from "../objects/textures/texture";
 import { TrsTransform } from "../core/transforms";
 
 import { Shader } from "../renderers/shaders";
 
 export abstract class RenderableObject extends Node {
+  public wireframeEnabled = false;
   private readonly textures_: Texture[] = [];
   private readonly transform_ = new TrsTransform();
   private geometry_ = new Geometry();
+  private wireframeGeometry_: WireframeGeometry | null = null;
   private programName_: Shader | null = null;
-  private wireframeEnabled_ = false;
 
   public addTexture(texture: Texture) {
     this.textures_.push(texture);
@@ -18,6 +20,11 @@ export abstract class RenderableObject extends Node {
 
   public get geometry() {
     return this.geometry_;
+  }
+
+  public get wireframeGeometry() {
+    this.wireframeGeometry_ ??= new WireframeGeometry(this.geometry);
+    return this.wireframeGeometry_;
   }
 
   public get textures() {
@@ -30,16 +37,7 @@ export abstract class RenderableObject extends Node {
 
   public set geometry(geometry: Geometry) {
     this.geometry_ = geometry;
-    if (this.wireframeEnabled_) {
-      this.generateWireframeIndicesIfNeeded();
-    }
-  }
-
-  public set wireframeOnShaded(enabled: boolean) {
-    this.wireframeEnabled_ = enabled;
-    if (this.wireframeEnabled_) {
-      this.generateWireframeIndicesIfNeeded();
-    }
+    this.wireframeGeometry_ = null;
   }
 
   public get programName(): Shader {
@@ -51,14 +49,6 @@ export abstract class RenderableObject extends Node {
 
   protected set programName(programName: Shader) {
     this.programName_ = programName;
-  }
-
-  private generateWireframeIndicesIfNeeded() {
-    const hasIndexData = this.geometry_.indexData.length > 0;
-    const hasWireframeIndexData = this.geometry_.wireframeIndexData.length > 0;
-    if (hasIndexData && !hasWireframeIndexData) {
-      this.geometry_.generateWireframeIndexData();
-    }
   }
 
   /**

--- a/packages/core/src/core/wireframe_geometry.ts
+++ b/packages/core/src/core/wireframe_geometry.ts
@@ -1,0 +1,51 @@
+import { Geometry } from "./geometry";
+import { Logger } from "../utilities/logger";
+
+export class WireframeGeometry extends Geometry {
+  constructor(geometry: Geometry) {
+    super();
+
+    if (geometry.primitive != "triangles") {
+      Logger.warn("WireframeGeometry", "Only indexed geometries are supported");
+      return;
+    }
+
+    if (geometry.indexData.length == 0) {
+      Logger.warn(
+        "WireframeGeometry",
+        "Only triangulated geometries are supported"
+      );
+      return;
+    }
+
+    this.primitive_ = "lines";
+    this.vertexData_ = geometry.vertexData;
+    this.attributes_ = geometry.attributes;
+
+    const edgeSet = new Set<{ i0: number; i1: number }>();
+    const wireframeIndices: number[] = [];
+    const addEdge = (a: number, b: number) => {
+      // Normalize edge order and use a set to deduplicate,
+      // since shared edges between triangles would otherwise
+      // be added multiple times.
+      const i0 = Math.min(a, b);
+      const i1 = Math.max(a, b);
+      if (!edgeSet.has({ i0, i1 })) {
+        edgeSet.add({ i0, i1 });
+        wireframeIndices.push(i0, i1);
+      }
+    };
+
+    const index = geometry.indexData;
+    for (let i = 0; i < index.length; i += 3) {
+      const i0 = index[i];
+      const i1 = index[i + 1];
+      const i2 = index[i + 2];
+      addEdge(i0, i1);
+      addEdge(i1, i2);
+      addEdge(i2, i0);
+    }
+
+    this.indexData_ = new Uint32Array(wireframeIndices);
+  }
+}

--- a/packages/core/src/renderers/shaders/index.ts
+++ b/packages/core/src/renderers/shaders/index.ts
@@ -7,10 +7,13 @@ import uintImageFragmentShader from "./uint_image_frag.glsl";
 import uintImageArrayFragmentShader from "./uint_image_array_frag.glsl";
 import pointsVertexShader from "./points_vert.glsl";
 import pointsFragmentShader from "./points_frag.glsl";
+import wireframeVertexShader from "./wireframe_vert.glsl";
+import wireframeFragmentShader from "./wireframe_frag.glsl";
 
 export type Shader =
   | "projectedLine"
   | "points"
+  | "wireframe"
   | "floatImage"
   | "floatImageArray"
   | "uintImage"
@@ -25,6 +28,10 @@ export const shaderCode: Record<Shader, { vertex: string; fragment: string }> =
     points: {
       vertex: pointsVertexShader,
       fragment: pointsFragmentShader,
+    },
+    wireframe: {
+      vertex: wireframeVertexShader,
+      fragment: wireframeFragmentShader,
     },
     // TODO: consolidate image shaders
     floatImage: {

--- a/packages/core/src/renderers/shaders/wireframe_frag.glsl
+++ b/packages/core/src/renderers/shaders/wireframe_frag.glsl
@@ -1,0 +1,11 @@
+#version 300 es
+
+precision mediump float;
+
+layout (location = 0) out vec4 fragColor;
+
+uniform float u_opacity;
+
+void main() {
+    fragColor = vec4(1.0, 1.0, 1.0, u_opacity);
+}

--- a/packages/core/src/renderers/shaders/wireframe_vert.glsl
+++ b/packages/core/src/renderers/shaders/wireframe_vert.glsl
@@ -1,0 +1,11 @@
+#version 300 es
+
+layout (location = 0) in vec3 inPosition;
+layout (location = 1) in vec3 inNormal;
+
+uniform mat4 Projection;
+uniform mat4 ModelView;
+
+void main() {
+    gl_Position = Projection * ModelView * vec4(inPosition, 1.0);
+}

--- a/packages/core/src/renderers/webgl_renderer.ts
+++ b/packages/core/src/renderers/webgl_renderer.ts
@@ -11,7 +11,7 @@ import { LayerManager } from "../core/layer_manager";
 import { Camera } from "../objects/cameras/camera";
 import { WebGLState } from "./WebGLState";
 import { RenderableObject } from "../core/renderable_object";
-import { Primitive } from "../core/geometry";
+import { Geometry, Primitive } from "../core/geometry";
 
 import { mat4 } from "gl-matrix";
 
@@ -92,14 +92,24 @@ export class WebGLRenderer extends Renderer {
     });
 
     const program = this.getShaderProgram(object.programName).use();
-    this.drawObject(layer, object, program);
+    this.drawGeometry(object.geometry, object, layer, program);
 
-    // TODO: If "wireframe on shaded" call draw object with different parameters
+    if (object.wireframeEnabled) {
+      this.bindings_.bindGeometry(object.wireframeGeometry);
+      const wireframeProgram = this.getShaderProgram("wireframe").use();
+      this.drawGeometry(
+        object.wireframeGeometry,
+        object,
+        layer,
+        wireframeProgram
+      );
+    }
   }
 
-  private drawObject(
-    layer: Layer,
+  private drawGeometry(
+    geometry: Geometry,
     object: RenderableObject,
+    layer: Layer,
     program: WebGLShaderProgram
   ) {
     const modelView = mat4.multiply(
@@ -136,21 +146,23 @@ export class WebGLRenderer extends Renderer {
       }
     }
 
-    const primitive = this.getGLPrimitve(object.geometry.primitive);
-    const index = object.geometry.indexData;
+    const primitive = this.glGetPrimitive(geometry.primitive);
+    const index = geometry.indexData;
     if (index.length) {
       this.gl.drawElements(primitive, index.length, this.gl.UNSIGNED_INT, 0);
     } else {
-      this.gl.drawArrays(primitive, 0, object.geometry.vertexCount);
+      this.gl.drawArrays(primitive, 0, geometry.vertexCount);
     }
   }
 
-  private getGLPrimitve(type: Primitive) {
+  private glGetPrimitive(type: Primitive) {
     switch (type) {
       case "points":
         return this.gl.POINTS;
       case "triangles":
         return this.gl.TRIANGLES;
+      case "lines":
+        return this.gl.LINES;
       default: {
         const exhaustiveCheck: never = type;
         throw new Error(`Unknown Primitive type: ${exhaustiveCheck}`);

--- a/packages/core/src/utilities/logger.ts
+++ b/packages/core/src/utilities/logger.ts
@@ -17,7 +17,7 @@ const Colors = {
 // Add new module names here as needed to represent different parts of the application
 type Module =
   | "ChunkManager"
-  | "Geometry"
+  | "WireframeGeometry"
   | "Idetik"
   | "ImageLayer"
   | "WebGLRenderer"


### PR DESCRIPTION
### Summary
This PR finalizes the wireframe-over-shaded-geometry feature. It introduces
a dedicated wireframe geometry to renderable objects, adds a basic passthrough
shader for rendering flat colors, and completes the necessary integration in WebGLRenderer.

**Next Steps**
I'm calling it done because the functionality is there, but I want to extend it in a follow-up:
- Implement layer-specific logic for displaying debug wireframes.
- Add color option for wireframes - for example, different wireframe colors may be desirable per LOD level.
- Apply polygon offset to ensure wireframes consistently render on top of shaded geometry.

### Related Issue
Closes #47

### Tests & Checks
- Manually verified — see attached video.
- To enable wireframes, set wireframeEnabled = true on renderable objects.
- All existing examples render correctly with no regressions.
- All checks have passed.


https://github.com/user-attachments/assets/6d2d61db-d22a-4d51-988c-28b60d75d353

