### PR TITLE
[small] Add support for color + layer transparency in Points renderable

### DIFF
--- a/packages/core/src/objects/renderable/points.ts
+++ b/packages/core/src/objects/renderable/points.ts
@@ -37,6 +37,7 @@ export class Points extends RenderableObject {
       point.color.r,
       point.color.g,
       point.color.b,
+      point.color.a,
       point.size,
       point.markerIndex,
     ]);
@@ -49,7 +50,7 @@ export class Points extends RenderableObject {
     });
     geometry.addAttribute({
       type: "color",
-      itemSize: 3,
+      itemSize: 4,
       offset: geometry.stride,
     });
     geometry.addAttribute({

--- a/packages/core/src/renderers/shaders/points_frag.glsl
+++ b/packages/core/src/renderers/shaders/points_frag.glsl
@@ -9,6 +9,8 @@ uniform mediump sampler2DArray markerAtlas;
 in vec4 color;
 flat in uint marker;
 
+uniform float u_opacity;
+
 
 void main() {
     float alpha = texture(markerAtlas, vec3(gl_PointCoord, marker)).r;
@@ -16,6 +18,6 @@ void main() {
     if (alpha < alpha_threshold) {
         discard;
     }
-    fragColor = vec4(color.rgb, 1.0);
+    fragColor = vec4(color.rgb, u_opacity * alpha * color.a);
 }
 

--- a/packages/core/src/renderers/shaders/points_vert.glsl
+++ b/packages/core/src/renderers/shaders/points_vert.glsl
@@ -3,7 +3,7 @@
 precision mediump float;
 
 layout (location = 0) in vec3 inPosition;
-layout (location = 7) in vec3 inColor;
+layout (location = 7) in vec4 inColor;
 layout (location = 8) in float inSize;
 layout (location = 9) in float inMarker;
 
@@ -17,7 +17,7 @@ flat out uint marker;
 void main() {
     gl_Position = Projection * ModelView * vec4(inPosition, 1.0);
     gl_PointSize = inSize;
-    color = vec4(inColor, 1.0);
+    color = inColor;
     marker = uint(inMarker);
 }
 


### PR DESCRIPTION
### Summary
This adds basic support for transparency in the `Points` renderable object. The shader also includes `u_opacity`, which corresponds to a layer-level opacity value. This also allows for alpha-based anti-aliasing depending on how the marker atlas is drawn or sampled. For any of this to work, a layer using this will need to set its `transparent` attribute to `true`.

### Related Issue
N/A

### Tests & Checks
Tested primarily in the Try CryoLens app, but the points example here still works.
