### PR TITLE
Define non-null point picking result value type

### DIFF
--- a/packages/core/examples/image_labels_overlay_with_value_picking/main.ts
+++ b/packages/core/examples/image_labels_overlay_with_value_picking/main.ts
@@ -104,7 +104,7 @@ const labelsLayer = new LabelImageLayer({
       World: (${world[0].toFixed(1)}, ${world[1].toFixed(1)}, ${world[2].toFixed(1)})<br/>
       Label Value: ${value}<br/>
     `;
-    if (typeof value !== "number") return;
+    if (value === null) return;
     console.debug(`Setting color for label ${value} to transparent`);
     labelsLayer.setColorMap({
       cycle: Array.from(labelsLayer.colorMap.cycle),

--- a/packages/core/examples/image_labels_overlay_with_value_picking/main.ts
+++ b/packages/core/examples/image_labels_overlay_with_value_picking/main.ts
@@ -104,7 +104,6 @@ const labelsLayer = new LabelImageLayer({
       World: (${world[0].toFixed(1)}, ${world[1].toFixed(1)}, ${world[2].toFixed(1)})<br/>
       Label Value: ${value}<br/>
     `;
-    if (value === null) return;
     console.debug(`Setting color for label ${value} to transparent`);
     labelsLayer.setColorMap({
       cycle: Array.from(labelsLayer.colorMap.cycle),

--- a/packages/core/src/layers/label_image_layer.ts
+++ b/packages/core/src/layers/label_image_layer.ts
@@ -13,7 +13,7 @@ import { vec2, vec3 } from "gl-matrix";
 
 export interface PointPickingResult {
   world: vec3;
-  value: number | null;
+  value: number;
 }
 
 export type LabelImageLayerProps = LayerOptions & {

--- a/packages/core/src/layers/label_image_layer.ts
+++ b/packages/core/src/layers/label_image_layer.ts
@@ -13,7 +13,7 @@ import { vec2, vec3 } from "gl-matrix";
 
 export interface PointPickingResult {
   world: vec3;
-  value: unknown | null;
+  value: number | null;
 }
 
 export type LabelImageLayerProps = LayerOptions & {


### PR DESCRIPTION
### Summary
I think this was missed in #370. If point picking results are returned by other layers they may need to relax the interface or make it generic to handle arrays of numbers for multi-channel images.

### Tests & Checks
I manually tested the point picking example.
