### PR TITLE
Move Z-plane slicing to the layer

### DIFF
--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -183,10 +183,6 @@ export class ChunkManagerSource {
     for (const chunk of this.chunks_) {
       if (chunk.lod !== this.lowestResLOD_ || chunk.state !== "unloaded")
         continue;
-
-      // TEMP: visibility is 2D. Ignore nonzero Z until chunk prioritization exists.
-      if (chunk.chunkIndex.z !== 0) continue;
-
       this.loadChunkData(chunk);
     }
   }
@@ -194,7 +190,7 @@ export class ChunkManagerSource {
   private loadChunkData(chunk: Chunk): void {
     chunk.state = "loading";
     this.loader_
-      .loadChunkDataFromRegion(chunk, this.region_)
+      .loadChunkData(chunk, this.region_)
       .then(() => {
         chunk.state = "loaded";
       })
@@ -240,9 +236,6 @@ export class ChunkManagerSource {
 
     const paddedBounds = this.getPaddedBounds(viewBounds3D);
     for (const chunk of this.chunks_) {
-      // TEMP: visibility is 2D. Ignore nonzero Z until chunk prioritization exists.
-      if (chunk.chunkIndex.z !== 0) continue;
-
       chunk.prefetch = false;
       chunk.visible = this.isChunkWithinBounds(chunk, viewBounds3D);
       if (!chunk.visible) {
@@ -338,13 +331,11 @@ export class ChunkManagerSource {
       this.attrs_[this.currentLOD_].chunks[this.yIdx_] *
       this.attrs_[this.currentLOD_].scale[this.yIdx_];
 
-    const chunkDepth =
-      this.attrs_[this.currentLOD_].chunks[this.zIdx_] *
-      this.attrs_[this.currentLOD_].scale[this.zIdx_];
-
     const padX = chunkWidth * PREFETCH_PADDING_CHUNKS;
     const padY = chunkHeight * PREFETCH_PADDING_CHUNKS;
-    const padZ = chunkDepth * PREFETCH_PADDING_CHUNKS;
+
+    // Disable prefetching in Z until chunk prioritization exists.
+    const padZ = 0;
 
     return new Box3(
       vec3.fromValues(

--- a/packages/core/src/data/chunk.ts
+++ b/packages/core/src/data/chunk.ts
@@ -11,7 +11,7 @@ const chunkDataTypes = [
   Uint32Array,
   Float32Array,
 ] as const;
-type ChunkData = InstanceType<(typeof chunkDataTypes)[number]>;
+export type ChunkData = InstanceType<(typeof chunkDataTypes)[number]>;
 
 export function isChunkData(value: unknown): value is ChunkData {
   if (chunkDataTypes.some((ChunkData) => value instanceof ChunkData)) {
@@ -75,7 +75,7 @@ export type ChunkLoader = {
     scheduler?: PromiseScheduler
   ): Promise<Chunk>;
 
-  loadChunkDataFromRegion(chunk: Chunk, region: Region): Promise<void>;
+  loadChunkData(chunk: Chunk, region: Region): Promise<void>;
 
   getAttributes(): ReadonlyArray<LoaderAttributes>;
 };

--- a/packages/core/src/data/ome_zarr_image_loader.ts
+++ b/packages/core/src/data/ome_zarr_image_loader.ts
@@ -49,33 +49,62 @@ export class OmeZarrImageLoader {
     this.lods_ = this.metadata_.datasets.length;
   }
 
-  public async loadChunkDataFromRegion(chunk: Chunk, region: Region) {
-    const attrs = this.loaderAttributes_[chunk.lod];
-    const array = this.arrays_[chunk.lod];
+  public buildChunkCoords(
+    chunk: Chunk,
+    region: Region,
+    attrs: LoaderAttributes
+  ) {
+    const dims = attrs.dimensionNames.map((d) => d.toLowerCase());
+    const coords = new Array(dims.length).fill(0);
+    const indices = this.regionToIndices(region, attrs);
 
-    const dimInfo = this.getDimInfoMap(region, chunk, attrs);
-    if (!dimInfo.has("x") || !dimInfo.has("y")) {
-      throw new Error("Missing required spatial axis x/y");
+    for (let dimIdx = 0; dimIdx < dims.length; dimIdx++) {
+      const dim = dims[dimIdx];
+      const chunkSize = attrs.chunks[dimIdx];
+      let coord: number;
+      switch (dim) {
+        case "x":
+          coord = chunk.chunkIndex.x;
+          break;
+        case "y":
+          coord = chunk.chunkIndex.y;
+          break;
+        case "z":
+          coord = chunk.chunkIndex.z ?? 0;
+          break;
+        default: {
+          // Non-spatial dimension (e.g., "t", "c", or any other).
+          // Pull from indices[dimIdx] if present otherwise default to 0.
+          const value = indices[dimIdx];
+          if (typeof value === "number") {
+            coord = Math.floor(value / chunkSize);
+          } else {
+            coord =
+              value.start === null ? 0 : Math.floor(value.start / chunkSize);
+          }
+          break;
+        }
+      }
+      const dimSize = attrs.shape[dimIdx];
+      const maxChunk = Math.max(0, Math.ceil(dimSize / chunkSize) - 1);
+      coords[dimIdx] = Math.max(0, Math.min(coord, maxChunk));
     }
 
-    const chunkCoords: number[] = [];
-    dimInfo.forEach((info) => chunkCoords.push(info.chunkIdx));
-    const subarray = await array.getChunk(chunkCoords);
+    return coords;
+  }
 
+  public async loadChunkData(chunk: Chunk, region: Region) {
+    const attrs = this.loaderAttributes_[chunk.lod];
+    const array = this.arrays_[chunk.lod];
+    const coords = this.buildChunkCoords(chunk, region, attrs);
+    const subarray = await array.getChunk(coords);
     const data = subarray.data;
     if (!isChunkData(data)) {
       throw new Error(
         `Subarray has an unsupported data type, data=${data.constructor.name}`
       );
     }
-
-    const sliceSize = chunk.shape.x * chunk.shape.y;
-    const zInfo = dimInfo.get("z") ?? dimInfo.get("Z");
-    const zOffset = zInfo
-      ? sliceSize * (zInfo.value % array.chunks[zInfo.dimIdx])
-      : 0;
-
-    chunk.data = data.slice(zOffset, zOffset + sliceSize);
+    chunk.data = data;
   }
 
   public async loadRegion(
@@ -162,34 +191,6 @@ export class OmeZarrImageLoader {
 
   public getAttributes(): ReadonlyArray<LoaderAttributes> {
     return this.loaderAttributes_;
-  }
-
-  private getDimInfoMap(region: Region, chunk: Chunk, attrs: LoaderAttributes) {
-    const indices = this.regionToIndices(region, attrs);
-    const output = new Map();
-    region.forEach((entry, dimIdx) => {
-      if (entry.dimension.toLowerCase() === "x") {
-        const value = 0; // not used for x dimension
-        output.set("x", { dimIdx, chunkIdx: chunk.chunkIndex.x, value });
-        return;
-      }
-
-      if (entry.dimension.toLowerCase() === "y") {
-        const value = 0; // not used for y dimension
-        output.set("y", { dimIdx, chunkIdx: chunk.chunkIndex.y, value });
-        return;
-      }
-
-      const value = indices[dimIdx];
-      if (typeof value !== "number") {
-        throw new Error(`Expected numeric index for ${entry.dimension}`);
-      }
-
-      const chunkIdx = Math.floor(value / attrs.chunks[dimIdx]);
-      output.set(entry.dimension, { dimIdx, chunkIdx, value });
-    });
-
-    return output;
   }
 
   private regionToIndices(

--- a/packages/core/src/layers/image_layer.ts
+++ b/packages/core/src/layers/image_layer.ts
@@ -207,12 +207,28 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
     return this.chunkManagerSource_;
   }
 
+  private slicePlane(chunk: Chunk, zValue: number) {
+    const zLocal = Math.round((zValue - chunk.offset.z) / chunk.scale.z);
+    const sliceSize = chunk.shape.x * chunk.shape.y;
+    const offset = sliceSize * (zLocal % chunk.shape.z);
+    return chunk.data?.slice(offset, offset + sliceSize);
+  }
+
   private createImage(chunk: Chunk, channelProps?: ChannelProps[]) {
     const geometry = new PlaneGeometry(chunk.shape.x, chunk.shape.y, 1, 1);
 
+    let data = chunk.data;
+    if (chunk.shape.z > 1) {
+      const zIdx = this.region_.find((r) => r.dimension.toLowerCase() === "z");
+      if (zIdx?.index.type !== "point") {
+        throw new Error("Expected Z index to be a point");
+      }
+      data = this.slicePlane(chunk, zIdx.index.value);
+    }
+
     const image = new ImageRenderable(
       geometry,
-      Texture2DArray.createWithChunk(chunk),
+      Texture2DArray.createWithChunk(chunk, data),
       channelProps
     );
 

--- a/packages/core/src/layers/image_layer.ts
+++ b/packages/core/src/layers/image_layer.ts
@@ -208,10 +208,11 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
   }
 
   private slicePlane(chunk: Chunk, zValue: number) {
+    if (!chunk.data) return;
     const zLocal = Math.round((zValue - chunk.offset.z) / chunk.scale.z);
     const sliceSize = chunk.shape.x * chunk.shape.y;
     const offset = sliceSize * (zLocal % chunk.shape.z);
-    return chunk.data?.slice(offset, offset + sliceSize);
+    return chunk.data.slice(offset, offset + sliceSize);
   }
 
   private createImage(chunk: Chunk, channelProps?: ChannelProps[]) {

--- a/packages/core/src/objects/textures/texture_2d_array.ts
+++ b/packages/core/src/objects/textures/texture_2d_array.ts
@@ -4,7 +4,7 @@ import {
   bufferToDataType,
 } from "../../objects/textures/texture";
 
-import { Chunk } from "../../data/chunk";
+import { Chunk, ChunkData } from "../../data/chunk";
 export class Texture2DArray extends Texture {
   private data_: DataTextureTypedArray;
   private readonly width_: number;
@@ -48,17 +48,14 @@ export class Texture2DArray extends Texture {
     return this.depth_;
   }
 
-  public static createWithChunk(chunk: Chunk) {
-    if (!chunk.data) {
+  public static createWithChunk(chunk: Chunk, data?: ChunkData) {
+    const source = data ?? chunk.data;
+    if (!source) {
       throw new Error(
         "Unabled to create texture, chunk data is not initialized."
       );
     }
-    const texture = new Texture2DArray(
-      chunk.data,
-      chunk.shape.x,
-      chunk.shape.y
-    );
+    const texture = new Texture2DArray(source, chunk.shape.x, chunk.shape.y);
     texture.unpackRowLength = chunk.rowStride;
     texture.unpackAlignment = chunk.rowAlignmentBytes;
     return texture;


### PR DESCRIPTION
### Summary

This PR modifies the chunk loading logic by storing the entire data set for
the chunk in the chunk data structure and moving the Z-plane slicing from the
loader to the image layer. I also refactored the loader now that I understand
the schema a little better by removing getDimInfoMap and writing a cleaner
helper.

### Tests & Checks

- Manually verified all existing examples work as expected
- Memory reflects the entire chunk size (~2GB without chunk disposal)
- All checks have passed