### PR TITLE
Move Z-plane slicing to the layer

### DIFF
--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -194,7 +194,7 @@ export class ChunkManagerSource {
   private loadChunkData(chunk: Chunk): void {
     chunk.state = "loading";
     this.loader_
-      .loadChunkDataFromRegion(chunk, this.region_)
+      .loadChunkData(chunk, this.region_)
       .then(() => {
         chunk.state = "loaded";
       })

--- a/packages/core/src/data/chunk.ts
+++ b/packages/core/src/data/chunk.ts
@@ -75,7 +75,7 @@ export type ChunkLoader = {
     scheduler?: PromiseScheduler
   ): Promise<Chunk>;
 
-  loadChunkDataFromRegion(chunk: Chunk, region: Region): Promise<void>;
+  loadChunkData(chunk: Chunk, region: Region): Promise<void>;
 
   getAttributes(): ReadonlyArray<LoaderAttributes>;
 };

--- a/packages/core/src/data/ome_zarr_image_loader.ts
+++ b/packages/core/src/data/ome_zarr_image_loader.ts
@@ -49,19 +49,54 @@ export class OmeZarrImageLoader {
     this.lods_ = this.metadata_.datasets.length;
   }
 
-  public async loadChunkDataFromRegion(chunk: Chunk, region: Region) {
-    const attrs = this.loaderAttributes_[chunk.lod];
-    const array = this.arrays_[chunk.lod];
+  public buildChunkCoords(
+    chunk: Chunk,
+    region: Region,
+    attrs: LoaderAttributes
+  ) {
+    const dims = attrs.dimensionNames.map((d) => d.toLowerCase());
+    const coords = new Array(dims.length).fill(0);
+    const indices = this.regionToIndices(region, attrs);
 
-    const dimInfo = this.getDimInfoMap(region, chunk, attrs);
-    if (!dimInfo.has("x") || !dimInfo.has("y")) {
-      throw new Error("Missing required spatial axis x/y");
+    for (let dimIdx = 0; dimIdx < dims.length; dimIdx++) {
+      const dim = dims[dimIdx];
+      const chunkSize = attrs.chunks[dimIdx];
+      let coord: number;
+      switch (dim) {
+        case "x":
+          coord = chunk.chunkIndex.x;
+          break;
+        case "y":
+          coord = chunk.chunkIndex.y;
+          break;
+        case "z":
+          coord = chunk.chunkIndex.z ?? 0;
+          break;
+        default: {
+          // Non-spatial dimension (e.g., "t", "c", or any other).
+          // Pull from indices[dimIdx] if present otherwise default to 0.
+          const idx = indices[dimIdx];
+          if (typeof idx === "number") {
+            coord = idx;
+          } else {
+            coord = idx.start === null ? 0 : Math.floor(idx.start / chunkSize);
+          }
+          break;
+        }
+      }
+      const dimSize = attrs.shape[dimIdx];
+      const maxChunk = Math.max(0, Math.ceil(dimSize / chunkSize) - 1);
+      coords[dimIdx] = Math.max(0, Math.min(coord, maxChunk));
     }
 
-    const chunkCoords: number[] = [];
-    dimInfo.forEach((info) => chunkCoords.push(info.chunkIdx));
-    const subarray = await array.getChunk(chunkCoords);
+    return coords;
+  }
 
+  public async loadChunkData(chunk: Chunk, region: Region) {
+    const attrs = this.loaderAttributes_[chunk.lod];
+    const array = this.arrays_[chunk.lod];
+    const coords = this.buildChunkCoords(chunk, region, attrs);
+    const subarray = await array.getChunk(coords);
     const data = subarray.data;
     if (!isChunkData(data)) {
       throw new Error(
@@ -69,13 +104,7 @@ export class OmeZarrImageLoader {
       );
     }
 
-    const sliceSize = chunk.shape.x * chunk.shape.y;
-    const zInfo = dimInfo.get("z") ?? dimInfo.get("Z");
-    const zOffset = zInfo
-      ? sliceSize * (zInfo.value % array.chunks[zInfo.dimIdx])
-      : 0;
-
-    chunk.data = data.slice(zOffset, zOffset + sliceSize);
+    chunk.data = data;
   }
 
   public async loadRegion(
@@ -162,34 +191,6 @@ export class OmeZarrImageLoader {
 
   public getAttributes(): ReadonlyArray<LoaderAttributes> {
     return this.loaderAttributes_;
-  }
-
-  private getDimInfoMap(region: Region, chunk: Chunk, attrs: LoaderAttributes) {
-    const indices = this.regionToIndices(region, attrs);
-    const output = new Map();
-    region.forEach((entry, dimIdx) => {
-      if (entry.dimension.toLowerCase() === "x") {
-        const value = 0; // not used for x dimension
-        output.set("x", { dimIdx, chunkIdx: chunk.chunkIndex.x, value });
-        return;
-      }
-
-      if (entry.dimension.toLowerCase() === "y") {
-        const value = 0; // not used for y dimension
-        output.set("y", { dimIdx, chunkIdx: chunk.chunkIndex.y, value });
-        return;
-      }
-
-      const value = indices[dimIdx];
-      if (typeof value !== "number") {
-        throw new Error(`Expected numeric index for ${entry.dimension}`);
-      }
-
-      const chunkIdx = Math.floor(value / attrs.chunks[dimIdx]);
-      output.set(entry.dimension, { dimIdx, chunkIdx, value });
-    });
-
-    return output;
   }
 
   private regionToIndices(

--- a/packages/core/src/layers/image_layer.ts
+++ b/packages/core/src/layers/image_layer.ts
@@ -209,8 +209,26 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
     return this.chunkManagerSource_;
   }
 
+  private slicePlane(chunk: Chunk, zValue: number) {
+    const zLocal = Math.floor((zValue - chunk.offset.z) / chunk.scale.z);
+    if (zLocal < 0 || zLocal >= chunk.shape.z) {
+      throw new Error("Requested Z plane is outside chunk range");
+    }
+    const sliceSize = chunk.shape.x * chunk.shape.y;
+    return chunk.data?.subarray(zLocal * sliceSize, (zLocal + 1) * sliceSize);
+  }
+
   private createImage(chunk: Chunk, channelProps?: ChannelProps[]) {
     const geometry = new PlaneGeometry(chunk.shape.x, chunk.shape.y, 1, 1);
+
+    const zIdx = this.region_.find((r) => r.dimension.toLowerCase() === "z");
+    if (chunk.shape.z > 1 && zIdx) {
+      const index = zIdx.index;
+      if (index.type !== "point") {
+        throw new Error("Expected Z index to be a point");
+      }
+      chunk.data = this.slicePlane(chunk, index.value);
+    }
 
     const image = new ImageRenderable(
       geometry,


### PR DESCRIPTION
### Summary

This PR modifies the chunk loading logic by storing the entire data set for
the chunk in the chunk data structure and moving the Z-plane slicing from the
loader to the image layer. I also refactored the loader now that I understand
the schema a little better by removing `getDimInfoMap` and writing a cleaner
helper.

### Tests & Checks

- In the process of testing and fixing issues
