### PR TITLE
feat: add value picking support to ImageLayer

### DIFF
--- a/packages/core/examples/image2d_from_omezarr5d_u8/index.html
+++ b/packages/core/examples/image2d_from_omezarr5d_u8/index.html
@@ -12,15 +12,39 @@
         display: flex;
         width: 100%;
         height: 100%;
+        font-family: monospace;
       }
+
       canvas {
         width: 100%;
         height: 100%;
+      }
+
+      #info-box {
+        display: flex;
+        flex-direction: column;
+        position: absolute;
+        top: 1em;
+        right: 1em;
+        width: 300px;
+        margin: 1em;
+        padding: 1em;
+        gap: 0.5em;
+        align-items: start;
+        justify-content: center;
+        background-color: rgba(0, 0, 0, 0.8);
+        color: white;
+        user-select: none;
       }
     </style>
   </head>
   <body>
     <canvas id="canvas"></canvas>
+    <div id="info-box">
+      <div><strong>Image Point Picking Demo</strong></div>
+      <div>Click on the image to pick pixel values</div>
+      <div id="pick-info">Click to see pick results...</div>
+    </div>
     <script type="module" src="./main.ts"></script>
   </body>
 </html>

--- a/packages/core/examples/image2d_from_omezarr5d_u8/main.ts
+++ b/packages/core/examples/image2d_from_omezarr5d_u8/main.ts
@@ -47,7 +47,6 @@ const channelProps: ChannelProps[] = [
   },
 ];
 
