### PR TITLE
Round values in scaled stats.js to prevent fuzziness

### DIFF
--- a/packages/core/src/utilities/vendored/stats.js
+++ b/packages/core/src/utilities/vendored/stats.js
@@ -114,20 +114,24 @@ var Stats = function(scale = 1) {
 Stats.Panel = function(name, fg, bg, scale) {
 
   var min = Infinity, max = 0, round = Math.round;
-  var PR = scale * round(window.devicePixelRatio || 1);
+  var PR = round(window.devicePixelRatio || 1);
 
-  var WIDTH = 80 * PR, HEIGHT = 48 * PR,
-    TEXT_X = 3 * PR, TEXT_Y = 2 * PR,
-    GRAPH_X = 3 * PR, GRAPH_Y = 15 * PR,
-    GRAPH_WIDTH = 74 * PR, GRAPH_HEIGHT = 30 * PR;
+  var WIDTH = round(80 * PR * scale);
+  var HEIGHT = round(48 * PR * scale);
+  var TEXT_X = round(3 * PR * scale);
+  var TEXT_Y = round(2 * PR * scale);
+  var GRAPH_X = round(3 * PR * scale);
+  var GRAPH_Y = round(15 * PR * scale);
+  var GRAPH_WIDTH = round(74 * PR * scale);
+  var GRAPH_HEIGHT = round(30 * PR * scale);
 
   var canvas = document.createElement('canvas');
   canvas.width = WIDTH;
   canvas.height = HEIGHT;
-  canvas.style.cssText = `width:${scale * 80}px;height:${scale * 48}px`;
+  canvas.style.cssText = `width:${round(scale * 80)}px;height:${round(scale * 48)}px`;
 
   var context = canvas.getContext('2d');
-  context.font = 'bold ' + (9 * PR) + 'px Helvetica,Arial,sans-serif';
+  context.font = 'bold ' + round(9 * PR * scale) + 'px Helvetica,Arial,sans-serif';
   context.textBaseline = 'top';
 
   context.fillStyle = bg;


### PR DESCRIPTION
### Summary
This properly rounds values in our vendored stats.js when scaling to align with pixel boundaries and prevent fuzzy bars in the chart.

`main`:
<img width="270" height="160" alt="Screenshot 2025-08-19 at 12 15 21 PM" src="https://github.com/user-attachments/assets/42c659b4-c0a5-4848-8e1a-9cf211828e68" />

this PR:
<img width="270" height="160" alt="Screenshot 2025-08-19 at 12 14 50 PM" src="https://github.com/user-attachments/assets/dc07ad6d-74fe-400c-af3d-e6b2f04d06a0" />

(images with scale = 3.5x to make the issue even more visible)

### Related Issue
Closes N/A

### Tests & Checks
Observed the stats.js bar chart in the chunk streaming on both my laptop ("retina") and desktop (4k) monitors.
