### PR TITLE
(Small) Add debug toggle to chunk streaming example

### DIFF
--- a/packages/core/examples/chunk_streaming/index.html
+++ b/packages/core/examples/chunk_streaming/index.html
@@ -35,7 +35,7 @@
 
       #chunk-info {
         position: absolute;
-        top: 4.5em;
+        bottom: 0.5em;
         right: 0.3em;
         width: 40%;
         margin: 1em;

--- a/packages/core/examples/chunk_streaming/main.ts
+++ b/packages/core/examples/chunk_streaming/main.ts
@@ -29,23 +29,14 @@ const region: Region = [
   { dimension: "x", index: { type: "full" } },
 ];
 
-const zIndex = region[2].index as Point;
-
-// values copied from source
-const z = { translate: 0.0, scale: 1.24, shape: 448 };
-const min = z.translate;
-const max = z.translate + z.scale * z.shape - z.scale;
-const zRange = { min, max };
-const gui = new GUI({ width: 500 });
-gui.add(zIndex, "value", zRange.min, zRange.max, z.scale).name("Z-index");
-
 const channelProps = [{ contrastLimits: [0, 255] as [number, number] }];
 const camera = new OrthographicCamera(left, right, top, bottom);
 const imageLayer = new ImageLayer({ source, region, channelProps });
 imageLayer.debugMode = true;
 
+const overlaySelector = document.querySelector<HTMLDivElement>("#chunk-info")!;
 const chunkInfoOverlay = new ChunkInfoOverlay({
-  textDiv: document.querySelector<HTMLDivElement>("#chunk-info")!,
+  textDiv: overlaySelector,
   imageLayer: imageLayer,
 });
 
@@ -57,3 +48,32 @@ new Idetik({
   overlays: [chunkInfoOverlay],
   showStats: true,
 }).start();
+
+const controls = {
+  zIndex: region[2].index as Point,
+  showWireframes: true,
+  showChunkInfoOverlay: true,
+};
+
+// values copied from source
+const z = { translate: 0.0, scale: 1.24, shape: 448 };
+const min = z.translate;
+const max = z.translate + z.scale * z.shape - z.scale;
+const zRange = { min, max };
+const gui = new GUI({ width: 500 });
+
+gui
+  .add(controls.zIndex, "value", zRange.min, zRange.max, z.scale)
+  .name("Z-index");
+
+gui
+  .add(controls, "showWireframes")
+  .name("Show tile wireframes")
+  .onChange((show: boolean) => (imageLayer.debugMode = show));
+
+gui
+  .add(controls, "showChunkInfoOverlay")
+  .name("Show chunk information overlay")
+  .onChange((show: boolean) => {
+    overlaySelector.style.display = show ? "block" : "none";
+  });

--- a/packages/core/src/core/layer.ts
+++ b/packages/core/src/core/layer.ts
@@ -23,7 +23,6 @@ export interface LayerOptions {
 
 export abstract class Layer {
   public abstract readonly type: string;
-  public debugMode = false;
 
   private objects_: RenderableObject[] = [];
   private state_: LayerState = "initialized";

--- a/packages/core/src/layers/image_layer.ts
+++ b/packages/core/src/layers/image_layer.ts
@@ -41,6 +41,7 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
   private extent_?: { x: number; y: number };
   private pointerDownPos_: vec2 | null = null;
   private zPrevPointWorld_?: number;
+  private debugMode_ = false;
 
   private readonly wireframeColors_ = [
     new Color(0.6, 0.3, 0.3),
@@ -261,7 +262,7 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
       channelProps
     );
 
-    if (this.debugMode) {
+    if (this.debugMode_) {
       image.wireframeEnabled = true;
       image.wireframeColor =
         this.wireframeColors_[chunk.lod % this.wireframeColors_.length];
@@ -295,5 +296,16 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
       }
     }
     return null;
+  }
+
+  public set debugMode(debug: boolean) {
+    this.debugMode_ = debug;
+    this.visibleChunks_.forEach((image, chunk) => {
+      image.wireframeEnabled = this.debugMode_;
+      if (this.debugMode_) {
+        image.wireframeColor =
+          this.wireframeColors_[chunk.lod % this.wireframeColors_.length];
+      }
+    });
   }
 }


### PR DESCRIPTION
### Summary

This PR adds debug controls to toggle tile wireframes and chunk info overlay.

### Tests & Checks
- Manual verification (see video below)
- Verified existing examples work as expected

https://github.com/user-attachments/assets/2bae07ae-1255-4864-9fb8-f5fc241af91c