-// Get the info div for displaying pick results
 const pickInfoDiv = document.querySelector<HTMLDivElement>("#pick-info")!;
 
 const onPickValue = (info: ImagePointPickingResult) => {
@@ -57,10 +56,6 @@ const onPickValue = (info: ImagePointPickingResult) => {
     World: (${world[0].toFixed(1)}, ${world[1].toFixed(1)}, ${world[2].toFixed(1)})<br/>
     Pixel Value: ${value}<br/>
   `;
-  console.log(
-    `Picked value at world position [${world[0].toFixed(2)}, ${world[1].toFixed(2)}]:`,
-    value
-  );
 };
 
 const layer = new ImageLayer({ source, region, channelProps, onPickValue });

--- a/packages/core/examples/image2d_from_omezarr5d_u8/main.ts
+++ b/packages/core/examples/image2d_from_omezarr5d_u8/main.ts
@@ -6,6 +6,7 @@ import {
   OmeZarrImageSource,
   OrthographicCamera,
   Region,
+  ImagePointPickingResult,
 } from "@";
 import { AxesLayer } from "@/layers/axes_layer";
 import { PanZoomControls } from "@/objects/cameras/controls";
@@ -45,7 +46,24 @@ const channelProps: ChannelProps[] = [
     contrastLimits: [0, 200],
   },
 ];
-const layer = new ImageLayer({ source, region, channelProps });
+
+// Get the info div for displaying pick results
+const pickInfoDiv = document.querySelector<HTMLDivElement>("#pick-info")!;
+
+const onPickValue = (info: ImagePointPickingResult) => {
+  const { world, value } = info;
+  pickInfoDiv.innerHTML = `
+    <strong>Pick Result:</strong><br/>
+    World: (${world[0].toFixed(1)}, ${world[1].toFixed(1)}, ${world[2].toFixed(1)})<br/>
+    Pixel Value: ${value}<br/>
+  `;
+  console.log(
+    `Picked value at world position [${world[0].toFixed(2)}, ${world[1].toFixed(2)}]:`,
+    value
+  );
+};
+
+const layer = new ImageLayer({ source, region, channelProps, onPickValue });
 const axes = new AxesLayer({
   length: 0.75 * xInfo.scale * xInfo.size,
   width: 0.01,

--- a/packages/core/examples/image2d_from_omezarr5d_u8/main.ts
+++ b/packages/core/examples/image2d_from_omezarr5d_u8/main.ts
@@ -6,7 +6,7 @@ import {
   OmeZarrImageSource,
   OrthographicCamera,
   Region,
-  ImagePointPickingResult,
+  PointPickingResult,
 } from "@";
 import { AxesLayer } from "@/layers/axes_layer";
 import { PanZoomControls } from "@/objects/cameras/controls";
@@ -49,7 +49,7 @@ const channelProps: ChannelProps[] = [
 
 const pickInfoDiv = document.querySelector<HTMLDivElement>("#pick-info")!;
 
-const onPickValue = (info: ImagePointPickingResult) => {
+const onPickValue = (info: PointPickingResult) => {
   const { world, value } = info;
   pickInfoDiv.innerHTML = `
     <strong>Pick Result:</strong><br/>

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,7 +15,6 @@ export { AxesLayer } from "./layers/axes_layer";
 export { ProjectedLineLayer } from "./layers/projected_line_layer";
 export { TracksLayer } from "./layers/tracks_layer";
 export { ImageLayer } from "./layers/image_layer";
-export type { ImagePointPickingResult } from "./layers/image_layer";
 export { LabelImageLayer } from "./layers/label_image_layer";
 export { ImageSeriesLayer } from "./layers/image_series_layer";
 export { OmeZarrImageSource } from "./data/ome_zarr_image_source";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,8 +15,8 @@ export { AxesLayer } from "./layers/axes_layer";
 export { ProjectedLineLayer } from "./layers/projected_line_layer";
 export { TracksLayer } from "./layers/tracks_layer";
 export { ImageLayer } from "./layers/image_layer";
-export type { ImagePointPickingResult } from "./layers/image_layer";
 export { LabelImageLayer } from "./layers/label_image_layer";
+export type { PointPickingResult } from "./layers/label_image_layer";
 export { ImageSeriesLayer } from "./layers/image_series_layer";
 export { OmeZarrImageSource } from "./data/ome_zarr_image_source";
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,6 +15,7 @@ export { AxesLayer } from "./layers/axes_layer";
 export { ProjectedLineLayer } from "./layers/projected_line_layer";
 export { TracksLayer } from "./layers/tracks_layer";
 export { ImageLayer } from "./layers/image_layer";
+export type { ImagePointPickingResult } from "./layers/image_layer";
 export { LabelImageLayer } from "./layers/label_image_layer";
 export { ImageSeriesLayer } from "./layers/image_series_layer";
 export { OmeZarrImageSource } from "./data/ome_zarr_image_source";

--- a/packages/core/src/layers/image_layer.ts
+++ b/packages/core/src/layers/image_layer.ts
@@ -9,11 +9,19 @@ import { Texture2DArray } from "../objects/textures/texture_2d_array";
 import { PlaneGeometry } from "../objects/geometry/plane_geometry";
 import { Logger } from "../utilities/logger";
 import { Color } from "../core/color";
+import { EventContext } from "../core/event_dispatcher";
+import { vec2, vec3 } from "gl-matrix";
+
+export interface ImagePointPickingResult {
+  world: vec3;
+  value: number;
+}
 
 export type ImageLayerProps = LayerOptions & {
   source: ChunkSource;
   region: Region;
   channelProps?: ChannelProps[];
+  onPickValue?: (info: ImagePointPickingResult) => void;
 };
 
 // Loads data from an image source into renderable objects.
@@ -26,12 +34,15 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
   private readonly region_: Region;
   private readonly useChunkManager_: boolean;
   private readonly initialChannelProps_?: ChannelProps[];
+  private readonly onPickValue_?: (info: ImagePointPickingResult) => void;
   private readonly channelChangeCallbacks_: Array<() => void> = [];
   private readonly visibleChunks_: Map<Chunk, ImageRenderable> = new Map();
   private chunkManagerSource_?: ChunkManagerSource;
   private channelProps_?: ChannelProps[];
   private image_?: ImageRenderable;
   private extent_?: { x: number; y: number };
+  private pointerDownPos_: vec2 | null = null;
+  private readonly dragThreshold_ = 3;
 
   private readonly wireframeColors_ = [
     new Color(0.6, 0.3, 0.3),
@@ -47,6 +58,7 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
     source,
     region,
     channelProps,
+    onPickValue,
     lod,
     ...layerOptions
   }: ImageLayerProps) {
@@ -56,6 +68,7 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
     this.region_ = region;
     this.channelProps_ = channelProps;
     this.initialChannelProps_ = channelProps;
+    this.onPickValue_ = onPickValue;
     this.lod_ = lod;
 
     const x = region.find((r) => r.dimension.toLowerCase() === "x");
@@ -126,6 +139,43 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
           const exhaustiveCheck: never = this.state;
           throw new Error(`Unhandled LayerState case: ${exhaustiveCheck}`);
         }
+      }
+    }
+  }
+
+  public onEvent(event: EventContext) {
+    if (!this.onPickValue_) return;
+    // console.log("onEvent", event);
+    switch (event.type) {
+      case "pointerdown": {
+        const e = event.event as PointerEvent;
+        this.pointerDownPos_ = vec2.fromValues(e.clientX, e.clientY);
+        break;
+      }
+
+      case "pointerup": {
+        if (!this.pointerDownPos_) break;
+
+        const e = event.event as PointerEvent;
+        const pointerUpPos = vec2.fromValues(e.clientX, e.clientY);
+        const dist = vec2.distance(this.pointerDownPos_, pointerUpPos);
+
+        if (dist < this.dragThreshold_) {
+          this.pointerDownPos_ = null;
+          const world = event.worldPos;
+          if (!world) return;
+          const value = this.getValueAtWorld(world);
+
+          if (value !== null) {
+            this.onPickValue_({ world, value });
+          }
+        }
+        break;
+      }
+
+      case "pointercancel": {
+        this.pointerDownPos_ = null;
+        break;
       }
     }
   }
