### PR TITLE
Factor out interface for channel-related layer properties

### DIFF
--- a/packages/core/src/core/layer.ts
+++ b/packages/core/src/core/layer.ts
@@ -1,6 +1,7 @@
 import { IdetikContext } from "../idetik";
 import { RenderableObject } from "./renderable_object";
 import { clamp } from "../utilities/clamp";
+import { ChannelProps } from "@/objects/textures/channel";
 
 export type LayerState = "initialized" | "loading" | "ready";
 export type blendMode = "normal" | "additive" | "subtractive" | "multiply";
@@ -106,4 +107,13 @@ export abstract class Layer {
   protected clearObjects() {
     this.objects_ = [];
   }
+}
+
+/** Layer that exposes channel controls. */
+export interface ChannelsEnabled {
+  channelProps: ChannelProps[] | undefined;
+  setChannelProps(channelProps: ChannelProps[]): void;
+  resetChannelProps(): void;
+  addChannelChangeCallback(callback: () => void): void;
+  removeChannelChangeCallback(callback: () => void): void;
 }

--- a/packages/core/src/core/layer.ts
+++ b/packages/core/src/core/layer.ts
@@ -1,7 +1,6 @@
 import { IdetikContext } from "../idetik";
 import { RenderableObject } from "./renderable_object";
 import { clamp } from "../utilities/clamp";
-import { ChannelProps } from "@/objects/textures/channel";
 
 export type LayerState = "initialized" | "loading" | "ready";
 export type blendMode = "normal" | "additive" | "subtractive" | "multiply";
