### PR TITLE
Add GPU texture information to chunk overlay

### DIFF
--- a/packages/core/examples/chunk_streaming/chunk_info_overlay.ts
+++ b/packages/core/examples/chunk_streaming/chunk_info_overlay.ts
@@ -16,7 +16,7 @@ export class ChunkInfoOverlay {
     this.imageLayer_ = imageLayer;
   }
 
-  public update(_idetik: Idetik, _timestamp?: DOMHighResTimeStamp): void {
+  public update(idetik: Idetik, _timestamp?: DOMHighResTimeStamp): void {
     const chunkManagerSource = this.imageLayer_.chunkManagerSource;
     if (!chunkManagerSource) {
       this.textDiv_.textContent = "No chunk manager source";
@@ -81,12 +81,19 @@ export class ChunkInfoOverlay {
       );
     });
 
+    const numTextures = idetik.textureInfo.textures;
+    const totalTextureSize = idetik.textureInfo.totalBytes;
+    const totalTextureSizeMB = Math.round(totalTextureSize / (1024 * 1024));
+
     this.textDiv_.innerHTML = [
       summary,
       "",
       ...counters,
       "",
       ...chunkDetails,
+      "",
+      `Number of textures ${numTextures}`,
+      `GPU Texture Memory in use ${totalTextureSizeMB}MB`,
     ].join("<br>");
   }
 }

--- a/packages/core/src/idetik.ts
+++ b/packages/core/src/idetik.ts
@@ -103,6 +103,10 @@ export class Idetik {
     return this.renderer_.height;
   }
 
+  public get textureInfo() {
+    return this.renderer_.textureInfo;
+  }
+
   public set cameraControls(controls: CameraControls | undefined) {
     this.cameraControls_ = controls;
   }

--- a/packages/core/src/renderers/webgl_renderer.ts
+++ b/packages/core/src/renderers/webgl_renderer.ts
@@ -79,6 +79,10 @@ export class WebGLRenderer extends Renderer {
     this.state_.setDepthMask(true);
   }
 
+  public get textureInfo() {
+    return this.textures_.textureInfo;
+  }
+
   private renderLayer(layer: Layer) {
     this.state_.setBlendingMode(layer.transparent ? layer.blendMode : "none");
     layer.objects.forEach((_, i) => this.renderObject(layer, i));

--- a/packages/core/src/renderers/webgl_textures.ts
+++ b/packages/core/src/renderers/webgl_textures.ts
@@ -21,10 +21,12 @@ export class WebGLTextures {
   private readonly textures_: Map<Texture, WebGLTexture> = new Map();
   private currentTexture_: Texture | null = null;
   private readonly maxTextureUnits_: number;
+  private gpuTextureBytes_ = 0;
+  private textureCount_ = 0;
 
   constructor(gl: WebGL2RenderingContext) {
     this.gl_ = gl;
-    this.maxTextureUnits_ = gl.MAX_TEXTURE_IMAGE_UNITS;
+    this.maxTextureUnits_ = gl.getParameter(gl.MAX_TEXTURE_IMAGE_UNITS);
   }
 
   public bindTexture(texture: Texture, index: number) {
@@ -67,13 +69,27 @@ export class WebGLTextures {
       if (this.currentTexture_ === texture) {
         this.currentTexture_ = null;
       }
+
+      const info = this.getDataFormatInfo(texture.dataFormat, texture.dataType);
+      const bytes = this.computeStorageBytes(texture, info);
+      this.gpuTextureBytes_ = Math.max(0, this.gpuTextureBytes_ - bytes);
+      this.textureCount_ = Math.max(0, this.textureCount_ - 1);
     }
   }
 
   public disposeAll() {
-    for (const texture of this.textures_.keys()) {
+    for (const texture of Array.from(this.textures_.keys())) {
       this.disposeTexture(texture);
     }
+    this.gpuTextureBytes_ = 0;
+    this.textureCount_ = 0;
+  }
+
+  public get textureInfo() {
+    return {
+      textures: this.textureCount_,
+      totalBytes: this.gpuTextureBytes_,
+    };
   }
 
   private alreadyActive(texture: Texture) {
@@ -111,6 +127,8 @@ export class WebGLTextures {
       throw new Error(`Unknown texture type ${texture.type}`);
     }
 
+    this.gpuTextureBytes_ += this.computeStorageBytes(texture, info);
+    this.textureCount_ += 1;
     this.textures_.set(texture, textureId);
     this.gl_.bindTexture(type, null);
   }
@@ -280,6 +298,50 @@ export class WebGLTextures {
       }
     }
     throw new Error(`Unsupported format/type: ${format}/${type}`);
+  }
+
+  private computeStorageBytes(
+    texture: Texture,
+    info: TextureFormatInfo
+  ): number {
+    const bytes = this.bytesPerTexel(info);
+    const levels = Math.max(1, texture.mipmapLevels);
+    const depth = this.isTexture2DArray(texture)
+      ? Math.max(1, texture.depth)
+      : 1;
+
+    let width = Math.max(1, texture.width);
+    let height = Math.max(1, texture.height);
+    let total = 0;
+    for (let level = 0; level < levels; level++) {
+      total += width * height * depth * bytes;
+      width = Math.max(1, width >> 1);
+      height = Math.max(1, height >> 1);
+    }
+
+    return total;
+  }
+
+  private bytesPerTexel(info: TextureFormatInfo): number {
+    const gl = this.gl_;
+    if (info.format === gl.RGB && info.type === gl.UNSIGNED_BYTE) return 3;
+    if (info.format === gl.RGBA && info.type === gl.UNSIGNED_BYTE) return 4;
+    if (info.format === gl.RED_INTEGER) {
+      switch (info.type) {
+        case gl.BYTE:
+        case gl.UNSIGNED_BYTE:
+          return 1;
+        case gl.SHORT:
+        case gl.UNSIGNED_SHORT:
+          return 2;
+        case gl.INT:
+        case gl.UNSIGNED_INT:
+          return 4;
+      }
+    }
+    if (info.format === gl.RED && info.type === gl.FLOAT) return 4;
+
+    throw new Error("bytesPerTexel: unsupported format/type");
   }
 
   private isTexture2D(texture: Texture): texture is Texture2D {


### PR DESCRIPTION
### Summary

This PR adds the number of textures and total texture memory usage
to the chunk info overlay. It provides useful debugging information
that can be used to verify the image renderable pool implementation.

### Tests & Checks
- All checks have passed
- Examples work as expected

<img width="513" height="285" alt="Screenshot 2025-08-26 at 11 24 16 AM" src="https://github.com/user-attachments/assets/a56f184f-0a2e-468f-823b-79a943a98c12" />

