### PR TITLE
Fix ImageLayer not marking any chunks visible for 2D images

### DIFF
--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -255,7 +255,7 @@ export class ChunkManagerSource {
 
   private getZBounds(): [number, number] {
     const zDim = this.dimensions_.z;
-    if (zDim === undefined) return [0, 0];
+    if (zDim === undefined) return [0, 1];
     const zIdx = zDim.sourceIndex;
     const lodAttrs = this.attrs_[this.currentLOD_];
 


### PR DESCRIPTION
`isChunkWithinBounds()` was comparing chunk z range `[0, 1]` to visible bounds `[0, 0]`. Since we're assuming absence of `z` means the shape is `1`, make default z bounds `[0, 1]`.