@@ -107,13 +106,4 @@ export abstract class Layer {
   protected clearObjects() {
     this.objects_ = [];
   }
-}
-
-/** Layer that exposes channel controls. */
-export interface ChannelsEnabled {
-  channelProps: ChannelProps[] | undefined;
-  setChannelProps(channelProps: ChannelProps[]): void;
-  resetChannelProps(): void;
-  addChannelChangeCallback(callback: () => void): void;
-  removeChannelChangeCallback(callback: () => void): void;
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,7 +7,7 @@ export { NullControls, PanZoomControls } from "./objects/cameras/controls";
 export type { CameraControls } from "./objects/cameras/controls";
 
 export { Layer } from "./core/layer";
-export type { LayerState } from "./core/layer";
+export type { ChannelsEnabled, LayerState } from "./core/layer";
 export { LayerManager } from "./core/layer_manager";
 
 export { AxesLayer } from "./layers/axes_layer";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,7 +7,7 @@ export { NullControls, PanZoomControls } from "./objects/cameras/controls";
 export type { CameraControls } from "./objects/cameras/controls";
 
 export { Layer } from "./core/layer";
-export type { ChannelsEnabled, LayerState } from "./core/layer";
+export type { LayerState } from "./core/layer";
 export { LayerManager } from "./core/layer_manager";
 
 export { AxesLayer } from "./layers/axes_layer";
@@ -33,7 +33,7 @@ export type {
 
 export { Color } from "./core/color";
 export type { ColorLike } from "./core/color";
-export type { ChannelProps } from "./objects/textures/channel";
+export type { ChannelProps, ChannelsEnabled } from "./objects/textures/channel";
 
 export { Points } from "./objects/renderable/points";
 export { Texture2DArray } from "./objects/textures/texture_2d_array";

--- a/packages/core/src/layers/image_layer.ts
+++ b/packages/core/src/layers/image_layer.ts
@@ -1,9 +1,9 @@
-import { ChannelsEnabled, Layer, LayerOptions } from "../core/layer";
+import { Layer, LayerOptions } from "../core/layer";
 import { IdetikContext } from "../idetik";
 import { Region } from "../data/region";
 import { ImageChunk, ImageChunkSource } from "../data/image_chunk";
 import { ChunkManagerSource } from "../core/chunk_manager";
-import { ChannelProps } from "../objects/textures/channel";
+import { ChannelProps, ChannelsEnabled } from "../objects/textures/channel";
 import { ImageRenderable } from "../objects/renderable/image_renderable";
 import { Texture2DArray } from "../objects/textures/texture_2d_array";
 import { PlaneGeometry } from "../objects/geometry/plane_geometry";

--- a/packages/core/src/layers/image_layer.ts
+++ b/packages/core/src/layers/image_layer.ts
@@ -55,6 +55,7 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
     this.source_ = source;
     this.region_ = region;
     this.channelProps_ = channelProps;
+    this.initialChannelProps_ = channelProps;
     this.lod_ = lod;
 
     const x = region.find((r) => r.dimension.toLowerCase() === "x");

--- a/packages/core/src/layers/image_layer.ts
+++ b/packages/core/src/layers/image_layer.ts
@@ -1,4 +1,4 @@
-import { Layer, LayerOptions } from "../core/layer";
+import { ChannelsEnabled, Layer, LayerOptions } from "../core/layer";
 import { IdetikContext } from "../idetik";
 import { Region } from "../data/region";
 import { ImageChunk, ImageChunkSource } from "../data/image_chunk";
@@ -17,7 +17,7 @@ export type ImageLayerProps = LayerOptions & {
 };
 
 // Loads data from an image source into renderable objects.
-export class ImageLayer extends Layer {
+export class ImageLayer extends Layer implements ChannelsEnabled {
   public readonly type = "ImageLayer";
 
   private readonly source_: ImageChunkSource;
@@ -25,11 +25,13 @@ export class ImageLayer extends Layer {
   // https://github.com/chanzuckerberg/idetik/issues/33
   private readonly region_: Region;
   private readonly useChunkManager_: boolean;
+  private readonly initialChannelProps_?: ChannelProps[];
+  private readonly channelChangeCallbacks_: Array<() => void> = [];
+  private readonly visibleChunks_: Map<ImageChunk, ImageRenderable> = new Map();
   private chunkManagerSource_?: ChunkManagerSource;
   private channelProps_?: ChannelProps[];
   private image_?: ImageRenderable;
   private extent_?: { x: number; y: number };
-  private readonly visibleChunks_: Map<ImageChunk, ImageRenderable> = new Map();
 
   private readonly wireframeColors_ = [
     new Color(0.6, 0.3, 0.3),
@@ -131,10 +133,28 @@ export class ImageLayer extends Layer {
     // TODO: should this return Channel[] instead of ChannelProps[]?
     return this.channelProps_;
   }
-
   public setChannelProps(channelProps: ChannelProps[]) {
     this.channelProps_ = channelProps;
     this.image_?.setChannelProps(channelProps);
+    this.channelChangeCallbacks_.forEach((callback) => {
+      callback();
+    });
+  }
+  public resetChannelProps(): void {
+    if (this.initialChannelProps_ !== undefined) {
+      this.setChannelProps(this.initialChannelProps_);
+    }
+  }
+
+  public addChannelChangeCallback(callback: () => void): void {
+    this.channelChangeCallbacks_.push(callback);
+  }
+  public removeChannelChangeCallback(callback: () => void): void {
+    const index = this.channelChangeCallbacks_.indexOf(callback);
+    if (index === undefined) {
+      throw new Error(`Callback to remove could not be found: ${callback}`);
+    }
+    this.channelChangeCallbacks_.splice(index, 1);
   }
 
   private async load(region: Region) {

--- a/packages/core/src/layers/image_series_layer.ts
+++ b/packages/core/src/layers/image_series_layer.ts
@@ -1,4 +1,4 @@
-import { Layer, LayerOptions } from "../core/layer";
+import { ChannelsEnabled, Layer, LayerOptions } from "../core/layer";
 import { Full, Interval, Region } from "../data/region";
 import {
   ImageChunk,
@@ -36,7 +36,7 @@ type SetIndexResult = {
 };
 
 // Loads 2D+z image data (Z-stack) from an image source into renderable objects.
-export class ImageSeriesLayer extends Layer {
+export class ImageSeriesLayer extends Layer implements ChannelsEnabled {
   public readonly type = "ImageSeriesLayer";
 
   private readonly source_: ImageChunkSource;
@@ -106,13 +106,9 @@ export class ImageSeriesLayer extends Layer {
     }
   }
 
-  /** useSyncExternalStore() compatible subscribe function. */
-  addChannelChangeCallback = (callback: () => void): (() => void) => {
+  public addChannelChangeCallback(callback: () => void): void {
     this.channelChangeCallbacks_.push(callback);
-    return () => {
-      this.removeChannelChangeCallback(callback);
-    };
-  };
+  }
   public removeChannelChangeCallback(callback: () => void): void {
     const index = this.channelChangeCallbacks_.indexOf(callback);
     if (index === undefined) {

--- a/packages/core/src/layers/image_series_layer.ts
+++ b/packages/core/src/layers/image_series_layer.ts
@@ -1,4 +1,4 @@
-import { ChannelsEnabled, Layer, LayerOptions } from "../core/layer";
+import { Layer, LayerOptions } from "../core/layer";
 import { Full, Interval, Region } from "../data/region";
 import {
   ImageChunk,
@@ -7,7 +7,7 @@ import {
 } from "../data/image_chunk";
 import { Texture2DArray } from "../objects/textures/texture_2d_array";
 import { AbortError, PromiseScheduler } from "../data/promise_scheduler";
-import { ChannelProps } from "../objects/textures/channel";
+import { ChannelProps, ChannelsEnabled } from "../objects/textures/channel";
 import { ImageRenderable } from "../objects/renderable/image_renderable";
 import { PlaneGeometry } from "../objects/geometry/plane_geometry";
 

--- a/packages/core/src/objects/textures/channel.ts
+++ b/packages/core/src/objects/textures/channel.ts
@@ -19,6 +19,15 @@ export type ChannelProps = {
   contrastLimits?: [number, number];
 };
 
+/** Layer that exposes channel controls. */
+export interface ChannelsEnabled {
+  channelProps: ChannelProps[] | undefined;
+  setChannelProps(channelProps: ChannelProps[]): void;
+  resetChannelProps(): void;
+  addChannelChangeCallback(callback: () => void): void;
+  removeChannelChangeCallback(callback: () => void): void;
+}
+
 export function validateChannel(
   texture: Texture | null,
   { visible, color, contrastLimits }: ChannelProps

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/components/ChannelControlsList/ChannelControlsList.tsx
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/components/ChannelControlsList/ChannelControlsList.tsx
@@ -6,14 +6,12 @@ import {
 } from "@czi-sds/components";
 import cns from "classnames";
 import { ChannelControl } from "./components/ChannelControl";
-import { ChannelProps, ColorLike, ImageSeriesLayer } from "@idetik/core";
+import { ChannelProps, ColorLike, ChannelsEnabled } from "@idetik/core";
 import { useSyncExternalStore } from "react";
 import { ExtraControlProps } from "../../utils";
 
 export interface ChannelControlsListProps {
-  // TODO: make this work with ImageLayer as well - need to refactor to add
-  // useSyncExternalStore-compatible methods to ImageLayer
-  layer: ImageSeriesLayer;
+  layer: ChannelsEnabled;
   // TODO: it's awkward to have labels and contrastRanges as separate props
   // but they're not needed for *rendering* so they don't belong in the library
   // - one option is to add a way to store related additional properties in the library


### PR DESCRIPTION
This is so `<OmeZarrImageViewer>` can support `ImageLayer` as well, since Jonathan's images are 2D.