### PR TITLE
Delete unused chunk data from memory

### DIFF
--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -161,7 +161,7 @@ export class ChunkManagerSource {
     for (const chunk of this.chunks_) {
       if (
         chunk.lod === this.currentLOD_ &&
-        chunk.state === "unloaded" &&
+        (chunk.state === "unloaded" || chunk.state === "disposed") &&
         (chunk.visible || chunk.prefetch)
       ) {
         this.loadChunkData(chunk);
@@ -226,10 +226,32 @@ export class ChunkManagerSource {
 
     const paddedBounds = this.getPaddedBounds(viewBounds3D);
     for (const chunk of this.chunks_) {
-      chunk.prefetch = false;
-      chunk.visible = this.isChunkWithinBounds(chunk, viewBounds3D);
-      if (!chunk.visible) {
-        chunk.prefetch = this.isChunkWithinBounds(chunk, paddedBounds);
+      const isVisible = this.isChunkWithinBounds(chunk, viewBounds3D);
+      const inPrefetchRegion =
+        !isVisible && this.isChunkWithinBounds(chunk, paddedBounds);
+
+      const isCurrent = chunk.lod === this.currentLOD_;
+      const isFallback = chunk.lod === this.lowestResLOD_;
+      const isLoaded = chunk.state === "loaded";
+
+      chunk.visible = isVisible;
+      chunk.prefetch = isCurrent && inPrefetchRegion && !isLoaded;
+
+      /*
+        Disposal rules:
+        - Keep fallback LOD pinned.
+        - For current LOD dispose if not visible AND not in prefetch region.
+        - For any other LOD dispose regardless.
+      */
+      if (isLoaded && !isFallback) {
+        const shouldDispose =
+          !isCurrent || (isCurrent && !isVisible && !inPrefetchRegion);
+
+        if (shouldDispose) {
+          chunk.data = undefined;
+          chunk.state = "disposed";
+          Logger.debug("ChunkManager", `Disposing chunk in LOD ${chunk.lod}`);
+        }
       }
     }
   }

--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -161,7 +161,7 @@ export class ChunkManagerSource {
     for (const chunk of this.chunks_) {
       if (
         chunk.lod === this.currentLOD_ &&
-        (chunk.state === "unloaded" || chunk.state === "disposed") &&
+        chunk.state === "unloaded" &&
         (chunk.visible || chunk.prefetch)
       ) {
         this.loadChunkData(chunk);
@@ -227,29 +227,23 @@ export class ChunkManagerSource {
     const paddedBounds = this.getPaddedBounds(viewBounds3D);
     for (const chunk of this.chunks_) {
       const isVisible = this.isChunkWithinBounds(chunk, viewBounds3D);
-      const inPrefetchRegion =
+      const eligibleForPrefetch =
         !isVisible && this.isChunkWithinBounds(chunk, paddedBounds);
 
-      const isCurrent = chunk.lod === this.currentLOD_;
-      const isFallback = chunk.lod === this.lowestResLOD_;
+      const isCurrentLOD = chunk.lod === this.currentLOD_;
+      const isFallbackLOD = chunk.lod === this.lowestResLOD_;
       const isLoaded = chunk.state === "loaded";
 
       chunk.visible = isVisible;
-      chunk.prefetch = isCurrent && inPrefetchRegion && !isLoaded;
+      chunk.prefetch = eligibleForPrefetch && isCurrentLOD && !isLoaded;
 
-      /*
-        Disposal rules:
-        - Keep fallback LOD pinned.
-        - For current LOD dispose if not visible AND not in prefetch region.
-        - For any other LOD dispose regardless.
-      */
-      if (isLoaded && !isFallback) {
+      if (isLoaded && !isFallbackLOD) {
         const shouldDispose =
-          !isCurrent || (isCurrent && !isVisible && !inPrefetchRegion);
+          !isCurrentLOD || (isCurrentLOD && !isVisible && !eligibleForPrefetch);
 
         if (shouldDispose) {
           chunk.data = undefined;
-          chunk.state = "disposed";
+          chunk.state = "unloaded";
           Logger.debug("ChunkManager", `Disposing chunk in LOD ${chunk.lod}`);
         }
       }

--- a/packages/core/src/data/chunk.ts
+++ b/packages/core/src/data/chunk.ts
@@ -26,7 +26,7 @@ export function isChunkData(value: unknown): value is ChunkData {
 
 export type Chunk = {
   data?: ChunkData;
-  state: "unloaded" | "loading" | "loaded" | "disposed";
+  state: "unloaded" | "loading" | "loaded";
   lod: number;
   visible: boolean;
   prefetch: boolean;

--- a/packages/core/src/data/chunk.ts
+++ b/packages/core/src/data/chunk.ts
@@ -26,7 +26,7 @@ export function isChunkData(value: unknown): value is ChunkData {
 
 export type Chunk = {
   data?: ChunkData;
-  state: "unloaded" | "loading" | "loaded";
+  state: "unloaded" | "loading" | "loaded" | "disposed";
   lod: number;
   visible: boolean;
   prefetch: boolean;

--- a/packages/core/src/layers/chunked_image_layer.ts
+++ b/packages/core/src/layers/chunked_image_layer.ts
@@ -151,7 +151,7 @@ export class ChunkedImageLayer extends Layer {
 
     const sliceSize = chunk.shape.x * chunk.shape.y;
     const offset = sliceSize * zClamped;
-    return chunk.data.subarray(offset, offset + sliceSize);
+    return chunk.data.slice(offset, offset + sliceSize);
   }
 
   private createImage(chunk: Chunk) {


### PR DESCRIPTION
### Summary
This PR updates chunk disposal logic in `updateChunkVisibility`
to ensure only the current LOD and fallback LOD keep CPU data.
All other LODs are disposed even if they are visible. Prefetching
is now limited to the current LOD and unloaded chunks. Fallback
LOD chunks remain pinned and never disposed.

### Tests & Checks
- Examples are working as expected
- Manual verification:
    - Use stats to track memory
    - Use chunk overlay to track number of "ready chunks"
    - Add log when chunk is disposed and ensure correct behavior
    - **NOTE** It may take the GC 10-20 seconds before it releases memory


https://github.com/user-attachments/assets/0a3bc656-6d66-40e0-b8fd-eacc5576ea9e

