### PR TITLE
fix: prioritize current LOD chunks in getValueAtWorld()

### DIFF
--- a/packages/core/src/layers/image_layer.ts
+++ b/packages/core/src/layers/image_layer.ts
@@ -277,33 +277,56 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
     return image;
   }
 
-  public getValueAtWorld(world: vec3): number | null {
-    // Iterate through all visible chunks to find the one containing the world position
-    for (const [chunk, image] of this.visibleChunks_) {
-      if (!chunk.data) continue;
-      const localPos = vec3.transformMat4(
-        vec3.create(),
-        world,
-        image.transform.inverse
-      );
+  private getValueFromChunk(
+    chunk: Chunk,
+    image: ImageRenderable,
+    world: vec3
+  ): number | null {
+    if (!chunk.data) return null;
 
-      const x = Math.floor(localPos[0]);
-      const y = Math.floor(localPos[1]);
+    const localPos = vec3.transformMat4(
+      vec3.create(),
+      world,
+      image.transform.inverse
+    );
 
-      // Check if this chunk contains the requested position
-      if (x >= 0 && x < chunk.shape.x && y >= 0 && y < chunk.shape.y) {
-        const dimensions = this.chunkManagerSource_?.dimensions;
+    const x = Math.floor(localPos[0]);
+    const y = Math.floor(localPos[1]);
 
-        const data =
-          dimensions?.z !== undefined
-            ? this.slicePlane(chunk, dimensions.z.pointWorld)!
-            : chunk.data;
-        const pixelIndex = y * chunk.rowStride + x;
+    // Check if this chunk contains the requested position
+    if (x >= 0 && x < chunk.shape.x && y >= 0 && y < chunk.shape.y) {
+      const dimensions = this.chunkManagerSource_?.dimensions;
 
-        // For multi-channel images, take the first channel value
-        return data[pixelIndex];
-      }
+      const data =
+        dimensions?.z !== undefined
+          ? this.slicePlane(chunk, dimensions.z.pointWorld)!
+          : chunk.data;
+      const pixelIndex = y * chunk.rowStride + x;
+
+      // For multi-channel images, take the first channel value
+      return data[pixelIndex];
     }
+
+    return null;
+  }
+
+  public getValueAtWorld(world: vec3): number | null {
+    const currentLOD = this.chunkManagerSource_?.currentLOD ?? 0;
+
+    // First, try to find the value in current LOD chunks (highest priority)
+    for (const [chunk, image] of this.visibleChunks_) {
+      if (chunk.lod !== currentLOD) continue;
+      const value = this.getValueFromChunk(chunk, image, world);
+      if (value !== null) return value;
+    }
+
+    // Fallback to low-res chunks if no current LOD chunk contains the position
+    for (const [chunk, image] of this.visibleChunks_) {
+      if (chunk.lod === currentLOD) continue;
+      const value = this.getValueFromChunk(chunk, image, world);
+      if (value !== null) return value;
+    }
+
     return null;
   }
 


### PR DESCRIPTION
  ## Summary
Fix pixel value picking to return high-resolution values when both high-res and low-res chunks contain the same world position

  ## Problem
  The `getValueAtWorld()` method in `ImageLayer` was returning low-resolution pixel values even when high-resolution chunks were  available. This happened because the method iterated through `visibleChunks_` and returned the first matching chunk, but low-res  fallback chunks could be encountered before current LOD chunks.

  ## Solution
  - Split chunk iteration into two passes: current LOD chunks first, then fallback to low-res chunks
  - Extract common chunk value extraction logic into `getValueFromChunk()` helper method
  - Maintain the same fallback behavior while prioritizing accuracy

## Test:
- enabled point picking in chunk streaming example to verify that point picking worked at multiple LODs and that the correct chunks were being used to extract a value.