@@ -207,5 +257,32 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
     image.transform.setScale([chunk.scale.x, chunk.scale.y, 1]);
     image.transform.setTranslation([chunk.offset.x, chunk.offset.y, 0]);
     return image;
+  }
+
+  public getValueAtWorld(world: vec3): number | null {
+    // Iterate through all visible chunks to find the one containing the world position
+    for (const [chunk, image] of this.visibleChunks_) {
+      if (!chunk.data) continue;
+
+      const localPos = vec3.transformMat4(
+        vec3.create(),
+        world,
+        image.transform.inverse
+      );
+
+      const x = Math.floor(localPos[0]);
+      const y = Math.floor(localPos[1]);
+
+      // Check if this chunk contains the requested position
+      if (x >= 0 && x < chunk.shape.x && y >= 0 && y < chunk.shape.y) {
+        const pixelIndex = y * chunk.rowStride + x;
+        const data = chunk.data;
+
+        // For multi-channel images, take the first channel value (planar format)
+        // In planar format: RRR...GGG...BBB... so first channel data comes first
+        return data[pixelIndex];
+      }
+    }
+    return null;
   }
 }

--- a/packages/core/src/layers/image_layer.ts
+++ b/packages/core/src/layers/image_layer.ts
@@ -150,7 +150,8 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
       this.pointerDownPos_,
       this.dragThreshold_,
       (world) => this.getValueAtWorld(world),
-      this.onPickValue_
+      this.onPickValue_,
+      "ImageLayer"
     );
   }
 

--- a/packages/core/src/layers/image_layer.ts
+++ b/packages/core/src/layers/image_layer.ts
@@ -150,7 +150,6 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
       this.pointerDownPos_,
       this.dragThreshold_,
       (world) => this.getValueAtWorld(world),
-      "ImageLayer",
       this.onPickValue_
     );
   }

--- a/packages/core/src/layers/image_layer.ts
+++ b/packages/core/src/layers/image_layer.ts
@@ -150,8 +150,8 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
       this.pointerDownPos_,
       this.dragThreshold_,
       (world) => this.getValueAtWorld(world),
-      this.onPickValue_,
-      "ImageLayer"
+      "ImageLayer",
+      this.onPickValue_
     );
   }
 

