### PR TITLE
Make box intersection test half-open

### DIFF
--- a/packages/core/src/math/box2.ts
+++ b/packages/core/src/math/box2.ts
@@ -20,7 +20,7 @@ export class Box2 {
   }
 
   public isEmpty(): boolean {
-    return this.max[0] < this.min[0] || this.max[1] < this.min[1];
+    return this.max[0] <= this.min[0] || this.max[1] <= this.min[1];
   }
 
   // Half-open interval intersection: returns true only if boxes overlap.

--- a/packages/core/src/math/box2.ts
+++ b/packages/core/src/math/box2.ts
@@ -23,10 +23,10 @@ export class Box2 {
     return this.max[0] < this.min[0] || this.max[1] < this.min[1];
   }
 
-  // Touching edges count as intersecting (closed intervals)
+  // Half-open interval intersection: returns true only if boxes overlap.
   public static intersects(a: Box2, b: Box2): boolean {
-    if (a.max[0] < b.min[0] || a.min[0] > b.max[0]) return false;
-    if (a.max[1] < b.min[1] || a.min[1] > b.max[1]) return false;
+    if (a.max[0] <= b.min[0] || a.min[0] >= b.max[0]) return false;
+    if (a.max[1] <= b.min[1] || a.min[1] >= b.max[1]) return false;
     return true;
   }
 }

--- a/packages/core/src/math/box3.ts
+++ b/packages/core/src/math/box3.ts
@@ -31,11 +31,11 @@ export class Box3 {
     );
   }
 
-  // Touching edges count as intersecting (closed intervals)
+  // Half-open interval intersection: returns true only if boxes overlap.
   public static intersects(a: Box3, b: Box3): boolean {
-    if (a.max[0] < b.min[0] || a.min[0] > b.max[0]) return false;
-    if (a.max[1] < b.min[1] || a.min[1] > b.max[1]) return false;
-    if (a.max[2] < b.min[2] || a.min[2] > b.max[2]) return false;
+    if (a.max[0] <= b.min[0] || a.min[0] >= b.max[0]) return false;
+    if (a.max[1] <= b.min[1] || a.min[1] >= b.max[1]) return false;
+    if (a.max[2] <= b.min[2] || a.min[2] >= b.max[2]) return false;
     return true;
   }
 }

--- a/packages/core/src/math/box3.ts
+++ b/packages/core/src/math/box3.ts
@@ -25,9 +25,9 @@ export class Box3 {
 
   public isEmpty(): boolean {
     return (
-      this.max[0] < this.min[0] ||
-      this.max[1] < this.min[1] ||
-      this.max[2] < this.min[2]
+      this.max[0] <= this.min[0] ||
+      this.max[1] <= this.min[1] ||
+      this.max[2] <= this.min[2]
     );
   }
 

--- a/packages/core/test/box2.test.ts
+++ b/packages/core/test/box2.test.ts
@@ -32,12 +32,12 @@ test("intersects: separated boxes return false", () => {
   expect(Box2.intersects(b, a)).toBe(false); // symmetry
 });
 
-test("intersects: touching edges count as intersecting", () => {
+test("intersects: touching edges do not count as intersecting", () => {
   const a = new Box2(vec2.fromValues(0, 0), vec2.fromValues(2, 2));
   const b = new Box2(vec2.fromValues(2, 0), vec2.fromValues(4, 2));
   const c = new Box2(vec2.fromValues(0, 2), vec2.fromValues(2, 4));
-  expect(Box2.intersects(a, b)).toBe(true);
-  expect(Box2.intersects(a, c)).toBe(true);
+  expect(Box2.intersects(a, b)).toBe(false);
+  expect(Box2.intersects(a, c)).toBe(false);
 });
 
 test("intersects: empty and non-empty box do not intersect", () => {

--- a/packages/core/test/box3.test.ts
+++ b/packages/core/test/box3.test.ts
@@ -36,14 +36,14 @@ test("intersects: separated boxes return false", () => {
   expect(Box3.intersects(b, a)).toBe(false); // symmetry
 });
 
-test("intersects: touching edges count as intersecting", () => {
+test("intersects: touching edges do not count as intersecting", () => {
   const a = new Box3(vec3.fromValues(0, 0, 0), vec3.fromValues(2, 2, 2));
   const b = new Box3(vec3.fromValues(2, 0, 0), vec3.fromValues(4, 2, 2));
   const c = new Box3(vec3.fromValues(2, 2, 0), vec3.fromValues(4, 4, 2));
   const d = new Box3(vec3.fromValues(2, 2, 2), vec3.fromValues(4, 4, 4));
-  expect(Box3.intersects(a, b)).toBe(true);
-  expect(Box3.intersects(a, c)).toBe(true);
-  expect(Box3.intersects(a, d)).toBe(true);
+  expect(Box3.intersects(a, b)).toBe(false);
+  expect(Box3.intersects(a, c)).toBe(false);
+  expect(Box3.intersects(a, d)).toBe(false);
 });
 
 test("intersects: empty and non-empty box do not intersect", () => {


### PR DESCRIPTION
### Summary

This PR makes box intersections half-open instead of closed intervals.

While working on layer slicing, I removed the temporary skip for non-zero Z-index chunks and disabled Z-axis prefetching. This unexpectedly increased the number of loaded chunks. The cause was our closed-interval intersection test, which marked face-touching chunks as intersecting. I switched to a half-open intersection test instead of adding offsets to the view bounds or chunk bounds since half-open checks are the more common convention in graphics math libraries. The only reason I used closed intervals before is that it was part of the initial implementation. I'm happy to reconsider if there's a good reason to.

### Tests & Checks

- All checks have passed
- Box intersection tests are updated accordingly
- Manual verification of chunk loading across Z
