### PR TITLE
Make label layers' colormap mutable

### DIFF
--- a/packages/core/examples/image_labels_overlay_with_value_picking/main.ts
+++ b/packages/core/examples/image_labels_overlay_with_value_picking/main.ts
@@ -98,7 +98,7 @@ const colorMaps = [
   {
     lookupTable: new Map([[103, Color.YELLOW]]),
     cycle: [Color.RED, Color.GREEN, Color.BLUE],
-  }
+  },
 ];
 const labelsLayer = new LabelImageLayer({
   source: labelsSource,
@@ -120,9 +120,9 @@ const labelsLayer = new LabelImageLayer({
 
 document.addEventListener("keyup", (event) => {
   if (event.key === "0") {
-    labelsLayer.setColorMap(colorMaps[0])
+    labelsLayer.setColorMap(colorMaps[0]);
   } else if (event.key === "1") {
-    labelsLayer.setColorMap(colorMaps[1])
+    labelsLayer.setColorMap(colorMaps[1]);
   }
 });
 

--- a/packages/core/examples/image_labels_overlay_with_value_picking/main.ts
+++ b/packages/core/examples/image_labels_overlay_with_value_picking/main.ts
@@ -104,18 +104,13 @@ const labelsLayer = new LabelImageLayer({
       World: (${world[0].toFixed(1)}, ${world[1].toFixed(1)}, ${world[2].toFixed(1)})<br/>
       Label Value: ${value}<br/>
     `;
-  },
-});
-
-document.addEventListener("keyup", (event) => {
-  if (event.key >= "0" && event.key <= "9") {
-    const label = parseInt(event.key, 10) + 100;
-    console.debug(`Setting color for label ${label} to transparent`);
+    if (typeof value !== "number") return;
+    console.debug(`Setting color for label ${value} to transparent`);
     labelsLayer.setColorMap({
       cycle: Array.from(labelsLayer.colorMap.cycle),
-      lookupTable: new Map([[label, Color.TRANSPARENT]]),
+      lookupTable: new Map([[value, Color.WHITE]]),
     });
-  }
+  },
 });
 
 new Idetik({

--- a/packages/core/examples/image_labels_overlay_with_value_picking/main.ts
+++ b/packages/core/examples/image_labels_overlay_with_value_picking/main.ts
@@ -90,16 +90,6 @@ const imageLayer = new ImageLayer({
 });
 
 // Create label image layer with picking functionality
-const colorMaps = [
-  {
-    lookupTable: new Map([[103, Color.GREEN]]),
-    cycle: [Color.YELLOW, Color.MAGENTA, Color.CYAN],
-  },
-  {
-    lookupTable: new Map([[103, Color.YELLOW]]),
-    cycle: [Color.RED, Color.GREEN, Color.BLUE],
-  },
-];
 const labelsLayer = new LabelImageLayer({
   source: labelsSource,
   region: labelsRegion,
@@ -107,7 +97,6 @@ const labelsLayer = new LabelImageLayer({
   opacity: 0.25,
   blendMode: "normal",
   lod,
-  colorMap: colorMaps[0],
   onPickValue: (info: PointPickingResult) => {
     const { world, value } = info;
     pickInfoDiv.innerHTML = `
@@ -119,10 +108,13 @@ const labelsLayer = new LabelImageLayer({
 });
 
 document.addEventListener("keyup", (event) => {
-  if (event.key === "0") {
-    labelsLayer.setColorMap(colorMaps[0]);
-  } else if (event.key === "1") {
-    labelsLayer.setColorMap(colorMaps[1]);
+  if (event.key >= "0" && event.key <= "9") {
+    const label = parseInt(event.key, 10) + 100;
+    console.debug(`Setting color for label ${event.key} to GREEN`);
+    labelsLayer.setColorMap({
+      cycle: Array.from(labelsLayer.colorMap.cycle),
+      lookupTable: new Map([[label, Color.TRANSPARENT]]),
+    });
   }
 });
 

--- a/packages/core/examples/image_labels_overlay_with_value_picking/main.ts
+++ b/packages/core/examples/image_labels_overlay_with_value_picking/main.ts
@@ -90,6 +90,16 @@ const imageLayer = new ImageLayer({
 });
 
 // Create label image layer with picking functionality
+const colorMaps = [
+  {
+    lookupTable: new Map([[103, Color.GREEN]]),
+    cycle: [Color.YELLOW, Color.MAGENTA, Color.CYAN],
+  },
+  {
+    lookupTable: new Map([[103, Color.YELLOW]]),
+    cycle: [Color.RED, Color.GREEN, Color.BLUE],
+  }
+];
 const labelsLayer = new LabelImageLayer({
   source: labelsSource,
   region: labelsRegion,
@@ -97,10 +107,7 @@ const labelsLayer = new LabelImageLayer({
   opacity: 0.25,
   blendMode: "normal",
   lod,
-  colorMap: {
-    lookupTable: new Map([[103, Color.GREEN]]),
-    cycle: [Color.YELLOW, Color.MAGENTA, Color.CYAN],
-  },
+  colorMap: colorMaps[0],
   onPickValue: (info: PointPickingResult) => {
     const { world, value } = info;
     pickInfoDiv.innerHTML = `
@@ -111,11 +118,17 @@ const labelsLayer = new LabelImageLayer({
   },
 });
 
-const idetik = new Idetik({
+document.addEventListener("keyup", (event) => {
+  if (event.key === "0") {
+    labelsLayer.setColorMap(colorMaps[0])
+  } else if (event.key === "1") {
+    labelsLayer.setColorMap(colorMaps[1])
+  }
+});
+
+new Idetik({
   canvas,
   camera,
   layers: [imageLayer, labelsLayer],
   cameraControls: new PanZoomControls(camera),
-});
-
-idetik.start();
+}).start();

--- a/packages/core/examples/image_labels_overlay_with_value_picking/main.ts
+++ b/packages/core/examples/image_labels_overlay_with_value_picking/main.ts
@@ -110,7 +110,7 @@ const labelsLayer = new LabelImageLayer({
 document.addEventListener("keyup", (event) => {
   if (event.key >= "0" && event.key <= "9") {
     const label = parseInt(event.key, 10) + 100;
-    console.debug(`Setting color for label ${event.key} to GREEN`);
+    console.debug(`Setting color for label ${event.key} to transparent`);
     labelsLayer.setColorMap({
       cycle: Array.from(labelsLayer.colorMap.cycle),
       lookupTable: new Map([[label, Color.TRANSPARENT]]),

--- a/packages/core/examples/image_labels_overlay_with_value_picking/main.ts
+++ b/packages/core/examples/image_labels_overlay_with_value_picking/main.ts
@@ -110,7 +110,7 @@ const labelsLayer = new LabelImageLayer({
 document.addEventListener("keyup", (event) => {
   if (event.key >= "0" && event.key <= "9") {
     const label = parseInt(event.key, 10) + 100;
-    console.debug(`Setting color for label ${event.key} to transparent`);
+    console.debug(`Setting color for label ${label} to transparent`);
     labelsLayer.setColorMap({
       cycle: Array.from(labelsLayer.colorMap.cycle),
       lookupTable: new Map([[label, Color.TRANSPARENT]]),

--- a/packages/core/examples/image_series_labels_overlay/index.html
+++ b/packages/core/examples/image_series_labels_overlay/index.html
@@ -71,6 +71,12 @@
           Layer State: &nbsp; <span id="layer-state">initialized</span>
           <input type="button" id="load-all" value="Load all slices" />
         </div>
+        <div class="control-row">
+          <div class="control-label">Color cycle:</div>
+          <input type="button" id="color-cycle-default" value="Default" />
+          <input type="button" id="color-cycle-cmy" value="CMY" />
+          <input type="button" id="color-cycle-rgb" value="RGB" />
+        </div>
       </div>
     </div>
     <script type="module" src="./main.ts"></script>

--- a/packages/core/examples/image_series_labels_overlay/main.ts
+++ b/packages/core/examples/image_series_labels_overlay/main.ts
@@ -170,7 +170,9 @@ document
   .querySelector<HTMLButtonElement>("#color-cycle-cmy")!
   .addEventListener("click", () => {
     console.debug("Resetting color map to CMY cycle");
-    labelsLayer.setColorMap({ cycle: [Color.CYAN, Color.MAGENTA, Color.YELLOW] });
+    labelsLayer.setColorMap({
+      cycle: [Color.CYAN, Color.MAGENTA, Color.YELLOW],
+    });
   });
 document
   .querySelector<HTMLButtonElement>("#color-cycle-rgb")!

--- a/packages/core/examples/image_series_labels_overlay/main.ts
+++ b/packages/core/examples/image_series_labels_overlay/main.ts
@@ -81,6 +81,8 @@ const labelsRegion: Region = [
   { dimension: "X", index: { type: "full" } },
 ];
 
+const rgbCycle = [Color.RED, Color.GREEN, Color.BLUE];
+const cmyCycle = [Color.CYAN, Color.MAGENTA, Color.YELLOW];
 const labelsLayer = new LabelImageSeriesLayer({
   source: labelsSource,
   region: labelsRegion,
@@ -89,10 +91,6 @@ const labelsLayer = new LabelImageSeriesLayer({
   opacity: 0.25,
   blendMode: "normal",
   lod,
-  colorMap: {
-    lookupTable: new Map([[103, Color.GREEN]]),
-    cycle: [Color.YELLOW, Color.MAGENTA, Color.CYAN],
-  },
 });
 
 const tSlider = document.querySelector<HTMLInputElement>("#t-slider")!;
@@ -163,3 +161,22 @@ async function setLayerIndex(index: number) {
     tIndexEl!.textContent = `${index}`;
   }
 }
+
+document
+  .querySelector<HTMLButtonElement>("#color-cycle-default")!
+  .addEventListener("click", () => {
+    console.debug("Resetting color map to default");
+    labelsLayer.setColorMap({});
+  });
+document
+  .querySelector<HTMLButtonElement>("#color-cycle-cmy")!
+  .addEventListener("click", () => {
+    console.debug("Resetting color map to CMY cycle");
+    labelsLayer.setColorMap({ cycle: cmyCycle });
+  });
+document
+  .querySelector<HTMLButtonElement>("#color-cycle-rgb")!
+  .addEventListener("click", () => {
+    console.debug("Resetting color map to RGB cycle");
+    labelsLayer.setColorMap({ cycle: rgbCycle });
+  });

--- a/packages/core/examples/image_series_labels_overlay/main.ts
+++ b/packages/core/examples/image_series_labels_overlay/main.ts
@@ -81,8 +81,6 @@ const labelsRegion: Region = [
   { dimension: "X", index: { type: "full" } },
 ];
 
-const rgbCycle = [Color.RED, Color.GREEN, Color.BLUE];
-const cmyCycle = [Color.CYAN, Color.MAGENTA, Color.YELLOW];
 const labelsLayer = new LabelImageSeriesLayer({
   source: labelsSource,
   region: labelsRegion,
@@ -172,11 +170,11 @@ document
   .querySelector<HTMLButtonElement>("#color-cycle-cmy")!
   .addEventListener("click", () => {
     console.debug("Resetting color map to CMY cycle");
-    labelsLayer.setColorMap({ cycle: cmyCycle });
+    labelsLayer.setColorMap({ cycle: [Color.CYAN, Color.MAGENTA, Color.YELLOW] });
   });
 document
   .querySelector<HTMLButtonElement>("#color-cycle-rgb")!
   .addEventListener("click", () => {
     console.debug("Resetting color map to RGB cycle");
-    labelsLayer.setColorMap({ cycle: rgbCycle });
+    labelsLayer.setColorMap({ cycle: [Color.RED, Color.GREEN, Color.BLUE] });
   });

--- a/packages/core/src/core/renderable_object.ts
+++ b/packages/core/src/core/renderable_object.ts
@@ -10,6 +10,7 @@ export abstract class RenderableObject extends Node {
   public wireframeEnabled = false;
   public wireframeColor = Color.WHITE;
   private readonly textures_: Texture[] = [];
+  private staleTextures_: Texture[] = [];
   private readonly transform_ = new TrsTransform();
   private geometry_ = new Geometry();
   private wireframeGeometry_: WireframeGeometry | null = null;
@@ -17,6 +18,22 @@ export abstract class RenderableObject extends Node {
 
   public addTexture(texture: Texture) {
     this.textures_.push(texture);
+  }
+
+  public setTexture(index: number, texture: Texture) {
+    if (index < 0 || index >= this.textures_.length) {
+      throw new Error(
+        `Texture index out of range: ${index}, number of textures: ${this.textures_.length}`
+      );
+    }
+    this.staleTextures_.push(this.textures_[index]);
+    this.textures_[index] = texture;
+  }
+
+  public popStaleTextures() {
+    const stale = this.staleTextures_;
+    this.staleTextures_ = [];
+    return stale;
   }
 
   public get geometry() {

--- a/packages/core/src/core/renderable_object.ts
+++ b/packages/core/src/core/renderable_object.ts
@@ -16,17 +16,11 @@ export abstract class RenderableObject extends Node {
   private wireframeGeometry_: WireframeGeometry | null = null;
   private programName_: Shader | null = null;
 
-  public addTexture(texture: Texture) {
-    this.textures_.push(texture);
-  }
-
   public setTexture(index: number, texture: Texture) {
-    if (index < 0 || index >= this.textures_.length) {
-      throw new Error(
-        `Texture index out of range: ${index}, number of textures: ${this.textures_.length}`
-      );
+    const oldTexture = this.textures_[index];
+    if (oldTexture !== undefined) {
+      this.staleTextures_.push(oldTexture);
     }
-    this.staleTextures_.push(this.textures_[index]);
     this.textures_[index] = texture;
   }
 

--- a/packages/core/src/layers/label_image_layer.ts
+++ b/packages/core/src/layers/label_image_layer.ts
@@ -26,7 +26,7 @@ export class LabelImageLayer extends Layer {
   private readonly source_: ImageChunkSource;
   private readonly region_: Region;
   private readonly lod_?: number;
-  private readonly colorMap_: LabelColorMap;
+  private colorMap_: LabelColorMap;
   private readonly onPickValue_?: (info: PointPickingResult) => void;
   private image_?: LabelImageRenderable;
   private pointerDownPos_: vec2 | null = null;
@@ -61,6 +61,13 @@ export class LabelImageLayer extends Layer {
         const exhaustiveCheck: never = this.state;
         throw new Error(`Unhandled LayerState case: ${exhaustiveCheck}`);
       }
+    }
+  }
+
+  public setColorMap(colorMap: LabelColorMap) {
+    this.colorMap_ = colorMap;
+    if (this.image_) {
+      this.image_.setColorMap(colorMap);
     }
   }
 

--- a/packages/core/src/layers/label_image_layer.ts
+++ b/packages/core/src/layers/label_image_layer.ts
@@ -3,7 +3,10 @@ import { Region } from "../data/region";
 import { ImageChunk, ImageChunkSource } from "../data/image_chunk";
 import { Texture2D } from "../objects/textures/texture_2d";
 import { PlaneGeometry } from "../objects/geometry/plane_geometry";
-import { LabelColorMap } from "../objects/renderable/label_color_map";
+import {
+  LabelColorMap,
+  LabelColorMapProps,
+} from "../objects/renderable/label_color_map";
 import { LabelImageRenderable } from "../objects/renderable/label_image_renderable";
 import { EventContext } from "../core/event_dispatcher";
 import { vec2, vec3 } from "gl-matrix";
@@ -16,7 +19,7 @@ export interface PointPickingResult {
 export type LabelImageLayerProps = LayerOptions & {
   source: ImageChunkSource;
   region: Region;
-  colorMap?: LabelColorMap;
+  colorMap?: LabelColorMapProps;
   onPickValue?: (info: PointPickingResult) => void;
 };
 
@@ -35,7 +38,7 @@ export class LabelImageLayer extends Layer {
   constructor({
     source,
     region,
-    colorMap = new LabelColorMap(),
+    colorMap = {},
     onPickValue,
     lod,
     ...layerOptions
@@ -44,7 +47,7 @@ export class LabelImageLayer extends Layer {
     this.setState("initialized");
     this.source_ = source;
     this.region_ = region;
-    this.colorMap_ = colorMap;
+    this.colorMap_ = new LabelColorMap(colorMap);
     this.onPickValue_ = onPickValue;
     this.lod_ = lod;
   }
@@ -64,10 +67,10 @@ export class LabelImageLayer extends Layer {
     }
   }
 
-  public setColorMap(colorMap: LabelColorMap) {
-    this.colorMap_ = colorMap;
+  public setColorMap(colorMap: LabelColorMapProps) {
+    this.colorMap_ = new LabelColorMap(colorMap);
     if (this.image_) {
-      this.image_.setColorMap(colorMap);
+      this.image_.setColorMap(this.colorMap_);
     }
   }
 

--- a/packages/core/src/layers/label_image_layer.ts
+++ b/packages/core/src/layers/label_image_layer.ts
@@ -67,6 +67,10 @@ export class LabelImageLayer extends Layer {
     }
   }
 
+  public get colorMap(): LabelColorMap {
+    return this.colorMap_;
+  }
+
   public setColorMap(colorMap: LabelColorMapProps) {
     this.colorMap_ = new LabelColorMap(colorMap);
     if (this.image_) {

--- a/packages/core/src/layers/label_image_series_layer.ts
+++ b/packages/core/src/layers/label_image_series_layer.ts
@@ -17,7 +17,7 @@ export type LabelImageSeriesLayerProps = LayerOptions & {
 export class LabelImageSeriesLayer extends Layer {
   public readonly type = "LabelImageSeriesLayer";
   private readonly seriesLoader_: ImageSeriesLoader;
-  private readonly colorMap_: LabelColorMap;
+  private colorMap_: LabelColorMap;
   private texture_: Texture2D | null = null;
   private image_?: LabelImageRenderable;
   private extent_?: { x: number; y: number };
@@ -45,6 +45,13 @@ export class LabelImageSeriesLayer extends Layer {
     if (this.state === "initialized") {
       this.setState("loading");
       this.seriesLoader_.loadSeriesAttributes();
+    }
+  }
+
+  public setColorMap(colorMap: LabelColorMap) {
+    this.colorMap_ = colorMap;
+    if (this.image_) {
+      this.image_.setColorMap(colorMap);
     }
   }
 

--- a/packages/core/src/layers/label_image_series_layer.ts
+++ b/packages/core/src/layers/label_image_series_layer.ts
@@ -51,6 +51,10 @@ export class LabelImageSeriesLayer extends Layer {
     }
   }
 
+  public get colorMap(): LabelColorMap {
+    return this.colorMap_;
+  }
+
   public setColorMap(colorMap: LabelColorMapProps) {
     // TODO: mark textures to be disposed.
     this.colorMap_ = new LabelColorMap(colorMap);

--- a/packages/core/src/layers/label_image_series_layer.ts
+++ b/packages/core/src/layers/label_image_series_layer.ts
@@ -56,7 +56,6 @@ export class LabelImageSeriesLayer extends Layer {
   }
 
   public setColorMap(colorMap: LabelColorMapProps) {
-    // TODO: mark textures to be disposed.
     this.colorMap_ = new LabelColorMap(colorMap);
     if (this.image_) {
       this.image_.setColorMap(this.colorMap_);

--- a/packages/core/src/layers/label_image_series_layer.ts
+++ b/packages/core/src/layers/label_image_series_layer.ts
@@ -4,14 +4,17 @@ import { ImageChunk, ImageChunkSource } from "../data/image_chunk";
 import { Texture2D } from "../objects/textures/texture_2d";
 import { LabelImageRenderable } from "../objects/renderable/label_image_renderable";
 import { PlaneGeometry } from "../objects/geometry/plane_geometry";
-import { LabelColorMap } from "../objects/renderable/label_color_map";
+import {
+  LabelColorMap,
+  LabelColorMapProps,
+} from "../objects/renderable/label_color_map";
 import { ImageSeriesLoader, SetIndexResult } from "./image_series_loader";
 
 export type LabelImageSeriesLayerProps = LayerOptions & {
   source: ImageChunkSource;
   region: Region;
   seriesDimensionName: string;
-  colorMap?: LabelColorMap;
+  colorMap?: LabelColorMapProps;
 };
 
 export class LabelImageSeriesLayer extends Layer {
@@ -26,13 +29,13 @@ export class LabelImageSeriesLayer extends Layer {
     source,
     region,
     seriesDimensionName,
-    colorMap = new LabelColorMap(),
+    colorMap = {},
     lod,
     ...layerOptions
   }: LabelImageSeriesLayerProps) {
     super(layerOptions);
     this.setState("initialized");
-    this.colorMap_ = colorMap;
+    this.colorMap_ = new LabelColorMap(colorMap);
     this.seriesLoader_ = new ImageSeriesLoader({
       source,
       region,
@@ -48,10 +51,11 @@ export class LabelImageSeriesLayer extends Layer {
     }
   }
 
-  public setColorMap(colorMap: LabelColorMap) {
-    this.colorMap_ = colorMap;
+  public setColorMap(colorMap: LabelColorMapProps) {
+    // TODO: mark textures to be disposed.
+    this.colorMap_ = new LabelColorMap(colorMap);
     if (this.image_) {
-      this.image_.setColorMap(colorMap);
+      this.image_.setColorMap(this.colorMap_);
     }
   }
 

--- a/packages/core/src/objects/renderable/image_renderable.ts
+++ b/packages/core/src/objects/renderable/image_renderable.ts
@@ -35,7 +35,7 @@ export class ImageRenderable extends RenderableObject {
   ) {
     super();
     this.geometry = geometry;
-    this.addTexture(texture);
+    this.setTexture(0, texture);
     this.channels_ = validateChannels(texture, channels);
     this.programName = textureToShader(texture);
   }

--- a/packages/core/src/objects/renderable/label_color_map.ts
+++ b/packages/core/src/objects/renderable/label_color_map.ts
@@ -26,7 +26,7 @@ function validateCycle(cycle?: ReadonlyArray<ColorLike>): ReadonlyArray<Color> {
   return cycle.map(Color.from);
 }
 
-type LabelColorMapProps = {
+export type LabelColorMapProps = {
   lookupTable?: ReadonlyMap<number, ColorLike>;
   cycle?: ColorLike[];
 };

--- a/packages/core/src/objects/renderable/label_image_renderable.ts
+++ b/packages/core/src/objects/renderable/label_image_renderable.ts
@@ -58,8 +58,8 @@ export class LabelImageRenderable extends RenderableObject {
   }
 
   public setColorMap(colorMap: LabelColorMap) {
-    this.textures[1] = this.makeColorCycleTexture(colorMap.cycle);
-    this.textures[2] = this.makeColorLookupTableTexture(colorMap.lookupTable);
+    this.setTexture(1, this.makeColorCycleTexture(colorMap.cycle));
+    this.setTexture(2, this.makeColorLookupTableTexture(colorMap.lookupTable));
   }
 
   private makeColorCycleTexture(cycle: ReadonlyArray<Color>) {

--- a/packages/core/src/objects/renderable/label_image_renderable.ts
+++ b/packages/core/src/objects/renderable/label_image_renderable.ts
@@ -35,13 +35,13 @@ export class LabelImageRenderable extends RenderableObject {
   constructor(props: LabelImageRenderableProps) {
     super();
     this.geometry = props.geometry;
-    this.addTexture(validateImageData(props.imageData));
+    this.setTexture(0, validateImageData(props.imageData));
     const colorCycleTexture = this.makeColorCycleTexture(props.colorMap.cycle);
-    this.addTexture(colorCycleTexture);
+    this.setTexture(1, colorCycleTexture);
     const colorLookupTableTexture = this.makeColorLookupTableTexture(
       props.colorMap.lookupTable
     );
-    this.addTexture(colorLookupTableTexture);
+    this.setTexture(2, colorLookupTableTexture);
     this.programName = "labelImage";
   }
 

--- a/packages/core/src/objects/renderable/label_image_renderable.ts
+++ b/packages/core/src/objects/renderable/label_image_renderable.ts
@@ -57,6 +57,11 @@ export class LabelImageRenderable extends RenderableObject {
     };
   }
 
+  public setColorMap(colorMap: LabelColorMap) {
+    this.textures[1] = this.makeColorCycleTexture(colorMap.cycle);
+    this.textures[2] = this.makeColorLookupTableTexture(colorMap.lookupTable);
+  }
+
   private makeColorCycleTexture(cycle: ReadonlyArray<Color>) {
     const data = new Uint8Array(
       cycle.flatMap((c) => c.rgba).map((v) => Math.round(v * 255))

--- a/packages/core/src/objects/renderable/points.ts
+++ b/packages/core/src/objects/renderable/points.ts
@@ -64,7 +64,7 @@ export class Points extends RenderableObject {
     });
 
     this.geometry = geometry;
-    this.addTexture(this.atlas_);
+    this.setTexture(0, this.atlas_);
   }
 
   public get type() {

--- a/packages/core/src/renderers/webgl_renderer.ts
+++ b/packages/core/src/renderers/webgl_renderer.ts
@@ -87,6 +87,9 @@ export class WebGLRenderer extends Renderer {
   protected renderObject(layer: Layer, objectIndex: number) {
     const object = layer.objects[objectIndex];
     this.bindings_.bindGeometry(object.geometry);
+    object.popStaleTextures().forEach((texture) => {
+      this.textures_.disposeTexture(texture);
+    });
     object.textures.forEach((texture, index) => {
       this.textures_.bindTexture(texture, index);
     });


### PR DESCRIPTION
### Summary
This makes the two label layer's colormap gettable and settable. It also handles the necessary texture updates when that is set.

In order to dispose of old textures that will never be used again, it adds a new core functionality to renderable objects to mark some textures as stale when they are replaced. The label renderable uses this core functionality to replace the color map textures. The WebGL renderer then disposes of any stale textures in the core rendering loop.

Rather than add new examples, I modified the existing examples that use label image layers to allow modification of their colormap with some basic interactions.
- Label picking on a 2D image: click a label to override it to be white.
- Label series image: click on a button to choose a different color cycle.

### Related Issue
Closes #342

### Tests & Checks
I manually tested the modified examples. 
