### PR TITLE
Update getValueAtWorld() take into account z

### DIFF
--- a/packages/core/src/layers/image_layer.ts
+++ b/packages/core/src/layers/image_layer.ts
@@ -1,7 +1,7 @@
 import { Layer, LayerOptions } from "../core/layer";
 import { IdetikContext } from "../idetik";
 import { Region } from "../data/region";
-import { Chunk, ChunkData, ChunkSource } from "../data/chunk";
+import { Chunk, ChunkSource } from "../data/chunk";
 import { ChunkManagerSource } from "../core/chunk_manager";
 import { ChannelProps, ChannelsEnabled } from "../objects/textures/channel";
 import { ImageRenderable } from "../objects/renderable/image_renderable";
@@ -298,7 +298,7 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
           dimensions?.z !== undefined
             ? this.slicePlane(chunk, dimensions.z.pointWorld)!
             : chunk.data;
-        const pixelIndex = y * chunk.shape.x + x;
+        const pixelIndex = y * chunk.rowStride + x;
 
         // For multi-channel images, take the first channel value
         return data[pixelIndex];

--- a/packages/core/src/layers/image_layer.ts
+++ b/packages/core/src/layers/image_layer.ts
@@ -293,10 +293,10 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
       // Check if this chunk contains the requested position
       if (x >= 0 && x < chunk.shape.x && y >= 0 && y < chunk.shape.y) {
         const dimensions = this.chunkManagerSource_?.dimensions;
+
         const data = dimensions?.z
           ? this.slicePlane(chunk, dimensions.z.pointWorld)!
           : chunk.data;
-
         const pixelIndex = y * chunk.shape.x + x; // Use shape.x for 2D slice stride
 
         // For multi-channel images, take the first channel value

--- a/packages/core/src/layers/image_layer.ts
+++ b/packages/core/src/layers/image_layer.ts
@@ -295,9 +295,6 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
         // Use the actual sliced data being displayed, not the full chunk data
         let data: ChunkData;
         const dimensions = this.chunkManagerSource_?.dimensions;
-        if (chunk.data === undefined) {
-          continue;
-        }
         if (dimensions?.z) {
           // When z-slicing is active, use the sliced data
           data = this.slicePlane(chunk, dimensions.z.pointWorld)!;

--- a/packages/core/src/layers/image_layer.ts
+++ b/packages/core/src/layers/image_layer.ts
@@ -292,17 +292,10 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
 
       // Check if this chunk contains the requested position
       if (x >= 0 && x < chunk.shape.x && y >= 0 && y < chunk.shape.y) {
-        // Use the actual sliced data being displayed, not the full chunk data
-        let data: ChunkData;
         const dimensions = this.chunkManagerSource_?.dimensions;
-        if (dimensions?.z) {
-          // When z-slicing is active, use the sliced data
-          data = this.slicePlane(chunk, dimensions.z.pointWorld)!;
-          if (!data) return null;
-        } else {
-          // When no z-slicing, use original chunk data
-          data = chunk.data;
-        }
+        const data = dimensions?.z
+          ? this.slicePlane(chunk, dimensions.z.pointWorld)!
+          : chunk.data;
 
         const pixelIndex = y * chunk.shape.x + x; // Use shape.x for 2D slice stride
 

--- a/packages/core/src/layers/image_layer.ts
+++ b/packages/core/src/layers/image_layer.ts
@@ -294,10 +294,11 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
       if (x >= 0 && x < chunk.shape.x && y >= 0 && y < chunk.shape.y) {
         const dimensions = this.chunkManagerSource_?.dimensions;
 
-        const data = dimensions?.z
-          ? this.slicePlane(chunk, dimensions.z.pointWorld)!
-          : chunk.data;
-        const pixelIndex = y * chunk.shape.x + x; // Use shape.x for 2D slice stride
+        const data =
+          dimensions?.z !== undefined
+            ? this.slicePlane(chunk, dimensions.z.pointWorld)!
+            : chunk.data;
+        const pixelIndex = y * chunk.shape.x + x;
 
         // For multi-channel images, take the first channel value
         return data[pixelIndex];

--- a/packages/core/src/layers/image_layer.ts
+++ b/packages/core/src/layers/image_layer.ts
@@ -1,7 +1,7 @@
 import { Layer, LayerOptions } from "../core/layer";
 import { IdetikContext } from "../idetik";
 import { Region } from "../data/region";
-import { Chunk, ChunkSource } from "../data/chunk";
+import { Chunk, ChunkData, ChunkSource } from "../data/chunk";
 import { ChunkManagerSource } from "../core/chunk_manager";
 import { ChannelProps, ChannelsEnabled } from "../objects/textures/channel";
 import { ImageRenderable } from "../objects/renderable/image_renderable";
@@ -292,8 +292,22 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
 
       // Check if this chunk contains the requested position
       if (x >= 0 && x < chunk.shape.x && y >= 0 && y < chunk.shape.y) {
-        const pixelIndex = y * chunk.rowStride + x;
-        const data = chunk.data;
+        // Use the actual sliced data being displayed, not the full chunk data
+        let data: ChunkData;
+        const dimensions = this.chunkManagerSource_?.dimensions;
+        if (chunk.data === undefined) {
+          continue;
+        }
+        if (dimensions?.z) {
+          // When z-slicing is active, use the sliced data
+          data = this.slicePlane(chunk, dimensions.z.pointWorld)!;
+          if (!data) return null;
+        } else {
+          // When no z-slicing, use original chunk data
+          data = chunk.data;
+        }
+
+        const pixelIndex = y * chunk.shape.x + x; // Use shape.x for 2D slice stride
 
         // For multi-channel images, take the first channel value
         return data[pixelIndex];


### PR DESCRIPTION
Point picking in the VCP HITL app (3D) stopped working with the addition of z slicing in `ImageLayer`.