### PR TITLE
Fix pan/sticking when dismissing context menu

### DIFF
--- a/packages/core/src/objects/cameras/controls.ts
+++ b/packages/core/src/objects/cameras/controls.ts
@@ -71,6 +71,10 @@ export class PanZoomControls implements CameraControls {
     target: EventTarget,
     clientToWorld: ClientToWorld
   ) {
+    if (event.button !== 0) {
+      return;
+    }
+
     const clientStart = vec2.fromValues(event.clientX, event.clientY);
     const worldStart = clientToWorld(clientStart, this.clipDepth);
     const pointerId = event.pointerId;


### PR DESCRIPTION
### Summary
This prevents #308 by changing `PanZoomControls` to ignore non-left-click `pointerdown` events.

I don't notice any ill effects with this change, but there might be a better/more thorough fix we can implement when taking on pinch-to-zoom for example.

### Related Issue
Closes #308 

### Tests & Checks
tested with organellebox data through `npm run components`
