### PR TITLE
Fix chunk visibility bounds check

### DIFF
--- a/packages/core/examples/image2d_from_omezarr5d_u8/main.ts
+++ b/packages/core/examples/image2d_from_omezarr5d_u8/main.ts
@@ -10,7 +10,8 @@ import {
 import { AxesLayer } from "@/layers/axes_layer";
 import { PanZoomControls } from "@/objects/cameras/controls";
 
-const url = "https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.4/96x0/marmoset_neurons.ome.zarr";
+const url =
+  "https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.4/96x0/marmoset_neurons.ome.zarr";
 const source = new OmeZarrImageSource(url);
 const loader = await source.open();
 const attributes = await loader.loadAttributes();
@@ -45,12 +46,15 @@ const channelProps: ChannelProps[] = [
   },
 ];
 const layer = new ImageLayer({ source, region, channelProps });
-const axes = new AxesLayer({ length: 0.75 * xInfo.scale * xInfo.size, width: 0.01 });
+const axes = new AxesLayer({
+  length: 0.75 * xInfo.scale * xInfo.size,
+  width: 0.01,
+});
 const camera = new OrthographicCamera(
   xInfo.offset,
   xInfo.offset + xInfo.scale * xInfo.size,
   yInfo.offset,
-  yInfo.offset + yInfo.scale * yInfo.size,
+  yInfo.offset + yInfo.scale * yInfo.size
 );
 
 new Idetik({

--- a/packages/core/examples/image2d_from_omezarr5d_u8/main.ts
+++ b/packages/core/examples/image2d_from_omezarr5d_u8/main.ts
@@ -56,10 +56,11 @@ const camera = new OrthographicCamera(
   yInfo.offset,
   yInfo.offset + yInfo.scale * yInfo.size
 );
+const cameraControls = new PanZoomControls(camera);
 
 new Idetik({
   canvas: document.querySelector<HTMLCanvasElement>("canvas")!,
   camera,
-  cameraControls: new PanZoomControls(camera),
+  cameraControls,
   layers: [layer, axes],
 }).start();

--- a/packages/core/examples/image2d_from_omezarr5d_u8/main.ts
+++ b/packages/core/examples/image2d_from_omezarr5d_u8/main.ts
@@ -1,4 +1,3 @@
-import { vec3 } from "gl-matrix";
 import {
   ChannelProps,
   Color,
@@ -6,55 +5,61 @@ import {
   ImageLayer,
   OmeZarrImageSource,
   OrthographicCamera,
-  PerspectiveCamera,
   Region,
 } from "@";
 import { AxesLayer } from "@/layers/axes_layer";
 import { PanZoomControls } from "@/objects/cameras/controls";
 
-const url =
-  "https://public.czbiohub.org/royerlab/ultrack/multi-color/image.zarr/";
-const orthoCam = new OrthographicCamera(-2000, 2000, -2000, 2000);
-const cameraPos = vec3.fromValues(0, 0, 5000);
-const perspectiveCam = new PerspectiveCamera({ fov: 60, position: cameraPos });
-
-// Source is technically 5D (even though Z is unitary),
-// so provide indices at 3 dimensions to project to 2D.
+const url = "https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.4/96x0/marmoset_neurons.ome.zarr";
 const source = new OmeZarrImageSource(url);
+const loader = await source.open();
+const attributes = await loader.loadAttributes();
+const attributesAtLod0 = attributes[0];
+
+const dimensionInfo = (dimensionName: string) => {
+  const index = attributesAtLod0.dimensionNames.findIndex(
+    (d) => d === dimensionName
+  );
+  return {
+    size: attributesAtLod0.shape[index],
+    scale: attributesAtLod0.scale[index],
+    offset: attributesAtLod0.translation[index],
+  };
+};
+
+const zInfo = dimensionInfo("z");
+const zMidPoint = zInfo.offset + 0.5 * zInfo.size * zInfo.scale;
+const yInfo = dimensionInfo("y");
+const xInfo = dimensionInfo("x");
+
 const region: Region = [
-  { dimension: "T", index: { type: "point", value: 150 } },
-  { dimension: "C", index: { type: "point", value: 0 } },
-  { dimension: "Z", index: { type: "point", value: 0 } },
-  { dimension: "Y", index: { type: "full" } },
-  { dimension: "X", index: { type: "full" } },
+  { dimension: "z", index: { type: "point", value: zMidPoint } },
+  { dimension: "y", index: { type: "full" } },
+  { dimension: "x", index: { type: "full" } },
 ];
 const channelProps: ChannelProps[] = [
   {
-    color: Color.GREEN,
-    contrastLimits: [0, 128],
+    visible: true,
+    color: Color.WHITE,
+    contrastLimits: [0, 200],
   },
 ];
 const layer = new ImageLayer({ source, region, channelProps });
-const axes = new AxesLayer({ length: 1920, width: 0.01 });
-const orthoCamControls = new PanZoomControls(orthoCam);
-const perspectiveCamControls = new PanZoomControls(perspectiveCam);
+const axes = new AxesLayer({ length: 0.75 * xInfo.scale * xInfo.size, width: 0.01 });
+const camera = new OrthographicCamera(
+  xInfo.offset,
+  xInfo.offset + xInfo.scale * xInfo.size,
+  yInfo.offset,
+  yInfo.offset + yInfo.scale * yInfo.size,
+);
+const controls = new PanZoomControls(camera, camera.position);
 
-const app = new Idetik({
+console.debug(camera);
+console.debug(xInfo, yInfo, zInfo);
+
+new Idetik({
   canvas: document.querySelector<HTMLCanvasElement>("canvas")!,
-  camera: perspectiveCam,
-  controls: perspectiveCamControls,
+  camera,
+  controls,
   layers: [layer, axes],
-}).start();
-
-document.addEventListener("keydown", (event) => {
-  if (event.key === " ") {
-    toggleCamera();
-  }
 });
-
-function toggleCamera() {
-  app.camera = app.camera === orthoCam ? perspectiveCam : orthoCam;
-  app.setControls(
-    app.camera === orthoCam ? orthoCamControls : perspectiveCamControls
-  );
-}

--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -67,6 +67,8 @@ export class ChunkManagerSource {
         this.attrs_[lod].shape.length === 3
           ? this.attrs_[lod].shape[this.channelIdx_]
           : 1;
+      const scale = this.attrs_[lod].scale;
+      const translation = this.attrs_[lod].translation;
       for (let x = 0; x < chunksX; ++x) {
         for (let y = 0; y < chunksY; ++y) {
           this.chunks_.push({
@@ -82,12 +84,12 @@ export class ChunkManagerSource {
             rowAlignmentBytes: 1,
             chunkIndex: { x, y },
             scale: {
-              x: this.attrs_[lod].scale[this.xIdx_],
-              y: this.attrs_[lod].scale[this.yIdx_],
+              x: scale[this.xIdx_],
+              y: scale[this.yIdx_],
             },
             offset: {
-              x: x * chunkWidth * this.attrs_[lod].scale[this.xIdx_],
-              y: y * chunkHeight * this.attrs_[lod].scale[this.yIdx_],
+              x: translation[this.xIdx_] + x * chunkWidth * scale[this.xIdx_],
+              y: translation[this.yIdx_] + y * chunkHeight * scale[this.yIdx_],
             },
           });
         }
@@ -200,34 +202,26 @@ export class ChunkManagerSource {
       return;
     }
 
+    const boundsMinX = visibleBounds.min[0];
+    const boundsMaxX = visibleBounds.max[0];
+    const boundsMinY = visibleBounds.min[1];
+    const boundsMaxY = visibleBounds.max[1];
+
     for (const chunk of this.chunks_) {
       if (!chunk.chunkIndex) {
         chunk.visible = false;
         continue;
       }
+      const chunkMinX = chunk.offset.x;
+      const chunkMaxX = chunkMinX + chunk.shape.x * chunk.scale.x;
+      const chunkMinY = chunk.offset.y;
+      const chunkMaxY = chunkMinY + chunk.shape.y * chunk.scale.y;
 
-      const chunkVirtualWidth = chunk.shape.x * chunk.scale.x;
-      const chunkVirtualHeight = chunk.shape.y * chunk.scale.y;
-
-      const minChunkIndexX = Math.floor(
-        visibleBounds.min[0] / chunkVirtualWidth
-      );
-      const maxChunkIndexX = Math.ceil(
-        visibleBounds.max[0] / chunkVirtualWidth
-      );
-      const minChunkIndexY = Math.floor(
-        visibleBounds.min[1] / chunkVirtualHeight
-      );
-      const maxChunkIndexY = Math.ceil(
-        visibleBounds.max[1] / chunkVirtualHeight
-      );
-
-      const { x, y } = chunk.chunkIndex;
       chunk.visible =
-        x >= minChunkIndexX &&
-        x <= maxChunkIndexX &&
-        y >= minChunkIndexY &&
-        y <= maxChunkIndexY;
+        chunkMinX <= boundsMaxX &&
+        chunkMaxX >= boundsMinX &&
+        chunkMinY <= boundsMaxY &&
+        chunkMaxY >= boundsMinY;
     }
   }
 

--- a/packages/core/src/data/image_chunk.ts
+++ b/packages/core/src/data/image_chunk.ts
@@ -68,6 +68,7 @@ export type LoaderAttributes = {
   dimensionUnits: (string | undefined)[];
   shape: readonly number[];
   scale: readonly number[];
+  translation: readonly number[];
 };
 
 export type ImageChunkLoader = {

--- a/packages/core/src/data/ome_zarr_image_loader.ts
+++ b/packages/core/src/data/ome_zarr_image_loader.ts
@@ -143,7 +143,11 @@ export class OmeZarrImageLoader {
 
     const calculateOffset = (i: number) => {
       const index = indices[i];
-      if (typeof index === "number" || index.start === null) return 0;
+      if (typeof index === "number") {
+        return index * scale[i] + translation[i];
+      } else if (index.start === null) {
+        return translation[i];
+      }
       return index.start * scale[i] + translation[i];
     };
     const xOffset = calculateOffset(indices.length - 1);
@@ -213,6 +217,7 @@ export class OmeZarrImageLoader {
           dimensionUnits: attr.dimensionUnits,
           shape: zarrArray.shape,
           scale: attr.scale,
+          translation: attr.translation,
         };
       })
     );
@@ -273,11 +278,11 @@ export class OmeZarrImageLoader {
         // null slice is the complete extent of a dimension like Python's `slice(None)`.
         index = zarr.slice(null);
       } else if (regionIndex.type === "point") {
-        index = Math.round(translation[i] + regionIndex.value / scale[i]);
+        index = Math.round((regionIndex.value - translation[i]) / scale[i]);
       } else {
         index = zarr.slice(
-          Math.floor(translation[i] + regionIndex.start / scale[i]),
-          Math.ceil(translation[i] + regionIndex.stop / scale[i])
+          Math.floor((regionIndex.start - translation[i]) / scale[i]),
+          Math.ceil((regionIndex.stop - translation[i]) / scale[i])
         );
       }
       indices.push(index);


### PR DESCRIPTION
### Summary
This fixes the visibility bounds check in the chunk manager, as well as a bug in how we handle translations in OME-Zarr metadata and the ultimate conversion to integer indices for an array at some multiscale level.

### Related Issue
Closes #355 

### Tests & Checks
I tested the existing examples to ensure they continue to work as expected.
I modified one of the existing examples to use OME-Zarr data that includes a translation to test that this fix also works when the underlying data contains an offset.
