### PR TITLE
Fix series layer preload to be awaitable

### DIFF
--- a/packages/core/src/layers/image_series_layer.ts
+++ b/packages/core/src/layers/image_series_layer.ts
@@ -96,7 +96,7 @@ export class ImageSeriesLayer extends Layer implements ChannelsEnabled {
   }
 
   public async preloadSeries() {
-    this.seriesLoader_.preloadAllChunks();
+    return this.seriesLoader_.preloadAllChunks();
   }
 
   public get extent(): { x: number; y: number } | undefined {

--- a/packages/core/src/layers/label_image_series_layer.ts
+++ b/packages/core/src/layers/label_image_series_layer.ts
@@ -77,7 +77,7 @@ export class LabelImageSeriesLayer extends Layer {
   }
 
   public async preloadSeries() {
-    this.seriesLoader_.preloadAllChunks();
+    return this.seriesLoader_.preloadAllChunks();
   }
 
   public get extent(): { x: number; y: number } | undefined {


### PR DESCRIPTION
### Summary
This change fixes the image and image label series layers `preloadSeries` method to be await-able by returning the promise that the underlying series loader returns.

This bug was introduced by the series loading refactor included in #347.

### Tests & Checks
I manually tested the core examples that use series.
I manually tested the React component examples.
