### PR TITLE
(Small) Fix incorrect visible bounds comparison in ChunkManager

### DIFF
--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -152,12 +152,8 @@ export class ChunkManagerSource {
   public update(lodFactor: number, visibleBounds: Bounds) {
     this.setLOD(lodFactor);
 
-    if (visibleBounds !== this.lastVisibleBounds_) {
+    if (this.visibleBoundsChanged(visibleBounds)) {
       this.updateChunkVisibility(visibleBounds);
-      this.lastVisibleBounds_ = {
-        min: vec2.clone(visibleBounds.min),
-        max: vec2.clone(visibleBounds.max),
-      };
     }
 
     this.loadVisibleChunks();
@@ -249,6 +245,23 @@ export class ChunkManagerSource {
         );
       }
     }
+  }
+
+  private visibleBoundsChanged(newBounds: Bounds): boolean {
+    const prev = this.lastVisibleBounds_;
+    const changed =
+      prev === null ||
+      !vec2.equals(prev.min, newBounds.min) ||
+      !vec2.equals(prev.max, newBounds.max);
+
+    if (changed) {
+      this.lastVisibleBounds_ = {
+        min: vec2.clone(newBounds.min),
+        max: vec2.clone(newBounds.max),
+      };
+    }
+
+    return changed;
   }
 }
 


### PR DESCRIPTION
### Summary

This PR resolves a bug where the `ChunkManager` always detected changes in
visible bounds, even when none occurred. The issue was caused by comparing
deep-copied `vec2` objects by reference instead of by value.

### Tests & Checks
- Manual verification
- All checks have passed
