### PR TITLE
Add Z-axis fields to Chunk type

### DIFF
--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -36,30 +36,31 @@ export class ChunkManagerSource {
     this.currentLOD_ = 0;
 
     this.xIdx_ = region.findIndex(
-      (entry) => entry.dimension.toLocaleLowerCase() === "x"
+      (entry) => entry.dimension.toLowerCase() === "x"
     );
     this.yIdx_ = region.findIndex(
-      (entry) => entry.dimension.toLocaleLowerCase() === "y"
+      (entry) => entry.dimension.toLowerCase() === "y"
     );
     this.zIdx_ = region.findIndex(
-      (entry) => entry.dimension.toLocaleLowerCase() === "z"
+      (entry) => entry.dimension.toLowerCase() === "z"
     );
     this.channelIdx_ = region.findIndex(
-      (entry) => entry.dimension.toLocaleLowerCase() === "c"
+      (entry) => entry.dimension.toLowerCase() === "c"
     );
 
-    if (this.xIdx_ === -1 || this.yIdx_ === -1 || this.zIdx_ === -1) {
-      throw new Error("Missing required spatial axis x/y/z");
+    if (this.xIdx_ === -1 || this.yIdx_ === -1) {
+      throw new Error("Missing required spatial axis x/y");
     }
 
-    this.validateScaleRatios(this.xIdx_, this.yIdx_, this.zIdx_);
+    this.validateXYScaleRatios(this.xIdx_, this.yIdx_);
 
     // generate chunks for each LOD without loading data
     this.chunks_ = [];
     for (let lod = 0; lod < this.attrs_.length; ++lod) {
       const chunkWidth = this.attrs_[lod].chunks[this.xIdx_];
       const chunkHeight = this.attrs_[lod].chunks[this.yIdx_];
-      const chunkDepth = this.attrs_[lod].chunks[this.zIdx_];
+      const chunkDepth =
+        this.zIdx_ !== -1 ? this.attrs_[lod].chunks[this.zIdx_] : 1;
 
       const chunksX = Math.ceil(
         this.attrs_[lod].shape[this.xIdx_] / chunkWidth
@@ -67,9 +68,10 @@ export class ChunkManagerSource {
       const chunksY = Math.ceil(
         this.attrs_[lod].shape[this.yIdx_] / chunkHeight
       );
-      const chunksZ = Math.ceil(
-        this.attrs_[lod].shape[this.zIdx_] / chunkDepth
-      );
+      const chunksZ =
+        this.zIdx_ !== -1
+          ? Math.ceil(this.attrs_[lod].shape[this.zIdx_] / chunkDepth)
+          : 1;
 
       const channels =
         this.channelIdx_ >= 0 ? this.attrs_[lod].shape[this.channelIdx_] : 1;
@@ -96,13 +98,17 @@ export class ChunkManagerSource {
               scale: {
                 x: scale[this.xIdx_],
                 y: scale[this.yIdx_],
-                z: scale[this.zIdx_],
+                z: this.zIdx_ !== -1 ? scale[this.zIdx_] : 1,
               },
               offset: {
                 x: translation[this.xIdx_] + x * chunkWidth * scale[this.xIdx_],
                 y:
                   translation[this.yIdx_] + y * chunkHeight * scale[this.yIdx_],
-                z: translation[this.zIdx_] + z * chunkDepth * scale[this.zIdx_],
+                z:
+                  this.zIdx_ !== -1
+                    ? translation[this.zIdx_] +
+                      z * chunkDepth * scale[this.zIdx_]
+                    : 0,
               },
             });
           }
@@ -235,21 +241,23 @@ export class ChunkManagerSource {
     }
   }
 
-  private validateScaleRatios(xIdx: number, yIdx: number, zIdx: number): void {
+  private validateXYScaleRatios(xIdx: number, yIdx: number): void {
+    // Validates that each LOD level is downsampled by a factor of 2 in X and Y.
+    // Z downsampling is not validated here because it may be inconsistent or
+    // completely absent in some pyramids.
     const availableScales = this.attrs_.map((attr) => attr.scale);
     for (let i = 1; i < availableScales.length; i++) {
       const prev = availableScales[i - 1];
       const curr = availableScales[i];
       const rx = curr[xIdx] / prev[xIdx];
       const ry = curr[yIdx] / prev[yIdx];
-      const rz = curr[zIdx] / prev[zIdx];
 
-      if (!almostEqual(rx, 2) || !almostEqual(ry, 2) || !almostEqual(rz, 2)) {
+      if (!almostEqual(rx, 2) || !almostEqual(ry, 2)) {
         throw new Error(
-          `Invalid scale ratio between LOD ${i - 1} and LOD ${i}: ` +
-            `expected (2, 2, 2), got ` +
-            `(${rx.toFixed(2)}, ${ry.toFixed(2)}, ${rz.toFixed(2)}) ` +
-            `from scales [${prev.join(", ")}] → [${curr.join(", ")}]`
+          `Invalid downsampling factor between levels ${i - 1} → ${i}: ` +
+            `expected (2× in X and Y), but got ` +
+            `(${rx.toFixed(2)}×, ${ry.toFixed(2)}×) from scale ` +
+            `[${prev.join(", ")}] → [${curr.join(", ")}]`
         );
       }
     }

--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -24,6 +24,7 @@ export class ChunkManagerSource {
   private currentLOD_: number = 0;
   private readonly xIdx_: number;
   private readonly yIdx_: number;
+  private readonly zIdx_: number;
   private readonly channelIdx_: number;
   private lastVisibleBounds_: Box2 | null = null;
 
@@ -40,58 +41,71 @@ export class ChunkManagerSource {
     this.yIdx_ = region.findIndex(
       (entry) => entry.dimension.toLocaleLowerCase() === "y"
     );
-    if (this.xIdx_ === -1 || this.yIdx_ === -1) {
-      throw new Error("Missing required spatial axis x/y");
-    }
-    this.validateScaleRatios(this.xIdx_, this.yIdx_);
-    let channelIdx = region.findIndex(
-      (entry) => entry.dimension.toLowerCase() === "c"
+    this.zIdx_ = region.findIndex(
+      (entry) => entry.dimension.toLocaleLowerCase() === "z"
     );
-    if (channelIdx === -1) {
-      channelIdx = 0;
+    this.channelIdx_ = region.findIndex(
+      (entry) => entry.dimension.toLocaleLowerCase() === "c"
+    );
+
+    if (this.xIdx_ === -1 || this.yIdx_ === -1 || this.zIdx_ === -1) {
+      throw new Error("Missing required spatial axis x/y/z");
     }
-    this.channelIdx_ = channelIdx;
+
+    this.validateScaleRatios(this.xIdx_, this.yIdx_, this.zIdx_);
+
     // generate chunks for each LOD without loading data
     this.chunks_ = [];
     for (let lod = 0; lod < this.attrs_.length; ++lod) {
       const chunkWidth = this.attrs_[lod].chunks[this.xIdx_];
       const chunkHeight = this.attrs_[lod].chunks[this.yIdx_];
+      const chunkDepth = this.attrs_[lod].chunks[this.zIdx_];
+
       const chunksX = Math.ceil(
         this.attrs_[lod].shape[this.xIdx_] / chunkWidth
       );
       const chunksY = Math.ceil(
         this.attrs_[lod].shape[this.yIdx_] / chunkHeight
       );
+      const chunksZ = Math.ceil(
+        this.attrs_[lod].shape[this.zIdx_] / chunkDepth
+      );
+
       const channels =
-        this.attrs_[lod].shape.length === 3
-          ? this.attrs_[lod].shape[this.channelIdx_]
-          : 1;
+        this.channelIdx_ >= 0 ? this.attrs_[lod].shape[this.channelIdx_] : 1;
+
       const scale = this.attrs_[lod].scale;
       const translation = this.attrs_[lod].translation;
       for (let x = 0; x < chunksX; ++x) {
         for (let y = 0; y < chunksY; ++y) {
-          this.chunks_.push({
-            state: "unloaded",
-            lod,
-            visible: false,
-            prefetch: false,
-            shape: {
-              x: chunkWidth,
-              y: chunkHeight,
-              c: channels,
-            },
-            rowStride: chunkWidth,
-            rowAlignmentBytes: 1,
-            chunkIndex: { x, y },
-            scale: {
-              x: scale[this.xIdx_],
-              y: scale[this.yIdx_],
-            },
-            offset: {
-              x: translation[this.xIdx_] + x * chunkWidth * scale[this.xIdx_],
-              y: translation[this.yIdx_] + y * chunkHeight * scale[this.yIdx_],
-            },
-          });
+          for (let z = 0; z < chunksZ; ++z) {
+            this.chunks_.push({
+              state: "unloaded",
+              lod,
+              visible: false,
+              prefetch: false,
+              shape: {
+                x: chunkWidth,
+                y: chunkHeight,
+                z: chunkDepth,
+                c: channels,
+              },
+              rowStride: chunkWidth,
+              rowAlignmentBytes: 1,
+              chunkIndex: { x, y, z },
+              scale: {
+                x: scale[this.xIdx_],
+                y: scale[this.yIdx_],
+                z: scale[this.zIdx_],
+              },
+              offset: {
+                x: translation[this.xIdx_] + x * chunkWidth * scale[this.xIdx_],
+                y:
+                  translation[this.yIdx_] + y * chunkHeight * scale[this.yIdx_],
+                z: translation[this.zIdx_] + z * chunkDepth * scale[this.zIdx_],
+              },
+            });
+          }
         }
       }
     }
@@ -156,9 +170,14 @@ export class ChunkManagerSource {
 
   private loadLowResChunks(): void {
     for (const chunk of this.chunks_) {
-      if (chunk.lod === this.lowestResLOD_ && chunk.state === "unloaded") {
-        this.loadChunkData(chunk);
-      }
+      if (chunk.lod !== this.lowestResLOD_ || chunk.state !== "unloaded")
+        continue;
+
+      // TEMP: visibility is 2D (Box2). Ignore nonzero Z until Box3 intersects() exists.
+      // In this case, changes to loadChunkDataFromRegion are also needed.
+      if (chunk.chunkIndex.z !== 0) continue;
+
+      this.loadChunkData(chunk);
     }
   }
 
@@ -172,7 +191,7 @@ export class ChunkManagerSource {
       .catch((error) => {
         Logger.error(
           "ChunkManager",
-          `Error loading chunk (${chunk.chunkIndex.x},${chunk.chunkIndex.y}): ${error}`
+          `Error loading chunk (${chunk.chunkIndex.x},${chunk.chunkIndex.y},${chunk.chunkIndex.z}): ${error}`
         );
         chunk.state = "unloaded";
       });
@@ -205,6 +224,9 @@ export class ChunkManagerSource {
 
     const paddedBounds = this.getPaddedBounds(visibleBounds);
     for (const chunk of this.chunks_) {
+      // TEMP: visibility is 2D (Box2). Ignore nonzero Z until Box3 intersects() exists.
+      if (chunk.chunkIndex.z !== 0) continue;
+
       chunk.prefetch = false;
       chunk.visible = this.isChunkWithinBounds(chunk, visibleBounds);
       if (!chunk.visible) {
@@ -213,17 +235,21 @@ export class ChunkManagerSource {
     }
   }
 
-  private validateScaleRatios(xIdx: number, yIdx: number): void {
+  private validateScaleRatios(xIdx: number, yIdx: number, zIdx: number): void {
     const availableScales = this.attrs_.map((attr) => attr.scale);
     for (let i = 1; i < availableScales.length; i++) {
       const prev = availableScales[i - 1];
       const curr = availableScales[i];
       const rx = curr[xIdx] / prev[xIdx];
       const ry = curr[yIdx] / prev[yIdx];
+      const rz = curr[zIdx] / prev[zIdx];
 
-      if (!almostEqual(rx, 2) || !almostEqual(ry, 2)) {
+      if (!almostEqual(rx, 2) || !almostEqual(ry, 2) || !almostEqual(rz, 2)) {
         throw new Error(
-          `Scales must be separated by factors of 2. Got ratio (${rx}, ${ry}) between scales ${prev} and ${curr}`
+          `Invalid scale ratio between LOD ${i - 1} and LOD ${i}: ` +
+            `expected (2, 2, 2), got ` +
+            `(${rx.toFixed(2)}, ${ry.toFixed(2)}, ${rz.toFixed(2)}) ` +
+            `from scales [${prev.join(", ")}] → [${curr.join(", ")}]`
         );
       }
     }
@@ -298,7 +324,7 @@ export class ChunkManager {
       );
     }
 
-    const visibleBounds = camera.getWorldViewRect2D();
+    const visibleBounds = camera.getWorldViewRect();
     const virtualWidth = Math.abs(visibleBounds.max[0] - visibleBounds.min[0]);
     const virtualUnitsPerScreenPixel = virtualWidth / bufferWidth;
     const lodFactor = Math.log2(1 / virtualUnitsPerScreenPixel);

--- a/packages/core/src/data/chunk.ts
+++ b/packages/core/src/data/chunk.ts
@@ -33,6 +33,7 @@ export type Chunk = {
   shape: {
     x: number;
     y: number;
+    z: number;
     c: number;
   };
   rowStride: number;
@@ -40,14 +41,17 @@ export type Chunk = {
   chunkIndex: {
     x: number;
     y: number;
+    z: number;
   };
   scale: {
     x: number;
     y: number;
+    z: number;
   };
   offset: {
     x: number;
     y: number;
+    z: number;
   };
 };
 

--- a/packages/core/src/data/ome_zarr_image_loader.ts
+++ b/packages/core/src/data/ome_zarr_image_loader.ts
@@ -146,9 +146,20 @@ export class OmeZarrImageLoader {
       }
       return index.start * scale[i] + translation[i];
     };
-    const xOffset = calculateOffset(indices.length - 1);
-    const yOffset = calculateOffset(indices.length - 2);
-    const zOffset = calculateOffset(indices.length - 3);
+
+    const xIdx = region.findIndex(
+      (entry) => entry.dimension.toLowerCase() === "x"
+    );
+    const yIdx = region.findIndex(
+      (entry) => entry.dimension.toLowerCase() === "y"
+    );
+    const zIdx = region.findIndex(
+      (entry) => entry.dimension.toLowerCase() === "z"
+    );
+
+    const xOffset = calculateOffset(xIdx);
+    const yOffset = calculateOffset(yIdx);
+    const zOffset = zIdx !== -1 ? calculateOffset(indices.length - 3) : 0;
 
     const chunk: Chunk = {
       state: "loaded",
@@ -159,7 +170,7 @@ export class OmeZarrImageLoader {
       shape: {
         x: subarray.shape[subarray.shape.length - 1],
         y: subarray.shape[subarray.shape.length - 2],
-        z: subarray.shape[subarray.shape.length - 3],
+        z: zIdx !== -1 ? subarray.shape[subarray.shape.length - 3] : 1,
         c: subarray.shape.length === 3 ? subarray.shape[0] : 1,
       },
       chunkIndex: { x: 0, y: 0, z: 0 },
@@ -168,7 +179,7 @@ export class OmeZarrImageLoader {
       scale: {
         x: scale[indices.length - 1],
         y: scale[indices.length - 2],
-        z: scale[indices.length - 3],
+        z: zIdx !== -1 ? scale[indices.length - 3] : 1,
       },
       offset: { x: xOffset, y: yOffset, z: zOffset },
     };

--- a/packages/core/src/data/ome_zarr_image_loader.ts
+++ b/packages/core/src/data/ome_zarr_image_loader.ts
@@ -147,19 +147,8 @@ export class OmeZarrImageLoader {
       return index.start * scale[i] + translation[i];
     };
 
-    const xIdx = region.findIndex(
-      (entry) => entry.dimension.toLowerCase() === "x"
-    );
-    const yIdx = region.findIndex(
-      (entry) => entry.dimension.toLowerCase() === "y"
-    );
-    const zIdx = region.findIndex(
-      (entry) => entry.dimension.toLowerCase() === "z"
-    );
-
-    const xOffset = calculateOffset(xIdx);
-    const yOffset = calculateOffset(yIdx);
-    const zOffset = zIdx !== -1 ? calculateOffset(indices.length - 3) : 0;
+    const xOffset = calculateOffset(indices.length - 1);
+    const yOffset = calculateOffset(indices.length - 2);
 
     const chunk: Chunk = {
       state: "loaded",
@@ -170,7 +159,7 @@ export class OmeZarrImageLoader {
       shape: {
         x: subarray.shape[subarray.shape.length - 1],
         y: subarray.shape[subarray.shape.length - 2],
-        z: zIdx !== -1 ? subarray.shape[subarray.shape.length - 3] : 1,
+        z: 1,
         c: subarray.shape.length === 3 ? subarray.shape[0] : 1,
       },
       chunkIndex: { x: 0, y: 0, z: 0 },
@@ -179,9 +168,9 @@ export class OmeZarrImageLoader {
       scale: {
         x: scale[indices.length - 1],
         y: scale[indices.length - 2],
-        z: zIdx !== -1 ? scale[indices.length - 3] : 1,
+        z: 1,
       },
-      offset: { x: xOffset, y: yOffset, z: zOffset },
+      offset: { x: xOffset, y: yOffset, z: 0 },
     };
     return chunk;
   }

--- a/packages/core/src/data/ome_zarr_image_loader.ts
+++ b/packages/core/src/data/ome_zarr_image_loader.ts
@@ -148,6 +148,7 @@ export class OmeZarrImageLoader {
     };
     const xOffset = calculateOffset(indices.length - 1);
     const yOffset = calculateOffset(indices.length - 2);
+    const zOffset = calculateOffset(indices.length - 3);
 
     const chunk: Chunk = {
       state: "loaded",
@@ -158,13 +159,18 @@ export class OmeZarrImageLoader {
       shape: {
         x: subarray.shape[subarray.shape.length - 1],
         y: subarray.shape[subarray.shape.length - 2],
+        z: subarray.shape[subarray.shape.length - 3],
         c: subarray.shape.length === 3 ? subarray.shape[0] : 1,
       },
-      chunkIndex: { x: 0, y: 0 },
+      chunkIndex: { x: 0, y: 0, z: 0 },
       rowStride: subarray.stride[subarray.stride.length - 2],
       rowAlignmentBytes: rowAlignment,
-      scale: { x: scale[indices.length - 1], y: scale[indices.length - 2] },
-      offset: { x: xOffset, y: yOffset },
+      scale: {
+        x: scale[indices.length - 1],
+        y: scale[indices.length - 2],
+        z: scale[indices.length - 3],
+      },
+      offset: { x: xOffset, y: yOffset, z: zOffset },
     };
     return chunk;
   }

--- a/packages/core/src/idetik.ts
+++ b/packages/core/src/idetik.ts
@@ -126,10 +126,12 @@ export class Idetik {
         return;
       }
 
-      this.chunkManager_.update(
-        this.camera as OrthographicCamera,
-        this.renderer_.width
-      );
+      if (this.camera.type === "OrthographicCamera") {
+        this.chunkManager_.update(
+          this.camera as OrthographicCamera,
+          this.renderer_.width
+        );
+      }
 
       // Must resize before render b/c changing canvas coordinate space clears it.
       if (this.needsResize_) {

--- a/packages/core/src/layers/image_layer.ts
+++ b/packages/core/src/layers/image_layer.ts
@@ -60,9 +60,13 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
 
     const x = region.find((r) => r.dimension.toLowerCase() === "x");
     const y = region.find((r) => r.dimension.toLowerCase() === "y");
+    const z = region.find((r) => r.dimension.toLowerCase() === "z");
     const hasIntervals = region.some((r) => r.index.type === "interval");
     this.useChunkManager_ =
-      !hasIntervals && x?.index.type === "full" && y?.index.type === "full";
+      !hasIntervals &&
+      x?.index.type === "full" &&
+      y?.index.type === "full" &&
+      z?.index.type === "point";
 
     if (this.useChunkManager_) {
       Logger.info("ImageLayer", "Loading data using the chunk manager");

--- a/packages/core/src/objects/cameras/orthographic_camera.ts
+++ b/packages/core/src/objects/cameras/orthographic_camera.ts
@@ -60,7 +60,7 @@ export class OrthographicCamera extends Camera {
     this.transform.addScale([inverseFactor, inverseFactor, 1.0]);
   }
 
-  public getWorldViewRect2D(): Box2 {
+  public getWorldViewRect(): Box2 {
     let topLeft = vec4.fromValues(-1.0, -1.0, 0.0, 1.0);
     let bottomRight = vec4.fromValues(1.0, 1.0, 0.0, 1.0);
 


### PR DESCRIPTION
### Summary

This PR adds Z-axis support to the `Chunk` type and related code paths. It
introduces z-dimension indices, shapes, scales, and offsets for all LODs,
ensuring the type can represent full 3D chunks. Visibility and loading logic
remain 2D-only for now, with nonzero Z slices gated until `Box3` intersection
tests are implemented. **This is a schema-only change**, preparing for future
3D visibility and prefetching support.

### Tests & Checks
- All checks have passed
