### PR TITLE
Remove local file example from index

### DIFF
--- a/packages/core/examples/index.html
+++ b/packages/core/examples/index.html
@@ -57,9 +57,6 @@
       <li>
         <a href="/image_labels_overlay/index.html">Image labels overlay</a>
       </li>
-      <li>
-        <a href="/local_files/index.html">Local File System</a>
-      </li>
     </ul>
   </body>
 </html>


### PR DESCRIPTION
### Summary
Clean up missed in https://github.com/chanzuckerberg/idetik/pull/321

### Tests & Checks
The core local file example is not longer shown in the index.
