### PR TITLE
Consolidate OME-Zarr loader attributes and array opens

### DIFF
--- a/packages/core/examples/image2d_from_omezarr5d_u8/main.ts
+++ b/packages/core/examples/image2d_from_omezarr5d_u8/main.ts
@@ -14,7 +14,7 @@ const url =
   "https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.4/96x0/marmoset_neurons.ome.zarr";
 const source = new OmeZarrImageSource(url);
 const loader = await source.open();
-const attributes = await loader.loadAttributes();
+const attributes = loader.getAttributes();
 const attributesAtLod0 = attributes[0];
 
 const dimensionInfo = (dimensionName: string) => {

--- a/packages/core/examples/image_labels_overlay_with_value_picking/main.ts
+++ b/packages/core/examples/image_labels_overlay_with_value_picking/main.ts
@@ -25,7 +25,7 @@ const labelsSource = new OmeZarrImageSource(labelsUrl);
 
 const lod = 0;
 const loader = await imageSource.open();
-const attributes = await loader.loadAttributes();
+const attributes = loader.getAttributes();
 const attributesAtLod = attributes[lod];
 
 // Phase contrast limits were chosen qualitatively.

--- a/packages/core/examples/image_mask_overlay/main.ts
+++ b/packages/core/examples/image_mask_overlay/main.ts
@@ -18,7 +18,7 @@ const maskUrl = `${baseUrl}/Annotations/100/membrane-1.0_segmentationmask.zarr`;
 // Source is 3D with axes (z, y, x), so we provide an interval in z
 const imageSource = new OmeZarrImageSource(imageUrl);
 const loader = await imageSource.open();
-const attributes = await loader.loadAttributes();
+const attributes = loader.getAttributes();
 const lods = attributes.length;
 const attributesForLastLod = attributes[lods - 1];
 

--- a/packages/core/examples/image_series_labels_overlay/main.ts
+++ b/packages/core/examples/image_series_labels_overlay/main.ts
@@ -23,7 +23,7 @@ const labelsSource = new OmeZarrImageSource(labelsUrl);
 
 const lod = 0;
 const loader = await imageSource.open();
-const attributes = await loader.loadAttributes();
+const attributes = loader.getAttributes();
 const attributesAtLod = attributes[lod];
 
 // Phase contrast limits were chosen qualitatively.

--- a/packages/core/examples/points/main.ts
+++ b/packages/core/examples/points/main.ts
@@ -189,7 +189,7 @@ virusLike.setDepth(INITIAL_Z_POSITION);
 
 const imageSource = new OmeZarrImageSource(imageUrl);
 const loader = await imageSource.open();
-const attributes = await loader.loadAttributes();
+const attributes = loader.getAttributes();
 const attributesForLastLod = attributes[attributes.length - 1];
 
 const zDimName = "z";

--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -19,7 +19,7 @@ export class ChunkManagerSource {
   private readonly chunks_: Chunk[];
   private readonly loader_;
   private readonly region_;
-  private readonly attrs_: LoaderAttributes[];
+  private readonly attrs_: ReadonlyArray<LoaderAttributes>;
   private readonly lowestResLOD_: number;
   private currentLOD_: number = 0;
   private readonly xIdx_: number;
@@ -28,7 +28,11 @@ export class ChunkManagerSource {
   private readonly channelIdx_: number;
   private lastVisibleBounds_: Box2 | null = null;
 
-  constructor(loader: ChunkLoader, attrs: LoaderAttributes[], region: Region) {
+  constructor(
+    loader: ChunkLoader,
+    attrs: ReadonlyArray<LoaderAttributes>,
+    region: Region
+  ) {
     this.loader_ = loader;
     this.region_ = region;
     this.attrs_ = attrs;
@@ -317,7 +321,7 @@ export class ChunkManager {
     let existing = this.sources_.get(source);
     if (!existing) {
       const loader = await source.open();
-      const attrs = await loader.loadAttributes();
+      const attrs = loader.getAttributes();
       existing = new ChunkManagerSource(loader, attrs, region);
       this.sources_.set(source, existing);
     }

--- a/packages/core/src/data/chunk.ts
+++ b/packages/core/src/data/chunk.ts
@@ -60,9 +60,9 @@ export type ChunkSource = {
 };
 
 export type LoaderAttributes = {
-  chunks: readonly number[];
   dimensionNames: string[];
   dimensionUnits: (string | undefined)[];
+  chunks: readonly number[];
   shape: readonly number[];
   scale: readonly number[];
   translation: readonly number[];
@@ -77,5 +77,5 @@ export type ChunkLoader = {
 
   loadChunkDataFromRegion(chunk: Chunk, region: Region): Promise<void>;
 
-  loadAttributes(): Promise<LoaderAttributes[]>;
+  getAttributes(): ReadonlyArray<LoaderAttributes>;
 };

--- a/packages/core/src/data/ome_zarr_image_loader.ts
+++ b/packages/core/src/data/ome_zarr_image_loader.ts
@@ -10,15 +10,6 @@ import { Image as OmeNgffImage } from "../data/ome_ngff/0.4/image";
 
 import { Readable } from "@zarrita/storage";
 
-type ImageAttributes = {
-  image: OmeNgffImage["multiscales"][number];
-  dimensionNames: string[];
-  dimensionUnits: (string | undefined)[];
-  datasetPath: string;
-  scale: number[];
-  translation: number[];
-};
-
 // Implements the interface required for getting array chunks in zarrita:
 // https://github.com/manzt/zarrita.js/blob/c15c1a14e42a83516972368ac962ebdf56a6dcdb/packages/indexing/src/types.ts#L52
 export class PromiseQueue<T> {
@@ -38,33 +29,31 @@ export class PromiseQueue<T> {
   }
 }
 
+type OmeZarrImageLoaderProps = {
+  metadata: OmeNgffImage["multiscales"][number];
+  arrays: zarr.Array<zarr.DataType, Readable>[];
+};
+
 // Loads chunks from a multiscale zarr image implementing OME-NGFF v0.4:
 // https://ngff.openmicroscopy.org/0.4/#image-layout
 export class OmeZarrImageLoader {
-  private readonly root_: zarr.Group<Readable>;
-  private readonly metadata_: OmeNgffImage;
+  private readonly metadata_: OmeNgffImage["multiscales"][number];
+  private readonly arrays_: ReadonlyArray<zarr.Array<zarr.DataType, Readable>>;
   private readonly lods_: number;
+  private readonly loaderAttributes_: ReadonlyArray<LoaderAttributes>;
 
-  constructor(root: zarr.Group<Readable>) {
-    this.root_ = root;
-    this.metadata_ = OmeNgffImage.parse(this.root_.attrs);
-    if (this.metadata_.multiscales.length !== 1) {
-      throw new Error(
-        `Can only handle one multiscale image. Found ${this.metadata_.multiscales.length}`
-      );
-    }
-
-    this.lods_ = this.metadata_.multiscales[0].datasets.length;
+  constructor(props: OmeZarrImageLoaderProps) {
+    this.metadata_ = props.metadata;
+    this.arrays_ = props.arrays;
+    this.loaderAttributes_ = getLoaderAttributes(this.metadata_, this.arrays_);
+    this.lods_ = this.metadata_.datasets.length;
   }
 
   public async loadChunkDataFromRegion(chunk: Chunk, region: Region) {
-    const attrs = this.getImageAttributes()[chunk.lod];
-    const array = await zarr.open.v2(this.root_.resolve(attrs.datasetPath), {
-      kind: "array",
-      attrs: false,
-    });
+    const attrs = this.loaderAttributes_[chunk.lod];
+    const array = this.arrays_[chunk.lod];
 
-    const dimInfo = await this.getDimInfoMap(region, chunk, attrs);
+    const dimInfo = this.getDimInfoMap(region, chunk, attrs);
     if (!dimInfo.has("x") || !dimInfo.has("y")) {
       throw new Error("Missing required spatial axis x/y");
     }
@@ -89,7 +78,7 @@ export class OmeZarrImageLoader {
     chunk.data = data.slice(zOffset, zOffset + sliceSize);
   }
 
-  async loadRegion(
+  public async loadRegion(
     region: Region,
     lod: number,
     scheduler?: PromiseScheduler
@@ -100,14 +89,11 @@ export class OmeZarrImageLoader {
       );
     }
 
-    const attributes = this.getImageAttributes()[lod];
+    const attributes = this.loaderAttributes_[lod];
     const indices = this.regionToIndices(region, attributes);
-    const { datasetPath, scale, translation } = attributes;
+    const { scale, translation } = attributes;
+    const array = this.arrays_[lod];
 
-    const array = await zarr.open.v2(this.root_.resolve(datasetPath), {
-      kind: "array",
-      attrs: false,
-    });
     let options = {};
     if (scheduler !== undefined) {
       options = {
@@ -174,68 +160,12 @@ export class OmeZarrImageLoader {
     return chunk;
   }
 
-  private getImageAttributes(): ImageAttributes[] {
-    const output: ImageAttributes[] = [];
-
-    for (let i = 0; i < this.lods_; ++i) {
-      const image = this.metadata_.multiscales[0];
-      const axes = image.axes;
-      const dimensionNames = image.axes.map((axis) => axis.name);
-      const dimensionUnits = image.axes.map((axis) => axis.unit);
-      const dataset = image.datasets[i];
-      const datasetPath = dataset.path;
-      const scale = dataset.coordinateTransformations[0].scale;
-      const translation =
-        dataset.coordinateTransformations.length === 2
-          ? dataset.coordinateTransformations[1].translation
-          : new Array(axes.length).fill(0);
-
-      output.push({
-        image,
-        dimensionNames,
-        dimensionUnits,
-        datasetPath,
-        scale,
-        translation,
-      });
-    }
-
-    return output;
+  public getAttributes(): ReadonlyArray<LoaderAttributes> {
+    return this.loaderAttributes_;
   }
 
-  public async loadAttributes(): Promise<LoaderAttributes[]> {
-    return await Promise.all(
-      this.getImageAttributes().map(async (attr) => {
-        const zarrArray = await zarr.open.v2(
-          this.root_.resolve(attr.datasetPath),
-          {
-            kind: "array",
-            attrs: false,
-          }
-        );
-        return {
-          chunks: zarrArray.chunks,
-          dimensionNames: attr.dimensionNames,
-          dimensionUnits: attr.dimensionUnits,
-          shape: zarrArray.shape,
-          scale: attr.scale,
-          translation: attr.translation,
-        };
-      })
-    );
-  }
-
-  private async getDimInfoMap(
-    region: Region,
-    chunk: Chunk,
-    attrs: ImageAttributes
-  ) {
+  private getDimInfoMap(region: Region, chunk: Chunk, attrs: LoaderAttributes) {
     const indices = this.regionToIndices(region, attrs);
-    const array = await zarr.open.v2(this.root_.resolve(attrs.datasetPath), {
-      kind: "array",
-      attrs: false,
-    });
-
     const output = new Map();
     region.forEach((entry, dimIdx) => {
       if (entry.dimension.toLowerCase() === "x") {
@@ -255,7 +185,7 @@ export class OmeZarrImageLoader {
         throw new Error(`Expected numeric index for ${entry.dimension}`);
       }
 
-      const chunkIdx = Math.floor(value / array.chunks[dimIdx]);
+      const chunkIdx = Math.floor(value / attrs.chunks[dimIdx]);
       output.set(entry.dimension, { dimIdx, chunkIdx, value });
     });
 
@@ -264,7 +194,7 @@ export class OmeZarrImageLoader {
 
   private regionToIndices(
     region: Region,
-    attributes: ImageAttributes
+    attributes: LoaderAttributes
   ): Array<Slice | number> {
     const { dimensionNames, scale, translation } = attributes;
 
@@ -291,4 +221,30 @@ export class OmeZarrImageLoader {
     }
     return indices;
   }
+}
+
+function getLoaderAttributes(
+  image: OmeNgffImage["multiscales"][number],
+  arrays: ReadonlyArray<zarr.Array<zarr.DataType, Readable>>
+): LoaderAttributes[] {
+  const output: LoaderAttributes[] = [];
+  const numAxes = image.axes.length;
+  for (let i = 0; i < image.datasets.length; i++) {
+    const dataset = image.datasets[i];
+    const array = arrays[i];
+    const scale = dataset.coordinateTransformations[0].scale;
+    const translation =
+      dataset.coordinateTransformations.length === 2
+        ? dataset.coordinateTransformations[1].translation
+        : new Array(numAxes).fill(0);
+    output.push({
+      dimensionNames: image.axes.map((axis) => axis.name),
+      dimensionUnits: image.axes.map((axis) => axis.unit),
+      chunks: array.chunks,
+      shape: array.shape,
+      scale,
+      translation,
+    });
+  }
+  return output;
 }

--- a/packages/core/src/data/ome_zarr_image_source.ts
+++ b/packages/core/src/data/ome_zarr_image_source.ts
@@ -27,12 +27,12 @@ export class OmeZarrImageSource {
         : new Location(new WebFileSystemStore(source), path);
   }
 
-  async open(): Promise<OmeZarrImageLoader> {
+  public async open(): Promise<OmeZarrImageLoader> {
     const root = await zarritaOpen.v2(this.location, { kind: "group" });
     const images = OmeNgffImage.parse(root.attrs).multiscales;
-    if (images.length > 1) {
+    if (images.length !== 1) {
       throw new Error(
-        `Currently only a single multiscale image is supported. Found ${images.length} images.`
+        `Exactly one multiscale image is supported. Found ${images.length} images.`
       );
     }
     const metadata = images[0];

--- a/packages/core/src/data/ome_zarr_image_source.ts
+++ b/packages/core/src/data/ome_zarr_image_source.ts
@@ -3,6 +3,7 @@ import FetchStore from "@zarrita/storage/fetch";
 import { OmeZarrImageLoader } from "../data/ome_zarr_image_loader";
 import WebFileSystemStore from "./zarrita/web_file_system_store";
 import { Readable } from "@zarrita/storage";
+import { Image as OmeNgffImage } from "../data/ome_ngff/0.4/image";
 
 /** Opens an OME-Zarr multiscale image Zarr group from either a URL or local directory. */
 export class OmeZarrImageSource {
@@ -28,6 +29,34 @@ export class OmeZarrImageSource {
 
   async open(): Promise<OmeZarrImageLoader> {
     const root = await zarritaOpen.v2(this.location, { kind: "group" });
-    return new OmeZarrImageLoader(root);
+    const images = OmeNgffImage.parse(root.attrs).multiscales;
+    if (images.length > 1) {
+      throw new Error(
+        `Currently only a single multiscale image is supported. Found ${images.length} images.`
+      );
+    }
+    const metadata = images[0];
+    if (metadata.datasets.length === 0) {
+      throw new Error(`No datasets found in the multiscale image.`);
+    }
+    const arrays = await Promise.all(
+      metadata.datasets.map((d) =>
+        zarritaOpen.v2(root.resolve(d.path), {
+          kind: "array",
+          attrs: false,
+        })
+      )
+    );
+    const shape = arrays[0].shape;
+    const axes = metadata.axes;
+    if (axes.length !== shape.length) {
+      throw new Error(
+        `Mismatch between number of axes (${axes.length}) and array shape (${shape.length})`
+      );
+    }
+    return new OmeZarrImageLoader({
+      metadata,
+      arrays,
+    });
   }
 }

--- a/packages/core/src/layers/image_layer.ts
+++ b/packages/core/src/layers/image_layer.ts
@@ -168,7 +168,7 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
     }
     this.setState("loading");
     const loader = await this.source_.open();
-    const attributes = await loader.loadAttributes();
+    const attributes = loader.getAttributes();
     const lod = this.lod_ ?? attributes.length - 1;
 
     const chunk = await loader.loadRegion(region, lod);

--- a/packages/core/src/layers/image_series_loader.ts
+++ b/packages/core/src/layers/image_series_loader.ts
@@ -100,7 +100,7 @@ export class ImageSeriesLoader {
       return this.seriesAttributes_;
     }
     const loader = await this.getLoader();
-    const attributes = await loader.loadAttributes();
+    const attributes = loader.getAttributes();
     const attributesForLOD = attributes[this.lod_ ?? attributes.length - 1];
 
     const seriesIndex = attributesForLOD.dimensionNames.findIndex(
@@ -151,7 +151,7 @@ export class ImageSeriesLoader {
     });
 
     const loader = await this.getLoader();
-    const attributes = await loader.loadAttributes();
+    const attributes = loader.getAttributes();
     const lod = this.lod_ ?? attributes.length - 1;
 
     const chunk = await loader.loadRegion(pointRegion, lod, this.scheduler_);

--- a/packages/core/src/layers/label_image_layer.ts
+++ b/packages/core/src/layers/label_image_layer.ts
@@ -122,7 +122,7 @@ export class LabelImageLayer extends Layer {
     }
     this.setState("loading");
     const loader = await this.source_.open();
-    const attributes = await loader.loadAttributes();
+    const attributes = loader.getAttributes();
     const lod = this.lod_ ?? attributes.length - 1;
     const chunk = await loader.loadRegion(region, lod);
     this.image_ = this.createImage(chunk);

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
@@ -420,7 +420,7 @@ async function loadImageMetadata(
   xCoordRange: [number, number];
 }> {
   const loader = await source.open();
-  const attrs = await loader.loadAttributes();
+  const attrs = loader.getAttributes();
   const attrsForLevel = attrs[resolutionLevel];
 
   // TODO: We assume that the last dimension will give us the x-unit,


### PR DESCRIPTION
### Summary
This is a refactor that consolidates OME-Zarr attribute types, as well calls to opening the underlying Zarr arrays that store the multi-scale image chunks.

Before this change, `ImageAttributes` and `LoaderAttributes` were storing very similar information. Since `LoaderAttributes` is publicly exposed and stores a little more information (i.e. the overall shape and chunk shape for a multi-scale level), I kept that here.

I also consolidated opening all the underlying Zarr arrays in the call to `OmeZarrImageSource.open` rather than scattered across various functions in `OmeZarrImageLoader`. These arrays are then passed through to the loader, which then allows us to populate the loader attributes synchronously on construction. The main motivation behind this change is simplification, though there may be some small performance gains. Note that any call to `loadAttributes` (e.g. in `ChunkManager.addSource`) was already opening all the arrays anyway, so this should be no worse in that case.

### Tests & Checks
I manually tested the existing examples.
I manually tested the main React component.
