### PR TITLE
Rename ImageChunk to Chunk

### DIFF
--- a/packages/core/examples/chunk_streaming/chunk_info_overlay.ts
+++ b/packages/core/examples/chunk_streaming/chunk_info_overlay.ts
@@ -1,6 +1,6 @@
 import { Idetik } from "../../src/idetik";
 import { ImageLayer } from "../../src/layers/image_layer";
-import { ImageChunk } from "../../src/data/image_chunk";
+import { Chunk } from "../../src/data/chunk";
 
 export interface ChunkInfoOverlayOptions {
   textDiv: HTMLDivElement;
@@ -36,7 +36,7 @@ export class ChunkInfoOverlay {
 
     let loadedChunks = 0;
     let loadingChunks = 0;
-    allChunks.forEach((chunk: ImageChunk) => {
+    allChunks.forEach((chunk: Chunk) => {
       if (chunk.state === "loaded") {
         loadedChunks++;
       } else if (chunk.state === "loading") {
@@ -54,7 +54,7 @@ export class ChunkInfoOverlay {
       prefetched: 0,
     }));
 
-    allChunks.forEach((chunk: ImageChunk) => {
+    allChunks.forEach((chunk: Chunk) => {
       if (chunk.visible) lodCounters[chunk.lod].visible++;
       // Prefetched chunks are only counted for the current LOD,
       // since higher/lower LODs are not actively rendered.
@@ -63,7 +63,7 @@ export class ChunkInfoOverlay {
       }
     });
 
-    renderedChunks.forEach((chunk: ImageChunk) => {
+    renderedChunks.forEach((chunk: Chunk) => {
       lodCounters[chunk.lod].rendered++;
     });
 

--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -1,9 +1,9 @@
 import {
-  ImageChunk,
-  ImageChunkLoader,
-  ImageChunkSource,
+  Chunk,
+  ChunkLoader,
+  ChunkSource,
   LoaderAttributes,
-} from "../data/image_chunk";
+} from "../data/chunk";
 import { Region } from "../data/region";
 import { Camera } from "../objects/cameras/camera";
 import { vec2, vec4, mat4 } from "gl-matrix";
@@ -17,7 +17,7 @@ type Bounds = { min: vec2; max: vec2 };
 const PREFETCH_PADDING_CHUNKS = 1;
 
 export class ChunkManagerSource {
-  private readonly chunks_: ImageChunk[];
+  private readonly chunks_: Chunk[];
   private readonly loader_;
   private readonly region_;
   private readonly attrs_: LoaderAttributes[];
@@ -28,11 +28,7 @@ export class ChunkManagerSource {
   private readonly channelIdx_: number;
   private lastVisibleBounds_: Bounds | null = null;
 
-  constructor(
-    loader: ImageChunkLoader,
-    attrs: LoaderAttributes[],
-    region: Region
-  ) {
+  constructor(loader: ChunkLoader, attrs: LoaderAttributes[], region: Region) {
     this.loader_ = loader;
     this.region_ = region;
     this.attrs_ = attrs;
@@ -102,7 +98,7 @@ export class ChunkManagerSource {
     }
   }
 
-  public getChunks(): ImageChunk[] {
+  public getChunks(): Chunk[] {
     const currentLODChunks = this.chunks_.filter(
       (chunk) =>
         chunk.lod === this.currentLOD_ &&
@@ -137,7 +133,7 @@ export class ChunkManagerSource {
     return this.lowestResLOD_ + 1;
   }
 
-  public get chunks(): ImageChunk[] {
+  public get chunks(): Chunk[] {
     return this.chunks_;
   }
 
@@ -167,7 +163,7 @@ export class ChunkManagerSource {
     }
   }
 
-  private loadChunkData(chunk: ImageChunk): void {
+  private loadChunkData(chunk: Chunk): void {
     chunk.state = "loading";
     this.loader_
       .loadChunkDataFromRegion(chunk, this.region_)
@@ -234,7 +230,7 @@ export class ChunkManagerSource {
     }
   }
 
-  private isChunkWithinBounds(chunk: ImageChunk, bounds: Bounds): boolean {
+  private isChunkWithinBounds(chunk: Chunk, bounds: Bounds): boolean {
     const boundsMinX = bounds.min[0];
     const boundsMaxX = bounds.max[0];
     const boundsMinY = bounds.min[1];
@@ -290,9 +286,9 @@ export class ChunkManagerSource {
 }
 
 export class ChunkManager {
-  private readonly sources_ = new Map<ImageChunkSource, ChunkManagerSource>();
+  private readonly sources_ = new Map<ChunkSource, ChunkManagerSource>();
 
-  public async addSource(source: ImageChunkSource, region: Region) {
+  public async addSource(source: ChunkSource, region: Region) {
     let existing = this.sources_.get(source);
     if (!existing) {
       const loader = await source.open();

--- a/packages/core/src/core/event_dispatcher.ts
+++ b/packages/core/src/core/event_dispatcher.ts
@@ -15,13 +15,13 @@ function isEventType(type: string): type is EventType {
 }
 
 export class EventContext {
-  readonly type: EventType;
-  readonly event: Event;
   private propagationStopped_: boolean = false;
+  public readonly type: EventType;
+  public readonly event?: Event;
   public worldPos?: vec3;
   public clipPos?: vec3;
 
-  constructor(type: EventType, event: Event) {
+  constructor(type: EventType, event?: Event) {
     this.type = type;
     this.event = event;
   }

--- a/packages/core/src/data/chunk.ts
+++ b/packages/core/src/data/chunk.ts
@@ -1,8 +1,8 @@
-import { Region } from "../data/region";
+import { Region } from "./region";
 import { TextureUnpackRowAlignment } from "../objects/textures/texture";
 import { PromiseScheduler } from "./promise_scheduler";
 
-const imageChunkDataTypes = [
+const chunkDataTypes = [
   Int8Array,
   Int16Array,
   Int32Array,
@@ -11,28 +11,21 @@ const imageChunkDataTypes = [
   Uint32Array,
   Float32Array,
 ] as const;
-type ImageChunkData = InstanceType<(typeof imageChunkDataTypes)[number]>;
+type ChunkData = InstanceType<(typeof chunkDataTypes)[number]>;
 
-export function isImageChunkData(value: unknown): value is ImageChunkData {
-  if (
-    imageChunkDataTypes.some(
-      (ImageChunkData) => value instanceof ImageChunkData
-    )
-  ) {
+export function isChunkData(value: unknown): value is ChunkData {
+  if (chunkDataTypes.some((ChunkData) => value instanceof ChunkData)) {
     return true;
   }
-  const supportedDataTypeNames = imageChunkDataTypes.map((dtype) => dtype.name);
+  const supportedDataTypeNames = chunkDataTypes.map((dtype) => dtype.name);
   console.debug(
-    `Unsupported image chunk data type: ${value}. Supported data types: ${supportedDataTypeNames}`
+    `Unsupported chunk data type: ${value}. Supported data types: ${supportedDataTypeNames}`
   );
   return false;
 }
 
-// One 2D chunk of n-dimensional image data.
-// TODO: include the region of this chunk.
-// https://github.com/chanzuckerberg/idetik/issues/34
-export type ImageChunk = {
-  data?: ImageChunkData;
+export type Chunk = {
+  data?: ChunkData;
   state: "unloaded" | "loading" | "loaded";
   lod: number;
   visible: boolean;
@@ -58,11 +51,10 @@ export type ImageChunk = {
   };
 };
 
-export type ImageChunkSource = {
-  open(): Promise<ImageChunkLoader>;
+export type ChunkSource = {
+  open(): Promise<ChunkLoader>;
 };
 
-// TODO: we should make this more comprehensive, such as for multiscale images, etc.
 export type LoaderAttributes = {
   chunks: readonly number[];
   dimensionNames: string[];
@@ -72,14 +64,14 @@ export type LoaderAttributes = {
   translation: readonly number[];
 };
 
-export type ImageChunkLoader = {
+export type ChunkLoader = {
   loadRegion(
     input: Region,
     lod: number,
     scheduler?: PromiseScheduler
-  ): Promise<ImageChunk>;
+  ): Promise<Chunk>;
 
-  loadChunkDataFromRegion(chunk: ImageChunk, region: Region): Promise<void>;
+  loadChunkDataFromRegion(chunk: Chunk, region: Region): Promise<void>;
 
   loadAttributes(): Promise<LoaderAttributes[]>;
 };

--- a/packages/core/src/data/ome_zarr_image_loader.ts
+++ b/packages/core/src/data/ome_zarr_image_loader.ts
@@ -2,11 +2,7 @@ import * as zarr from "zarrita";
 import { Slice } from "@zarrita/indexing";
 
 import { Region } from "../data/region";
-import {
-  ImageChunk,
-  isImageChunkData,
-  LoaderAttributes,
-} from "../data/image_chunk";
+import { Chunk, isChunkData, LoaderAttributes } from "./chunk";
 import { isTextureUnpackRowAlignment } from "../objects/textures/texture";
 import { PromiseScheduler } from "./promise_scheduler";
 
@@ -62,7 +58,7 @@ export class OmeZarrImageLoader {
     this.lods_ = this.metadata_.multiscales[0].datasets.length;
   }
 
-  public async loadChunkDataFromRegion(chunk: ImageChunk, region: Region) {
+  public async loadChunkDataFromRegion(chunk: Chunk, region: Region) {
     const attrs = this.getImageAttributes()[chunk.lod];
     const array = await zarr.open.v2(this.root_.resolve(attrs.datasetPath), {
       kind: "array",
@@ -79,7 +75,7 @@ export class OmeZarrImageLoader {
     const subarray = await array.getChunk(chunkCoords);
 
     const data = subarray.data;
-    if (!isImageChunkData(data)) {
+    if (!isChunkData(data)) {
       throw new Error(
         `Subarray has an unsupported data type, data=${data.constructor.name}`
       );
@@ -98,7 +94,7 @@ export class OmeZarrImageLoader {
     region: Region,
     lod: number,
     scheduler?: PromiseScheduler
-  ): Promise<ImageChunk> {
+  ): Promise<Chunk> {
     if (lod >= this.lods_) {
       throw new Error(
         `Invalid LOD index: ${lod}. Only ${this.lods_} lod(s) available`
@@ -122,7 +118,7 @@ export class OmeZarrImageLoader {
     }
     const subarray = await zarr.get(array, indices, options);
 
-    if (!isImageChunkData(subarray.data)) {
+    if (!isChunkData(subarray.data)) {
       throw new Error(
         `Subarray has an unsupported data type, data=${subarray.data.constructor.name}`
       );
@@ -153,7 +149,7 @@ export class OmeZarrImageLoader {
     const xOffset = calculateOffset(indices.length - 1);
     const yOffset = calculateOffset(indices.length - 2);
 
-    const chunk: ImageChunk = {
+    const chunk: Chunk = {
       state: "loaded",
       lod: lod,
       visible: true,
@@ -226,7 +222,7 @@ export class OmeZarrImageLoader {
 
   private async getDimInfoMap(
     region: Region,
-    chunk: ImageChunk,
+    chunk: Chunk,
     attrs: ImageAttributes
   ) {
     const indices = this.regionToIndices(region, attrs);

--- a/packages/core/src/idetik.ts
+++ b/packages/core/src/idetik.ts
@@ -26,17 +26,17 @@ export type IdetikContext = {
 };
 
 export class Idetik {
-  public layerManager: LayerManager;
-  public camera: Camera;
   private cameraControls_?: CameraControls;
-  public readonly canvas: HTMLCanvasElement;
-  public readonly overlays: Overlay[];
-  private readonly eventDispatcher_: EventDispatcher;
-  private readonly renderer_: WebGLRenderer;
-  private readonly context_: IdetikContext;
-  private readonly chunkManager_: ChunkManager;
   private lastAnimationId_?: number;
   private needsResize_ = false;
+  private readonly chunkManager_: ChunkManager;
+  private readonly context_: IdetikContext;
+  private readonly renderer_: WebGLRenderer;
+  public camera: Camera;
+  public layerManager: LayerManager;
+  public readonly canvas: HTMLCanvasElement;
+  public readonly events: EventDispatcher;
+  public readonly overlays: Overlay[];
 
   constructor(params: IdetikParams) {
     if (!params.canvas && !params.canvasSelector) {
@@ -70,8 +70,8 @@ export class Idetik {
 
     this.overlays = params.overlays ?? [];
 
-    this.eventDispatcher_ = new EventDispatcher(canvas);
-    this.eventDispatcher_.addEventListener((event: EventContext) => {
+    this.events = new EventDispatcher(canvas);
+    this.events.addEventListener((event: EventContext) => {
       if (
         event.event instanceof PointerEvent ||
         event.event instanceof WheelEvent

--- a/packages/core/src/layers/image_layer.ts
+++ b/packages/core/src/layers/image_layer.ts
@@ -1,7 +1,7 @@
 import { Layer, LayerOptions } from "../core/layer";
 import { IdetikContext } from "../idetik";
 import { Region } from "../data/region";
-import { ImageChunk, ImageChunkSource } from "../data/image_chunk";
+import { Chunk, ChunkSource } from "../data/chunk";
 import { ChunkManagerSource } from "../core/chunk_manager";
 import { ChannelProps, ChannelsEnabled } from "../objects/textures/channel";
 import { ImageRenderable } from "../objects/renderable/image_renderable";
@@ -11,7 +11,7 @@ import { Logger } from "../utilities/logger";
 import { Color } from "../core/color";
 
 export type ImageLayerProps = LayerOptions & {
-  source: ImageChunkSource;
+  source: ChunkSource;
   region: Region;
   channelProps?: ChannelProps[];
 };
@@ -20,14 +20,14 @@ export type ImageLayerProps = LayerOptions & {
 export class ImageLayer extends Layer implements ChannelsEnabled {
   public readonly type = "ImageLayer";
 
-  private readonly source_: ImageChunkSource;
+  private readonly source_: ChunkSource;
   // TODO: remove this when region is passed through to update.
   // https://github.com/chanzuckerberg/idetik/issues/33
   private readonly region_: Region;
   private readonly useChunkManager_: boolean;
   private readonly initialChannelProps_?: ChannelProps[];
   private readonly channelChangeCallbacks_: Array<() => void> = [];
-  private readonly visibleChunks_: Map<ImageChunk, ImageRenderable> = new Map();
+  private readonly visibleChunks_: Map<Chunk, ImageRenderable> = new Map();
   private chunkManagerSource_?: ChunkManagerSource;
   private channelProps_?: ChannelProps[];
   private image_?: ImageRenderable;
@@ -189,12 +189,12 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
     return this.chunkManagerSource_;
   }
 
-  private createImage(chunk: ImageChunk, channelProps?: ChannelProps[]) {
+  private createImage(chunk: Chunk, channelProps?: ChannelProps[]) {
     const geometry = new PlaneGeometry(chunk.shape.x, chunk.shape.y, 1, 1);
 
     const image = new ImageRenderable(
       geometry,
-      Texture2DArray.createWithImageChunk(chunk),
+      Texture2DArray.createWithChunk(chunk),
       channelProps
     );
 

--- a/packages/core/src/layers/image_series_layer.ts
+++ b/packages/core/src/layers/image_series_layer.ts
@@ -1,6 +1,6 @@
 import { Layer, LayerOptions } from "../core/layer";
 import { Region } from "../data/region";
-import { ImageChunk, ImageChunkSource } from "../data/image_chunk";
+import { Chunk, ChunkSource } from "../data/chunk";
 import { Texture2DArray } from "../objects/textures/texture_2d_array";
 import { ChannelProps, ChannelsEnabled } from "../objects/textures/channel";
 import { ImageRenderable } from "../objects/renderable/image_renderable";
@@ -8,7 +8,7 @@ import { PlaneGeometry } from "../objects/geometry/plane_geometry";
 import { ImageSeriesLoader, SetIndexResult } from "./image_series_loader";
 
 export type ImageSeriesLayerProps = LayerOptions & {
-  source: ImageChunkSource;
+  source: ChunkSource;
   region: Region;
   seriesDimensionName: string;
   channelProps?: ChannelProps[];
@@ -111,9 +111,9 @@ export class ImageSeriesLayer extends Layer implements ChannelsEnabled {
     return result;
   }
 
-  private setData(chunk: ImageChunk) {
+  private setData(chunk: Chunk) {
     if (!this.texture_ || !this.image_) {
-      this.texture_ = Texture2DArray.createWithImageChunk(chunk);
+      this.texture_ = Texture2DArray.createWithChunk(chunk);
       this.image_ = this.createImage(chunk, this.texture_, this.channelProps_);
       this.addObject(this.image_);
 
@@ -128,7 +128,7 @@ export class ImageSeriesLayer extends Layer implements ChannelsEnabled {
   }
 
   private createImage(
-    chunk: ImageChunk,
+    chunk: Chunk,
     texture: Texture2DArray,
     channelProps?: ChannelProps[]
   ) {

--- a/packages/core/src/layers/image_series_loader.ts
+++ b/packages/core/src/layers/image_series_loader.ts
@@ -1,9 +1,5 @@
 import { Full, Interval, Region } from "../data/region";
-import {
-  ImageChunk,
-  ImageChunkLoader,
-  ImageChunkSource,
-} from "../data/image_chunk";
+import { Chunk, ChunkLoader, ChunkSource } from "../data/chunk";
 import { AbortError, PromiseScheduler } from "../data/promise_scheduler";
 
 type SeriesAttributes = {
@@ -21,27 +17,27 @@ type LoadingToken = {
 export type SetIndexResult = {
   success: boolean;
   reason?: "duplicate" | "canceled";
-  chunk?: ImageChunk;
+  chunk?: Chunk;
 };
 
 type ImageSeriesLoaderProps = {
-  source: ImageChunkSource;
+  source: ChunkSource;
   region: Region;
   seriesDimensionName: string;
   lod?: number;
 };
 
 export class ImageSeriesLoader {
-  private readonly source_: ImageChunkSource;
+  private readonly source_: ChunkSource;
   private readonly region_: Region;
   private readonly seriesDimensionName_: string;
   private readonly seriesIndex_: Interval | Full;
   private readonly scheduler_: PromiseScheduler = new PromiseScheduler(16);
   private readonly lod_?: number;
-  private loader_: ImageChunkLoader | null = null;
+  private loader_: ChunkLoader | null = null;
   private seriesAttributes_?: SeriesAttributes;
   private loadingToken_: LoadingToken | null = null;
-  public dataChunks_: ImageChunk[] = [];
+  public dataChunks_: Chunk[] = [];
 
   constructor(props: ImageSeriesLoaderProps) {
     this.source_ = props.source;

--- a/packages/core/src/layers/label_image_layer.ts
+++ b/packages/core/src/layers/label_image_layer.ts
@@ -1,6 +1,6 @@
 import { Layer, LayerOptions } from "../core/layer";
 import { Region } from "../data/region";
-import { ImageChunk, ImageChunkSource } from "../data/image_chunk";
+import { Chunk, ChunkSource } from "../data/chunk";
 import { Texture2D } from "../objects/textures/texture_2d";
 import { PlaneGeometry } from "../objects/geometry/plane_geometry";
 import {
@@ -17,7 +17,7 @@ export interface PointPickingResult {
 }
 
 export type LabelImageLayerProps = LayerOptions & {
-  source: ImageChunkSource;
+  source: ChunkSource;
   region: Region;
   colorMap?: LabelColorMapProps;
   onPickValue?: (info: PointPickingResult) => void;
@@ -26,13 +26,13 @@ export type LabelImageLayerProps = LayerOptions & {
 export class LabelImageLayer extends Layer {
   public readonly type = "LabelImageLayer";
 
-  private readonly source_: ImageChunkSource;
+  private readonly source_: ChunkSource;
   private readonly region_: Region;
   private readonly lod_?: number;
   private colorMap_: LabelColorMap;
   private readonly onPickValue_?: (info: PointPickingResult) => void;
   private image_?: LabelImageRenderable;
-  private imageChunk_?: ImageChunk;
+  private imageChunk_?: Chunk;
   private pointerDownPos_: vec2 | null = null;
   private readonly dragThreshold_ = 3;
 
@@ -130,12 +130,12 @@ export class LabelImageLayer extends Layer {
     this.setState("ready");
   }
 
-  private createImage(chunk: ImageChunk) {
+  private createImage(chunk: Chunk) {
     this.imageChunk_ = chunk; // Store chunk for value picking
     const geometry = new PlaneGeometry(chunk.shape.x, chunk.shape.y, 1, 1);
     const image = new LabelImageRenderable({
       geometry,
-      imageData: Texture2D.createWithImageChunk(chunk),
+      imageData: Texture2D.createWithChunk(chunk),
       colorMap: this.colorMap_,
     });
     image.transform.setScale([chunk.scale.x, chunk.scale.y, 1]);

--- a/packages/core/src/layers/label_image_series_layer.ts
+++ b/packages/core/src/layers/label_image_series_layer.ts
@@ -1,6 +1,6 @@
 import { Layer, LayerOptions } from "../core/layer";
 import { Region } from "../data/region";
-import { ImageChunk, ImageChunkSource } from "../data/image_chunk";
+import { Chunk, ChunkSource } from "../data/chunk";
 import { Texture2D } from "../objects/textures/texture_2d";
 import { LabelImageRenderable } from "../objects/renderable/label_image_renderable";
 import { PlaneGeometry } from "../objects/geometry/plane_geometry";
@@ -11,7 +11,7 @@ import {
 import { ImageSeriesLoader, SetIndexResult } from "./image_series_loader";
 
 export type LabelImageSeriesLayerProps = LayerOptions & {
-  source: ImageChunkSource;
+  source: ChunkSource;
   region: Region;
   seriesDimensionName: string;
   colorMap?: LabelColorMapProps;
@@ -92,9 +92,9 @@ export class LabelImageSeriesLayer extends Layer {
     return result;
   }
 
-  private setData(chunk: ImageChunk) {
+  private setData(chunk: Chunk) {
     if (!this.texture_ || !this.image_) {
-      this.texture_ = Texture2D.createWithImageChunk(chunk);
+      this.texture_ = Texture2D.createWithChunk(chunk);
       this.image_ = this.createImage(chunk, this.texture_);
       this.addObject(this.image_);
 
@@ -108,7 +108,7 @@ export class LabelImageSeriesLayer extends Layer {
     }
   }
 
-  private createImage(chunk: ImageChunk, texture: Texture2D) {
+  private createImage(chunk: Chunk, texture: Texture2D) {
     const geometry = new PlaneGeometry(chunk.shape.x, chunk.shape.y, 1, 1);
     const image = new LabelImageRenderable({
       geometry,

--- a/packages/core/src/objects/cameras/controls.ts
+++ b/packages/core/src/objects/cameras/controls.ts
@@ -32,10 +32,6 @@ export class PanZoomControls implements CameraControls {
       case "pointercancel":
         this.onPointerEnd(event);
         break;
-      default: {
-        const exhaustiveCheck: never = event.type;
-        throw new Error(`Unknown event type: ${exhaustiveCheck}`);
-      }
     }
   }
 

--- a/packages/core/src/objects/textures/texture_2d.ts
+++ b/packages/core/src/objects/textures/texture_2d.ts
@@ -3,7 +3,7 @@ import {
   Texture,
   bufferToDataType,
 } from "../../objects/textures/texture";
-import { ImageChunk } from "../../data/image_chunk";
+import { Chunk } from "../../data/chunk";
 
 export class Texture2D extends Texture {
   private data_: DataTextureTypedArray;
@@ -41,7 +41,7 @@ export class Texture2D extends Texture {
     return this.height_;
   }
 
-  public static createWithImageChunk(chunk: ImageChunk) {
+  public static createWithChunk(chunk: Chunk) {
     if (!chunk.data) {
       throw new Error(
         "Unabled to create texture, chunk data is not initialized."

--- a/packages/core/src/objects/textures/texture_2d_array.ts
+++ b/packages/core/src/objects/textures/texture_2d_array.ts
@@ -4,7 +4,7 @@ import {
   bufferToDataType,
 } from "../../objects/textures/texture";
 
-import { ImageChunk } from "../../data/image_chunk";
+import { Chunk } from "../../data/chunk";
 export class Texture2DArray extends Texture {
   private data_: DataTextureTypedArray;
   private readonly width_: number;
@@ -48,7 +48,7 @@ export class Texture2DArray extends Texture {
     return this.depth_;
   }
 
-  public static createWithImageChunk(chunk: ImageChunk) {
+  public static createWithChunk(chunk: Chunk) {
     if (!chunk.data) {
       throw new Error(
         "Unabled to create texture, chunk data is not initialized."


### PR DESCRIPTION
### Summary

This PR renames `ImageChunk` to `Chunk`. In upcoming work, a chunk will hold
3D data, which will be sliced at the layer (or image renderable) level. This
rename reflects that change and aligns with the terminology we agreed on.

### Tests & Checks
- All checks have passed
- All examples run as expected
