### PR TITLE
Hide z-related tools when 2D and make bottom tool containers take less space

### DIFF
--- a/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
@@ -245,49 +245,25 @@ export function OmeZarrImageViewer({
     <div className={cns("w-full", "h-full", "relative", classNames?.root)}>
       <IdetikCanvas />
       {imageLayerRef.current && (
-        <ChannelControlsList
-          layer={imageLayerRef.current}
-          extraControlProps={extraControlProps}
-          classNames={{ root: "absolute top-0 left-0 z-10" }}
-        />
-      )}
-      {sourceRef.current && (
-        <div
-          className={cns(
-            "flex",
-            "absolute",
-            "bottom-0",
-            "w-full",
-            "items-end",
-            "justify-between",
-            "gap-sds-l"
-          )}
-        >
+        <>
+          <ChannelControlsList
+            layer={imageLayerRef.current}
+            extraControlProps={extraControlProps}
+            classNames={{ root: "absolute top-0 left-0 z-10" }}
+          />
           {scaleBar.visible && (
-            <div
-              className={cns(
-                "flex",
-                "flex-col",
-                "m-sds-l",
-                "w-1/5",
-                "select-none"
-              )}
-            >
+            <div className="flex flex-col m-sds-l w-1/5 select-none absolute bottom-0 left-0">
               <ScaleBar unit={unit} align={scaleBar.align} />
             </div>
           )}
           <div
             className={cns(
-              "flex",
-              "flex-col",
-              "grow",
-              "items-end",
-              "p-sds-l",
-              "gap-sds-l",
+              "flex flex-col grow items-end p-sds-l gap-sds-l absolute bottom-0 right-0",
               classNames?.sliceMetadataContainer
             )}
           >
-            {!loading ? (
+            {loading && <LoadingIndicator sdsStyle="tag" />}
+            {!loading && seriesDimensionName && (
               <div
                 // These share styles with ChannelControlsList
                 className={cns(
@@ -309,23 +285,8 @@ export function OmeZarrImageViewer({
                 {typeof indexIndicatorText === "undefined" &&
                   `Slice ${zIndex}/${zRange[1] - zRange[0]}`}
               </div>
-            ) : (
-              <LoadingIndicator sdsStyle="tag" />
             )}
-            {!allSlicesLoaded ? (
-              <Button
-                sdsType="primary"
-                sdsStyle="square"
-                size="small"
-                disabled={loading}
-                onClick={loadAllSlicesCallback}
-                className={cns("shadow-sds-m", classNames?.load3dButton)}
-              >
-                {typeof loadAllButtonText === "string" && loadAllButtonText}
-                {typeof loadAllButtonText === "function" && loadAllButtonText()}
-                {typeof loadAllButtonText === "undefined" && "Load 3D high-res"}
-              </Button>
-            ) : (
+            {allSlicesLoaded && (
               <div
                 className={cns(
                   "w-full md:w-[200px]",
@@ -354,8 +315,22 @@ export function OmeZarrImageViewer({
                 />
               </div>
             )}
+            {!allSlicesLoaded && seriesDimensionName && (
+              <Button
+                sdsType="primary"
+                sdsStyle="square"
+                size="small"
+                disabled={loading}
+                onClick={loadAllSlicesCallback}
+                className={cns("shadow-sds-m", classNames?.load3dButton)}
+              >
+                {typeof loadAllButtonText === "string" && loadAllButtonText}
+                {typeof loadAllButtonText === "function" && loadAllButtonText()}
+                {typeof loadAllButtonText === "undefined" && "Load 3D high-res"}
+              </Button>
+            )}
           </div>
-        </div>
+        </>
       )}
     </div>
   );


### PR DESCRIPTION
The `<div>`s were blocking mouse actions on the bottom of the viewer.

Diff looks better when hiding whitespace.