### PR TITLE
Add prefetching on X/Y axes

### DIFF
--- a/packages/core/examples/chunk_streaming/chunk_info_overlay.ts
+++ b/packages/core/examples/chunk_streaming/chunk_info_overlay.ts
@@ -8,8 +8,8 @@ export interface ChunkInfoOverlayOptions {
 }
 
 export class ChunkInfoOverlay {
-  private textDiv_: HTMLDivElement;
-  private imageLayer_: ImageLayer;
+  private readonly textDiv_: HTMLDivElement;
+  private readonly imageLayer_: ImageLayer;
 
   constructor({ textDiv, imageLayer }: ChunkInfoOverlayOptions) {
     this.textDiv_ = textDiv;
@@ -17,31 +17,25 @@ export class ChunkInfoOverlay {
   }
 
   public update(_idetik: Idetik, _timestamp?: DOMHighResTimeStamp): void {
-    // Access the chunk manager source through the image layer
     const chunkManagerSource = this.imageLayer_.chunkManagerSource;
-
     if (!chunkManagerSource) {
       this.textDiv_.textContent = "No chunk manager source";
       return;
     }
 
-    const visibleChunks = chunkManagerSource.getChunks();
-    const allChunks = chunkManagerSource.allChunks;
-
+    const allChunks = chunkManagerSource.chunks;
     if (!allChunks) {
       this.textDiv_.textContent = "No chunks available";
       return;
     }
 
+    const chunkDetails: string[] = [];
+    const currentLOD = chunkManagerSource.currentLOD;
+    const renderedChunks = chunkManagerSource.getChunks();
     const totalChunks = allChunks.length;
+
     let loadedChunks = 0;
     let loadingChunks = 0;
-    const chunkDetails: string[] = [];
-
-    // Get the actual current LOD from the chunk manager source
-    const currentLOD = chunkManagerSource.currentLOD;
-
-    // Count chunks by state
     allChunks.forEach((chunk: ImageChunk) => {
       if (chunk.state === "loaded") {
         loadedChunks++;
@@ -50,54 +44,47 @@ export class ChunkInfoOverlay {
       }
     });
 
-    // Group chunks by LOD and count visible/rendered per LOD
-    const lodStats = new Map<number, { visible: number; rendered: number }>();
+    const lodCounters: {
+      visible: number;
+      rendered: number;
+      prefetched: number;
+    }[] = Array.from({ length: chunkManagerSource.lodCount }, () => ({
+      visible: 0,
+      rendered: 0,
+      prefetched: 0,
+    }));
 
-    // Count visible chunks per LOD
     allChunks.forEach((chunk: ImageChunk) => {
-      if (chunk.visible) {
-        const lod = chunk.lod;
-        if (!lodStats.has(lod)) {
-          lodStats.set(lod, { visible: 0, rendered: 0 });
-        }
-        lodStats.get(lod)!.visible++;
+      if (chunk.visible) lodCounters[chunk.lod].visible++;
+      // Prefetched chunks are only counted for the current LOD,
+      // since higher/lower LODs are not actively rendered.
+      if (chunk.lod === currentLOD && chunk.prefetch) {
+        lodCounters[chunk.lod].prefetched++;
       }
     });
 
-    // Count rendered chunks per LOD
-    visibleChunks.forEach((chunk: ImageChunk) => {
-      const lod = chunk.lod;
-      if (!lodStats.has(lod)) {
-        lodStats.set(lod, { visible: 0, rendered: 0 });
-      }
-      lodStats.get(lod)!.rendered++;
+    renderedChunks.forEach((chunk: ImageChunk) => {
+      lodCounters[chunk.lod].rendered++;
     });
 
-    // Show total rendered chunks
-    if (visibleChunks.length > 0) {
-      chunkDetails.push(`Total rendered: ${visibleChunks.length} chunks`);
+    if (renderedChunks.length > 0) {
+      chunkDetails.push(`Total rendered: ${renderedChunks.length} chunks`);
     }
 
     const status = loadingChunks > 0 ? "Loading..." : "Ready";
     const summary = `Chunks: ${loadedChunks}/${totalChunks} ${status}`;
-
-    // Create per-LOD breakdown
-    const lodBreakdown: string[] = [];
-    const sortedLODs = Array.from(lodStats.keys()).sort((a, b) => a - b);
-
-    for (const lod of sortedLODs) {
-      const stats = lodStats.get(lod)!;
-      const isCurrentLOD = lod === currentLOD;
-      const lodLabel = isCurrentLOD ? `LOD ${lod} (current)` : `LOD ${lod}`;
-      lodBreakdown.push(
-        `${lodLabel}: Visible: ${stats.visible} | Rendered: ${stats.rendered}`
+    const counters: string[] = [];
+    lodCounters.forEach((counter, lod) => {
+      const prefix = lod === currentLOD ? `LOD ${lod} (current)` : `LOD ${lod}`;
+      counters.push(
+        `${prefix}: Visible ${counter.visible} | Rendered ${counter.rendered} | Prefetched ${counter.prefetched}`
       );
-    }
+    });
 
     this.textDiv_.innerHTML = [
       summary,
       "",
-      ...lodBreakdown,
+      ...counters,
       "",
       ...chunkDetails,
     ].join("<br>");

--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -130,7 +130,7 @@ export class ChunkManagerSource {
     if (this.visibleBoundsChanged(visibleBounds)) {
       this.updateChunkVisibility(visibleBounds);
     }
-    this.loadVisibleChunks();
+    this.loadPendingChunks();
   }
 
   public get lodCount() {
@@ -145,7 +145,7 @@ export class ChunkManagerSource {
     return this.currentLOD_;
   }
 
-  private loadVisibleChunks() {
+  private loadPendingChunks() {
     this.loadLowResChunks();
 
     for (const chunk of this.chunks_) {
@@ -154,7 +154,7 @@ export class ChunkManagerSource {
         chunk.state === "unloaded" &&
         (chunk.visible || chunk.prefetch)
       ) {
-        this.processChunkData(chunk);
+        this.loadChunkData(chunk);
       }
     }
   }
@@ -162,12 +162,12 @@ export class ChunkManagerSource {
   private loadLowResChunks(): void {
     for (const chunk of this.chunks_) {
       if (chunk.lod === this.lowestResLOD_ && chunk.state === "unloaded") {
-        this.processChunkData(chunk);
+        this.loadChunkData(chunk);
       }
     }
   }
 
-  private processChunkData(chunk: ImageChunk): void {
+  private loadChunkData(chunk: ImageChunk): void {
     chunk.state = "loading";
     this.loader_
       .loadChunkDataFromRegion(chunk, this.region_)
@@ -177,7 +177,7 @@ export class ChunkManagerSource {
       .catch((error) => {
         Logger.error(
           "ChunkManager",
-          `Error loading chunk (${chunk.chunkIndex?.x},${chunk.chunkIndex?.y}): ${error}`
+          `Error loading chunk (${chunk.chunkIndex.x},${chunk.chunkIndex.y}): ${error}`
         );
         chunk.state = "unloaded";
       });

--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -12,6 +12,10 @@ import { Logger } from "../utilities/logger";
 
 type Bounds = { min: vec2; max: vec2 };
 
+// Number of chunks to extend beyond the visible bounds in each direction (x/y/z)
+// These additional chunks are prefetched to improve responsiveness when panning.
+const PREFETCH_PADDING_CHUNKS = 1;
+
 export class ChunkManagerSource {
   private readonly chunks_: ImageChunk[];
   private readonly loader_;
@@ -75,6 +79,7 @@ export class ChunkManagerSource {
             state: "unloaded",
             lod,
             visible: false,
+            prefetch: false,
             shape: {
               x: chunkWidth,
               y: chunkHeight,
@@ -120,7 +125,19 @@ export class ChunkManagerSource {
     return [...lowResChunks, ...currentLODChunks];
   }
 
-  public get allChunks(): ImageChunk[] {
+  public update(lodFactor: number, visibleBounds: Bounds) {
+    this.setLOD(lodFactor);
+    if (this.visibleBoundsChanged(visibleBounds)) {
+      this.updateChunkVisibility(visibleBounds);
+    }
+    this.loadVisibleChunks();
+  }
+
+  public get lodCount() {
+    return this.lowestResLOD_ + 1;
+  }
+
+  public get chunks(): ImageChunk[] {
     return this.chunks_;
   }
 
@@ -132,11 +149,10 @@ export class ChunkManagerSource {
     this.loadLowResChunks();
 
     for (const chunk of this.chunks_) {
-      // Only load chunks for current LOD
       if (
         chunk.lod === this.currentLOD_ &&
         chunk.state === "unloaded" &&
-        chunk.visible
+        (chunk.visible || chunk.prefetch)
       ) {
         this.processChunkData(chunk);
       }
@@ -149,16 +165,6 @@ export class ChunkManagerSource {
         this.processChunkData(chunk);
       }
     }
-  }
-
-  public update(lodFactor: number, visibleBounds: Bounds) {
-    this.setLOD(lodFactor);
-
-    if (this.visibleBoundsChanged(visibleBounds)) {
-      this.updateChunkVisibility(visibleBounds);
-    }
-
-    this.loadVisibleChunks();
   }
 
   private processChunkData(chunk: ImageChunk): void {
@@ -202,26 +208,13 @@ export class ChunkManagerSource {
       return;
     }
 
-    const boundsMinX = visibleBounds.min[0];
-    const boundsMaxX = visibleBounds.max[0];
-    const boundsMinY = visibleBounds.min[1];
-    const boundsMaxY = visibleBounds.max[1];
-
+    const paddedBounds = this.getPaddedBounds(visibleBounds);
     for (const chunk of this.chunks_) {
-      if (!chunk.chunkIndex) {
-        chunk.visible = false;
-        continue;
+      chunk.prefetch = false;
+      chunk.visible = this.isChunkWithinBounds(chunk, visibleBounds);
+      if (!chunk.visible) {
+        chunk.prefetch = this.isChunkWithinBounds(chunk, paddedBounds);
       }
-      const chunkMinX = chunk.offset.x;
-      const chunkMaxX = chunkMinX + chunk.shape.x * chunk.scale.x;
-      const chunkMinY = chunk.offset.y;
-      const chunkMaxY = chunkMinY + chunk.shape.y * chunk.scale.y;
-
-      chunk.visible =
-        chunkMinX <= boundsMaxX &&
-        chunkMaxX >= boundsMinX &&
-        chunkMinY <= boundsMaxY &&
-        chunkMaxY >= boundsMinY;
     }
   }
 
@@ -241,6 +234,25 @@ export class ChunkManagerSource {
     }
   }
 
+  private isChunkWithinBounds(chunk: ImageChunk, bounds: Bounds): boolean {
+    const boundsMinX = bounds.min[0];
+    const boundsMaxX = bounds.max[0];
+    const boundsMinY = bounds.min[1];
+    const boundsMaxY = bounds.max[1];
+
+    const minX = chunk.offset.x;
+    const maxX = minX + chunk.shape.x * chunk.scale.x;
+    const minY = chunk.offset.y;
+    const maxY = minY + chunk.shape.y * chunk.scale.y;
+
+    return (
+      minX <= boundsMaxX &&
+      maxX >= boundsMinX &&
+      minY <= boundsMaxY &&
+      maxY >= boundsMinY
+    );
+  }
+
   private visibleBoundsChanged(newBounds: Bounds): boolean {
     const prev = this.lastVisibleBounds_;
     const changed =
@@ -256,6 +268,24 @@ export class ChunkManagerSource {
     }
 
     return changed;
+  }
+
+  private getPaddedBounds(bounds: Bounds): Bounds {
+    const chunkWidth =
+      this.attrs_[this.currentLOD_].chunks[this.xIdx_] *
+      this.attrs_[this.currentLOD_].scale[this.xIdx_];
+
+    const chunkHeight =
+      this.attrs_[this.currentLOD_].chunks[this.yIdx_] *
+      this.attrs_[this.currentLOD_].scale[this.yIdx_];
+
+    const padX = chunkWidth * PREFETCH_PADDING_CHUNKS;
+    const padY = chunkHeight * PREFETCH_PADDING_CHUNKS;
+
+    return {
+      min: vec2.fromValues(bounds.min[0] - padX, bounds.min[1] - padY),
+      max: vec2.fromValues(bounds.max[0] + padX, bounds.max[1] + padY),
+    };
   }
 }
 

--- a/packages/core/src/data/image_chunk.ts
+++ b/packages/core/src/data/image_chunk.ts
@@ -36,6 +36,7 @@ export type ImageChunk = {
   state: "unloaded" | "loading" | "loaded";
   lod: number;
   visible: boolean;
+  prefetch: boolean;
   shape: {
     x: number;
     y: number;

--- a/packages/core/src/data/ome_zarr_image_loader.ts
+++ b/packages/core/src/data/ome_zarr_image_loader.ts
@@ -157,6 +157,7 @@ export class OmeZarrImageLoader {
       state: "loaded",
       lod: lod,
       visible: true,
+      prefetch: false,
       data: subarray.data,
       shape: {
         x: subarray.shape[subarray.shape.length - 1],


### PR DESCRIPTION
### Summary

This PR introduces prefetching along the X and Y axes by checking for
intersections with padded visible bounds, allowing the system to prefetch
chunk data that isn't currently visible but is likely to be soon. It also refactors
the chunk info overlay to include details about prefetched chunks. The approach
is designed to scale to the Z axis once chunk manager support is added.

### Tests & Checks
- Manual verification, added "prefetched" information to the chunk overlay
- All checks have passed
