### PR TITLE
Ignore all coverage sub-directories for linting

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -43,5 +43,5 @@ export default [
       ],
     }
   },
-  { ignores: ["node_modules", "coverage", "**/dist"] },
+  { ignores: ["node_modules", "**/coverage", "**/dist"] },
 ];


### PR DESCRIPTION
### Summary
This change changes the ignore list in the eslint configuration file to ignore all sub-directories named `coverage`. 

### Related Issue
Closes #354

### Tests & Checks
In `packages/core`, I ran `npm run test-with-coverage` followed by `npm run lint`.

Before this PR, I get two warnings. After this PR, I get no warnings. On CI, we run the linter before the tests, so do not see this error.
