### PR TITLE
Add 3D visibility support to the chunk manager

### DIFF
--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -5,8 +5,9 @@ import {
   LoaderAttributes,
 } from "../data/chunk";
 import { Region } from "../data/region";
-import { vec2 } from "gl-matrix";
+import { vec2, vec3 } from "gl-matrix";
 import { Box2 } from "../math/box2";
+import { Box3 } from "../math/box3";
 import { almostEqual } from "../utilities/almost_equal";
 import { Logger } from "../utilities/logger";
 import { OrthographicCamera } from "@/objects/cameras/orthographic_camera";
@@ -26,7 +27,7 @@ export class ChunkManagerSource {
   private readonly yIdx_: number;
   private readonly zIdx_: number;
   private readonly channelIdx_: number;
-  private lastVisibleBounds_: Box2 | null = null;
+  private lastViewBounds2D_: Box2 | null = null;
 
   constructor(
     loader: ChunkLoader,
@@ -144,10 +145,10 @@ export class ChunkManagerSource {
     return [...lowResChunks, ...currentLODChunks];
   }
 
-  public update(lodFactor: number, visibleBounds: Box2) {
+  public update(lodFactor: number, viewBounds2D: Box2) {
     this.setLOD(lodFactor);
-    if (this.visibleBoundsChanged(visibleBounds)) {
-      this.updateChunkVisibility(visibleBounds);
+    if (this.viewBounds2DChanged(viewBounds2D)) {
+      this.updateChunkVisibility(viewBounds2D);
     }
     this.loadPendingChunks();
   }
@@ -223,7 +224,7 @@ export class ChunkManagerSource {
     }
   }
 
-  private updateChunkVisibility(visibleBounds: Box2): void {
+  private updateChunkVisibility(viewBounds2D: Box2): void {
     if (this.chunks_.length === 0) {
       Logger.warn(
         "ChunkManager",
@@ -232,13 +233,14 @@ export class ChunkManagerSource {
       return;
     }
 
-    const paddedBounds = this.getPaddedBounds(visibleBounds);
+    const viewBounds3D = this.makeViewBounds3D(viewBounds2D);
+    const paddedBounds = this.getPaddedBounds(viewBounds3D);
     for (const chunk of this.chunks_) {
       // TEMP: visibility is 2D (Box2). Ignore nonzero Z until Box3 intersects() exists.
       if (chunk.chunkIndex.z !== 0) continue;
 
       chunk.prefetch = false;
-      chunk.visible = this.isChunkWithinBounds(chunk, visibleBounds);
+      chunk.visible = this.isChunkWithinBounds(chunk, viewBounds3D);
       if (!chunk.visible) {
         chunk.prefetch = this.isChunkWithinBounds(chunk, paddedBounds);
       }
@@ -267,26 +269,65 @@ export class ChunkManagerSource {
     }
   }
 
-  private isChunkWithinBounds(chunk: Chunk, bounds: Box2): boolean {
-    const chunkBounds = new Box2(
-      vec2.fromValues(chunk.offset.x, chunk.offset.y),
-      vec2.fromValues(
+  private isChunkWithinBounds(chunk: Chunk, bounds: Box3): boolean {
+    const chunkBounds = new Box3(
+      vec3.fromValues(chunk.offset.x, chunk.offset.y, chunk.offset.z),
+      vec3.fromValues(
         chunk.offset.x + chunk.shape.x * chunk.scale.x,
-        chunk.offset.y + chunk.shape.y * chunk.scale.y
+        chunk.offset.y + chunk.shape.y * chunk.scale.y,
+        chunk.offset.z + chunk.shape.z * chunk.scale.z
       )
     );
-    return Box2.intersects(chunkBounds, bounds);
+    return Box3.intersects(chunkBounds, bounds);
   }
 
-  private visibleBoundsChanged(newBounds: Box2): boolean {
-    const prev = this.lastVisibleBounds_;
+  private makeViewBounds3D(bounds: Box2): Box3 {
+    if (this.zIdx_ === -1) {
+      return new Box3(
+        vec3.fromValues(bounds.min[0], bounds.min[1], 0),
+        vec3.fromValues(bounds.max[0], bounds.max[1], 0)
+      );
+    }
+
+    const index = this.region_[this.zIdx_].index;
+    if (index.type !== "point") {
+      return new Box3(
+        vec3.fromValues(bounds.min[0], bounds.min[1], 0),
+        vec3.fromValues(bounds.max[0], bounds.max[1], 0)
+      );
+    }
+
+    const shapeZ = this.attrs_[this.currentLOD_].shape[this.zIdx_];
+    const scaleZ = this.attrs_[this.currentLOD_].scale[this.zIdx_];
+    const transZ = this.attrs_[this.currentLOD_].translation[this.zIdx_];
+    const chunkDepth = this.attrs_[this.currentLOD_].chunks[this.zIdx_];
+    const pointZ = Math.floor((index.value - transZ) / scaleZ);
+    const chunkZ = Math.max(
+      0,
+      Math.min(
+        Math.floor(pointZ / chunkDepth),
+        Math.ceil(shapeZ / chunkDepth) - 1
+      )
+    );
+
+    const zMin = transZ + chunkZ * chunkDepth * scaleZ;
+    const zMax = transZ + (chunkZ + 1) * chunkDepth * scaleZ;
+
+    return new Box3(
+      vec3.fromValues(bounds.min[0], bounds.min[1], zMin),
+      vec3.fromValues(bounds.max[0], bounds.max[1], zMax)
+    );
+  }
+
+  private viewBounds2DChanged(newBounds: Box2): boolean {
+    const prev = this.lastViewBounds2D_;
     const changed =
       prev === null ||
       !vec2.equals(prev.min, newBounds.min) ||
       !vec2.equals(prev.max, newBounds.max);
 
     if (changed) {
-      this.lastVisibleBounds_ = new Box2(
+      this.lastViewBounds2D_ = new Box2(
         vec2.clone(newBounds.min),
         vec2.clone(newBounds.max)
       );
@@ -295,7 +336,7 @@ export class ChunkManagerSource {
     return changed;
   }
 
-  private getPaddedBounds(bounds: Box2): Box2 {
+  private getPaddedBounds(bounds: Box3): Box3 {
     const chunkWidth =
       this.attrs_[this.currentLOD_].chunks[this.xIdx_] *
       this.attrs_[this.currentLOD_].scale[this.xIdx_];
@@ -304,12 +345,25 @@ export class ChunkManagerSource {
       this.attrs_[this.currentLOD_].chunks[this.yIdx_] *
       this.attrs_[this.currentLOD_].scale[this.yIdx_];
 
+    const chunkDepth =
+      this.attrs_[this.currentLOD_].chunks[this.zIdx_] *
+      this.attrs_[this.currentLOD_].scale[this.zIdx_];
+
     const padX = chunkWidth * PREFETCH_PADDING_CHUNKS;
     const padY = chunkHeight * PREFETCH_PADDING_CHUNKS;
+    const padZ = chunkDepth * PREFETCH_PADDING_CHUNKS;
 
-    return new Box2(
-      vec2.fromValues(bounds.min[0] - padX, bounds.min[1] - padY),
-      vec2.fromValues(bounds.max[0] + padX, bounds.max[1] + padY)
+    return new Box3(
+      vec3.fromValues(
+        bounds.min[0] - padX,
+        bounds.min[1] - padY,
+        bounds.min[2] - padZ
+      ),
+      vec3.fromValues(
+        bounds.max[0] + padX,
+        bounds.max[1] + padY,
+        bounds.max[2] + padZ
+      )
     );
   }
 }
@@ -336,13 +390,13 @@ export class ChunkManager {
       );
     }
 
-    const visibleBounds = camera.getWorldViewRect();
-    const virtualWidth = Math.abs(visibleBounds.max[0] - visibleBounds.min[0]);
+    const viewBounds2D = camera.getWorldViewRect();
+    const virtualWidth = Math.abs(viewBounds2D.max[0] - viewBounds2D.min[0]);
     const virtualUnitsPerScreenPixel = virtualWidth / bufferWidth;
     const lodFactor = Math.log2(1 / virtualUnitsPerScreenPixel);
 
     for (const [_, chunkManagerSource] of this.sources_) {
-      chunkManagerSource.update(lodFactor, visibleBounds);
+      chunkManagerSource.update(lodFactor, viewBounds2D);
     }
   }
 }

--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -184,8 +184,7 @@ export class ChunkManagerSource {
       if (chunk.lod !== this.lowestResLOD_ || chunk.state !== "unloaded")
         continue;
 
-      // TEMP: visibility is 2D (Box2). Ignore nonzero Z until Box3 intersects() exists.
-      // In this case, changes to loadChunkDataFromRegion are also needed.
+      // TEMP: visibility is 2D. Ignore nonzero Z until chunk prioritization exists.
       if (chunk.chunkIndex.z !== 0) continue;
 
       this.loadChunkData(chunk);
@@ -233,10 +232,15 @@ export class ChunkManagerSource {
       return;
     }
 
-    const viewBounds3D = this.makeViewBounds3D(viewBounds2D);
+    const [zMin, zMax] = this.getZBounds();
+    const viewBounds3D = new Box3(
+      vec3.fromValues(viewBounds2D.min[0], viewBounds2D.min[1], zMin),
+      vec3.fromValues(viewBounds2D.max[0], viewBounds2D.max[1], zMax)
+    );
+
     const paddedBounds = this.getPaddedBounds(viewBounds3D);
     for (const chunk of this.chunks_) {
-      // TEMP: visibility is 2D (Box2). Ignore nonzero Z until Box3 intersects() exists.
+      // TEMP: visibility is 2D. Ignore nonzero Z until chunk prioritization exists.
       if (chunk.chunkIndex.z !== 0) continue;
 
       chunk.prefetch = false;
@@ -281,42 +285,31 @@ export class ChunkManagerSource {
     return Box3.intersects(chunkBounds, bounds);
   }
 
-  private makeViewBounds3D(bounds: Box2): Box3 {
-    if (this.zIdx_ === -1) {
-      return new Box3(
-        vec3.fromValues(bounds.min[0], bounds.min[1], 0),
-        vec3.fromValues(bounds.max[0], bounds.max[1], 0)
-      );
-    }
-
+  private getZBounds(): [number, number] {
+    if (this.zIdx_ === -1) return [0, 0];
     const index = this.region_[this.zIdx_].index;
     if (index.type !== "point") {
-      return new Box3(
-        vec3.fromValues(bounds.min[0], bounds.min[1], 0),
-        vec3.fromValues(bounds.max[0], bounds.max[1], 0)
-      );
+      throw new Error("Intervals are currently not supported.");
     }
 
-    const shapeZ = this.attrs_[this.currentLOD_].shape[this.zIdx_];
-    const scaleZ = this.attrs_[this.currentLOD_].scale[this.zIdx_];
-    const transZ = this.attrs_[this.currentLOD_].translation[this.zIdx_];
+    const zShape = this.attrs_[this.currentLOD_].shape[this.zIdx_];
+    const zScale = this.attrs_[this.currentLOD_].scale[this.zIdx_];
+    const zTran = this.attrs_[this.currentLOD_].translation[this.zIdx_];
+    const zPoint = Math.floor((index.value - zTran) / zScale);
     const chunkDepth = this.attrs_[this.currentLOD_].chunks[this.zIdx_];
-    const pointZ = Math.floor((index.value - transZ) / scaleZ);
-    const chunkZ = Math.max(
+
+    const zChunk = Math.max(
       0,
       Math.min(
-        Math.floor(pointZ / chunkDepth),
-        Math.ceil(shapeZ / chunkDepth) - 1
+        Math.floor(zPoint / chunkDepth),
+        Math.ceil(zShape / chunkDepth) - 1
       )
     );
 
-    const zMin = transZ + chunkZ * chunkDepth * scaleZ;
-    const zMax = transZ + (chunkZ + 1) * chunkDepth * scaleZ;
-
-    return new Box3(
-      vec3.fromValues(bounds.min[0], bounds.min[1], zMin),
-      vec3.fromValues(bounds.max[0], bounds.max[1], zMax)
-    );
+    return [
+      zTran + zChunk * chunkDepth * zScale,
+      zTran + (zChunk + 1) * chunkDepth * zScale,
+    ];
   }
 
   private viewBounds2DChanged(newBounds: Box2): boolean {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -20,6 +20,7 @@ export { ImageSeriesLayer } from "./layers/image_series_layer";
 export { OmeZarrImageSource } from "./data/ome_zarr_image_source";
 
 export { Box2 } from "./math/box2";
+export { Box3 } from "./math/box3";
 
 export type { Region } from "./data/region";
 export type { Image as OmeNgffImage } from "./data/ome_ngff/0.4/image";

--- a/packages/core/src/layers/image_layer.ts
+++ b/packages/core/src/layers/image_layer.ts
@@ -60,13 +60,9 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
 
     const x = region.find((r) => r.dimension.toLowerCase() === "x");
     const y = region.find((r) => r.dimension.toLowerCase() === "y");
-    const z = region.find((r) => r.dimension.toLowerCase() === "z");
     const hasIntervals = region.some((r) => r.index.type === "interval");
     this.useChunkManager_ =
-      !hasIntervals &&
-      x?.index.type === "full" &&
-      y?.index.type === "full" &&
-      z?.index.type === "point";
+      !hasIntervals && x?.index.type === "full" && y?.index.type === "full";
 
     if (this.useChunkManager_) {
       Logger.info("ImageLayer", "Loading data using the chunk manager");

--- a/packages/core/src/math/box2.ts
+++ b/packages/core/src/math/box2.ts
@@ -8,8 +8,7 @@ export class Box2 {
    * Initializes as an empty box if no values are provided using the
    * "empty-by-sentinel" pattern: min = +Infinity, max = -Infinity.
    * This allows expansion functions to work without special-casing
-   * the first element, and avoids biasing toward (0,0). This pattern
-   * is common in geometry/math libraries.
+   * the first element, and avoids biasing toward (0,0).
    */
   constructor(min?: vec2, max?: vec2) {
     this.min = min ? vec2.clone(min) : vec2.fromValues(+Infinity, +Infinity);
@@ -24,6 +23,7 @@ export class Box2 {
     return this.max[0] < this.min[0] || this.max[1] < this.min[1];
   }
 
+  // Touching edges count as intersecting (closed intervals)
   public static intersects(a: Box2, b: Box2): boolean {
     if (a.max[0] < b.min[0] || a.min[0] > b.max[0]) return false;
     if (a.max[1] < b.min[1] || a.min[1] > b.max[1]) return false;

--- a/packages/core/src/math/box3.ts
+++ b/packages/core/src/math/box3.ts
@@ -1,0 +1,41 @@
+import { vec3 } from "gl-matrix";
+
+export class Box3 {
+  public min: vec3;
+  public max: vec3;
+
+  /**
+   * Initializes as an empty box if no values are provided using the
+   * "empty-by-sentinel" pattern: min = +Infinity, max = -Infinity.
+   * This allows expansion functions to work without special-casing
+   * the first element, and avoids biasing toward (0,0,0).
+   */
+  constructor(min?: vec3, max?: vec3) {
+    this.min = min
+      ? vec3.clone(min)
+      : vec3.fromValues(+Infinity, +Infinity, +Infinity);
+    this.max = max
+      ? vec3.clone(max)
+      : vec3.fromValues(-Infinity, -Infinity, -Infinity);
+  }
+
+  public clone() {
+    return new Box3(this.min, this.max);
+  }
+
+  public isEmpty(): boolean {
+    return (
+      this.max[0] < this.min[0] ||
+      this.max[1] < this.min[1] ||
+      this.max[2] < this.min[2]
+    );
+  }
+
+  // Touching edges count as intersecting (closed intervals)
+  public static intersects(a: Box3, b: Box3): boolean {
+    if (a.max[0] < b.min[0] || a.min[0] > b.max[0]) return false;
+    if (a.max[1] < b.min[1] || a.min[1] > b.max[1]) return false;
+    if (a.max[2] < b.min[2] || a.min[2] > b.max[2]) return false;
+    return true;
+  }
+}

--- a/packages/core/test/box3.test.ts
+++ b/packages/core/test/box3.test.ts
@@ -1,0 +1,68 @@
+import { expect, test } from "vitest";
+import { vec3 } from "gl-matrix";
+
+import { Box3 } from "@";
+
+test("default constructor yields an empty box", () => {
+  const b = new Box3();
+  expect(b.isEmpty()).toBe(true);
+});
+
+test("non-empty when min <= max on all axes", () => {
+  const b = new Box3(vec3.fromValues(0, 0, 0), vec3.fromValues(1, 1, 1));
+  expect(b.isEmpty()).toBe(false);
+});
+
+test("isEmpty detects inverted bounds", () => {
+  const invX = new Box3(vec3.fromValues(1, 0, 0), vec3.fromValues(0, 1, 1));
+  const invY = new Box3(vec3.fromValues(0, 1, 0), vec3.fromValues(1, 0, 1));
+  const invZ = new Box3(vec3.fromValues(0, 0, 1), vec3.fromValues(1, 1, 0));
+  expect(invX.isEmpty()).toBe(true);
+  expect(invY.isEmpty()).toBe(true);
+  expect(invZ.isEmpty()).toBe(true);
+});
+
+test("intersects: overlapping boxes return true", () => {
+  const a = new Box3(vec3.fromValues(0, 0, 0), vec3.fromValues(2, 2, 2));
+  const b = new Box3(vec3.fromValues(1, 1, 1), vec3.fromValues(3, 3, 3));
+  expect(Box3.intersects(a, b)).toBe(true);
+  expect(Box3.intersects(b, a)).toBe(true); // symmetry
+});
+
+test("intersects: separated boxes return false", () => {
+  const a = new Box3(vec3.fromValues(0, 0, 0), vec3.fromValues(1, 1, 1));
+  const b = new Box3(vec3.fromValues(2, 2, 2), vec3.fromValues(3, 3, 3));
+  expect(Box3.intersects(a, b)).toBe(false);
+  expect(Box3.intersects(b, a)).toBe(false); // symmetry
+});
+
+test("intersects: touching edges count as intersecting", () => {
+  const a = new Box3(vec3.fromValues(0, 0, 0), vec3.fromValues(2, 2, 2));
+  const b = new Box3(vec3.fromValues(2, 0, 0), vec3.fromValues(4, 2, 2));
+  const c = new Box3(vec3.fromValues(2, 2, 0), vec3.fromValues(4, 4, 2));
+  const d = new Box3(vec3.fromValues(2, 2, 2), vec3.fromValues(4, 4, 4));
+  expect(Box3.intersects(a, b)).toBe(true);
+  expect(Box3.intersects(a, c)).toBe(true);
+  expect(Box3.intersects(a, d)).toBe(true);
+});
+
+test("intersects: empty and non-empty box do not intersect", () => {
+  const a = new Box3(); // empty
+  const b = new Box3(vec3.fromValues(0, 0, 0), vec3.fromValues(1, 1, 1));
+  expect(a.isEmpty()).toBe(true);
+  expect(b.isEmpty()).toBe(false);
+  expect(Box3.intersects(a, b)).toBe(false);
+});
+
+test("clone creates a deep copy", () => {
+  const a = new Box3(vec3.fromValues(0, 0, 0), vec3.fromValues(1, 1, 1));
+  const b = a.clone();
+
+  a.min[0] = 10;
+  a.max[2] = 20;
+
+  expect(b.min[0]).toBe(0);
+  expect(b.max[2]).toBe(1);
+  expect(a.min[0]).not.toBe(b.min[0]);
+  expect(a.max[2]).not.toBe(b.max[2]);
+});


### PR DESCRIPTION
### Summary

This change extends `ChunkManager` to support Z-dimension visibility,
enabling intersection checks in full 3D. A new `makeViewBounds3D()` method
builds a `Box3` view volume from the camera’s 2D bounds and the current Z
index in the region, mapping it to the correct chunk in world space. Chunk
visibility and prefetch checks now operate against 3D bounds using
`Box3.intersects()`.

### Notes
- Prefetching on Z remains disabled (see _`TEMP`_ comments in class). With the current zebra fish dataset, extending Z in both directions would load the entire dataset. Enabling this confidently will require:
  1. Prioritized loading so non-prefetched chunks load first (otherwise this change will slow things down).
  2. Fixed-size logical chunks or temporary logic to prefetch Z only when the point is near a chunk boundary.
- I’m still building confidence in this change. I plan to run more manual tests and possibly add unit tests before merging, but I think it’s ready for initial review.

### Tests & Checks
- manually verified that all examples are working correctly
- manually verified using debug overlay that chunk intersection works as before
- all checks have passed 
