### PR TITLE
Export ScaleBar through OmeZarrImageViewer barrel file

### DIFF
--- a/packages/react/src/components/viewers/OmeZarrImageViewer/index.tsx
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/index.tsx
@@ -1,2 +1,3 @@
 export { OmeZarrImageViewer } from "./OmeZarrImageViewer";
 export { ChannelControlsList } from "./components/ChannelControlsList";
+export { ScaleBar } from "./components/ScaleBar";


### PR DESCRIPTION
### Summary
This exports the ScaleBar component from `@idetik/react` for use in downstream applications, separate from the OmeZarrImageViewer component.

### Related Issue
N/A

### Tests & Checks
Tested by publishing the [Try Cryolens demo](https://fluffy-chainsaw-rwkolj6.pages.github.io/) built with this branch of idetik/core and idetik/react.
