### PR TITLE
(Small) Add wireframe color to renderable objects

### DIFF
--- a/packages/core/examples/chunk_streaming/main.ts
+++ b/packages/core/examples/chunk_streaming/main.ts
@@ -39,6 +39,8 @@ const chunkInfoOverlay = new ChunkInfoOverlay({
   imageLayer: imageLayer,
 });
 
+imageLayer.debugMode = true;
+
 new Idetik({
   canvas: document.querySelector<HTMLCanvasElement>("#canvas")!,
   camera,

--- a/packages/core/examples/chunk_streaming/main.ts
+++ b/packages/core/examples/chunk_streaming/main.ts
@@ -1,6 +1,5 @@
 import {
   Idetik,
-  AxesLayer,
   ImageLayer,
   OmeZarrImageSource,
   OrthographicCamera,
@@ -28,23 +27,23 @@ const region: Region = [
   { dimension: "x", index: { type: "full" } },
 ];
 const channelProps = [{ contrastLimits: [0, 255] as [number, number] }];
-const imageLayer = new ImageLayer({ source, region, channelProps });
-const axesLayer = new AxesLayer({ length: 1500, width: 0.01 });
 const camera = new OrthographicCamera(left, right, top, bottom);
 const fpsOverlay = new FpsOverlay({
   textDiv: document.querySelector<HTMLDivElement>("#fps-text")!,
 });
+
+const imageLayer = new ImageLayer({ source, region, channelProps });
+imageLayer.debugMode = true;
+
 const chunkInfoOverlay = new ChunkInfoOverlay({
   textDiv: document.querySelector<HTMLDivElement>("#chunk-info")!,
   imageLayer: imageLayer,
 });
 
-imageLayer.debugMode = true;
-
 new Idetik({
   canvas: document.querySelector<HTMLCanvasElement>("#canvas")!,
   camera,
   controls: new PanZoomControls(camera, camera.position),
-  layers: [imageLayer, axesLayer],
+  layers: [imageLayer],
   overlays: [fpsOverlay, chunkInfoOverlay],
 }).start();

--- a/packages/core/src/core/color.ts
+++ b/packages/core/src/core/color.ts
@@ -3,10 +3,16 @@ import { vec3, vec4 } from "gl-matrix";
 export type ColorLike = Color | vec3 | vec4;
 
 export class Color {
+  public static readonly RED: Color = new Color(1.0, 0.0, 0.0);
+  public static readonly GREEN: Color = new Color(0.0, 1.0, 0.0);
+  public static readonly BLUE: Color = new Color(0.0, 0.0, 1.0);
+  public static readonly BLACK: Color = new Color(0.0, 0.0, 0.0);
+  public static readonly WHITE: Color = new Color(1.0, 1.0, 1.0);
+
   // RGBA color values in the range [0, 1]
   private readonly rgba_: readonly [number, number, number, number];
 
-  constructor(r: number = 1.0, g: number = 1.0, b: number = 1.0, a?: number) {
+  constructor(r: number, g: number, b: number, a?: number) {
     if (r < 0 || r > 1 || g < 0 || g > 1 || b < 0 || b > 1) {
       throw new Error("RGB values must be in the range [0, 1]");
     }
@@ -68,12 +74,6 @@ export class Color {
       1.0
     );
   }
-
-  public static RED: Color = new Color(1.0, 0.0, 0.0);
-  public static GREEN: Color = new Color(0.0, 1.0, 0.0);
-  public static BLUE: Color = new Color(0.0, 0.0, 1.0);
-  public static BLACK: Color = new Color(0.0, 0.0, 0.0);
-  public static WHITE: Color = new Color(1.0, 1.0, 1.0);
 
   private toHexComponent(value: number): string {
     const hex = Math.round(value * 255)

--- a/packages/core/src/core/color.ts
+++ b/packages/core/src/core/color.ts
@@ -6,7 +6,7 @@ export class Color {
   // RGBA color values in the range [0, 1]
   private readonly rgba_: readonly [number, number, number, number];
 
-  constructor(r: number, g: number, b: number, a?: number) {
+  constructor(r: number = 1.0, g: number = 1.0, b: number = 1.0, a?: number) {
     if (r < 0 || r > 1 || g < 0 || g > 1 || b < 0 || b > 1) {
       throw new Error("RGB values must be in the range [0, 1]");
     }

--- a/packages/core/src/core/layer.ts
+++ b/packages/core/src/core/layer.ts
@@ -22,6 +22,7 @@ export interface LayerOptions {
 
 export abstract class Layer {
   public abstract readonly type: string;
+  public debugMode = false;
 
   private objects_: RenderableObject[] = [];
   private state_: LayerState = "initialized";

--- a/packages/core/src/core/renderable_object.ts
+++ b/packages/core/src/core/renderable_object.ts
@@ -3,11 +3,12 @@ import { Geometry } from "../core/geometry";
 import { WireframeGeometry } from "../core/wireframe_geometry";
 import { Texture } from "../objects/textures/texture";
 import { TrsTransform } from "../core/transforms";
-
 import { Shader } from "../renderers/shaders";
+import { Color } from "../core/color";
 
 export abstract class RenderableObject extends Node {
   public wireframeEnabled = false;
+  public wireframeColor = new Color();
   private readonly textures_: Texture[] = [];
   private readonly transform_ = new TrsTransform();
   private geometry_ = new Geometry();

--- a/packages/core/src/core/renderable_object.ts
+++ b/packages/core/src/core/renderable_object.ts
@@ -8,7 +8,7 @@ import { Color } from "../core/color";
 
 export abstract class RenderableObject extends Node {
   public wireframeEnabled = false;
-  public wireframeColor = new Color();
+  public wireframeColor = Color.WHITE;
   private readonly textures_: Texture[] = [];
   private readonly transform_ = new TrsTransform();
   private geometry_ = new Geometry();

--- a/packages/core/src/layers/image_layer.ts
+++ b/packages/core/src/layers/image_layer.ts
@@ -179,7 +179,8 @@ export class ImageLayer extends Layer {
 
     if (this.debugMode) {
       image.wireframeEnabled = true;
-      image.wireframeColor = this.wireframeColors_[chunk.lod];
+      image.wireframeColor =
+        this.wireframeColors_[chunk.lod % this.wireframeColors_.length];
     }
 
     image.transform.setScale([chunk.scale.x, chunk.scale.y, 1]);

--- a/packages/core/src/layers/image_layer.ts
+++ b/packages/core/src/layers/image_layer.ts
@@ -8,6 +8,7 @@ import { ImageRenderable } from "../objects/renderable/image_renderable";
 import { Texture2DArray } from "../objects/textures/texture_2d_array";
 import { PlaneGeometry } from "../objects/geometry/plane_geometry";
 import { Logger } from "../utilities/logger";
+import { Color } from "../core/color";
 
 export type ImageLayerProps = LayerOptions & {
   source: ImageChunkSource;
@@ -23,15 +24,22 @@ export class ImageLayer extends Layer {
   // TODO: remove this when region is passed through to update.
   // https://github.com/chanzuckerberg/idetik/issues/33
   private readonly region_: Region;
-  private useChunkManager_: boolean;
+  private readonly useChunkManager_: boolean;
   private chunkManagerSource_?: ChunkManagerSource;
   private channelProps_?: ChannelProps[];
   private image_?: ImageRenderable;
   private extent_?: { x: number; y: number };
-  private visibleChunks_: Map<ImageChunk, ImageRenderable> = new Map();
-  private readonly lod_?: number;
+  private readonly visibleChunks_: Map<ImageChunk, ImageRenderable> = new Map();
+
+  private readonly wireframeColors_ = [
+    new Color(0.6, 0.3, 0.3),
+    new Color(0.3, 0.6, 0.4),
+    new Color(0.4, 0.4, 0.7),
+    new Color(0.6, 0.5, 0.3),
+  ];
 
   // TODO:(shlomnissan) Remove this parameter when chunk manager is used by default
+  private readonly lod_?: number;
 
   constructor({
     source,
@@ -168,6 +176,11 @@ export class ImageLayer extends Layer {
       Texture2DArray.createWithImageChunk(chunk),
       channelProps
     );
+
+    if (this.debugMode) {
+      image.wireframeEnabled = true;
+      image.wireframeColor = this.wireframeColors_[chunk.lod];
+    }
 
     image.transform.setScale([chunk.scale.x, chunk.scale.y, 1]);
     image.transform.setTranslation([chunk.offset.x, chunk.offset.y, 0]);

--- a/packages/core/src/renderers/shaders/wireframe_frag.glsl
+++ b/packages/core/src/renderers/shaders/wireframe_frag.glsl
@@ -5,7 +5,8 @@ precision mediump float;
 layout (location = 0) out vec4 fragColor;
 
 uniform float u_opacity;
+uniform vec3 u_color;
 
 void main() {
-    fragColor = vec4(1.0, 1.0, 1.0, u_opacity);
+    fragColor = vec4(u_color, u_opacity);
 }

--- a/packages/core/src/renderers/webgl_renderer.ts
+++ b/packages/core/src/renderers/webgl_renderer.ts
@@ -97,6 +97,7 @@ export class WebGLRenderer extends Renderer {
     if (object.wireframeEnabled) {
       this.bindings_.bindGeometry(object.wireframeGeometry);
       const wireframeProgram = this.programs_.get("wireframe").use();
+      wireframeProgram.setUniform("u_color", object.wireframeColor.rgb);
       this.drawGeometry(
         object.wireframeGeometry,
         object,

--- a/packages/core/src/renderers/webgl_shader_program.ts
+++ b/packages/core/src/renderers/webgl_shader_program.ts
@@ -10,8 +10,10 @@ type ShaderMap = {
 export class WebGLShaderProgram {
   private readonly gl_: WebGL2RenderingContext;
   private readonly program_: WebGLProgram;
-  private uniformInfo_: Map<string, [WebGLUniformLocation, WebGLActiveInfo]> =
-    new Map();
+  private readonly uniformInfo_: Map<
+    string,
+    [WebGLUniformLocation, WebGLActiveInfo]
+  > = new Map();
   private shaders_: ShaderMap = {};
 
   constructor(
@@ -30,9 +32,9 @@ export class WebGLShaderProgram {
     this.addShader(vertexShaderSource, gl.VERTEX_SHADER);
     this.addShader(fragmentShaderSource, gl.FRAGMENT_SHADER);
     this.link();
-    this.validateProgram();
-    this.preprocessUniformLocations();
     this.deleteShaders();
+    this.validate();
+    this.preprocessUniformLocations();
   }
 
   public setUniform(name: string, value: unknown) {
@@ -124,7 +126,7 @@ export class WebGLShaderProgram {
     }
   }
 
-  private validateProgram() {
+  private validate() {
     this.gl_.validateProgram(this.program_);
     if (!this.getParameter(this.gl_.VALIDATE_STATUS)) {
       this.deleteShaders();

--- a/packages/core/src/renderers/webgl_shader_program.ts
+++ b/packages/core/src/renderers/webgl_shader_program.ts
@@ -30,6 +30,9 @@ export class WebGLShaderProgram {
     this.addShader(vertexShaderSource, gl.VERTEX_SHADER);
     this.addShader(fragmentShaderSource, gl.FRAGMENT_SHADER);
     this.link();
+    this.validateProgram();
+    this.preprocessUniformLocations();
+    this.deleteShaders();
   }
 
   public setUniform(name: string, value: unknown) {
@@ -37,7 +40,6 @@ export class WebGLShaderProgram {
     if (!location || !info) {
       throw new Error(`Uniform "${name}" not found in shader program`);
     }
-
     const type = info.type as SupportedUniformType;
     switch (type) {
       // There is no dedicated uniform1b in WebGL, but passing through
@@ -120,16 +122,15 @@ export class WebGLShaderProgram {
       const message = this.gl_.getProgramInfoLog(this.program_);
       throw new Error(`Error linking program: ${message}`);
     }
+  }
 
+  private validateProgram() {
     this.gl_.validateProgram(this.program_);
     if (!this.getParameter(this.gl_.VALIDATE_STATUS)) {
       this.deleteShaders();
       const message = this.gl_.getProgramInfoLog(this.program_);
       throw new Error(`Error validating program: ${message}`);
     }
-
-    this.preprocessUniformLocations();
-    this.deleteShaders();
   }
 
   public use() {


### PR DESCRIPTION
### Summary

This PR introduces a wireframe color option for renderable objects. This 
feature is especially helpful for debugging scenarios, such as assigning 
different wireframe colors to individual LOD tiles.  Additionally, a `debugMode`
flag has been added to the base layer class to support this and other
debug-related functionality.

### Notes
I think adding a `debugMode` flag to the layer and letting each layer define  its own behavior is sufficient for now. For example, in the case of `ImageLayer`, enabling `debugMode` simply adds  wireframes to its image renderables. That said, I'm open to a more structured approach if others have suggestions.

### Related Issue
N/A

### Tests & Checks
- Manual verification: See screenshots below
- All checks have passed

| <img width="1425" height="1099" alt="Screenshot 2025-07-22 at 12 57 34 PM" src="https://github.com/user-attachments/assets/da9473ce-54c3-4cad-8dc3-211317a9ba54" /> | <img width="1427" height="1099" alt="Screenshot 2025-07-22 at 12 57 46 PM" src="https://github.com/user-attachments/assets/e0861e12-c327-4871-9ec3-242871a5d056" /> | <img width="1426" height="1099" alt="Screenshot 2025-07-22 at 12 57 57 PM" src="https://github.com/user-attachments/assets/3c615eb5-a0ae-4801-9073-089866ad9e86" /> |
|--------|--------|--------|
