### PR TITLE
Add dynamic slicing along Z to chunk manager

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "idetik",
+  "name": "web-viewer",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -9,6 +9,9 @@
         "packages/react",
         "packages/ultrack-prototype"
       ],
+      "dependencies": {
+        "lil-gui": "^0.20.0"
+      },
       "devDependencies": {
         "@rollup/plugin-typescript": "^12.1.2",
         "@types/webgl2": "^0.0.11",
@@ -5616,6 +5619,11 @@
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       }
+    },
+    "node_modules/lil-gui": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/lil-gui/-/lil-gui-0.20.0.tgz",
+      "integrity": "sha512-k7Ipr0ztqslMA2XvM5z5ZaWhxQtnEOwJBfI/hmSuRh6q4iMG9L0boqqrnZSzBR1jzyJ28OMl47l65ILzRe1TdA=="
     },
     "node_modules/lilconfig": {
       "version": "3.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "web-viewer",
+  "name": "idetik",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -9,9 +9,6 @@
         "packages/react",
         "packages/ultrack-prototype"
       ],
-      "dependencies": {
-        "lil-gui": "^0.20.0"
-      },
       "devDependencies": {
         "@rollup/plugin-typescript": "^12.1.2",
         "@types/webgl2": "^0.0.11",
@@ -25,6 +22,7 @@
         "eslint-plugin-react-refresh": "^0.4.19",
         "globals": "^15.9.0",
         "jsdom": "^24.1.1",
+        "lil-gui": "^0.20.0",
         "playwright": "1.46.0",
         "prettier": "^3.3.2",
         "rollup": "^4.34.9",
@@ -5623,7 +5621,8 @@
     "node_modules/lil-gui": {
       "version": "0.20.0",
       "resolved": "https://registry.npmjs.org/lil-gui/-/lil-gui-0.20.0.tgz",
-      "integrity": "sha512-k7Ipr0ztqslMA2XvM5z5ZaWhxQtnEOwJBfI/hmSuRh6q4iMG9L0boqqrnZSzBR1jzyJ28OMl47l65ILzRe1TdA=="
+      "integrity": "sha512-k7Ipr0ztqslMA2XvM5z5ZaWhxQtnEOwJBfI/hmSuRh6q4iMG9L0boqqrnZSzBR1jzyJ28OMl47l65ILzRe1TdA==",
+      "dev": true
     },
     "node_modules/lilconfig": {
       "version": "3.1.3",

--- a/package.json
+++ b/package.json
@@ -36,5 +36,8 @@
     "vite-plugin-eslint": "^1.8.1",
     "vite-plugin-glsl": "^1.3.0",
     "vitest": "^3.0.9"
+  },
+  "dependencies": {
+    "lil-gui": "^0.20.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "eslint-plugin-react-refresh": "^0.4.19",
     "globals": "^15.9.0",
     "jsdom": "^24.1.1",
+    "lil-gui": "^0.20.0",
     "playwright": "1.46.0",
     "prettier": "^3.3.2",
     "rollup": "^4.34.9",
@@ -36,8 +37,5 @@
     "vite-plugin-eslint": "^1.8.1",
     "vite-plugin-glsl": "^1.3.0",
     "vitest": "^3.0.9"
-  },
-  "dependencies": {
-    "lil-gui": "^0.20.0"
   }
 }

--- a/packages/core/examples/chunk_streaming/index.html
+++ b/packages/core/examples/chunk_streaming/index.html
@@ -49,7 +49,6 @@
 
   <body>
     <canvas id="canvas"></canvas>
-    <div id="chunk-info">Chunks: Loading...</div>
     <script type="module" src="./main.ts"></script>
   </body>
 </html>

--- a/packages/core/examples/chunk_streaming/index.html
+++ b/packages/core/examples/chunk_streaming/index.html
@@ -35,8 +35,8 @@
 
       #chunk-info {
         position: absolute;
-        top: 1em;
-        right: 1em;
+        top: 4.5em;
+        right: 0.3em;
         width: 40%;
         margin: 1em;
         padding: 1em;
@@ -49,6 +49,7 @@
 
   <body>
     <canvas id="canvas"></canvas>