--- a/packages/core/src/layers/image_layer.ts
+++ b/packages/core/src/layers/image_layer.ts
@@ -145,14 +145,12 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
   }
 
   public onEvent(event: EventContext) {
-    if (!this.onPickValue_) return;
-
     this.pointerDownPos_ = handlePointPickingEvent(
       event,
       this.pointerDownPos_,
       this.dragThreshold_,
       (world) => this.getValueAtWorld(world),
-      (info) => this.onPickValue_!(info)
+      this.onPickValue_
     );
   }
 

--- a/packages/core/src/layers/image_layer.ts
+++ b/packages/core/src/layers/image_layer.ts
@@ -10,11 +10,8 @@ import { PlaneGeometry } from "../objects/geometry/plane_geometry";
 import { Logger } from "../utilities/logger";
 import { Color } from "../core/color";
 import { EventContext } from "../core/event_dispatcher";
-import { vec3 } from "gl-matrix";
-import {
-  handlePointPickingEvent,
-  PointPickingState,
-} from "../utilities/point_picking";
+import { vec2, vec3 } from "gl-matrix";
+import { handlePointPickingEvent } from "../utilities/point_picking";
 
 export interface ImagePointPickingResult {
   world: vec3;
@@ -45,10 +42,8 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
   private channelProps_?: ChannelProps[];
   private image_?: ImageRenderable;
   private extent_?: { x: number; y: number };
-  private readonly pointPickingState_: PointPickingState = {
-    pointerDownPos: null,
-    dragThreshold: 3,
-  };
+  private pointerDownPos_: vec2 | null = null;
+  private readonly dragThreshold_ = 3;
 
   private readonly wireframeColors_ = [
     new Color(0.6, 0.3, 0.3),
@@ -152,9 +147,10 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
   public onEvent(event: EventContext) {
     if (!this.onPickValue_) return;
 
-    handlePointPickingEvent(
+    this.pointerDownPos_ = handlePointPickingEvent(
       event,
-      this.pointPickingState_,
+      this.pointerDownPos_,
+      this.dragThreshold_,
       (world) => this.getValueAtWorld(world),
       (info) => this.onPickValue_!(info)
     );

--- a/packages/core/src/layers/image_layer.ts
+++ b/packages/core/src/layers/image_layer.ts
@@ -12,17 +12,13 @@ import { Color } from "../core/color";
 import { EventContext } from "../core/event_dispatcher";
 import { vec2, vec3 } from "gl-matrix";
 import { handlePointPickingEvent } from "../utilities/point_picking";
-
-export interface ImagePointPickingResult {
-  world: vec3;
-  value: number;
-}
+import { PointPickingResult } from "./label_image_layer";
 
 export type ImageLayerProps = LayerOptions & {
   source: ChunkSource;
   region: Region;
   channelProps?: ChannelProps[];
-  onPickValue?: (info: ImagePointPickingResult) => void;
+  onPickValue?: (info: PointPickingResult) => void;
 };
 
 // Loads data from an image source into renderable objects.
@@ -35,7 +31,7 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
   private readonly region_: Region;
   private readonly useChunkManager_: boolean;
   private readonly initialChannelProps_?: ChannelProps[];
-  private readonly onPickValue_?: (info: ImagePointPickingResult) => void;
+  private readonly onPickValue_?: (info: PointPickingResult) => void;
   private readonly channelChangeCallbacks_: Array<() => void> = [];
   private readonly visibleChunks_: Map<Chunk, ImageRenderable> = new Map();
   private chunkManagerSource_?: ChunkManagerSource;

--- a/packages/core/src/layers/image_layer.ts
+++ b/packages/core/src/layers/image_layer.ts
@@ -10,7 +10,11 @@ import { PlaneGeometry } from "../objects/geometry/plane_geometry";
 import { Logger } from "../utilities/logger";
 import { Color } from "../core/color";
 import { EventContext } from "../core/event_dispatcher";
-import { vec2, vec3 } from "gl-matrix";
+import { vec3 } from "gl-matrix";
+import {
+  handlePointPickingEvent,
+  PointPickingState,
+} from "../utilities/point_picking";
 
 export interface ImagePointPickingResult {
   world: vec3;
@@ -41,8 +45,10 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
   private channelProps_?: ChannelProps[];
   private image_?: ImageRenderable;
   private extent_?: { x: number; y: number };
-  private pointerDownPos_: vec2 | null = null;
-  private readonly dragThreshold_ = 3;
+  private readonly pointPickingState_: PointPickingState = {
+    pointerDownPos: null,
+    dragThreshold: 3,
+  };
 
   private readonly wireframeColors_ = [
     new Color(0.6, 0.3, 0.3),
@@ -145,38 +151,13 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
 
   public onEvent(event: EventContext) {
     if (!this.onPickValue_) return;
-    switch (event.type) {
-      case "pointerdown": {
-        const e = event.event as PointerEvent;
-        this.pointerDownPos_ = vec2.fromValues(e.clientX, e.clientY);
-        break;
-      }
 
-      case "pointerup": {
-        if (!this.pointerDownPos_) break;
-
-        const e = event.event as PointerEvent;
-        const pointerUpPos = vec2.fromValues(e.clientX, e.clientY);
-        const dist = vec2.distance(this.pointerDownPos_, pointerUpPos);
-
-        if (dist < this.dragThreshold_) {
-          this.pointerDownPos_ = null;
-          const world = event.worldPos;
-          if (!world) return;
-          const value = this.getValueAtWorld(world);
-
-          if (value !== null) {
-            this.onPickValue_({ world, value });
-          }
-        }
-        break;
-      }
-
-      case "pointercancel": {
-        this.pointerDownPos_ = null;
-        break;
-      }
-    }
+    handlePointPickingEvent(
+      event,
+      this.pointPickingState_,
+      (world) => this.getValueAtWorld(world),
+      (info) => this.onPickValue_!(info)
+    );
   }
 
   public get channelProps(): ChannelProps[] | undefined {

--- a/packages/core/src/layers/image_layer.ts
+++ b/packages/core/src/layers/image_layer.ts
@@ -145,7 +145,6 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
 
   public onEvent(event: EventContext) {
     if (!this.onPickValue_) return;
-    // console.log("onEvent", event);
     switch (event.type) {
       case "pointerdown": {
         const e = event.event as PointerEvent;
@@ -263,7 +262,6 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
     // Iterate through all visible chunks to find the one containing the world position
     for (const [chunk, image] of this.visibleChunks_) {
       if (!chunk.data) continue;
-
       const localPos = vec3.transformMat4(
         vec3.create(),
         world,
@@ -278,8 +276,7 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
         const pixelIndex = y * chunk.rowStride + x;
         const data = chunk.data;
 
-        // For multi-channel images, take the first channel value (planar format)
-        // In planar format: RRR...GGG...BBB... so first channel data comes first
+        // For multi-channel images, take the first channel value
         return data[pixelIndex];
       }
     }

--- a/packages/core/src/layers/label_image_layer.ts
+++ b/packages/core/src/layers/label_image_layer.ts
@@ -86,8 +86,8 @@ export class LabelImageLayer extends Layer {
       this.pointerDownPos_,
       this.dragThreshold_,
       (world) => this.getValueAtWorld(world),
-      this.onPickValue_,
-      "LabelImageLayer"
+      "LabelImageLayer",
+      this.onPickValue_
     );
   }
 

--- a/packages/core/src/layers/label_image_layer.ts
+++ b/packages/core/src/layers/label_image_layer.ts
@@ -86,7 +86,8 @@ export class LabelImageLayer extends Layer {
       this.pointerDownPos_,
       this.dragThreshold_,
       (world) => this.getValueAtWorld(world),
-      this.onPickValue_
+      this.onPickValue_,
+      "LabelImageLayer"
     );
   }
 

--- a/packages/core/src/layers/label_image_layer.ts
+++ b/packages/core/src/layers/label_image_layer.ts
@@ -9,11 +9,8 @@ import {
 } from "../objects/renderable/label_color_map";
 import { LabelImageRenderable } from "../objects/renderable/label_image_renderable";
 import { EventContext } from "../core/event_dispatcher";
-import { vec3 } from "gl-matrix";
-import {
-  handlePointPickingEvent,
-  PointPickingState,
-} from "../utilities/point_picking";
+import { vec2, vec3 } from "gl-matrix";
+import { handlePointPickingEvent } from "../utilities/point_picking";
 
 export interface PointPickingResult {
   world: vec3;
@@ -37,10 +34,8 @@ export class LabelImageLayer extends Layer {
   private readonly onPickValue_?: (info: PointPickingResult) => void;
   private image_?: LabelImageRenderable;
   private imageChunk_?: Chunk;
-  private readonly pointPickingState_: PointPickingState = {
-    pointerDownPos: null,
-    dragThreshold: 3,
-  };
+  private pointerDownPos_: vec2 | null = null;
+  private readonly dragThreshold_ = 3;
 
   constructor({
     source,
@@ -88,9 +83,10 @@ export class LabelImageLayer extends Layer {
   public onEvent(event: EventContext) {
     if (!this.onPickValue_) return;
 
-    handlePointPickingEvent(
+    this.pointerDownPos_ = handlePointPickingEvent(
       event,
-      this.pointPickingState_,
+      this.pointerDownPos_,
+      this.dragThreshold_,
       (world) => this.getValueAtWorld(world),
       (info) => this.onPickValue_!(info)
     );

--- a/packages/core/src/layers/label_image_layer.ts
+++ b/packages/core/src/layers/label_image_layer.ts
@@ -9,7 +9,11 @@ import {
 } from "../objects/renderable/label_color_map";
 import { LabelImageRenderable } from "../objects/renderable/label_image_renderable";
 import { EventContext } from "../core/event_dispatcher";
-import { vec2, vec3 } from "gl-matrix";
+import { vec3 } from "gl-matrix";
+import {
+  handlePointPickingEvent,
+  PointPickingState,
+} from "../utilities/point_picking";
 
 export interface PointPickingResult {
   world: vec3;
@@ -33,8 +37,10 @@ export class LabelImageLayer extends Layer {
   private readonly onPickValue_?: (info: PointPickingResult) => void;
   private image_?: LabelImageRenderable;
   private imageChunk_?: Chunk;
-  private pointerDownPos_: vec2 | null = null;
-  private readonly dragThreshold_ = 3;
+  private readonly pointPickingState_: PointPickingState = {
+    pointerDownPos: null,
+    dragThreshold: 3,
+  };
 
   constructor({
     source,
@@ -82,38 +88,12 @@ export class LabelImageLayer extends Layer {
   public onEvent(event: EventContext) {
     if (!this.onPickValue_) return;
 
-    switch (event.type) {
-      case "pointerdown": {
-        const e = event.event as PointerEvent;
-        this.pointerDownPos_ = vec2.fromValues(e.clientX, e.clientY);
-        break;
-      }
-
-      case "pointerup": {
-        if (!this.pointerDownPos_) break;
-
-        const e = event.event as PointerEvent;
-        const pointerUpPos = vec2.fromValues(e.clientX, e.clientY);
-        const dist = vec2.distance(this.pointerDownPos_, pointerUpPos);
-
-        if (dist < this.dragThreshold_) {
-          this.pointerDownPos_ = null;
-          const world = event.worldPos;
-          if (!world) return;
-          const value = this.getValueAtWorld(world);
-
-          if (value !== null) {
-            this.onPickValue_({ world, value });
-          }
-        }
-        break;
-      }
-
-      case "pointercancel": {
-        this.pointerDownPos_ = null;
-        break;
-      }
-    }
+    handlePointPickingEvent(
+      event,
+      this.pointPickingState_,
+      (world) => this.getValueAtWorld(world),
+      (info) => this.onPickValue_!(info)
+    );
   }
 
   private async load(region: Region) {

--- a/packages/core/src/layers/label_image_layer.ts
+++ b/packages/core/src/layers/label_image_layer.ts
@@ -81,14 +81,12 @@ export class LabelImageLayer extends Layer {
   }
 
   public onEvent(event: EventContext) {
-    if (!this.onPickValue_) return;
-
     this.pointerDownPos_ = handlePointPickingEvent(
       event,
       this.pointerDownPos_,
       this.dragThreshold_,
       (world) => this.getValueAtWorld(world),
-      (info) => this.onPickValue_!(info)
+      this.onPickValue_
     );
   }
 

--- a/packages/core/src/layers/label_image_layer.ts
+++ b/packages/core/src/layers/label_image_layer.ts
@@ -86,7 +86,6 @@ export class LabelImageLayer extends Layer {
       this.pointerDownPos_,
       this.dragThreshold_,
       (world) => this.getValueAtWorld(world),
-      "LabelImageLayer",
       this.onPickValue_
     );
   }

--- a/packages/core/src/utilities/logger.ts
+++ b/packages/core/src/utilities/logger.ts
@@ -20,6 +20,7 @@ type Module =
   | "EventDispatcher"
   | "Idetik"
   | "ImageLayer"
+  | "LabelImageLayer"
   | "WebGLRenderer"
   | "WebGLShaderProgram"
   | "WebGLTexture"

--- a/packages/core/src/utilities/point_picking.ts
+++ b/packages/core/src/utilities/point_picking.ts
@@ -7,7 +7,8 @@ export function handlePointPickingEvent<T>(
   pointerDownPos: vec2 | null,
   dragThreshold: number,
   getValueAtWorld: (world: vec3) => T | null,
-  onPickValue?: (info: { world: vec3; value: T }) => void
+  onPickValue?: (info: { world: vec3; value: T }) => void,
+  layerName: string
 ): vec2 | null {
   switch (event.type) {
     case "pointerdown": {
@@ -31,7 +32,7 @@ export function handlePointPickingEvent<T>(
               onPickValue({ world, value });
             } else {
               Logger.warn(
-                "PointPicking",
+                layerName,
                 "Point picking attempted but no onPickValue callback provided"
               );
             }

--- a/packages/core/src/utilities/point_picking.ts
+++ b/packages/core/src/utilities/point_picking.ts
@@ -2,7 +2,7 @@ import { EventContext } from "../core/event_dispatcher";
 import { vec2, vec3 } from "gl-matrix";
 import { Logger } from "./logger";
 
-export function handlePointPickingEvent(
+export function handlePointPickingEvent<T>(
   event: EventContext,
   pointerDownPos: vec2 | null,
   dragThreshold: number,

--- a/packages/core/src/utilities/point_picking.ts
+++ b/packages/core/src/utilities/point_picking.ts
@@ -2,13 +2,15 @@ import { EventContext } from "../core/event_dispatcher";
 import { vec2, vec3 } from "gl-matrix";
 import { Logger } from "./logger";
 
+type LoggerModule = "ImageLayer" | "LabelImageLayer";
+
 export function handlePointPickingEvent<T>(
   event: EventContext,
   pointerDownPos: vec2 | null,
   dragThreshold: number,
   getValueAtWorld: (world: vec3) => T | null,
   onPickValue?: (info: { world: vec3; value: T }) => void,
-  layerName: string
+  layerName: LoggerModule
 ): vec2 | null {
   switch (event.type) {
     case "pointerdown": {

--- a/packages/core/src/utilities/point_picking.ts
+++ b/packages/core/src/utilities/point_picking.ts
@@ -2,7 +2,7 @@ import { EventContext } from "../core/event_dispatcher";
 import { vec2, vec3 } from "gl-matrix";
 import { Logger } from "./logger";
 
-export function handlePointPickingEvent<T>(
+export function handlePointPickingEvent(
   event: EventContext,
   pointerDownPos: vec2 | null,
   dragThreshold: number,

--- a/packages/core/src/utilities/point_picking.ts
+++ b/packages/core/src/utilities/point_picking.ts
@@ -1,0 +1,52 @@
+import { EventContext } from "../core/event_dispatcher";
+import { vec2, vec3 } from "gl-matrix";
+import { Logger } from "./logger";
+
+export function handlePointPickingEvent<T>(
+  event: EventContext,
+  pointerDownPos: vec2 | null,
+  dragThreshold: number,
+  getValueAtWorld: (world: vec3) => T | null,
+  onPickValue?: (info: { world: vec3; value: T }) => void
+): vec2 | null {
+  switch (event.type) {
+    case "pointerdown": {
+      const e = event.event as PointerEvent;
+      return vec2.fromValues(e.clientX, e.clientY);
+    }
+
+    case "pointerup": {
+      if (!pointerDownPos) return pointerDownPos;
+
+      const e = event.event as PointerEvent;
+      const pointerUpPos = vec2.fromValues(e.clientX, e.clientY);
+      const dist = vec2.distance(pointerDownPos, pointerUpPos);
+
+      if (dist < dragThreshold) {
+        const world = event.worldPos;
+        if (world) {
+          const value = getValueAtWorld(world);
+          if (value !== null) {
+            if (onPickValue) {
+              onPickValue({ world, value });
+            } else {
+              Logger.warn(
+                "PointPicking",
+                "Point picking attempted but no onPickValue callback provided"
+              );
+            }
+          }
+        }
+        return null;
+      }
+      return pointerDownPos;
+    }
+
+    case "pointercancel": {
+      return null;
+    }
+
+    default:
+      return pointerDownPos;
+  }
+}

--- a/packages/core/src/utilities/point_picking.ts
+++ b/packages/core/src/utilities/point_picking.ts
@@ -1,15 +1,11 @@
 import { EventContext } from "../core/event_dispatcher";
 import { vec2, vec3 } from "gl-matrix";
-import { Logger } from "./logger";
-
-type LoggerModule = "ImageLayer" | "LabelImageLayer";
 
 export function handlePointPickingEvent<T>(
   event: EventContext,
   pointerDownPos: vec2 | null,
   dragThreshold: number,
   getValueAtWorld: (world: vec3) => T | null,
-  layerName: LoggerModule,
   onPickValue?: (info: { world: vec3; value: T }) => void
 ): vec2 | null {
   switch (event.type) {
@@ -26,18 +22,13 @@ export function handlePointPickingEvent<T>(
       const dist = vec2.distance(pointerDownPos, pointerUpPos);
 
       if (dist < dragThreshold) {
+        if (!onPickValue) return null;
+
         const world = event.worldPos;
         if (world) {
           const value = getValueAtWorld(world);
           if (value !== null) {
-            if (onPickValue) {
-              onPickValue({ world, value });
-            } else {
-              Logger.warn(
-                layerName,
-                "Point picking attempted but no onPickValue callback provided"
-              );
-            }
+            onPickValue({ world, value });
           }
         }
         return null;

--- a/packages/core/src/utilities/point_picking.ts
+++ b/packages/core/src/utilities/point_picking.ts
@@ -9,8 +9,8 @@ export function handlePointPickingEvent<T>(
   pointerDownPos: vec2 | null,
   dragThreshold: number,
   getValueAtWorld: (world: vec3) => T | null,
-  onPickValue?: (info: { world: vec3; value: T }) => void,
-  layerName: LoggerModule
+  layerName: LoggerModule,
+  onPickValue?: (info: { world: vec3; value: T }) => void
 ): vec2 | null {
   switch (event.type) {
     case "pointerdown": {


### PR DESCRIPTION
###  Summary

  Adds value picking functionality to ImageLayer similar to existing LabelImageLayer implementation, with support for progressive loading.

  Changes

  - Added value picking to ImageLayer: Supports clicking to get pixel values at world coordinates
  - Progressive loading compatibility: Works with chunk manager and multiple visible chunks
  - Multi-channel support: Returns first channel value for multi-channel images
  - Updated uint8 example: Added point picking overlay demo with visual feedback
  - Shared utility function: Created handlePointPickingEvent to DRY out common pointer logic between layers
  - Type definitions: Added ImagePointPickingResult interface

  Key Features

  - Works with both single and multi-channel images (returns first channel)
  - Supports progressive loading with multiple chunks
  - Provides world coordinates and pixel values in callback
  - Includes visual overlay example for testing

  Test Plan

  - Point picking works in image2d_from_omezarr5d_u8 example
  - Shared pointer event logic works in both ImageLayer and LabelImageLayer