### PR TITLE
Refactor camera controls

### DIFF
--- a/packages/core/examples/chunk_streaming/main.ts
+++ b/packages/core/examples/chunk_streaming/main.ts
@@ -43,7 +43,7 @@ const chunkInfoOverlay = new ChunkInfoOverlay({
 new Idetik({
   canvas: document.querySelector<HTMLCanvasElement>("#canvas")!,
   camera,
-  controls: new PanZoomControls(camera, camera.position),
+  cameraControls: new PanZoomControls(camera),
   layers: [imageLayer],
   overlays: [fpsOverlay, chunkInfoOverlay],
 }).start();

--- a/packages/core/examples/image2d_from_omezarr4d_hcs/main.ts
+++ b/packages/core/examples/image2d_from_omezarr4d_hcs/main.ts
@@ -34,11 +34,11 @@ wellPaths.forEach((path) => {
 });
 
 const camera = new OrthographicCamera(0, 840, 0, 360);
-const controls = new PanZoomControls(camera, camera.position);
+const controls = new PanZoomControls(camera);
 const app = new Idetik({
   canvas: document.querySelector<HTMLCanvasElement>("canvas")!,
   camera,
-  controls,
+  cameraControls: controls,
 }).start();
 
 const region: Region = [
@@ -84,7 +84,6 @@ const onImageChange = async () => {
     if (state === "ready" && newLayer.extent) {
       camera.setFrame(0, newLayer.extent.x, 0, newLayer.extent.y);
       camera.update();
-      controls.panTarget = camera.position;
     }
   });
 };

--- a/packages/core/examples/image2d_from_omezarr5d_u16/main.ts
+++ b/packages/core/examples/image2d_from_omezarr5d_u16/main.ts
@@ -39,7 +39,7 @@ const scaleBar = new ScaleBar({
 new Idetik({
   canvas: document.querySelector<HTMLCanvasElement>("canvas")!,
   camera,
-  controls: new PanZoomControls(camera, camera.position),
+  cameraControls: new PanZoomControls(camera),
   layers: [layer, axes],
   overlays: [scaleBar],
 }).start();

--- a/packages/core/examples/image2d_from_omezarr5d_u8/main.ts
+++ b/packages/core/examples/image2d_from_omezarr5d_u8/main.ts
@@ -1,4 +1,3 @@
-import { vec3 } from "gl-matrix";
 import {
   ChannelProps,
   Color,
@@ -6,7 +5,6 @@ import {
   ImageLayer,
   OmeZarrImageSource,
   OrthographicCamera,
-  PerspectiveCamera,
   Region,
 } from "@";
 import { AxesLayer } from "@/layers/axes_layer";
@@ -14,9 +12,7 @@ import { PanZoomControls } from "@/objects/cameras/controls";
 
 const url =
   "https://public.czbiohub.org/royerlab/ultrack/multi-color/image.zarr/";
-const orthoCam = new OrthographicCamera(-2000, 2000, -2000, 2000);
-const cameraPos = vec3.fromValues(0, 0, 5000);
-const perspectiveCam = new PerspectiveCamera({ fov: 60, position: cameraPos });
+const camera = new OrthographicCamera(-2000, 2000, -2000, 2000);
 
 // Source is technically 5D (even though Z is unitary),
 // so provide indices at 3 dimensions to project to 2D.
@@ -36,28 +32,11 @@ const channelProps: ChannelProps[] = [
 ];
 const layer = new ImageLayer({ source, region, channelProps });
 const axes = new AxesLayer({ length: 1920, width: 0.01 });
-const orthoCamControls = new PanZoomControls(orthoCam);
-const perspectiveCamControls = new PanZoomControls(perspectiveCam);
+const cameraControls = new PanZoomControls(camera);
 
-const app = new Idetik({
+new Idetik({
   canvas: document.querySelector<HTMLCanvasElement>("canvas")!,
-  camera: perspectiveCam,
-  cameraControls: perspectiveCamControls,
+  camera,
+  cameraControls,
   layers: [layer, axes],
 }).start();
-
-document.addEventListener("keydown", (event) => {
-  if (event.key === " ") {
-    toggleCamera();
-  }
-});
-
-function toggleCamera() {
-  if (app.camera === orthoCam) {
-    app.camera = orthoCam;
-    app.cameraControls = orthoCamControls;
-  } else {
-    app.camera = perspectiveCam;
-    app.cameraControls = perspectiveCamControls;
-  }
-}

--- a/packages/core/examples/image2d_from_omezarr5d_u8/main.ts
+++ b/packages/core/examples/image2d_from_omezarr5d_u8/main.ts
@@ -42,7 +42,7 @@ const perspectiveCamControls = new PanZoomControls(perspectiveCam);
 const app = new Idetik({
   canvas: document.querySelector<HTMLCanvasElement>("canvas")!,
   camera: perspectiveCam,
-  controls: perspectiveCamControls,
+  cameraControls: perspectiveCamControls,
   layers: [layer, axes],
 }).start();
 
@@ -53,8 +53,11 @@ document.addEventListener("keydown", (event) => {
 });
 
 function toggleCamera() {
-  app.camera = app.camera === orthoCam ? perspectiveCam : orthoCam;
-  app.setControls(
-    app.camera === orthoCam ? orthoCamControls : perspectiveCamControls
-  );
+  if (app.camera === orthoCam) {
+    app.camera = orthoCam;
+    app.cameraControls = orthoCamControls;
+  } else {
+    app.camera = perspectiveCam;
+    app.cameraControls = perspectiveCamControls;
+  }
 }

--- a/packages/core/examples/image_labels_overlay_with_value_picking/main.ts
+++ b/packages/core/examples/image_labels_overlay_with_value_picking/main.ts
@@ -113,7 +113,7 @@ const idetik = new Idetik({
   canvas,
   camera,
   layers: [imageLayer, labelsLayer],
-  controls: new PanZoomControls(camera, camera.position),
+  cameraControls: new PanZoomControls(camera),
 });
 
 idetik.start();

--- a/packages/core/examples/image_mask_overlay/main.ts
+++ b/packages/core/examples/image_mask_overlay/main.ts
@@ -103,7 +103,7 @@ imageLayer.setIndex(zSlider.valueAsNumber);
 const setCameraFrame = (newState: LayerState) => {
   if (newState === "ready" && imageLayer.extent !== undefined) {
     camera.setFrame(0, imageLayer.extent.x, 0, imageLayer.extent.y);
-    app.setControls(new PanZoomControls(camera, camera.position));
+    app.cameraControls = new PanZoomControls(camera);
     camera.update();
     // remove the callback to only set the camera frame once
     imageLayer.removeStateChangeCallback(setCameraFrame);

--- a/packages/core/examples/points/main.ts
+++ b/packages/core/examples/points/main.ts
@@ -224,7 +224,7 @@ const app = new Idetik({
 const onFirstImageLoad = (newState: LayerState) => {
   if (newState === "ready" && imageLayer.extent !== undefined) {
     camera.setFrame(0, imageLayer.extent.x, 0, imageLayer.extent.y);
-    app.setControls(new PanZoomControls(camera, camera.position));
+    app.cameraControls = new PanZoomControls(camera);
     camera.update();
 
     app.layerManager.add(ribosomes);

--- a/packages/core/examples/tracks/main.ts
+++ b/packages/core/examples/tracks/main.ts
@@ -119,6 +119,6 @@ camera.zoom(0.5);
 new Idetik({
   canvas: document.querySelector<HTMLCanvasElement>("canvas")!,
   camera,
-  controls: new PanZoomControls(camera, camera.position),
+  cameraControls: new PanZoomControls(camera),
   layers: [imageSeriesLayer, lineLayer],
 }).start();

--- a/packages/core/src/core/event_dispatcher.ts
+++ b/packages/core/src/core/event_dispatcher.ts
@@ -19,6 +19,7 @@ export class EventContext {
   readonly event: Event;
   private propagationStopped_: boolean = false;
   public worldPos?: vec3;
+  public clipPos?: vec3;
 
   constructor(type: EventType, event: Event) {
     this.type = type;

--- a/packages/core/src/core/renderer.ts
+++ b/packages/core/src/core/renderer.ts
@@ -1,8 +1,6 @@
-import { vec2, vec3 } from "gl-matrix";
 import { LayerManager } from "./layer_manager";
 import { Camera } from "../objects/cameras/camera";
 import { Color, ColorLike } from "./color";
-import { CameraControls, NullControls } from "../objects/cameras/controls";
 import { Layer } from "./layer";
 
 export abstract class Renderer {
@@ -11,8 +9,6 @@ export abstract class Renderer {
   private height_ = 0;
   private backgroundColor_: Color = new Color(0, 0, 0, 0);
   private activeCamera_: Camera | null = null;
-  private controls_: CameraControls = new NullControls();
-  private controlCallbacks_: [string, (event: Event) => void][] = [];
 
   protected abstract resize(width: number, height: number): void;
   protected abstract renderObject(layer: Layer, objectIndex: number): void;
@@ -35,30 +31,6 @@ export abstract class Renderer {
   public updateSize(): void {
     this.updateRendererSize();
     this.resize(this.width_, this.height_);
-  }
-
-  public setControls(controls: CameraControls) {
-    this.unbindControls();
-    this.controls_ = controls;
-    this.bindControls();
-  }
-
-  private unbindControls() {
-    this.controlCallbacks_.forEach(([event, listener]) => {
-      this.canvas.removeEventListener(event, listener);
-    });
-    this.controlCallbacks_ = [];
-  }
-
-  private bindControls() {
-    const clientToClip = this.clientToClip.bind(this);
-    this.controlCallbacks_ = this.controls_.callbacks(
-      this.canvas,
-      clientToClip
-    );
-    this.controlCallbacks_.forEach(([event, listener]) => {
-      this.canvas.addEventListener(event, listener, { passive: false });
-    });
   }
 
   private updateRendererSize() {
@@ -105,15 +77,5 @@ export abstract class Renderer {
       );
     }
     return this.activeCamera_;
-  }
-
-  public clientToClip(position: vec2, depth: number = 0): vec3 {
-    const [x, y] = position;
-    const rect = this.canvas.getBoundingClientRect();
-    return vec3.fromValues(
-      (2 * (x - rect.x)) / this.canvas.clientWidth - 1,
-      (2 * (y - rect.y)) / this.canvas.clientHeight - 1,
-      depth
-    );
   }
 }

--- a/packages/core/src/core/transforms.ts
+++ b/packages/core/src/core/transforms.ts
@@ -1,7 +1,4 @@
-import { mat4, vec3, quat, vec2 } from "gl-matrix";
-
-export type ClientToClip = (clientPos: vec2, depth?: number) => vec3;
-export type ClientToWorld = (clientPos: vec2, depth?: number) => vec3;
+import { mat4, vec3, quat } from "gl-matrix";
 
 export class TrsTransform {
   private dirty_ = true;

--- a/packages/core/src/idetik.ts
+++ b/packages/core/src/idetik.ts
@@ -16,7 +16,7 @@ type IdetikParams = {
   canvas?: HTMLCanvasElement;
   canvasSelector?: string;
   camera: Camera;
-  controls?: CameraControls;
+  cameraControls?: CameraControls;
   layers?: Layer[];
   overlays?: Overlay[];
 };
@@ -28,6 +28,7 @@ export type IdetikContext = {
 export class Idetik {
   public layerManager: LayerManager;
   public camera: Camera;
+  private cameraControls_?: CameraControls;
   public readonly canvas: HTMLCanvasElement;
   public readonly overlays: Overlay[];
   private readonly eventDispatcher_: EventDispatcher;
@@ -46,6 +47,7 @@ export class Idetik {
     }
 
     this.camera = params.camera;
+    this.cameraControls_ = params.cameraControls;
     const canvas =
       params.canvas ??
       document.querySelector<HTMLCanvasElement>(params.canvasSelector!);
@@ -60,11 +62,6 @@ export class Idetik {
     };
     this.layerManager = new LayerManager(this.context_);
 
-    if (params.controls) {
-      // TODO: move controls to the idetik class
-      this.renderer_.setControls(params.controls);
-    }
-
     if (params.layers) {
       for (const layer of params.layers) {
         this.layerManager.add(layer);
@@ -75,22 +72,20 @@ export class Idetik {
 
     this.eventDispatcher_ = new EventDispatcher(canvas);
     this.eventDispatcher_.addEventListener((event: EventContext) => {
-      if (event.event instanceof PointerEvent) {
-        const client = vec2.fromValues(
-          event.event.clientX,
-          event.event.clientY
-        );
-        Object.defineProperties(event, {
-          worldPos: {
-            get: () => this.camera.clipToWorld(this.clientToClip(client, 0)),
-          },
-        });
+      if (
+        event.event instanceof PointerEvent ||
+        event.event instanceof WheelEvent
+      ) {
+        const { clientX, clientY } = event.event;
+        const client = vec2.fromValues(clientX, clientY);
+        event.clipPos = this.clientToClip(client, 0);
+        event.worldPos = this.camera.clipToWorld(event.clipPos);
       }
       for (const layer of this.layerManager.layers) {
         layer.onEvent(event);
         if (event.propagationStopped) return;
       }
-      // TODO: pass event to camera controls if needed
+      this.cameraControls_?.onEvent(event);
     });
   }
 
@@ -102,16 +97,18 @@ export class Idetik {
     return this.renderer_.height;
   }
 
-  // TODO: this should be modified once the controls are moved to the idetik class
-  public setControls(controls: CameraControls) {
-    this.renderer_.setControls(controls);
+  public set cameraControls(controls: CameraControls | undefined) {
+    this.cameraControls_ = controls;
   }
 
-  // TODO: this can be moved directly to this class, but will need access to (and possibly expose)
-  // the canvas element
-  // let's do it at the same time `setControls` is moved to this class
   public clientToClip(position: vec2, depth: number = 0): vec3 {
-    return this.renderer_.clientToClip(position, depth);
+    const [x, y] = position;
+    const rect = this.canvas.getBoundingClientRect();
+    return vec3.fromValues(
+      (2 * (x - rect.x)) / this.canvas.clientWidth - 1,
+      (2 * (y - rect.y)) / this.canvas.clientHeight - 1,
+      depth
+    );
   }
 
   public start() {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,7 +3,7 @@ export { Idetik } from "./idetik";
 export { WebGLRenderer } from "./renderers/webgl_renderer";
 export { OrthographicCamera } from "./objects/cameras/orthographic_camera";
 export { PerspectiveCamera } from "./objects/cameras/perspective_camera";
-export { NullControls, PanZoomControls } from "./objects/cameras/controls";
+export { PanZoomControls } from "./objects/cameras/controls";
 export type { CameraControls } from "./objects/cameras/controls";
 
 export { Layer } from "./core/layer";
@@ -34,7 +34,6 @@ export type {
 
 export { Color } from "./core/color";
 export type { ColorLike } from "./core/color";
-export type { ClientToClip } from "./core/transforms";
 export type { ChannelProps, ChannelsEnabled } from "./objects/textures/channel";
 
 export { Points } from "./objects/renderable/points";

--- a/packages/core/src/layers/label_image_layer.ts
+++ b/packages/core/src/layers/label_image_layer.ts
@@ -107,7 +107,6 @@ export class LabelImageLayer extends Layer {
 
           if (value !== null) {
             this.onPickValue_({ world, value });
-            event.stopPropagation();
           }
         }
         break;

--- a/packages/core/src/objects/cameras/controls.ts
+++ b/packages/core/src/objects/cameras/controls.ts
@@ -1,5 +1,5 @@
 import { vec3 } from "gl-matrix";
-import { Camera } from "./camera";
+import { OrthographicCamera } from "./orthographic_camera";
 import { EventContext } from "../../core/event_dispatcher";
 
 const LEFT_MOUSE_BUTTON = 0;
@@ -9,11 +9,11 @@ export interface CameraControls {
 }
 
 export class PanZoomControls implements CameraControls {
-  private readonly camera_: Camera;
+  private readonly camera_: OrthographicCamera;
   private dragActive_ = false;
   private dragStart_: vec3 = vec3.create();
 
-  constructor(camera: Camera) {
+  constructor(camera: OrthographicCamera) {
     this.camera_ = camera;
   }
 

--- a/packages/core/src/objects/cameras/controls.ts
+++ b/packages/core/src/objects/cameras/controls.ts
@@ -1,138 +1,81 @@
-import { vec2, vec3 } from "gl-matrix";
+import { vec3 } from "gl-matrix";
 import { Camera } from "./camera";
-import { ClientToClip, ClientToWorld } from "../../core/transforms";
+import { EventContext } from "../../core/event_dispatcher";
+
+const LEFT_MOUSE_BUTTON = 0;
 
 export interface CameraControls {
-  callbacks(
-    target: EventTarget,
-    clientToClip: ClientToClip
-  ): [string, EventListener][];
-}
-
-export class NullControls implements CameraControls {
-  public callbacks(
-    _target: EventTarget,
-    _clientToClip: ClientToClip
-  ): [string, EventListener][] {
-    return [];
-  }
+  onEvent(event: EventContext): void;
 }
 
 export class PanZoomControls implements CameraControls {
-  private camera_: Camera;
-  private panTarget_: vec3;
+  private readonly camera_: Camera;
+  private dragActive_ = false;
+  private dragStart_: vec3 = vec3.create();
 
-  constructor(camera: Camera, panTarget: vec3 = vec3.fromValues(0, 0, 0)) {
+  constructor(camera: Camera) {
     this.camera_ = camera;
-    this.panTarget_ = panTarget;
   }
 
-  public callbacks(
-    target: EventTarget,
-    clientToClip: ClientToClip
-  ): [string, EventListener][] {
-    const clientToWorld: ClientToWorld = (clientPos, depth) => {
-      const clipPos = clientToClip(clientPos, depth);
-      return this.camera_.clipToWorld(clipPos);
-    };
-    return [
-      [
-        "wheel",
-        (event: Event) => this.wheel(event as WheelEvent, clientToWorld),
-      ],
-      [
-        "pointerdown",
-        (event: Event) =>
-          this.pointerdown(event as PointerEvent, target, clientToWorld),
-      ],
-    ];
-  }
-
-  private wheel(event: WheelEvent, clientToWorld: ClientToWorld) {
-    event.preventDefault();
-    const clientPos = vec2.fromValues(event.clientX, event.clientY);
-    const preZoomPos = clientToWorld(clientPos, this.clipDepth);
-    const zoomFactor = 1.05;
-    if (event.deltaY < 0) {
-      this.camera_.zoom(zoomFactor);
-    } else {
-      this.camera_.zoom(1.0 / zoomFactor);
-    }
-    // pan to zoom in on the mouse position
-    const postZoomPos = clientToWorld(clientPos, this.clipDepth);
-    const deltaWorld = vec3.sub(vec3.create(), preZoomPos, postZoomPos);
-    this.pan(deltaWorld);
-  }
-
-  private pointerdown(
-    event: PointerEvent,
-    target: EventTarget,
-    clientToWorld: ClientToWorld
-  ) {
-    if (event.button !== 0) {
-      return;
-    }
-
-    const clientStart = vec2.fromValues(event.clientX, event.clientY);
-    const worldStart = clientToWorld(clientStart, this.clipDepth);
-    const pointerId = event.pointerId;
-
-    // capture the pointer to ensure we receive events even when outside the element
-    if (target instanceof Element) {
-      target.setPointerCapture(pointerId);
-    }
-
-    const onPointerMove = (event: Event) => {
-      if (!(event instanceof PointerEvent) || event.pointerId !== pointerId) {
-        return;
+  public onEvent(event: EventContext): void {
+    switch (event.type) {
+      case "wheel":
+        this.onWheel(event);
+        break;
+      case "pointerdown":
+        this.onPointerDown(event);
+        break;
+      case "pointermove":
+        this.onPointerMove(event);
+        break;
+      case "pointerup":
+      case "pointercancel":
+        this.onPointerEnd(event);
+        break;
+      default: {
+        const exhaustiveCheck: never = event.type;
+        throw new Error(`Unknown event type: ${exhaustiveCheck}`);
       }
-      const clientPos = vec2.fromValues(event.clientX, event.clientY);
-      const worldPos = clientToWorld(clientPos, this.clipDepth);
-      const deltaWorld = vec3.sub(vec3.create(), worldStart, worldPos);
-      this.pan(deltaWorld);
-    };
-
-    const onPointerUp = (event: Event) => {
-      if (!(event instanceof PointerEvent) || event.pointerId !== pointerId) {
-        return;
-      }
-      target.removeEventListener("pointermove", onPointerMove);
-      target.removeEventListener("pointerup", onPointerUp);
-      target.removeEventListener("pointercancel", onPointerUp);
-
-      if (target instanceof Element) {
-        target.releasePointerCapture(pointerId);
-      }
-    };
-
-    target.addEventListener("pointermove", onPointerMove);
-    target.addEventListener("pointerup", onPointerUp);
-    target.addEventListener("pointercancel", onPointerUp);
+    }
   }
 
-  private pan(deltaWorld: vec3) {
-    this.camera_.pan(deltaWorld);
-    vec3.add(this.panTarget_, this.panTarget_, deltaWorld);
+  private onWheel(event: EventContext) {
+    if (!event.worldPos || !event.clipPos) return;
+    const e = event.event as WheelEvent;
+
+    const posBeforeZoom = vec3.clone(event.worldPos);
+    const zoomFactor = e.deltaY < 0 ? 1.05 : 0.95;
+
+    this.camera_.zoom(zoomFactor);
+
+    const posAfterZoom = this.camera_.clipToWorld(event.clipPos);
+    const delta = vec3.sub(vec3.create(), posBeforeZoom, posAfterZoom);
+    this.camera_.pan(delta);
   }
 
-  public set panTarget(panTarget: vec3) {
-    this.panTarget_ = panTarget;
+  private onPointerDown(event: EventContext) {
+    const e = event.event as PointerEvent;
+    if (!event.worldPos || e.button !== LEFT_MOUSE_BUTTON) return;
+
+    this.dragStart_ = vec3.clone(event.worldPos);
+    this.dragActive_ = true;
+
+    (e.target as Element)?.setPointerCapture?.(e.pointerId);
   }
 
-  private get clipDepth() {
-    const targetToPosition = vec3.sub(
-      vec3.create(),
-      this.panTarget_,
-      this.camera_.position
-    );
-    const projectedViewVector = vec3.transformMat4(
-      vec3.create(),
-      targetToPosition,
-      this.camera_.projectionMatrix
-    );
-    // TODO: the distance should be projected onto the camera's view
-    // normal when we start rotating cameras
-    const distance = vec3.length(projectedViewVector);
-    return distance;
+  private onPointerMove(event: EventContext) {
+    if (!this.dragActive_ || !event.worldPos) return;
+
+    const delta = vec3.sub(vec3.create(), this.dragStart_, event.worldPos);
+    this.camera_.pan(delta);
+  }
+
+  private onPointerEnd(event: EventContext) {
+    const e = event.event as PointerEvent;
+    if (!this.dragActive_ || e.button !== LEFT_MOUSE_BUTTON) return;
+
+    this.dragActive_ = false;
+
+    (e.target as Element)?.releasePointerCapture?.(e.pointerId);
   }
 }

--- a/packages/react/src/components/providers/IdetikProvider.tsx
+++ b/packages/react/src/components/providers/IdetikProvider.tsx
@@ -11,11 +11,11 @@ export const IdetikProvider = ({ children }: PropsWithChildren) => {
     runtime: null,
     initializeWithCanvas: (canvas: HTMLCanvasElement) => {
       const camera = new OrthographicCamera(0, 128, 0, 128, -1000, 1000);
-      const controls = new PanZoomControls(camera, camera.position);
+      const cameraControls = new PanZoomControls(camera);
       const newIdetik = new Idetik({
         canvas,
         camera,
-        controls,
+        cameraControls,
       });
       newIdetik.start();
       setIdetikContext({

--- a/packages/ultrack-prototype/frontend/components/Renderer.tsx
+++ b/packages/ultrack-prototype/frontend/components/Renderer.tsx
@@ -6,8 +6,6 @@ import {
   OrthographicCamera,
   TracksLayer,
   WebGLRenderer,
-  NullControls,
-  PanZoomControls,
 } from "@idetik/core";
 
 // TODO: imageURL should come from the server (probably with each task)
@@ -19,7 +17,6 @@ const canvasId = "canvas";
 
 // TODO: consider useRef for these objects
 const camera = new OrthographicCamera(0, 1920, 0, 1440);
-const controls = new PanZoomControls(camera, camera.position);
 const layerManager = new LayerManager();
 
 export default function Renderer({
@@ -66,7 +63,6 @@ export default function Renderer({
       const extent = tracksLayer.extent;
       camera.setFrame(extent.xMin, extent.xMax, extent.yMax, extent.yMin);
       camera.zoom(0.25);
-      controls.panTarget = camera.position;
     };
     if (imageSeriesLayer.state === "ready") {
       onReady();
@@ -90,7 +86,6 @@ export default function Renderer({
     let lastRequestId = 0;
     const canvas = document.querySelector<HTMLCanvasElement>(`#${canvasId}`)!;
     const renderer = new WebGLRenderer(canvas);
-    renderer.setControls(controls);
     function animate() {
       renderer.render(layerManager, camera);
       lastRequestId = requestAnimationFrame(animate);
@@ -98,7 +93,6 @@ export default function Renderer({
     animate();
     return () => {
       // TODO: cleanup by disposing objects owned by the renderer and camera.
-      renderer.setControls(new NullControls());
       if (lastRequestId > 0) {
         console.debug(`Cancelling animation frame ${lastRequestId}`);
         cancelAnimationFrame(lastRequestId);


### PR DESCRIPTION
### Summary

This PR refactors the camera controls with the following changes:
- Rewrites the `PanZoomControls` logic for clarity and simplicity.
- Moves camera controls out of the renderer and into the runtime, improving separation of concerns.
- Replaces internal event handling with the centralized event dispatcher workflow.
- Removes unused functions and types for a leaner implementation.

### Notes

- @aganders3 I wasn’t entirely sure about the original rationale behind some of the design choices, so I took the liberty of rewriting the implementation in a way that seemed more straightforward to me. This refactor significantly reduced code complexity without breaking any functionality (I think?). I’d appreciate a close review to make sure I didn’t miss any edge cases or design constraints.
- FWIW zooming toward the cursor feels unnatural to me, probably because it's uncommon in typical 3D navigation controls. I generally expect zooming to be centered on the screen, which would also simplify some of this logic.

### Tests & Checks

- Manual verification
- All checks are passing

https://github.com/user-attachments/assets/117d70f2-1a9b-4840-ab6a-16aaf6087896