+    <div id="chunk-info">Chunks: Loading...</div>
     <script type="module" src="./main.ts"></script>
   </body>
 </html>

--- a/packages/core/examples/chunk_streaming/main.ts
+++ b/packages/core/examples/chunk_streaming/main.ts
@@ -5,8 +5,9 @@ import {
   OrthographicCamera,
   Region,
 } from "@";
+import { Point } from "@/data/region";
 import { PanZoomControls } from "@/objects/cameras/controls";
-import { ChunkInfoOverlay } from "./chunk_info_overlay";
+import GUI from "lil-gui";
 
 const url =
   "https://public.czbiohub.org/royerlab/zebrahub/imaging/single-objective/ZSNS001.ome.zarr/";
@@ -18,6 +19,7 @@ const bottom = 900;
 // Source is 5D, so provide indices at 3 dimensions to project to 2D.
 // Also specify a subregion in x and y to exercise that part of the API.
 const source = new OmeZarrImageSource(url);
+
 const region: Region = [
   { dimension: "t", index: { type: "point", value: 400 } },
   { dimension: "c", index: { type: "point", value: 0 } },
@@ -25,22 +27,22 @@ const region: Region = [
   { dimension: "y", index: { type: "full" } },
   { dimension: "x", index: { type: "full" } },
 ];
+
+const zIndex = region[2].index as Point;
+const zRange = { min: 0, max: 448 }; // max value taken from source
+const gui = new GUI({ width: 500 });
+gui.add(zIndex, "value", zRange.min, zRange.max, 1).name("Z-index");
+
 const channelProps = [{ contrastLimits: [0, 255] as [number, number] }];
 const camera = new OrthographicCamera(left, right, top, bottom);
-
 const imageLayer = new ImageLayer({ source, region, channelProps });
 imageLayer.debugMode = true;
-
-const chunkInfoOverlay = new ChunkInfoOverlay({
-  textDiv: document.querySelector<HTMLDivElement>("#chunk-info")!,
-  imageLayer: imageLayer,
-});
 
 new Idetik({
   canvas: document.querySelector<HTMLCanvasElement>("#canvas")!,
   camera,
   cameraControls: new PanZoomControls(camera),
   layers: [imageLayer],
-  overlays: [chunkInfoOverlay],
+  overlays: [],
   showStats: true,
 }).start();

--- a/packages/core/examples/chunk_streaming/main.ts
+++ b/packages/core/examples/chunk_streaming/main.ts
@@ -7,6 +7,7 @@ import {
 } from "@";
 import { Point } from "@/data/region";
 import { PanZoomControls } from "@/objects/cameras/controls";
+import { ChunkInfoOverlay } from "./chunk_info_overlay";
 import GUI from "lil-gui";
 
 const url =
@@ -29,20 +30,30 @@ const region: Region = [
 ];
 
 const zIndex = region[2].index as Point;
-const zRange = { min: 0, max: 448 }; // max value taken from source
+
+// values copied from source
+const z = { translate: 0.0, scale: 1.24, shape: 448 };
+const min = z.translate;
+const max = z.translate + z.scale * z.shape - z.scale;
+const zRange = { min, max };
 const gui = new GUI({ width: 500 });
-gui.add(zIndex, "value", zRange.min, zRange.max, 1).name("Z-index");
+gui.add(zIndex, "value", zRange.min, zRange.max, z.scale).name("Z-index");
 
 const channelProps = [{ contrastLimits: [0, 255] as [number, number] }];
 const camera = new OrthographicCamera(left, right, top, bottom);
 const imageLayer = new ImageLayer({ source, region, channelProps });
 imageLayer.debugMode = true;
 
+const chunkInfoOverlay = new ChunkInfoOverlay({
+  textDiv: document.querySelector<HTMLDivElement>("#chunk-info")!,
+  imageLayer: imageLayer,
+});
+
 new Idetik({
   canvas: document.querySelector<HTMLCanvasElement>("#canvas")!,
   camera,
   cameraControls: new PanZoomControls(camera),
   layers: [imageLayer],
-  overlays: [],
+  overlays: [chunkInfoOverlay],
   showStats: true,
 }).start();

--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -20,11 +20,13 @@ const PREFETCH_PADDING_CHUNKS = 1;
 export class ChunkManagerSource {
   private readonly chunks_: Chunk[];
   private readonly loader_;
-  private readonly dimensions_: DimensionMap;
   private readonly attrs_: ReadonlyArray<LoaderAttributes>;
   private readonly lowestResLOD_: number;
+  private readonly region_: Region;
+  private dimensions_: DimensionMap;
   private currentLOD_: number = 0;
   private lastViewBounds2D_: Box2 | null = null;
+  private lastZBounds_?: [number, number];
 
   constructor(
     loader: ChunkLoader,
@@ -33,10 +35,11 @@ export class ChunkManagerSource {
   ) {
     this.loader_ = loader;
     this.attrs_ = attrs;
+    this.region_ = region;
     this.lowestResLOD_ = attrs.length - 1;
     this.currentLOD_ = 0;
 
-    this.dimensions_ = this.loader_.getDimensionMap(region);
+    this.dimensions_ = this.loader_.getDimensionMap(this.region_);
     const xIdx = this.dimensions_.x.sourceIndex;
     const yIdx = this.dimensions_.y.sourceIndex;
     const zIdx = this.dimensions_.z?.sourceIndex ?? -1;
@@ -122,14 +125,27 @@ export class ChunkManagerSource {
 
   public update(lodFactor: number, viewBounds2D: Box2) {
     this.setLOD(lodFactor);
-    if (this.viewBounds2DChanged(viewBounds2D)) {
+    this.dimensions_ = this.loader_.getDimensionMap(this.region_);
+
+    const zBounds = this.getZBounds();
+
+    if (
+      this.viewBounds2DChanged(viewBounds2D) ||
+      this.zBoundsChanged(zBounds)
+    ) {
       this.updateChunkVisibility(viewBounds2D);
+      this.lastZBounds_ = zBounds;
     }
+
     this.loadPendingChunks();
   }
 
   public get lodCount() {
     return this.lowestResLOD_ + 1;
+  }
+
+  public get dimensions() {
+    return this.dimensions_;
   }
 
   public get chunks(): Chunk[] {
@@ -294,6 +310,11 @@ export class ChunkManagerSource {
     }
 
     return changed;
+  }
+
+  private zBoundsChanged(newBounds: [number, number]): boolean {
+    const prev = this.lastZBounds_;
+    return !prev || prev[0] !== newBounds[0] || prev[1] !== newBounds[1];
   }
 
   private getPaddedBounds(bounds: Box3): Box3 {

--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -134,7 +134,6 @@ export class ChunkManagerSource {
       this.zBoundsChanged(zBounds)
     ) {
       this.updateChunkVisibility(viewBounds2D);
-      this.lastZBounds_ = zBounds;
     }
 
     this.loadPendingChunks();
@@ -314,7 +313,11 @@ export class ChunkManagerSource {
 
   private zBoundsChanged(newBounds: [number, number]): boolean {
     const prev = this.lastZBounds_;
-    return !prev || prev[0] !== newBounds[0] || prev[1] !== newBounds[1];
+    const changed = !prev || !vec2.equals(prev, newBounds);
+    if (changed) {
+      this.lastZBounds_ = newBounds;
+    }
+    return changed;
   }
 
   private getPaddedBounds(bounds: Box3): Box3 {

--- a/packages/core/src/layers/image_layer.ts
+++ b/packages/core/src/layers/image_layer.ts
@@ -12,6 +12,7 @@ import { Color } from "../core/color";
 import { EventContext } from "../core/event_dispatcher";
 import { vec2, vec3 } from "gl-matrix";
 import { handlePointPickingEvent, PointPickingResult } from "./point_picking";
+import { almostEqual } from "@/utilities/almost_equal";
 
 export type ImageLayerProps = LayerOptions & {
   source: ChunkSource;
@@ -233,15 +234,10 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
     const zIdx = Math.round(zLocal);
     const zClamped = Math.max(0, Math.min(zIdx, chunk.shape.z - 1));
 
-    // Allow for small overshoot to account for rounding and
-    // floating point error. Anything larger means the requested
-    // zValue is truly outside the chunk extent.
-    if (zIdx !== zClamped) {
-      const delta = Math.abs(zLocal - zClamped);
-      const eps = 1e-6;
-      if (delta > 1 + eps) {
-        Logger.error("ImageLayer", "slicePlane zValue outside extent");
-      }
+    // Treat values within ~1 voxel (plus tiny floating-point error) as OK.
+    // Anything further away means the requested zValue is outside.
+    if (!almostEqual(zLocal, zClamped, 1 + 1e-6)) {
+      Logger.error("ImageLayer", "slicePlane zValue outside extent");
     }
 
     const sliceSize = chunk.shape.x * chunk.shape.y;

--- a/packages/core/src/layers/image_layer.ts
+++ b/packages/core/src/layers/image_layer.ts
@@ -95,8 +95,6 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
       this.setState("ready");
     }
 
-    this.resliceIfZChanged();
-
     // TODO:(shlomnissan) Reuse images instead of deleting and creating new ones.
     //
     // This loop removes image renderables for chunks that are no longer visible
@@ -143,6 +141,7 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
   public update() {
     if (this.useChunkManager_) {
       this.updateChunks();
+      this.resliceIfZChanged();
     } else {
       switch (this.state) {
         case "initialized":
@@ -230,9 +229,9 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
 
   private slicePlane(chunk: Chunk, zValue: number) {
     if (!chunk.data) return;
+    const sliceSize = chunk.shape.x * chunk.shape.y;
     const zLocal = Math.round((zValue - chunk.offset.z) / chunk.scale.z);
     const zClamped = Math.max(0, Math.min(zLocal, chunk.shape.z - 1));
-    const sliceSize = chunk.shape.x * chunk.shape.y;
     const offset = sliceSize * zClamped;
     return chunk.data.slice(offset, offset + sliceSize);
   }

--- a/packages/core/src/layers/image_layer.ts
+++ b/packages/core/src/layers/image_layer.ts
@@ -12,7 +12,8 @@ import { Color } from "../core/color";
 import { EventContext } from "../core/event_dispatcher";
 import { vec2, vec3 } from "gl-matrix";
 import { handlePointPickingEvent, PointPickingResult } from "./point_picking";
-import { almostEqual } from "@/utilities/almost_equal";
+import { almostEqual } from "../utilities/almost_equal";
+import { clamp } from "../utilities/clamp";
 
 export type ImageLayerProps = LayerOptions & {
   source: ChunkSource;
@@ -232,7 +233,7 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
     if (!chunk.data) return;
     const zLocal = (zValue - chunk.offset.z) / chunk.scale.z;
     const zIdx = Math.round(zLocal);
-    const zClamped = Math.max(0, Math.min(zIdx, chunk.shape.z - 1));
+    const zClamped = clamp(zIdx, 0, chunk.shape.z - 1);
 
     // Treat values within ~1 voxel (plus tiny floating-point error) as OK.
     // Anything further away means the requested zValue is outside.

--- a/packages/core/src/layers/image_layer.ts
+++ b/packages/core/src/layers/image_layer.ts
@@ -229,11 +229,24 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
 
   private slicePlane(chunk: Chunk, zValue: number) {
     if (!chunk.data) return;
+    const zLocal = (zValue - chunk.offset.z) / chunk.scale.z;
+    const zIdx = Math.round(zLocal);
+    const zClamped = Math.max(0, Math.min(zIdx, chunk.shape.z - 1));
+
+    // Allow for small overshoot to account for rounding and
+    // floating point error. Anything larger means the requested
+    // zValue is truly outside the chunk extent.
+    if (zIdx !== zClamped) {
+      const delta = Math.abs(zLocal - zClamped);
+      const eps = 1e-6;
+      if (delta > 1 + eps) {
+        Logger.error("ImageLayer", "slicePlane zValue outside extent");
+      }
+    }
+
     const sliceSize = chunk.shape.x * chunk.shape.y;
-    const zLocal = Math.round((zValue - chunk.offset.z) / chunk.scale.z);
-    const zClamped = Math.max(0, Math.min(zLocal, chunk.shape.z - 1));
     const offset = sliceSize * zClamped;
-    return chunk.data.slice(offset, offset + sliceSize);
+    return chunk.data.subarray(offset, offset + sliceSize);
   }
 
   private createImage(chunk: Chunk, channelProps?: ChannelProps[]) {

--- a/packages/core/src/layers/image_layer.ts
+++ b/packages/core/src/layers/image_layer.ts
@@ -38,6 +38,7 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
   private image_?: ImageRenderable;
   private extent_?: { x: number; y: number };
   private pointerDownPos_: vec2 | null = null;
+  private zPrevPointWorld_?: number;
 
   private readonly wireframeColors_ = [
     new Color(0.6, 0.3, 0.3),
@@ -94,6 +95,8 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
       this.setState("ready");
     }
 
+    this.resliceIfZChanged();
+
     // TODO:(shlomnissan) Reuse images instead of deleting and creating new ones.
     //
     // This loop removes image renderables for chunks that are no longer visible
@@ -117,6 +120,24 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
         this.addObject(image);
       }
     });
+  }
+
+  private resliceIfZChanged() {
+    const dimensions = this.chunkManagerSource_?.dimensions;
+    const pointWorld = dimensions?.z?.pointWorld;
+    if (pointWorld === undefined || this.zPrevPointWorld_ === pointWorld) {
+      return;
+    }
+
+    for (const [chunk, image] of this.visibleChunks_) {
+      if (chunk.state !== "loaded" || !chunk.data) continue;
+      const data = this.slicePlane(chunk, pointWorld);
+      if (data) {
+        image.textures[0].data = data;
+      }
+    }
+
+    this.zPrevPointWorld_ = pointWorld;
   }
 
   public update() {
@@ -210,8 +231,9 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
   private slicePlane(chunk: Chunk, zValue: number) {
     if (!chunk.data) return;
     const zLocal = Math.round((zValue - chunk.offset.z) / chunk.scale.z);
+    const zClamped = Math.max(0, Math.min(zLocal, chunk.shape.z - 1));
     const sliceSize = chunk.shape.x * chunk.shape.y;
-    const offset = sliceSize * (zLocal % chunk.shape.z);
+    const offset = sliceSize * zClamped;
     return chunk.data.slice(offset, offset + sliceSize);
   }
 
@@ -219,12 +241,9 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
     const geometry = new PlaneGeometry(chunk.shape.x, chunk.shape.y, 1, 1);
 
     let data = chunk.data;
-    if (chunk.shape.z > 1) {
-      const zIdx = this.region_.find((r) => r.dimension.toLowerCase() === "z");
-      if (zIdx?.index.type !== "point") {
-        throw new Error("Expected Z index to be a point");
-      }
-      data = this.slicePlane(chunk, zIdx.index.value);
+    const dimensions = this.chunkManagerSource?.dimensions;
+    if (dimensions?.z) {
+      data = this.slicePlane(chunk, dimensions.z.pointWorld);
     }
 
     const image = new ImageRenderable(

--- a/packages/core/src/objects/textures/texture.ts
+++ b/packages/core/src/objects/textures/texture.ts
@@ -91,6 +91,7 @@ export abstract class Texture extends Node {
   public abstract get width(): number;
   public abstract get height(): number;
   public abstract get data(): TexImageSource | ArrayBufferView | null;
+  public abstract set data(data: DataTextureTypedArray);
 
   public get type() {
     return "Texture";


### PR DESCRIPTION
### Summary

This PR adds dynamic slicing along Z in the context of the chunk manager.

### Notes

- Prefetching along Z remains disabled. I think we'll need to address it separately, since enabling it would significantly increase memory usage and could introduce order-dependent rendering issues.
- The region is currently used not only for cropping but also to trigger reslicing and visible chunk recomputation. While this works as a temporary solution, in the medium-to-long term we’ll need to separate these into two distinct concepts: an initial data crop and a virtual camera.
- Similar to previous PRs, the focus here is on slicing along Z. Eventually, we’ll need to generalize this to support orthoslices across multiple planes, but the right time to address that will be when we integrate orthoslices into Idetik.

### Tests & Checks
- All examples are working as expected
- Manual verification, dynamic slicing works as expected
- Pull the branch and test on your end before reviewing the PR in case I missed anything.
