### PR TITLE
feat: Implement getValueAtWorld method for LabelImageLayer value picking

### DIFF
--- a/packages/core/examples/image_labels_overlay_with_value_picking/main.ts
+++ b/packages/core/examples/image_labels_overlay_with_value_picking/main.ts
@@ -106,7 +106,7 @@ const labelsLayer = new LabelImageLayer({
     pickInfoDiv.innerHTML = `
       <strong>Pick Result:</strong><br/>
       World: (${world[0].toFixed(1)}, ${world[1].toFixed(1)}, ${world[2].toFixed(1)})<br/>
-      Value: ${value ?? "null"}<br/>
+      Label Value: ${value}<br/>
     `;
   },
 });

--- a/packages/core/src/layers/label_image_layer.ts
+++ b/packages/core/src/layers/label_image_layer.ts
@@ -154,7 +154,7 @@ export class LabelImageLayer extends Layer {
       return null;
     }
 
-    const pixelIndex = y * this.imageChunk_.shape.x + x;
+    const pixelIndex = y * this.imageChunk_.rowStride + x;
     const data = this.imageChunk_.data;
     return data[pixelIndex];
   }

--- a/packages/core/src/layers/label_image_layer.ts
+++ b/packages/core/src/layers/label_image_layer.ts
@@ -154,17 +154,8 @@ export class LabelImageLayer extends Layer {
       return null;
     }
 
-    // Sample pixel value from chunk data
     const pixelIndex = y * this.imageChunk_.shape.x + x;
     const data = this.imageChunk_.data;
-
-    if (
-      data instanceof Uint8Array ||
-      data instanceof Uint16Array ||
-      data instanceof Uint32Array
-    ) {
-      return data[pixelIndex];
-    }
-    return null;
+    return data[pixelIndex];
   }
 }

--- a/packages/core/src/layers/label_image_layer.ts
+++ b/packages/core/src/layers/label_image_layer.ts
@@ -29,6 +29,7 @@ export class LabelImageLayer extends Layer {
   private readonly colorMap_: LabelColorMap;
   private readonly onPickValue_?: (info: PointPickingResult) => void;
   private image_?: LabelImageRenderable;
+  private imageChunk_?: ImageChunk;
   private pointerDownPos_: vec2 | null = null;
   private readonly dragThreshold_ = 3;
 
@@ -117,6 +118,7 @@ export class LabelImageLayer extends Layer {
   }
 
   private createImage(chunk: ImageChunk) {
+    this.imageChunk_ = chunk; // Store chunk for value picking
     const geometry = new PlaneGeometry(chunk.shape.x, chunk.shape.y, 1, 1);
     const image = new LabelImageRenderable({
       geometry,
@@ -128,8 +130,41 @@ export class LabelImageLayer extends Layer {
     return image;
   }
 
-  public getValueAtWorld(world: vec3): vec3 /* TODO: label value */ | null {
-    // TODO: replace with actual sampling from renderable data (e.g. texture buffer)
-    return world; // stub - currently returns world coordinates instead of label value
+  public getValueAtWorld(world: vec3): number | null {
+    if (!this.image_ || !this.imageChunk_?.data) {
+      return null;
+    }
+
+    // Transform world to local texture coordinates using inverse transform
+    const localPos = vec3.transformMat4(
+      vec3.create(),
+      world,
+      this.image_.transform.inverse
+    );
+
+    // Convert to pixel coordinates and bounds check
+    const x = Math.floor(localPos[0]);
+    const y = Math.floor(localPos[1]);
+    if (
+      x < 0 ||
+      x >= this.imageChunk_.shape.x ||
+      y < 0 ||
+      y >= this.imageChunk_.shape.y
+    ) {
+      return null;
+    }
+
+    // Sample pixel value from chunk data
+    const pixelIndex = y * this.imageChunk_.shape.x + x;
+    const data = this.imageChunk_.data;
+
+    if (
+      data instanceof Uint8Array ||
+      data instanceof Uint16Array ||
+      data instanceof Uint32Array
+    ) {
+      return data[pixelIndex];
+    }
+    return null;
   }
 }


### PR DESCRIPTION
  Summary

  Implements the `getValueAtWorld` method in `LabelImageLayer` to enable pixel value picking on segmentation layers. This allows users to click on label images and retrieve the underlying label ID values.

This approach will need to be adjusted if we end up enabling progressive loading for the `LabelImageLayer`

  Changes Made

  - LabelImageLayer: Implemented `getValueAtWorld` method that was previously a stub
  - Coordinate transformation: Converts world coordinates to texture coordinates using the image transform's inverse matrix
  - Value sampling: Samples label values directly from the original chunk data for accuracy
  - Data storage: Added imageChunk_ property to store raw chunk data alongside the rendered texture
  - Example update: Enhanced the value picking example to display "Label Value" instead of generic "Value"


  Testing

  - Updated existing point picking example demonstrates the functionality
  - Clicking on segmented regions now displays the correct label ID values
  - Proper handling of out-of-bounds clicks and missing data

  This enables interactive exploration of segmentation data, allowing users to identify specific labeled regions by clicking on them.

https://github.com/user-attachments/assets/9ba14801-6964-46c5-ab4a-ba8c750f279a

