### PR TITLE
Support images with no series in <OmeZarrImageViewer>

### DIFF
--- a/packages/react/examples/local-files/App.tsx
+++ b/packages/react/examples/local-files/App.tsx
@@ -3,7 +3,6 @@ import { OmeZarrImageViewer } from "../../src/components/viewers/OmeZarrImageVie
 import { useState } from "react";
 
 const region: Region = [
-  { dimension: "z", index: { type: "full" } },
   { dimension: "y", index: { type: "full" } },
   { dimension: "x", index: { type: "full" } },
 ];
@@ -22,7 +21,6 @@ export default function App() {
       <OmeZarrImageViewer
         sourceLocalDirectory={directory && { directory }}
         region={region}
-        seriesDimensionName="z"
         fallbackContrastLimits={[0, 1]}
         initialIndex="middle"
         loadAllButtonText="Load all"

--- a/packages/react/examples/local-files/App.tsx
+++ b/packages/react/examples/local-files/App.tsx
@@ -3,7 +3,7 @@ import { OmeZarrImageViewer } from "../../src/components/viewers/OmeZarrImageVie
 import { useState } from "react";
 
 const region: Region = [
-  { dimension: "z", index: { type: "full" } },
+  // { dimension: "z", index: { type: "full" } },
   { dimension: "y", index: { type: "full" } },
   { dimension: "x", index: { type: "full" } },
 ];
@@ -22,10 +22,11 @@ export default function App() {
       <OmeZarrImageViewer
         sourceLocalDirectory={directory && { directory }}
         region={region}
-        seriesDimensionName="z"
+        // seriesDimensionName="z"
+        fallbackContrastLimits={[0, 1]}
         initialIndex="middle"
         loadAllButtonText="Load all"
-        resolutionLevel={2}
+        resolutionLevel={0}
         classNames={{
           root: "bg-dark-sds-color-primitive-gray-100 flex-auto min-h-0",
         }}

--- a/packages/react/examples/local-files/App.tsx
+++ b/packages/react/examples/local-files/App.tsx
@@ -3,7 +3,7 @@ import { OmeZarrImageViewer } from "../../src/components/viewers/OmeZarrImageVie
 import { useState } from "react";
 
 const region: Region = [
-  // { dimension: "z", index: { type: "full" } },
+  { dimension: "z", index: { type: "full" } },
   { dimension: "y", index: { type: "full" } },
   { dimension: "x", index: { type: "full" } },
 ];
@@ -22,7 +22,7 @@ export default function App() {
       <OmeZarrImageViewer
         sourceLocalDirectory={directory && { directory }}
         region={region}
-        // seriesDimensionName="z"
+        seriesDimensionName="z"
         fallbackContrastLimits={[0, 1]}
         initialIndex="middle"
         loadAllButtonText="Load all"

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
@@ -10,6 +10,7 @@ import {
   loadOmeroDefaultZ,
   ChannelProps,
   Idetik,
+  ImageLayer,
 } from "@idetik/core";
 import { useIdetik } from "../../../hooks/useIdetik";
 import { IdetikCanvas } from "../../IdetikCanvas";
@@ -33,7 +34,7 @@ export interface OmeZarrImageViewerProps {
     path?: `/${string}`;
   };
   region: Region;
-  seriesDimensionName: string;
+  seriesDimensionName?: string;
   fallbackContrastLimits?: [number, number];
   resolutionLevel?: number;
   shouldAutoLoadAllSlices?: boolean;
@@ -99,7 +100,7 @@ export function OmeZarrImageViewer({
     ExtraControlProps[]
   >([]);
   const sourceRef = useRef<OmeZarrImageSource | null>(null);
-  const imageLayerRef = useRef<ImageSeriesLayer | null>(null);
+  const imageLayerRef = useRef<ImageLayer | ImageSeriesLayer | null>(null);
 
   // #region Initialization
   const { directory, path } = sourceLocalDirectory ?? {};
@@ -139,12 +140,12 @@ export function OmeZarrImageViewer({
         source,
         region,
         channelProps,
-        seriesDimensionName,
-        resolutionLevel
+        resolutionLevel,
+        seriesDimensionName
       );
       imageLayerRef.current = layer;
       onLayerCreated?.();
-      await updateSeriesIndex(zValue);
+      await updateSeriesIndex(zValue, zRange);
       if (sourceRef.current !== source) {
         return;
       }
@@ -184,8 +185,13 @@ export function OmeZarrImageViewer({
 
   // #region Callbacks
 
-  const updateSeriesIndex = async (zValue: number) => {
-    if (!imageLayerRef.current) return;
+  const updateSeriesIndex = async (
+    zValue: number,
+    zRange: [number, number]
+  ) => {
+    if (!(imageLayerRef.current instanceof ImageSeriesLayer)) {
+      return;
+    }
     let didSetLoadingTrue = false;
     const t = setTimeout(() => {
       setLoading(true);
@@ -208,7 +214,9 @@ export function OmeZarrImageViewer({
     async (event?: React.MouseEvent) => {
       const currentSource = sourceRef.current;
       const currentImageLayer = imageLayerRef.current;
-      if (!currentImageLayer) return;
+      if (!(currentImageLayer instanceof ImageSeriesLayer)) {
+        return;
+      }
       if (event !== undefined) {
         onLoadAllSlicesClicked?.();
       }
@@ -339,7 +347,7 @@ export function OmeZarrImageViewer({
                   onChange={(_, val: number | number[]) => {
                     if (typeof val === "number") {
                       setZValue(val);
-                      updateSeriesIndex(val);
+                      updateSeriesIndex(val, zRange);
                     }
                   }}
                 />
@@ -403,7 +411,13 @@ async function loadImageMetadata(
   initialIndex: string,
   shouldLoadMiddleZ: boolean,
   seriesDimensionName?: string
-): Promise<{ xUnit?: string; zRange: [number, number]; zValue: number }> {
+): Promise<{
+  xUnit?: string;
+  zValue: number;
+  zRange: [number, number];
+  yRange: [number, number];
+  xRange: [number, number];
+}> {
   const loader = await source.open();
   const attrs = await loader.loadAttributes();
   const attrsForLevel = attrs[resolutionLevel];
@@ -412,18 +426,21 @@ async function loadImageMetadata(
   // which currently holds with idetik but is fragile.
   const dimensionUnits = attrsForLevel.dimensionUnits;
   const xUnit = dimensionUnits[dimensionUnits.length - 1];
+  
+  const zIdx = attrsForLevel.dimensionNames.findIndex(
+    (d: string) => d.toUpperCase() === seriesDimensionName.toUpperCase()
+  );
+  const xRange = [0, attrsForLevel.chunks[]]
+  const yRange = []
 
   if (seriesDimensionName === undefined) {
     return {
       xUnit,
-      zRange: [0, 0],
       zValue: 0,
+      zRange: [0, 0],
     };
   }
 
-  const zIdx = attrsForLevel.dimensionNames.findIndex(
-    (d: string) => d.toUpperCase() === seriesDimensionName.toUpperCase()
-  );
 
   const min = 0;
   const max = attrsForLevel.shape[zIdx] - 1;
@@ -498,20 +515,26 @@ function createLayer(
   source: OmeZarrImageSource,
   region: Region,
   channelProps: ChannelProps[],
-  seriesDimensionName: string,
-  resolutionLevel: number
-): ImageSeriesLayer {
-  // TODO(bchu): Add ImageLayer.
-  return new ImageSeriesLayer({
-    source,
-    region,
-    channelProps,
-    seriesDimensionName,
-    lod: resolutionLevel,
-  });
+  resolutionLevel: number,
+  seriesDimensionName?: string
+): ImageLayer | ImageSeriesLayer {
+  return seriesDimensionName === undefined
+    ? new ImageLayer({
+        source,
+        region,
+        channelProps,
+        lod: resolutionLevel,
+      })
+    : new ImageSeriesLayer({
+        source,
+        region,
+        channelProps,
+        seriesDimensionName,
+        lod: resolutionLevel,
+      });
 }
 
-function zoomToFit(layer: ImageSeriesLayer, runtime: Idetik) {
+function zoomToFit(layer: ImageLayer | ImageSeriesLayer, runtime: Idetik) {
   if (layer.extent) {
     const { x, y } = layer.extent;
     const camera = runtime.camera as OrthographicCamera;

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
@@ -128,7 +128,8 @@ export function OmeZarrImageViewer({
       );
       const { channelProps, extraControlProps } =
         await loadChannelMetadataPromise;
-      const { xUnit, zRange, zValue } = await loadImageMetadataPromise;
+      const { xUnit, zValue, zRange, yCoordRange, xCoordRange } =
+        await loadImageMetadataPromise;
       if (sourceRef.current !== source) {
         return;
       }
@@ -150,7 +151,7 @@ export function OmeZarrImageViewer({
         return;
       }
       runtime.layerManager.add(layer);
-      zoomToFit(layer, runtime);
+      zoomToFit(xCoordRange, yCoordRange, runtime);
       setLoading(false);
       onFirstSliceLoaded?.();
       if (shouldAutoLoadAllSlices) {
@@ -415,8 +416,8 @@ async function loadImageMetadata(
   xUnit?: string;
   zValue: number;
   zRange: [number, number];
-  yRange: [number, number];
-  xRange: [number, number];
+  yCoordRange: [number, number];
+  xCoordRange: [number, number];
 }> {
   const loader = await source.open();
   const attrs = await loader.loadAttributes();
@@ -426,30 +427,45 @@ async function loadImageMetadata(
   // which currently holds with idetik but is fragile.
   const dimensionUnits = attrsForLevel.dimensionUnits;
   const xUnit = dimensionUnits[dimensionUnits.length - 1];
-  
-  const zIdx = attrsForLevel.dimensionNames.findIndex(
-    (d: string) => d.toUpperCase() === seriesDimensionName.toUpperCase()
+
+  const yIdx = attrsForLevel.dimensionNames.findIndex(
+    (d: string) => d.toUpperCase() === "Y"
   );
-  const xRange = [0, attrsForLevel.chunks[]]
-  const yRange = []
+  const xIdx = attrsForLevel.dimensionNames.findIndex(
+    (d: string) => d.toUpperCase() === "X"
+  );
+  const yCoordRange: [number, number] = [
+    0,
+    attrsForLevel.shape[yIdx] * attrsForLevel.scale[xIdx],
+  ];
+  const xCoordRange: [number, number] = [
+    0,
+    attrsForLevel.shape[yIdx] * attrsForLevel.scale[xIdx],
+  ];
 
   if (seriesDimensionName === undefined) {
     return {
       xUnit,
       zValue: 0,
       zRange: [0, 0],
+      yCoordRange,
+      xCoordRange,
     };
   }
 
-
+  const zIdx = attrsForLevel.dimensionNames.findIndex(
+    (d: string) => d.toUpperCase() === seriesDimensionName.toUpperCase()
+  );
   const min = 0;
   const max = attrsForLevel.shape[zIdx] - 1;
 
   if (max - min <= 0) {
     return {
       xUnit,
-      zRange: [0, 0],
       zValue: 0,
+      zRange: [0, 0],
+      yCoordRange,
+      xCoordRange,
     };
   }
 
@@ -506,8 +522,10 @@ async function loadImageMetadata(
 
   return {
     xUnit,
-    zRange: [min, max],
     zValue,
+    zRange: [min, max],
+    yCoordRange,
+    xCoordRange,
   };
 }
 
@@ -534,10 +552,11 @@ function createLayer(
       });
 }
 
-function zoomToFit(layer: ImageLayer | ImageSeriesLayer, runtime: Idetik) {
-  if (layer.extent) {
-    const { x, y } = layer.extent;
-    const camera = runtime.camera as OrthographicCamera;
-    camera?.setFrame(0, x, y, 0);
-  }
+function zoomToFit(
+  xRange: [number, number],
+  yRange: [number, number],
+  runtime: Idetik
+) {
+  const camera = runtime.camera as OrthographicCamera;
+  camera?.setFrame(xRange[0], xRange[1], yRange[1], yRange[0]);
 }

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
@@ -456,6 +456,7 @@ async function loadImageMetadata(
   const zIdx = attrsForLevel.dimensionNames.findIndex(
     (d: string) => d.toUpperCase() === seriesDimensionName.toUpperCase()
   );
+
   const min = 0;
   const max = attrsForLevel.shape[zIdx] - 1;
 

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
@@ -436,11 +436,11 @@ async function loadImageMetadata(
   );
   const yCoordRange: [number, number] = [
     0,
-    attrsForLevel.shape[yIdx] * attrsForLevel.scale[xIdx],
+    attrsForLevel.shape[yIdx] * attrsForLevel.scale[yIdx],
   ];
   const xCoordRange: [number, number] = [
     0,
-    attrsForLevel.shape[yIdx] * attrsForLevel.scale[xIdx],
+    attrsForLevel.shape[xIdx] * attrsForLevel.scale[xIdx],
   ];
 
   if (seriesDimensionName === undefined) {


### PR DESCRIPTION
- Adds `ImageLayer` support.
- This switches from using `layer.extent` to adjust the camera (which doesn't work with `ImageLayer` right now) to just grabbing it from the existing `loadAttributes()` call. It would've been nice to just use `extent` but I'm not sure if/where something like that should belong given the current chunk manager work (I'm not sure if chunk manager really cares what the extent is, only what needs to be loaded? And we were already fetching attributes anyways in `loadImageAttributes()` for other things).
- This also fixes a bug where I referenced `zRange` but forgot that state isn't updated immediately.