### PR TITLE
Fix image layer object render order

### DIFF
--- a/packages/core/src/layers/image_layer.ts
+++ b/packages/core/src/layers/image_layer.ts
@@ -103,9 +103,8 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
     // creating new texture objects. Note: GPU resources are not currently being
     // released, so this will also need to be addressed soon.
     const currentChunks = new Set(this.chunkManagerSource_.getChunks());
-    this.visibleChunks_.forEach((image, chunk) => {
+    this.visibleChunks_.forEach((_image, chunk) => {
       if (!currentChunks.has(chunk)) {
-        this.removeObject(image);
         this.visibleChunks_.delete(chunk); // safe
       }
     });
@@ -114,6 +113,15 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
       if (chunk.state === "loaded" && !this.visibleChunks_.has(chunk)) {
         const image = this.createImage(chunk, this.channelProps);
         this.visibleChunks_.set(chunk, image);
+      }
+    });
+
+    // Add all objects anew so that they respect the chunk order, which may
+    // capture details important for rendering, such as LOD.
+    this.clearObjects();
+    currentChunks.forEach((chunk) => {
+      const image = this.visibleChunks_.get(chunk);
+      if (image) {
         this.addObject(image);
       }
     });

--- a/packages/core/src/layers/image_layer.ts
+++ b/packages/core/src/layers/image_layer.ts
@@ -109,21 +109,17 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
       }
     });
 
-    currentChunks.forEach((chunk) => {
-      if (chunk.state === "loaded" && !this.visibleChunks_.has(chunk)) {
-        const image = this.createImage(chunk, this.channelProps);
-        this.visibleChunks_.set(chunk, image);
-      }
-    });
-
     // Add all objects anew so that they respect the chunk order, which may
-    // capture details important for rendering, such as LOD.
+    // capture details important for rendering, such as LOD, instead of the
+    // creation order, which is dependent on when the chunks were loaded.
     this.clearObjects();
     currentChunks.forEach((chunk) => {
-      const image = this.visibleChunks_.get(chunk);
-      if (image) {
-        this.addObject(image);
+      let image = this.visibleChunks_.get(chunk);
+      if (!image && chunk.state === "loaded") {
+        image = this.createImage(chunk, this.channelProps);
+        this.visibleChunks_.set(chunk, image);
       }
+      if (image) this.addObject(image);
     });
   }
 

--- a/packages/core/src/layers/image_layer.ts
+++ b/packages/core/src/layers/image_layer.ts
@@ -111,7 +111,7 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
 
     // Add all objects anew so that they respect the chunk order, which may
     // capture details important for rendering, such as LOD, instead of the
-    // creation order, which is dependent on when the chunks were loaded.
+    // creation order, which is dependent on when the chunks finished loading.
     this.clearObjects();
     currentChunks.forEach((chunk) => {
       let image = this.visibleChunks_.get(chunk);


### PR DESCRIPTION
### Summary
This fixes a render issue related to visible chunks at different LODs described in the related issue. Credit to @aganders3, who effectively suggested this fix in Slack.

### Related Issue
Closes #389

### Tests & Checks
I manually tested the chunk streaming example before and after this fix with the browser cache enabled.