### PR TITLE
feat: add outline mode for selected segments in LabelImageLayer

### DIFF
--- a/packages/core/examples/image_labels_overlay_with_value_picking/main.ts
+++ b/packages/core/examples/image_labels_overlay_with_value_picking/main.ts
@@ -72,6 +72,21 @@ const canvas = document.querySelector<HTMLCanvasElement>("canvas")!;
 // Get the info div for displaying pick results
 const pickInfoDiv = document.querySelector<HTMLDivElement>("#pick-info")!;
 
+// Add outline mode toggle
+let outlineMode = false;
+const toggleButton = document.createElement("button");
+toggleButton.textContent = "Mode: Fill";
+toggleButton.style.position = "absolute";
+toggleButton.style.top = "10px";
+toggleButton.style.right = "10px";
+toggleButton.style.padding = "8px 16px";
+toggleButton.style.backgroundColor = "#007acc";
+toggleButton.style.color = "white";
+toggleButton.style.border = "none";
+toggleButton.style.borderRadius = "4px";
+toggleButton.style.cursor = "pointer";
+document.body.appendChild(toggleButton);
+
 // Create base image layer
 const imageLayer = new ChunkedImageLayer({
   source: imageSource,
@@ -80,32 +95,64 @@ const imageLayer = new ChunkedImageLayer({
   channelProps: { contrastLimits: phaseContrastLimits },
 });
 
-// Create label image layer with picking functionality
-const labelsLayer = new LabelImageLayer({
-  source: labelsSource,
-  region: labelsRegion,
-  transparent: true,
-  opacity: 0.25,
-  blendMode: "normal",
-  lod,
-  onPickValue: (info: PointPickingResult) => {
-    const { world, value } = info;
-    pickInfoDiv.innerHTML = `
-      <strong>Pick Result:</strong><br/>
-      World: (${world[0].toFixed(1)}, ${world[1].toFixed(1)}, ${world[2].toFixed(1)})<br/>
-      Label Value: ${value}<br/>
-    `;
-    console.debug(`Setting color for label ${value} to transparent`);
-    labelsLayer.setColorMap({
-      cycle: Array.from(labelsLayer.colorMap.cycle),
-      lookupTable: new Map([[value, Color.WHITE]]),
-    });
-  },
-});
+// Function to create label layer with current mode
+function createLabelsLayer() {
+  return new LabelImageLayer({
+    source: labelsSource,
+    region: labelsRegion,
+    transparent: true,
+    opacity: 0.25,
+    blendMode: "normal",
+    lod,
+    outlineSelected: outlineMode,
+    onPickValue: (info: PointPickingResult) => {
+      const { world, value } = info;
+      pickInfoDiv.innerHTML = `
+        <strong>Pick Result:</strong><br/>
+        World: (${world[0].toFixed(1)}, ${world[1].toFixed(1)}, ${world[2].toFixed(1)})<br/>
+        Label Value: ${value}<br/>
+        Mode: ${outlineMode ? "Outline" : "Fill"}
+      `;
+      
+      if (outlineMode) {
+        // In outline mode, the layer handles the selection internally
+      } else {
+        // In fill mode, use the old white fill behavior
+        labelsLayer.setColorMap({
+          cycle: Array.from(labelsLayer.colorMap.cycle),
+          lookupTable: new Map([[value, Color.WHITE]]),
+        });
+      }
+    },
+  });
+}
 
-new Idetik({
+// Create initial label layer
+let labelsLayer = createLabelsLayer();
+
+// Create Idetik instance
+const idetik = new Idetik({
   canvas,
   camera,
   layers: [imageLayer, labelsLayer],
   cameraControls: new PanZoomControls(camera),
-}).start();
+});
+
+// Add toggle button functionality
+toggleButton.addEventListener("click", () => {
+  outlineMode = !outlineMode;
+  toggleButton.textContent = `Mode: ${outlineMode ? "Outline" : "Fill"}`;
+  
+  // Remove old layer and create new one with updated mode
+  idetik.layerManager.remove(labelsLayer);
+  labelsLayer = createLabelsLayer();
+  idetik.layerManager.add(labelsLayer);
+  
+  // Clear pick info
+  pickInfoDiv.innerHTML = `
+    <strong>Mode changed to:</strong> ${outlineMode ? "Outline" : "Fill"}<br/>
+    Click on a label to see the effect.
+  `;
+});
+
+idetik.start();

--- a/packages/core/examples/image_labels_overlay_with_value_picking/main.ts
+++ b/packages/core/examples/image_labels_overlay_with_value_picking/main.ts
@@ -74,18 +74,12 @@ const pickInfoDiv = document.querySelector<HTMLDivElement>("#pick-info")!;
 
 // Add outline mode toggle
 let outlineMode = false;
-const toggleButton = document.createElement("button");
-toggleButton.textContent = "Mode: Fill";
-toggleButton.style.position = "absolute";
-toggleButton.style.top = "10px";
-toggleButton.style.right = "10px";
-toggleButton.style.padding = "8px 16px";
-toggleButton.style.backgroundColor = "#007acc";
-toggleButton.style.color = "white";
-toggleButton.style.border = "none";
-toggleButton.style.borderRadius = "4px";
-toggleButton.style.cursor = "pointer";
-document.body.appendChild(toggleButton);
+const infoBox = document.querySelector<HTMLDivElement>("#info-box")!;
+const toggleDiv = document.createElement("div");
+toggleDiv.innerHTML =
+  '<strong>Mode:</strong> <span id="mode-text" style="cursor: pointer; text-decoration: underline;">Fill</span>';
+toggleDiv.style.cursor = "pointer";
+infoBox.appendChild(toggleDiv);
 
 // Create base image layer
 const imageLayer = new ChunkedImageLayer({
@@ -110,8 +104,7 @@ function createLabelsLayer() {
       pickInfoDiv.innerHTML = `
         <strong>Pick Result:</strong><br/>
         World: (${world[0].toFixed(1)}, ${world[1].toFixed(1)}, ${world[2].toFixed(1)})<br/>
-        Label Value: ${value}<br/>
-        Mode: ${outlineMode ? "Outline" : "Fill"}
+        Label Value: ${value}
       `;
 
       if (outlineMode) {
@@ -138,10 +131,11 @@ const idetik = new Idetik({
   cameraControls: new PanZoomControls(camera),
 });
 
-// Add toggle button functionality
-toggleButton.addEventListener("click", () => {
+// Add toggle functionality
+const modeText = document.querySelector<HTMLSpanElement>("#mode-text")!;
+toggleDiv.addEventListener("click", () => {
   outlineMode = !outlineMode;
-  toggleButton.textContent = `Mode: ${outlineMode ? "Outline" : "Fill"}`;
+  modeText.textContent = outlineMode ? "Outline" : "Fill";
 
   // Remove old layer and create new one with updated mode
   idetik.layerManager.remove(labelsLayer);

--- a/packages/core/examples/image_labels_overlay_with_value_picking/main.ts
+++ b/packages/core/examples/image_labels_overlay_with_value_picking/main.ts
@@ -141,12 +141,6 @@ toggleDiv.addEventListener("click", () => {
   idetik.layerManager.remove(labelsLayer);
   labelsLayer = createLabelsLayer();
   idetik.layerManager.add(labelsLayer);
-
-  // Clear pick info
-  pickInfoDiv.innerHTML = `
-    <strong>Mode changed to:</strong> ${outlineMode ? "Outline" : "Fill"}<br/>
-    Click on a label to see the effect.
-  `;
 });
 
 idetik.start();

--- a/packages/core/examples/image_labels_overlay_with_value_picking/main.ts
+++ b/packages/core/examples/image_labels_overlay_with_value_picking/main.ts
@@ -113,7 +113,7 @@ function createLabelsLayer() {
         Label Value: ${value}<br/>
         Mode: ${outlineMode ? "Outline" : "Fill"}
       `;
-      
+
       if (outlineMode) {
         // In outline mode, the layer handles the selection internally
       } else {
@@ -142,12 +142,12 @@ const idetik = new Idetik({
 toggleButton.addEventListener("click", () => {
   outlineMode = !outlineMode;
   toggleButton.textContent = `Mode: ${outlineMode ? "Outline" : "Fill"}`;
-  
+
   // Remove old layer and create new one with updated mode
   idetik.layerManager.remove(labelsLayer);
   labelsLayer = createLabelsLayer();
   idetik.layerManager.add(labelsLayer);
-  
+
   // Clear pick info
   pickInfoDiv.innerHTML = `
     <strong>Mode changed to:</strong> ${outlineMode ? "Outline" : "Fill"}<br/>

--- a/packages/core/src/layers/label_image_layer.ts
+++ b/packages/core/src/layers/label_image_layer.ts
@@ -18,6 +18,7 @@ export type LabelImageLayerProps = LayerOptions & {
   colorMap?: LabelColorMapProps;
   onPickValue?: (info: PointPickingResult) => void;
   lod?: number;
+  outlineSelected?: boolean;
 };
 
 export class LabelImageLayer extends Layer {
@@ -28,9 +29,11 @@ export class LabelImageLayer extends Layer {
   private readonly lod_?: number;
   private colorMap_: LabelColorMap;
   private readonly onPickValue_?: (info: PointPickingResult) => void;
+  private readonly outlineSelected_: boolean;
   private image_?: LabelImageRenderable;
   private imageChunk_?: Chunk;
   private pointerDownPos_: vec2 | null = null;
+  private selectedValue_: number | null = null;
 
   constructor({
     source,
@@ -38,6 +41,7 @@ export class LabelImageLayer extends Layer {
     colorMap = {},
     onPickValue,
     lod,
+    outlineSelected = false,
     ...layerOptions
   }: LabelImageLayerProps) {
     super(layerOptions);
@@ -47,6 +51,7 @@ export class LabelImageLayer extends Layer {
     this.colorMap_ = new LabelColorMap(colorMap);
     this.onPickValue_ = onPickValue;
     this.lod_ = lod;
+    this.outlineSelected_ = outlineSelected;
   }
 
   public update() {
@@ -75,12 +80,24 @@ export class LabelImageLayer extends Layer {
     }
   }
 
+  public setSelectedValue(value: number | null) {
+    this.selectedValue_ = value;
+    if (this.image_) {
+      this.image_.setSelectedValue(this.selectedValue_);
+    }
+  }
+
   public onEvent(event: EventContext) {
     this.pointerDownPos_ = handlePointPickingEvent(
       event,
       this.pointerDownPos_,
       (world) => this.getValueAtWorld(world),
-      this.onPickValue_
+      this.outlineSelected_ 
+        ? (info: PointPickingResult) => {
+            this.setSelectedValue(info.value);
+            this.onPickValue_?.(info);
+          }
+        : this.onPickValue_
     );
   }
 
@@ -105,6 +122,8 @@ export class LabelImageLayer extends Layer {
       geometry,
       imageData: Texture2D.createWithChunk(chunk),
       colorMap: this.colorMap_,
+      outlineSelected: this.outlineSelected_,
+      selectedValue: this.selectedValue_,
     });
     image.transform.setScale([chunk.scale.x, chunk.scale.y, 1]);
     image.transform.setTranslation([chunk.offset.x, chunk.offset.y, 0]);

--- a/packages/core/src/layers/label_image_layer.ts
+++ b/packages/core/src/layers/label_image_layer.ts
@@ -92,7 +92,7 @@ export class LabelImageLayer extends Layer {
       event,
       this.pointerDownPos_,
       (world) => this.getValueAtWorld(world),
-      this.outlineSelected_ 
+      this.outlineSelected_
         ? (info: PointPickingResult) => {
             this.setSelectedValue(info.value);
             this.onPickValue_?.(info);

--- a/packages/core/src/objects/renderable/label_image_renderable.ts
+++ b/packages/core/src/objects/renderable/label_image_renderable.ts
@@ -9,6 +9,8 @@ type LabelImageRenderableProps = {
   geometry: Geometry;
   imageData: Texture;
   colorMap: LabelColorMap;
+  outlineSelected?: boolean;
+  selectedValue?: number | null;
 };
 
 const supportedDataTypes = new Set<TextureDataType>([
@@ -32,6 +34,9 @@ function validateImageData(imageData: Texture) {
 }
 
 export class LabelImageRenderable extends RenderableObject {
+  private outlineSelected_: boolean;
+  private selectedValue_: number | null;
+
   constructor(props: LabelImageRenderableProps) {
     super();
     this.geometry = props.geometry;
@@ -42,6 +47,8 @@ export class LabelImageRenderable extends RenderableObject {
       props.colorMap.lookupTable
     );
     this.setTexture(2, colorLookupTableTexture);
+    this.outlineSelected_ = props.outlineSelected ?? false;
+    this.selectedValue_ = props.selectedValue ?? null;
     this.programName = "labelImage";
   }
 
@@ -54,12 +61,18 @@ export class LabelImageRenderable extends RenderableObject {
       ImageSampler: 0,
       ColorCycleSampler: 1,
       ColorLookupTableSampler: 2,
+      u_outlineSelected: this.outlineSelected_ ? 1.0 : 0.0,
+      u_selectedValue: this.selectedValue_ ?? -1.0,
     };
   }
 
   public setColorMap(colorMap: LabelColorMap) {
     this.setTexture(1, this.makeColorCycleTexture(colorMap.cycle));
     this.setTexture(2, this.makeColorLookupTableTexture(colorMap.lookupTable));
+  }
+
+  public setSelectedValue(value: number | null) {
+    this.selectedValue_ = value;
   }
 
   private makeColorCycleTexture(cycle: ReadonlyArray<Color>) {

--- a/packages/core/src/renderers/shaders/label_image_frag.glsl
+++ b/packages/core/src/renderers/shaders/label_image_frag.glsl
@@ -10,7 +10,7 @@ uniform mediump sampler2D ColorCycleSampler;
 uniform highp usampler2D ColorLookupTableSampler;
 
 uniform float u_opacity;
-uniform float u_outlineSelected;
+uniform float u_outlineSelected; // Note: Using float instead of bool due to framework uniform handling
 uniform float u_selectedValue;
 
 in vec2 TexCoords;
@@ -23,7 +23,7 @@ vec4 unpackRgba(uint packed) {
     return vec4(float(r), float(g), float(b), float(a)) / 255.0;
 }
 
-bool isEdgePixel(uint centerValue, vec2 texCoords) {
+bool isEdgePixel(uint centerValue) {
     vec2 texSize = vec2(textureSize(ImageSampler, 0));
     vec2 texelSize = 1.0 / texSize;
     
@@ -32,7 +32,7 @@ bool isEdgePixel(uint centerValue, vec2 texCoords) {
         for (int dy = -1; dy <= 1; dy++) {
             if (dx == 0 && dy == 0) continue; // Skip center pixel
             
-            vec2 neighborCoords = texCoords + vec2(float(dx), float(dy)) * texelSize;
+            vec2 neighborCoords = TexCoords + vec2(float(dx), float(dy)) * texelSize;
             
             // Skip if out of bounds
             if (neighborCoords.x < 0.0 || neighborCoords.x > 1.0 || 
@@ -52,15 +52,16 @@ bool isEdgePixel(uint centerValue, vec2 texCoords) {
 void main() {
     uint texel = texture(ImageSampler, TexCoords).r;
     
+    // Check if this pixel is the selected value
+    bool isSelectedValue = u_outlineSelected > 0.5 && u_selectedValue >= 0.0 && float(texel) == u_selectedValue;
+    
     // Check if we should outline this selected segment
-    if (u_outlineSelected > 0.5 && u_selectedValue >= 0.0 && float(texel) == u_selectedValue) {
-        if (isEdgePixel(texel, TexCoords)) {
-            // Draw outline in bright white with full opacity
-            fragColor = vec4(1.0, 1.0, 1.0, 1.0);
+    if (isSelectedValue) {
+        if (isEdgePixel(texel)) {
+            // Draw outline in bright white with layer opacity
+            fragColor = vec4(1.0, 1.0, 1.0, u_opacity);
             return;
         }
-        // For non-edge pixels of selected segment, use normal coloring but more transparent
-        // to make the outline stand out more
     }
 
     uint mapLength = uint(textureSize(ColorLookupTableSampler, 0).x);
@@ -71,9 +72,7 @@ void main() {
             vec4 color = unpackRgba(value);
             
             // If this is the selected segment and outlining is enabled, make it slightly transparent
-            float alpha = (u_outlineSelected > 0.5 && u_selectedValue >= 0.0 && float(texel) == u_selectedValue) 
-                ? u_opacity * color.a * 0.9 
-                : u_opacity * color.a;
+            float alpha = isSelectedValue ? u_opacity * color.a * 0.9 : u_opacity * color.a;
             
             fragColor = vec4(color.rgb, alpha);
             return;
@@ -85,9 +84,7 @@ void main() {
     vec4 color = texelFetch(ColorCycleSampler, ivec2(index, 0), 0);
     
     // If this is the selected segment and outlining is enabled, make it slightly transparent
-    float alpha = (u_outlineSelected > 0.5 && u_selectedValue >= 0.0 && float(texel) == u_selectedValue) 
-        ? u_opacity * color.a * 0.9 
-        : u_opacity * color.a;
+    float alpha = isSelectedValue ? u_opacity * color.a * 0.9 : u_opacity * color.a;
     
     fragColor = vec4(color.rgb, alpha);
 }

--- a/packages/core/src/renderers/shaders/label_image_frag.glsl
+++ b/packages/core/src/renderers/shaders/label_image_frag.glsl
@@ -72,7 +72,7 @@ void main() {
             
             // If this is the selected segment and outlining is enabled, make it slightly transparent
             float alpha = (u_outlineSelected > 0.5 && u_selectedValue >= 0.0 && float(texel) == u_selectedValue) 
-                ? u_opacity * color.a * 0.3 
+                ? u_opacity * color.a * 0.9 
                 : u_opacity * color.a;
             
             fragColor = vec4(color.rgb, alpha);
@@ -86,7 +86,7 @@ void main() {
     
     // If this is the selected segment and outlining is enabled, make it slightly transparent
     float alpha = (u_outlineSelected > 0.5 && u_selectedValue >= 0.0 && float(texel) == u_selectedValue) 
-        ? u_opacity * color.a * 0.3 
+        ? u_opacity * color.a * 0.9 
         : u_opacity * color.a;
     
     fragColor = vec4(color.rgb, alpha);

--- a/packages/core/src/renderers/shaders/label_image_frag.glsl
+++ b/packages/core/src/renderers/shaders/label_image_frag.glsl
@@ -10,6 +10,8 @@ uniform mediump sampler2D ColorCycleSampler;
 uniform highp usampler2D ColorLookupTableSampler;
 
 uniform float u_opacity;
+uniform float u_outlineSelected;
+uniform float u_selectedValue;
 
 in vec2 TexCoords;
 
@@ -21,8 +23,45 @@ vec4 unpackRgba(uint packed) {
     return vec4(float(r), float(g), float(b), float(a)) / 255.0;
 }
 
+bool isEdgePixel(uint centerValue, vec2 texCoords) {
+    vec2 texSize = vec2(textureSize(ImageSampler, 0));
+    vec2 texelSize = 1.0 / texSize;
+    
+    // Check 8-connected neighbors
+    for (int dx = -1; dx <= 1; dx++) {
+        for (int dy = -1; dy <= 1; dy++) {
+            if (dx == 0 && dy == 0) continue; // Skip center pixel
+            
+            vec2 neighborCoords = texCoords + vec2(float(dx), float(dy)) * texelSize;
+            
+            // Skip if out of bounds
+            if (neighborCoords.x < 0.0 || neighborCoords.x > 1.0 || 
+                neighborCoords.y < 0.0 || neighborCoords.y > 1.0) {
+                continue;
+            }
+            
+            uint neighborValue = texture(ImageSampler, neighborCoords).r;
+            if (neighborValue != centerValue) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
 void main() {
     uint texel = texture(ImageSampler, TexCoords).r;
+    
+    // Check if we should outline this selected segment
+    if (u_outlineSelected > 0.5 && u_selectedValue >= 0.0 && float(texel) == u_selectedValue) {
+        if (isEdgePixel(texel, TexCoords)) {
+            // Draw outline in bright white with full opacity
+            fragColor = vec4(1.0, 1.0, 1.0, 1.0);
+            return;
+        }
+        // For non-edge pixels of selected segment, use normal coloring but more transparent
+        // to make the outline stand out more
+    }
 
     uint mapLength = uint(textureSize(ColorLookupTableSampler, 0).x);
     for (uint i = 0u; i < mapLength; ++i) {
@@ -30,7 +69,13 @@ void main() {
         if (texel == key) {
             uint value = texelFetch(ColorLookupTableSampler, ivec2(i, 1), 0).r;
             vec4 color = unpackRgba(value);
-            fragColor = vec4(color.rgb, u_opacity * color.a);
+            
+            // If this is the selected segment and outlining is enabled, make it slightly transparent
+            float alpha = (u_outlineSelected > 0.5 && u_selectedValue >= 0.0 && float(texel) == u_selectedValue) 
+                ? u_opacity * color.a * 0.3 
+                : u_opacity * color.a;
+            
+            fragColor = vec4(color.rgb, alpha);
             return;
         }
     }
@@ -38,5 +83,11 @@ void main() {
     uint cycleLength = uint(textureSize(ColorCycleSampler, 0).x);
     uint index = uint(texel - 1u) % cycleLength;
     vec4 color = texelFetch(ColorCycleSampler, ivec2(index, 0), 0);
-    fragColor = vec4(color.rgb, u_opacity * color.a);
+    
+    // If this is the selected segment and outlining is enabled, make it slightly transparent
+    float alpha = (u_outlineSelected > 0.5 && u_selectedValue >= 0.0 && float(texel) == u_selectedValue) 
+        ? u_opacity * color.a * 0.3 
+        : u_opacity * color.a;
+    
+    fragColor = vec4(color.rgb, alpha);
 }


### PR DESCRIPTION
  ### Summary
  Adds an optional outline rendering mode for selected segments in `LabelImageLayer`, providing an alternative to the existing  fill-based selection highlighting.

  ### Changes
  - **LabelImageLayer**: Added `outlineSelected` option to enable outline mode for selected segments
  - **LabelImageRenderable**: Added support for outline uniforms (`u_outlineSelected`, `u_selectedValue`)
  - **Shader**: Enhanced label image fragment shader with edge detection and white outline rendering
  - **Example**: Updated image labels example with toggle button to switch between Fill and Outline modes

  ### Features
  - White outline rendering around selected segment boundaries using edge detection
  - Toggle between traditional fill mode (entire segment turns white) and new outline mode
  - Selected segments become slightly transparent (90% opacity) in outline mode to enhance outline visibility
  - Integrated toggle UI that matches existing info box styling

  ### Technical Details
  - Edge detection checks 8-connected neighbors to identify segment boundaries
  - Uses float uniforms for WebGL compatibility (boolean uniforms converted to 0.0/1.0)
  - Maintains backward compatibility - outline mode is opt-in via `outlineSelected` parameter

  ### Testing
  - Updated example demonstrates both modes with interactive toggle
  - Works with existing label picking and color mapping functionality


https://github.com/user-attachments/assets/900d1886-b1c4-4dc7-9a18-c7a8107f4f59

