### PR TITLE
Define distinct ChunkedImageLayer for chunk streaming

### DIFF
--- a/packages/core/examples/chunk_streaming/chunk_info_overlay.ts
+++ b/packages/core/examples/chunk_streaming/chunk_info_overlay.ts
@@ -1,15 +1,15 @@
 import { Idetik } from "../../src/idetik";
-import { ImageLayer } from "../../src/layers/image_layer";
+import { ChunkedImageLayer } from "../../src/layers/chunked_image_layer";
 import { Chunk } from "../../src/data/chunk";
 
 export interface ChunkInfoOverlayOptions {
   textDiv: HTMLDivElement;
-  imageLayer: ImageLayer;
+  imageLayer: ChunkedImageLayer;
 }
 
 export class ChunkInfoOverlay {
   private readonly textDiv_: HTMLDivElement;
-  private readonly imageLayer_: ImageLayer;
+  private readonly imageLayer_: ChunkedImageLayer;
 
   constructor({ textDiv, imageLayer }: ChunkInfoOverlayOptions) {
     this.textDiv_ = textDiv;

--- a/packages/core/examples/chunk_streaming/main.ts
+++ b/packages/core/examples/chunk_streaming/main.ts
@@ -1,4 +1,5 @@
 import {
+  ChannelProps,
   Idetik,
   ChunkedImageLayer,
   OmeZarrImageSource,
@@ -29,7 +30,7 @@ const region: Region = [
   { dimension: "x", index: { type: "full" } },
 ];
 
-const channelProps = { contrastLimits: [0, 255] as [number, number] };
+const channelProps: ChannelProps = { contrastLimits: [0, 255] };
 const camera = new OrthographicCamera(left, right, top, bottom);
 const imageLayer = new ChunkedImageLayer({ source, region, channelProps });
 imageLayer.debugMode = true;

--- a/packages/core/examples/chunk_streaming/main.ts
+++ b/packages/core/examples/chunk_streaming/main.ts
@@ -1,6 +1,6 @@
 import {
   Idetik,
-  ImageLayer,
+  ChunkedImageLayer,
   OmeZarrImageSource,
   OrthographicCamera,
   Region,
@@ -29,9 +29,9 @@ const region: Region = [
   { dimension: "x", index: { type: "full" } },
 ];
 
-const channelProps = [{ contrastLimits: [0, 255] as [number, number] }];
+const channelProps = { contrastLimits: [0, 255] as [number, number] };
 const camera = new OrthographicCamera(left, right, top, bottom);
-const imageLayer = new ImageLayer({ source, region, channelProps });
+const imageLayer = new ChunkedImageLayer({ source, region, channelProps });
 imageLayer.debugMode = true;
 
 const overlaySelector = document.querySelector<HTMLDivElement>("#chunk-info")!;

--- a/packages/core/examples/image_labels_overlay_with_value_picking/main.ts
+++ b/packages/core/examples/image_labels_overlay_with_value_picking/main.ts
@@ -4,7 +4,7 @@ import {
   OrthographicCamera,
   Region,
   Color,
-  ImageLayer,
+  ChunkedImageLayer,
 } from "@";
 import { LabelImageLayer } from "@/layers/label_image_layer";
 import { PointPickingResult } from "@/layers/point_picking";
@@ -73,18 +73,11 @@ const canvas = document.querySelector<HTMLCanvasElement>("canvas")!;
 const pickInfoDiv = document.querySelector<HTMLDivElement>("#pick-info")!;
 
 // Create base image layer
-const imageLayer = new ImageLayer({
+const imageLayer = new ChunkedImageLayer({
   source: imageSource,
   region: imageRegion,
   transparent: true,
-  channelProps: [
-    {
-      visible: true,
-      color: Color.WHITE,
-      contrastLimits: phaseContrastLimits,
-    },
-  ],
-  lod,
+  channelProps: { contrastLimits: phaseContrastLimits },
 });
 
 // Create label image layer with picking functionality

--- a/packages/core/examples/ome_zarr_v05/main.ts
+++ b/packages/core/examples/ome_zarr_v05/main.ts
@@ -1,6 +1,5 @@
 import {
   ChannelProps,
-  Color,
   Idetik,
   ChunkedImageLayer,
   OmeZarrImageSource,
@@ -39,11 +38,7 @@ const region: Region = [
   { dimension: "y", index: { type: "full" } },
   { dimension: "x", index: { type: "full" } },
 ];
-const channelProps: ChannelProps = {
-  visible: true,
-  color: Color.WHITE,
-  contrastLimits: [0, 200],
-};
+const channelProps: ChannelProps = { contrastLimits: [0, 200] };
 
 const pickInfoDiv = document.querySelector<HTMLDivElement>("#pick-info")!;
 
@@ -56,7 +51,12 @@ const onPickValue = (info: PointPickingResult) => {
   `;
 };
 
-const layer = new ChunkedImageLayer({ source, region, channelProps, onPickValue });
+const layer = new ChunkedImageLayer({
+  source,
+  region,
+  channelProps,
+  onPickValue,
+});
 const axes = new AxesLayer({
   length: 0.75 * xInfo.scale * xInfo.size,
   width: 0.01,

--- a/packages/core/examples/ome_zarr_v05/main.ts
+++ b/packages/core/examples/ome_zarr_v05/main.ts
@@ -2,7 +2,7 @@ import {
   ChannelProps,
   Color,
   Idetik,
-  ImageLayer,
+  ChunkedImageLayer,
   OmeZarrImageSource,
   OrthographicCamera,
   Region,
@@ -39,13 +39,11 @@ const region: Region = [
   { dimension: "y", index: { type: "full" } },
   { dimension: "x", index: { type: "full" } },
 ];
-const channelProps: ChannelProps[] = [
-  {
-    visible: true,
-    color: Color.WHITE,
-    contrastLimits: [0, 200],
-  },
-];
+const channelProps: ChannelProps = {
+  visible: true,
+  color: Color.WHITE,
+  contrastLimits: [0, 200],
+};
 
 const pickInfoDiv = document.querySelector<HTMLDivElement>("#pick-info")!;
 
@@ -58,7 +56,7 @@ const onPickValue = (info: PointPickingResult) => {
   `;
 };
 
-const layer = new ImageLayer({ source, region, channelProps, onPickValue });
+const layer = new ChunkedImageLayer({ source, region, channelProps, onPickValue });
 const axes = new AxesLayer({
   length: 0.75 * xInfo.scale * xInfo.size,
   width: 0.01,

--- a/packages/core/src/core/layer.ts
+++ b/packages/core/src/core/layer.ts
@@ -15,10 +15,6 @@ export interface LayerOptions {
   transparent?: boolean;
   opacity?: number;
   blendMode?: blendMode;
-
-  // TODO:(shlomnissan) Remove this parameter—LOD will be computed
-  // dynamically by the chunk manager.
-  lod?: number;
 }
 
 export abstract class Layer {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,6 +14,7 @@ export type { EventContext } from "./core/event_dispatcher";
 export { AxesLayer } from "./layers/axes_layer";
 export { ProjectedLineLayer } from "./layers/projected_line_layer";
 export { TracksLayer } from "./layers/tracks_layer";
+export { ChunkedImageLayer } from "./layers/chunked_image_layer";
 export { ImageLayer } from "./layers/image_layer";
 export { LabelImageLayer } from "./layers/label_image_layer";
 export type { PointPickingResult } from "./layers/point_picking";

--- a/packages/core/src/layers/chunked_image_layer.ts
+++ b/packages/core/src/layers/chunked_image_layer.ts
@@ -1,0 +1,224 @@
+import { Layer, LayerOptions } from "../core/layer";
+import { IdetikContext } from "../idetik";
+import { Chunk, ChunkSource } from "../data/chunk";
+import { ChunkManagerSource } from "../core/chunk_manager";
+import { ChannelProps } from "../objects/textures/channel";
+import { ImageRenderable } from "../objects/renderable/image_renderable";
+import { Texture2DArray } from "../objects/textures/texture_2d_array";
+import { PlaneGeometry } from "../objects/geometry/plane_geometry";
+import { Logger } from "../utilities/logger";
+import { Color } from "../core/color";
+import { EventContext } from "../core/event_dispatcher";
+import { vec2, vec3 } from "gl-matrix";
+import { handlePointPickingEvent, PointPickingResult } from "./point_picking";
+import { almostEqual } from "../utilities/almost_equal";
+import { clamp } from "../utilities/clamp";
+import { Region } from "../data/region";
+
+export type ChunkedImageLayerProps = LayerOptions & {
+  source: ChunkSource;
+  region: Region;
+  channelProps?: ChannelProps;
+  onPickValue?: (info: PointPickingResult) => void;
+};
+
+export class ChunkedImageLayer extends Layer {
+  public readonly type = "ChunkedImageLayer";
+
+  private readonly source_: ChunkSource;
+  private readonly region_: Region;
+  private readonly onPickValue_?: (info: PointPickingResult) => void;
+  private readonly visibleChunks_: Map<Chunk, ImageRenderable> = new Map();
+  private channelProps_?: ChannelProps;
+  private chunkManagerSource_?: ChunkManagerSource;
+  private pointerDownPos_: vec2 | null = null;
+  private zPrevPointWorld_?: number;
+  private debugMode_ = false;
+
+  private readonly wireframeColors_ = [
+    new Color(0.6, 0.3, 0.3),
+    new Color(0.3, 0.6, 0.4),
+    new Color(0.4, 0.4, 0.7),
+    new Color(0.6, 0.5, 0.3),
+  ];
+
+  constructor({
+    source,
+    region,
+    channelProps,
+    onPickValue,
+    ...layerOptions
+  }: ChunkedImageLayerProps) {
+    super(layerOptions);
+    this.setState("initialized");
+    this.source_ = source;
+    this.region_ = region;
+    this.channelProps_ = channelProps;
+    this.onPickValue_ = onPickValue;
+  }
+
+  public async onAttached(context: IdetikContext) {
+    this.chunkManagerSource_ = await context.chunkManager.addSource(
+      this.source_,
+      this.region_
+    );
+  }
+
+  public update() {
+    this.updateChunks();
+    this.resliceIfZChanged();
+  }
+
+  private updateChunks() {
+    if (!this.chunkManagerSource_) return;
+
+    // Temporary until we decide how to approach state management
+    if (this.state !== "ready") {
+      this.setState("ready");
+    }
+
+    // TODO:(shlomnissan) Reuse images instead of deleting and creating new ones.
+    //
+    // This loop removes image renderables for chunks that are no longer visible
+    // or no longer returned by getChunks() (e.g., due to LOD changes).
+    // While this approach works for now, it may be more efficient in the future
+    // to reuse renderables by updating their underlying data instead of repeatedly
+    // creating new texture objects. Note: GPU resources are not currently being
+    // released, so this will also need to be addressed soon.
+    const currentChunks = new Set(this.chunkManagerSource_.getChunks());
+    this.visibleChunks_.forEach((_image, chunk) => {
+      if (!currentChunks.has(chunk)) {
+        this.visibleChunks_.delete(chunk); // safe
+      }
+    });
+
+    // Add all objects anew so that they respect the chunk order, which may
+    // capture details important for rendering, such as LOD, instead of the
+    // creation order, which is dependent on when the chunks finished loading.
+    this.clearObjects();
+    currentChunks.forEach((chunk) => {
+      let image = this.visibleChunks_.get(chunk);
+      if (!image && chunk.state === "loaded") {
+        image = this.createImage(chunk);
+        this.visibleChunks_.set(chunk, image);
+      }
+      if (image) this.addObject(image);
+    });
+  }
+
+  private resliceIfZChanged() {
+    const dimensions = this.chunkManagerSource_?.dimensions;
+    const pointWorld = dimensions?.z?.pointWorld;
+    if (pointWorld === undefined || this.zPrevPointWorld_ === pointWorld) {
+      return;
+    }
+
+    for (const [chunk, image] of this.visibleChunks_) {
+      if (chunk.state !== "loaded" || !chunk.data) continue;
+      const data = this.slicePlane(chunk, pointWorld);
+      if (data) {
+        image.textures[0].data = data;
+      }
+    }
+
+    this.zPrevPointWorld_ = pointWorld;
+  }
+
+  public onEvent(event: EventContext) {
+    this.pointerDownPos_ = handlePointPickingEvent(
+      event,
+      this.pointerDownPos_,
+      (world) => this.getValueAtWorld(world),
+      this.onPickValue_
+    );
+  }
+
+  public get chunkManagerSource(): ChunkManagerSource | undefined {
+    return this.chunkManagerSource_;
+  }
+
+  private slicePlane(chunk: Chunk, zValue: number) {
+    if (!chunk.data) return;
+    const zLocal = (zValue - chunk.offset.z) / chunk.scale.z;
+    const zIdx = Math.round(zLocal);
+    const zClamped = clamp(zIdx, 0, chunk.shape.z - 1);
+
+    // Treat values within ~1 voxel (plus tiny floating-point error) as OK.
+    // Anything further away means the requested zValue is outside.
+    if (!almostEqual(zLocal, zClamped, 1 + 1e-6)) {
+      Logger.error("ImageLayer", "slicePlane zValue outside extent");
+    }
+
+    const sliceSize = chunk.shape.x * chunk.shape.y;
+    const offset = sliceSize * zClamped;
+    return chunk.data.subarray(offset, offset + sliceSize);
+  }
+
+  private createImage(chunk: Chunk) {
+    const geometry = new PlaneGeometry(chunk.shape.x, chunk.shape.y, 1, 1);
+
+    let data = chunk.data;
+    const dimensions = this.chunkManagerSource?.dimensions;
+    if (dimensions?.z) {
+      data = this.slicePlane(chunk, dimensions.z.pointWorld);
+    }
+
+    const image = new ImageRenderable(
+      geometry,
+      Texture2DArray.createWithChunk(chunk, data),
+      this.channelProps_ ? [this.channelProps_] : [{}]
+    );
+
+    if (this.debugMode_) {
+      image.wireframeEnabled = true;
+      image.wireframeColor =
+        this.wireframeColors_[chunk.lod % this.wireframeColors_.length];
+    }
+
+    image.transform.setScale([chunk.scale.x, chunk.scale.y, 1]);
+    image.transform.setTranslation([chunk.offset.x, chunk.offset.y, 0]);
+    return image;
+  }
+
+  public getValueAtWorld(world: vec3): number | null {
+    if (!this.chunkManagerSource_) return null;
+    // Iterate through all visible chunks to find the one containing the world position
+    for (const [chunk, image] of this.visibleChunks_) {
+      if (!chunk.data) continue;
+      const localPos = vec3.transformMat4(
+        vec3.create(),
+        world,
+        image.transform.inverse
+      );
+
+      const x = Math.floor(localPos[0]);
+      const y = Math.floor(localPos[1]);
+
+      // Check if this chunk contains the requested position
+      if (x >= 0 && x < chunk.shape.x && y >= 0 && y < chunk.shape.y) {
+        const dimensions = this.chunkManagerSource_.dimensions;
+
+        const data =
+          dimensions?.z !== undefined
+            ? this.slicePlane(chunk, dimensions.z.pointWorld)!
+            : chunk.data;
+        const pixelIndex = y * chunk.rowStride + x;
+
+        // For multi-channel images, take the first channel value
+        return data[pixelIndex];
+      }
+    }
+    return null;
+  }
+
+  public set debugMode(debug: boolean) {
+    this.debugMode_ = debug;
+    this.visibleChunks_.forEach((image, chunk) => {
+      image.wireframeEnabled = this.debugMode_;
+      if (this.debugMode_) {
+        image.wireframeColor =
+          this.wireframeColors_[chunk.lod % this.wireframeColors_.length];
+      }
+    });
+  }
+}

--- a/packages/core/src/layers/image_layer.ts
+++ b/packages/core/src/layers/image_layer.ts
@@ -1,57 +1,36 @@
 import { Layer, LayerOptions } from "../core/layer";
-import { IdetikContext } from "../idetik";
 import { Region } from "../data/region";
 import { Chunk, ChunkSource } from "../data/chunk";
-import { ChunkManagerSource } from "../core/chunk_manager";
 import { ChannelProps, ChannelsEnabled } from "../objects/textures/channel";
 import { ImageRenderable } from "../objects/renderable/image_renderable";
 import { Texture2DArray } from "../objects/textures/texture_2d_array";
 import { PlaneGeometry } from "../objects/geometry/plane_geometry";
-import { Logger } from "../utilities/logger";
-import { Color } from "../core/color";
 import { EventContext } from "../core/event_dispatcher";
 import { vec2, vec3 } from "gl-matrix";
 import { handlePointPickingEvent, PointPickingResult } from "./point_picking";
-import { almostEqual } from "../utilities/almost_equal";
-import { clamp } from "../utilities/clamp";
 
 export type ImageLayerProps = LayerOptions & {
   source: ChunkSource;
   region: Region;
   channelProps?: ChannelProps[];
   onPickValue?: (info: PointPickingResult) => void;
+  lod?: number;
 };
 
-// Loads data from an image source into renderable objects.
 export class ImageLayer extends Layer implements ChannelsEnabled {
   public readonly type = "ImageLayer";
 
   private readonly source_: ChunkSource;
-  // TODO: remove this when region is passed through to update.
-  // https://github.com/chanzuckerberg/idetik/issues/33
   private readonly region_: Region;
-  private readonly useChunkManager_: boolean;
-  private readonly initialChannelProps_?: ChannelProps[];
+  private readonly lod_?: number;
   private readonly onPickValue_?: (info: PointPickingResult) => void;
+  private readonly initialChannelProps_?: ChannelProps[];
   private readonly channelChangeCallbacks_: Array<() => void> = [];
-  private readonly visibleChunks_: Map<Chunk, ImageRenderable> = new Map();
-  private chunkManagerSource_?: ChunkManagerSource;
   private channelProps_?: ChannelProps[];
   private image_?: ImageRenderable;
+  private chunk_?: Chunk;
   private extent_?: { x: number; y: number };
   private pointerDownPos_: vec2 | null = null;
-  private zPrevPointWorld_?: number;
-  private debugMode_ = false;
-
-  private readonly wireframeColors_ = [
-    new Color(0.6, 0.3, 0.3),
-    new Color(0.3, 0.6, 0.4),
-    new Color(0.4, 0.4, 0.7),
-    new Color(0.6, 0.5, 0.3),
-  ];
-
-  // TODO:(shlomnissan) Remove this parameter when chunk manager is used by default
-  private readonly lod_?: number;
 
   constructor({
     source,
@@ -69,98 +48,19 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
     this.initialChannelProps_ = channelProps;
     this.onPickValue_ = onPickValue;
     this.lod_ = lod;
-
-    const x = region.find((r) => r.dimension.toLowerCase() === "x");
-    const y = region.find((r) => r.dimension.toLowerCase() === "y");
-    const hasIntervals = region.some((r) => r.index.type === "interval");
-    this.useChunkManager_ =
-      !hasIntervals && x?.index.type === "full" && y?.index.type === "full";
-
-    if (this.useChunkManager_) {
-      Logger.info("ImageLayer", "Loading data using the chunk manager");
-    }
-  }
-
-  public async onAttached(context: IdetikContext) {
-    if (this.useChunkManager_) {
-      this.chunkManagerSource_ = await context.chunkManager.addSource(
-        this.source_,
-        this.region_
-      );
-    }
-  }
-
-  private updateChunks() {
-    if (!this.chunkManagerSource_) return;
-
-    // Temporary until we decide how to approach state management
-    if (this.state !== "ready") {
-      this.setState("ready");
-    }
-
-    // TODO:(shlomnissan) Reuse images instead of deleting and creating new ones.
-    //
-    // This loop removes image renderables for chunks that are no longer visible
-    // or no longer returned by getChunks() (e.g., due to LOD changes).
-    // While this approach works for now, it may be more efficient in the future
-    // to reuse renderables by updating their underlying data instead of repeatedly
-    // creating new texture objects. Note: GPU resources are not currently being
-    // released, so this will also need to be addressed soon.
-    const currentChunks = new Set(this.chunkManagerSource_.getChunks());
-    this.visibleChunks_.forEach((_image, chunk) => {
-      if (!currentChunks.has(chunk)) {
-        this.visibleChunks_.delete(chunk); // safe
-      }
-    });
-
-    // Add all objects anew so that they respect the chunk order, which may
-    // capture details important for rendering, such as LOD, instead of the
-    // creation order, which is dependent on when the chunks finished loading.
-    this.clearObjects();
-    currentChunks.forEach((chunk) => {
-      let image = this.visibleChunks_.get(chunk);
-      if (!image && chunk.state === "loaded") {
-        image = this.createImage(chunk, this.channelProps);
-        this.visibleChunks_.set(chunk, image);
-      }
-      if (image) this.addObject(image);
-    });
-  }
-
-  private resliceIfZChanged() {
-    const dimensions = this.chunkManagerSource_?.dimensions;
-    const pointWorld = dimensions?.z?.pointWorld;
-    if (pointWorld === undefined || this.zPrevPointWorld_ === pointWorld) {
-      return;
-    }
-
-    for (const [chunk, image] of this.visibleChunks_) {
-      if (chunk.state !== "loaded" || !chunk.data) continue;
-      const data = this.slicePlane(chunk, pointWorld);
-      if (data) {
-        image.textures[0].data = data;
-      }
-    }
-
-    this.zPrevPointWorld_ = pointWorld;
   }
 
   public update() {
-    if (this.useChunkManager_) {
-      this.updateChunks();
-      this.resliceIfZChanged();
-    } else {
-      switch (this.state) {
-        case "initialized":
-          this.load(this.region_);
-          break;
-        case "loading":
-        case "ready":
-          break;
-        default: {
-          const exhaustiveCheck: never = this.state;
-          throw new Error(`Unhandled LayerState case: ${exhaustiveCheck}`);
-        }
+    switch (this.state) {
+      case "initialized":
+        this.load(this.region_);
+        break;
+      case "loading":
+      case "ready":
+        break;
+      default: {
+        const exhaustiveCheck: never = this.state;
+        throw new Error(`Unhandled LayerState case: ${exhaustiveCheck}`);
       }
     }
   }
@@ -178,6 +78,7 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
     // TODO: should this return Channel[] instead of ChannelProps[]?
     return this.channelProps_;
   }
+
   public setChannelProps(channelProps: ChannelProps[]) {
     this.channelProps_ = channelProps;
     this.image_?.setChannelProps(channelProps);
@@ -185,6 +86,7 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
       callback();
     });
   }
+
   public resetChannelProps(): void {
     if (this.initialChannelProps_ !== undefined) {
       this.setChannelProps(this.initialChannelProps_);
@@ -194,6 +96,7 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
   public addChannelChangeCallback(callback: () => void): void {
     this.channelChangeCallbacks_.push(callback);
   }
+
   public removeChannelChangeCallback(callback: () => void): void {
     const index = this.channelChangeCallbacks_.indexOf(callback);
     if (index === undefined) {
@@ -217,8 +120,8 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
       y: chunk.shape.y * chunk.scale.y,
     };
 
-    this.image_ = this.createImage(chunk, this.channelProps_);
-    this.visibleChunks_.set(chunk, this.image_);
+    this.image_ = this.createImage(chunk);
+    this.chunk_ = chunk;
     this.addObject(this.image_);
 
     this.setState("ready");
@@ -230,91 +133,41 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
     return this.extent_;
   }
 
-  public get chunkManagerSource(): ChunkManagerSource | undefined {
-    return this.chunkManagerSource_;
-  }
-
-  private slicePlane(chunk: Chunk, zValue: number) {
-    if (!chunk.data) return;
-    const zLocal = (zValue - chunk.offset.z) / chunk.scale.z;
-    const zIdx = Math.round(zLocal);
-    const zClamped = clamp(zIdx, 0, chunk.shape.z - 1);
-
-    // Treat values within ~1 voxel (plus tiny floating-point error) as OK.
-    // Anything further away means the requested zValue is outside.
-    if (!almostEqual(zLocal, zClamped, 1 + 1e-6)) {
-      Logger.error("ImageLayer", "slicePlane zValue outside extent");
-    }
-
-    const sliceSize = chunk.shape.x * chunk.shape.y;
-    const offset = sliceSize * zClamped;
-    return chunk.data.subarray(offset, offset + sliceSize);
-  }
-
-  private createImage(chunk: Chunk, channelProps?: ChannelProps[]) {
+  private createImage(chunk: Chunk) {
     const geometry = new PlaneGeometry(chunk.shape.x, chunk.shape.y, 1, 1);
-
-    let data = chunk.data;
-    const dimensions = this.chunkManagerSource?.dimensions;
-    if (dimensions?.z) {
-      data = this.slicePlane(chunk, dimensions.z.pointWorld);
-    }
-
     const image = new ImageRenderable(
       geometry,
-      Texture2DArray.createWithChunk(chunk, data),
-      channelProps
+      Texture2DArray.createWithChunk(chunk),
+      this.channelProps
     );
-
-    if (this.debugMode_) {
-      image.wireframeEnabled = true;
-      image.wireframeColor =
-        this.wireframeColors_[chunk.lod % this.wireframeColors_.length];
-    }
-
     image.transform.setScale([chunk.scale.x, chunk.scale.y, 1]);
     image.transform.setTranslation([chunk.offset.x, chunk.offset.y, 0]);
     return image;
   }
 
   public getValueAtWorld(world: vec3): number | null {
-    // Iterate through all visible chunks to find the one containing the world position
-    for (const [chunk, image] of this.visibleChunks_) {
-      if (!chunk.data) continue;
-      const localPos = vec3.transformMat4(
-        vec3.create(),
-        world,
-        image.transform.inverse
-      );
+    if (!this.image_) return null;
+    if (!this.chunk_?.data) return null;
+    const localPos = vec3.transformMat4(
+      vec3.create(),
+      world,
+      this.image_.transform.inverse
+    );
 
-      const x = Math.floor(localPos[0]);
-      const y = Math.floor(localPos[1]);
+    const x = Math.floor(localPos[0]);
+    const y = Math.floor(localPos[1]);
 
-      // Check if this chunk contains the requested position
-      if (x >= 0 && x < chunk.shape.x && y >= 0 && y < chunk.shape.y) {
-        const dimensions = this.chunkManagerSource_?.dimensions;
-
-        const data =
-          dimensions?.z !== undefined
-            ? this.slicePlane(chunk, dimensions.z.pointWorld)!
-            : chunk.data;
-        const pixelIndex = y * chunk.rowStride + x;
-
-        // For multi-channel images, take the first channel value
-        return data[pixelIndex];
-      }
+    // Check if this chunk contains the requested position
+    if (
+      x >= 0 &&
+      x < this.chunk_.shape.x &&
+      y >= 0 &&
+      y < this.chunk_.shape.y
+    ) {
+      const pixelIndex = y * this.chunk_.rowStride + x;
+      // For multi-channel images, take the first channel value
+      return this.chunk_.data[pixelIndex];
     }
     return null;
-  }
-
-  public set debugMode(debug: boolean) {
-    this.debugMode_ = debug;
-    this.visibleChunks_.forEach((image, chunk) => {
-      image.wireframeEnabled = this.debugMode_;
-      if (this.debugMode_) {
-        image.wireframeColor =
-          this.wireframeColors_[chunk.lod % this.wireframeColors_.length];
-      }
-    });
   }
 }

--- a/packages/core/src/layers/image_series_layer.ts
+++ b/packages/core/src/layers/image_series_layer.ts
@@ -12,6 +12,7 @@ export type ImageSeriesLayerProps = LayerOptions & {
   region: Region;
   seriesDimensionName: string;
   channelProps?: ChannelProps[];
+  lod?: number;
 };
 
 export class ImageSeriesLayer extends Layer implements ChannelsEnabled {

--- a/packages/core/src/layers/label_image_layer.ts
+++ b/packages/core/src/layers/label_image_layer.ts
@@ -17,6 +17,7 @@ export type LabelImageLayerProps = LayerOptions & {
   region: Region;
   colorMap?: LabelColorMapProps;
   onPickValue?: (info: PointPickingResult) => void;
+  lod?: number;
 };
 
 export class LabelImageLayer extends Layer {

--- a/packages/core/src/layers/label_image_series_layer.ts
+++ b/packages/core/src/layers/label_image_series_layer.ts
@@ -15,6 +15,7 @@ export type LabelImageSeriesLayerProps = LayerOptions & {
   region: Region;
   seriesDimensionName: string;
   colorMap?: LabelColorMapProps;
+  lod?: number;
 };
 
 export class LabelImageSeriesLayer extends Layer {

--- a/packages/core/src/utilities/logger.ts
+++ b/packages/core/src/utilities/logger.ts
@@ -19,6 +19,7 @@ type Module =
   | "ChunkManager"
   | "EventDispatcher"
   | "Idetik"
+  | "ChunkedImageLayer"
   | "ImageLayer"
   | "LabelImageLayer"
   | "WebGLRenderer"


### PR DESCRIPTION
### Summary
This splits the existing image layer into two classes.

1. `ImageLayer`: this encapsulates the pre-chunk-streaming image layer, which is crude but simple. This is currently used by the main React component and the applications that use that.

2. `ChunkedImageLayer`: this uses chunk-streaming for a better experience and performance, as well as built-in support for image series, but at the cost of some complexity. This does not support some features of the `ImageLayer` (e.g. multiple channels). This will eventually replace at least the `ImageLayer` and `ImageSeriesLayer`.

The main motivation of this change is clarity. Since `ChunkedImageLayer` has a very different loading pattern, the existing image layer had become hard to read and maintain. This also allows us to move more quickly on developing chunk streaming without breaking existing usage of older layers.

Going forward, we intend to leave `ImageLayer` and `ImageSeriesLayer` alone except for important maintenance, and will eventually delete them in favor of `ChunkedImageLayer`. At the point, we may want to rename `ChunkedImageLayer`.

I updated all the examples that I'm aware of using chunk streaming to use the `ChunkedImageLayer`.

### Tests & Checks
I manually tested the existing examples and React components.
