### PR TITLE
Add image renderable pool

### DIFF
--- a/packages/core/src/layers/chunked_image_layer.ts
+++ b/packages/core/src/layers/chunked_image_layer.ts
@@ -14,6 +14,10 @@ import { handlePointPickingEvent, PointPickingResult } from "./point_picking";
 import { almostEqual } from "../utilities/almost_equal";
 import { clamp } from "../utilities/clamp";
 import { Region } from "../data/region";
+import {
+  RenderablePool,
+  poolKeyForImageRenderable,
+} from "../utilities/renderable_pool";
 
 export type ChunkedImageLayerProps = LayerOptions & {
   source: ChunkSource;
@@ -29,7 +33,8 @@ export class ChunkedImageLayer extends Layer {
   private readonly region_: Region;
   private readonly onPickValue_?: (info: PointPickingResult) => void;
   private readonly visibleChunks_: Map<Chunk, ImageRenderable> = new Map();
-  private channelProps_?: ChannelProps;
+  private readonly channelProps_?: ChannelProps;
+  private readonly pool_ = new RenderablePool<ImageRenderable>();
   private chunkManagerSource_?: ChunkManagerSource;
   private pointerDownPos_: vec2 | null = null;
   private zPrevPointWorld_?: number;
@@ -71,39 +76,27 @@ export class ChunkedImageLayer extends Layer {
 
   private updateChunks() {
     if (!this.chunkManagerSource_) return;
+    if (this.state !== "ready") this.setState("ready");
 
-    // Temporary until we decide how to approach state management
-    if (this.state !== "ready") {
-      this.setState("ready");
-    }
+    const ordered = this.chunkManagerSource_.getChunks();
+    const current = new Set(ordered);
 
-    // TODO:(shlomnissan) Reuse images instead of deleting and creating new ones.
-    //
-    // This loop removes image renderables for chunks that are no longer visible
-    // or no longer returned by getChunks() (e.g., due to LOD changes).
-    // While this approach works for now, it may be more efficient in the future
-    // to reuse renderables by updating their underlying data instead of repeatedly
-    // creating new texture objects. Note: GPU resources are not currently being
-    // released, so this will also need to be addressed soon.
-    const currentChunks = new Set(this.chunkManagerSource_.getChunks());
-    this.visibleChunks_.forEach((_image, chunk) => {
-      if (!currentChunks.has(chunk)) {
-        this.visibleChunks_.delete(chunk); // safe
+    // Release dropped chunks to the pool
+    this.visibleChunks_.forEach((image, chunk) => {
+      if (!current.has(chunk)) {
+        this.visibleChunks_.delete(chunk);
+        this.pool_.release(poolKeyForImageRenderable(chunk), image);
       }
     });
 
-    // Add all objects anew so that they respect the chunk order, which may
-    // capture details important for rendering, such as LOD, instead of the
-    // creation order, which is dependent on when the chunks finished loading.
+    // Rebuild draw list in correct order
     this.clearObjects();
-    currentChunks.forEach((chunk) => {
-      let image = this.visibleChunks_.get(chunk);
-      if (!image && chunk.state === "loaded") {
-        image = this.createImage(chunk);
-        this.visibleChunks_.set(chunk, image);
-      }
-      if (image) this.addObject(image);
-    });
+    for (const chunk of ordered) {
+      if (chunk.state !== "loaded") continue;
+      const image = this.getImageForChunk(chunk);
+      this.visibleChunks_.set(chunk, image);
+      this.addObject(image);
+    }
   }
 
   private resliceIfZChanged() {
@@ -117,7 +110,8 @@ export class ChunkedImageLayer extends Layer {
       if (chunk.state !== "loaded" || !chunk.data) continue;
       const data = this.slicePlane(chunk, pointWorld);
       if (data) {
-        image.textures[0].data = data;
+        const texture = image.textures[0] as Texture2DArray;
+        texture.updateWithChunk(chunk, data);
       }
     }
 
@@ -154,30 +148,54 @@ export class ChunkedImageLayer extends Layer {
     return chunk.data.slice(offset, offset + sliceSize);
   }
 
-  private createImage(chunk: Chunk) {
-    const geometry = new PlaneGeometry(chunk.shape.x, chunk.shape.y, 1, 1);
+  private getImageForChunk(chunk: Chunk) {
+    const existing = this.visibleChunks_.get(chunk);
+    if (existing) return existing;
 
-    let data = chunk.data;
-    const dimensions = this.chunkManagerSource?.dimensions;
-    if (dimensions?.z) {
-      data = this.slicePlane(chunk, dimensions.z.pointWorld);
+    const pooled = this.pool_.acquire(poolKeyForImageRenderable(chunk));
+    if (pooled) {
+      const texture = pooled.textures[0] as Texture2DArray;
+      texture.updateWithChunk(chunk, this.getDataForImage(chunk));
+      this.updateImageChunk(pooled, chunk);
+      return pooled;
     }
 
+    return this.createImage(chunk);
+  }
+
+  private createImage(chunk: Chunk) {
+    const geometry = new PlaneGeometry(chunk.shape.x, chunk.shape.y, 1, 1);
     const image = new ImageRenderable(
       geometry,
-      Texture2DArray.createWithChunk(chunk, data),
+      Texture2DArray.createWithChunk(chunk, this.getDataForImage(chunk)),
       this.channelProps_ ? [this.channelProps_] : [{}]
     );
+    this.updateImageChunk(image, chunk);
+    return image;
+  }
 
+  private getDataForImage(chunk: Chunk) {
+    const dims = this.chunkManagerSource_?.dimensions;
+    const data = dims?.z
+      ? this.slicePlane(chunk, dims.z.pointWorld)
+      : chunk.data;
+    if (!data) {
+      Logger.warn("ChunkedImageLayer", "No data for image");
+      return;
+    }
+    return data;
+  }
+
+  private updateImageChunk(image: ImageRenderable, chunk: Chunk) {
     if (this.debugMode_) {
       image.wireframeEnabled = true;
       image.wireframeColor =
         this.wireframeColors_[chunk.lod % this.wireframeColors_.length];
+    } else {
+      image.wireframeEnabled = false;
     }
-
     image.transform.setScale([chunk.scale.x, chunk.scale.y, 1]);
     image.transform.setTranslation([chunk.offset.x, chunk.offset.y, 0]);
-    return image;
   }
 
   public getValueAtWorld(world: vec3): number | null {

--- a/packages/core/src/layers/chunked_image_layer.ts
+++ b/packages/core/src/layers/chunked_image_layer.ts
@@ -14,10 +14,7 @@ import { handlePointPickingEvent, PointPickingResult } from "./point_picking";
 import { almostEqual } from "../utilities/almost_equal";
 import { clamp } from "../utilities/clamp";
 import { Region } from "../data/region";
-import {
-  RenderablePool,
-  poolKeyForImageRenderable,
-} from "../utilities/renderable_pool";
+import { RenderablePool } from "../utilities/renderable_pool";
 
 export type ChunkedImageLayerProps = LayerOptions & {
   source: ChunkSource;
@@ -78,10 +75,9 @@ export class ChunkedImageLayer extends Layer {
     if (!this.chunkManagerSource_) return;
     if (this.state !== "ready") this.setState("ready");
 
-    const ordered = this.chunkManagerSource_.getChunks();
-    const current = new Set(ordered);
+    const orderedByLOD = this.chunkManagerSource_.getChunks();
+    const current = new Set(orderedByLOD);
 
-    // Release dropped chunks to the pool
     this.visibleChunks_.forEach((image, chunk) => {
       if (!current.has(chunk)) {
         this.visibleChunks_.delete(chunk);
@@ -89,9 +85,8 @@ export class ChunkedImageLayer extends Layer {
       }
     });
 
-    // Rebuild draw list in correct order
     this.clearObjects();
-    for (const chunk of ordered) {
+    for (const chunk of orderedByLOD) {
       if (chunk.state !== "loaded") continue;
       const image = this.getImageForChunk(chunk);
       this.visibleChunks_.set(chunk, image);
@@ -261,4 +256,13 @@ export class ChunkedImageLayer extends Layer {
       }
     });
   }
+}
+
+export function poolKeyForImageRenderable(chunk: Chunk) {
+  return [
+    `lod${chunk.lod}`,
+    `shape${chunk.shape.x}x${chunk.shape.y}`,
+    `stride${chunk.rowStride}`,
+    `align${chunk.rowAlignmentBytes}`,
+  ].join(":");
 }

--- a/packages/core/src/layers/image_series_layer.ts
+++ b/packages/core/src/layers/image_series_layer.ts
@@ -124,7 +124,7 @@ export class ImageSeriesLayer extends Layer implements ChannelsEnabled {
         y: chunk.shape.y * chunk.scale.y,
       };
     } else if (chunk.data) {
-      this.texture_.data = chunk.data;
+      this.texture_.updateWithChunk(chunk);
     }
   }
 

--- a/packages/core/src/layers/label_image_series_layer.ts
+++ b/packages/core/src/layers/label_image_series_layer.ts
@@ -105,7 +105,7 @@ export class LabelImageSeriesLayer extends Layer {
         y: chunk.shape.y * chunk.scale.y,
       };
     } else if (chunk.data) {
-      this.texture_.data = chunk.data;
+      this.texture_.updateWithChunk(chunk);
     }
   }
 

--- a/packages/core/src/objects/textures/texture_2d.ts
+++ b/packages/core/src/objects/textures/texture_2d.ts
@@ -3,7 +3,7 @@ import {
   Texture,
   bufferToDataType,
 } from "../../objects/textures/texture";
-import { Chunk } from "../../data/chunk";
+import { Chunk, ChunkData } from "../../data/chunk";
 
 export class Texture2D extends Texture {
   private data_: DataTextureTypedArray;
@@ -41,13 +41,36 @@ export class Texture2D extends Texture {
     return this.height_;
   }
 
-  public static createWithChunk(chunk: Chunk) {
-    if (!chunk.data) {
+  public updateWithChunk(chunk: Chunk, data?: ChunkData) {
+    const source = data ?? chunk.data;
+    if (!source) {
       throw new Error(
-        "Unabled to create texture, chunk data is not initialized."
+        "Unable to update texture, chunk data is not initialized."
       );
     }
-    const texture = new Texture2D(chunk.data, chunk.shape.x, chunk.shape.y);
+
+    if (this.data === source) return;
+
+    if (
+      this.width != chunk.shape.x ||
+      this.height != chunk.shape.y ||
+      this.dataType != bufferToDataType(source)
+    ) {
+      throw new Error("Unable to update texture, texture buffer mismatch.");
+    }
+
+    this.data = source;
+  }
+
+  public static createWithChunk(chunk: Chunk, data?: ChunkData) {
+    const source = data ?? chunk.data;
+    if (!source) {
+      throw new Error(
+        "Unable to create texture, chunk data is not initialized."
+      );
+    }
+
+    const texture = new Texture2D(source, chunk.shape.x, chunk.shape.y);
     texture.unpackRowLength = chunk.rowStride;
     texture.unpackAlignment = chunk.rowAlignmentBytes;
     return texture;

--- a/packages/core/src/objects/textures/texture_2d_array.ts
+++ b/packages/core/src/objects/textures/texture_2d_array.ts
@@ -48,11 +48,36 @@ export class Texture2DArray extends Texture {
     return this.depth_;
   }
 
+  public updateWithChunk(chunk: Chunk, data?: ChunkData) {
+    const source = data ?? chunk.data;
+    if (!source) {
+      throw new Error(
+        "Unable to update texture, chunk data is not initialized."
+      );
+    }
+
+    if (this.data === source) return;
+
+    const width = chunk.shape.x;
+    const height = chunk.shape.y;
+    const depth = source.length / (width * height);
+    if (
+      this.width != width ||
+      this.height != height ||
+      this.depth_ != depth ||
+      this.dataType != bufferToDataType(source)
+    ) {
+      throw new Error("Unable to update texture, texture buffer mismatch.");
+    }
+
+    this.data = source;
+  }
+
   public static createWithChunk(chunk: Chunk, data?: ChunkData) {
     const source = data ?? chunk.data;
     if (!source) {
       throw new Error(
-        "Unabled to create texture, chunk data is not initialized."
+        "Unable to create texture, chunk data is not initialized."
       );
     }
     const texture = new Texture2DArray(source, chunk.shape.x, chunk.shape.y);

--- a/packages/core/src/utilities/logger.ts
+++ b/packages/core/src/utilities/logger.ts
@@ -17,11 +17,12 @@ const Colors = {
 // Add new module names here as needed to represent different parts of the application
 type Module =
   | "ChunkManager"
+  | "ChunkedImageLayer"
   | "EventDispatcher"
   | "Idetik"
-  | "ChunkedImageLayer"
   | "ImageLayer"
   | "LabelImageLayer"
+  | "RenderablePool"
   | "WebGLRenderer"
   | "WebGLShaderProgram"
   | "WebGLTexture"

--- a/packages/core/src/utilities/renderable_pool.ts
+++ b/packages/core/src/utilities/renderable_pool.ts
@@ -1,5 +1,4 @@
 import { RenderableObject } from "../core/renderable_object";
-import { Chunk } from "../data/chunk";
 import { Logger } from "./logger";
 
 export class RenderablePool<T extends RenderableObject> {
@@ -28,13 +27,4 @@ export class RenderablePool<T extends RenderableObject> {
     if (disposer) for (const bin of this.bins_.values()) bin.forEach(disposer);
     this.bins_.clear();
   }
-}
-
-export function poolKeyForImageRenderable(chunk: Chunk) {
-  return [
-    `lod${chunk.lod}`,
-    `shape${chunk.shape.x}x${chunk.shape.y}`,
-    `stride${chunk.rowStride}`,
-    `align${chunk.rowAlignmentBytes}`,
-  ].join(":");
 }

--- a/packages/core/src/utilities/renderable_pool.ts
+++ b/packages/core/src/utilities/renderable_pool.ts
@@ -1,0 +1,40 @@
+import { RenderableObject } from "../core/renderable_object";
+import { Chunk } from "../data/chunk";
+import { Logger } from "./logger";
+
+export class RenderablePool<T extends RenderableObject> {
+  private readonly bins_ = new Map<string, T[]>();
+
+  acquire(key: string) {
+    const bin = this.bins_.get(key);
+    const item = bin?.pop();
+    if (item) {
+      Logger.debug("RenderablePool", "Renderable object acquired");
+    }
+    return item;
+  }
+
+  release(key: string, item: T) {
+    let bin = this.bins_.get(key);
+    if (!bin) {
+      bin = [];
+      this.bins_.set(key, bin);
+    }
+    bin.push(item);
+    Logger.debug("RenderablePool", "Renderable object released");
+  }
+
+  clearAll(disposer?: (t: T) => void) {
+    if (disposer) for (const bin of this.bins_.values()) bin.forEach(disposer);
+    this.bins_.clear();
+  }
+}
+
+export function poolKeyForImageRenderable(chunk: Chunk) {
+  return [
+    `lod${chunk.lod}`,
+    `shape${chunk.shape.x}x${chunk.shape.y}`,
+    `stride${chunk.rowStride}`,
+    `align${chunk.rowAlignmentBytes}`,
+  ].join(":");
+}

--- a/packages/core/test/renderable_pool.test.ts
+++ b/packages/core/test/renderable_pool.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test, vi, beforeEach } from "vitest";
+import {
+  RenderablePool,
+  poolKeyForImageRenderable,
+} from "@/utilities/renderable_pool";
+import { RenderableObject } from "@/core/renderable_object";
+
+class RenderableStub extends RenderableObject {
+  public readonly type = "RenderableStub";
+}
+
+describe("RenderablePool", () => {
+  let pool: RenderablePool<RenderableStub>;
+
+  beforeEach(() => {
+    pool = new RenderablePool<RenderableStub>();
+    vi.restoreAllMocks();
+  });
+
+  test("acquire returns undefined when empty", () => {
+    const item = pool.acquire("k1");
+    expect(item).toBeUndefined();
+  });
+
+  test("release then acquire returns the same item", () => {
+    const a = new RenderableStub();
+    const b = new RenderableStub();
+
+    pool.release("k1", a);
+    pool.release("k1", b);
+
+    expect(pool.acquire("k1")).toBe(b);
+    expect(pool.acquire("k1")).toBe(a);
+    expect(pool.acquire("k1")).toBeUndefined();
+  });
+
+  test("bins are separated by key", () => {
+    const a = new RenderableStub();
+    const b = new RenderableStub();
+
+    pool.release("k1", a);
+    pool.release("k2", b);
+
+    expect(pool.acquire("k1")).toBe(a);
+    expect(pool.acquire("k2")).toBe(b);
+    expect(pool.acquire("k1")).toBeUndefined();
+    expect(pool.acquire("k2")).toBeUndefined();
+  });
+
+  test("clearAll calls disposer for all items and empties the pool", () => {
+    const a = new RenderableStub();
+    const b = new RenderableStub();
+    const c = new RenderableStub();
+    const disposer = vi.fn();
+
+    pool.release("k1", a);
+    pool.release("k1", b);
+    pool.release("k2", c);
+    pool.clearAll(disposer);
+
+    const args = disposer.mock.calls.map(([arg]) => arg);
+
+    expect(disposer).toHaveBeenCalledTimes(3);
+    expect(args).toEqual(expect.arrayContaining([a, b, c]));
+    expect(pool.acquire("k1")).toBeUndefined();
+    expect(pool.acquire("k2")).toBeUndefined();
+  });
+});
+
+describe("poolKeyForImageRenderable", () => {
+  test("builds a stable key string from chunk layout fields", () => {
+    const chunk = {
+      lod: 2,
+      shape: { x: 256, y: 128 },
+      rowStride: 256,
+      rowAlignmentBytes: 4,
+    } as unknown as import("../src/data/chunk").Chunk;
+
+    const key = poolKeyForImageRenderable(chunk);
+    expect(key).toBe("lod2:shape256x128:stride256:align4");
+  });
+});

--- a/packages/core/test/renderable_pool.test.ts
+++ b/packages/core/test/renderable_pool.test.ts
@@ -1,9 +1,7 @@
 import { describe, expect, test, vi, beforeEach } from "vitest";
-import {
-  RenderablePool,
-  poolKeyForImageRenderable,
-} from "@/utilities/renderable_pool";
+import { RenderablePool } from "@/utilities/renderable_pool";
 import { RenderableObject } from "@/core/renderable_object";
+import { poolKeyForImageRenderable } from "@/layers/chunked_image_layer";
 
 class RenderableStub extends RenderableObject {
   public readonly type = "RenderableStub";


### PR DESCRIPTION
### Summary

This PR introduces a renderable pool to recycle image renderables,
reducing allocation overhead. It also refactors the chunked image
layer to eliminate repetitive logic and adds defensive checks when
updating texture data.

### Tests & Checks
- Chunk info overlay shows:
  - Number of textures never exceeds the total number of tiles
  - Texture memory usage is bounded by the same limit
- Basic unit tests for verifying the pool's functionality
- Console logs when items are acquired or released from the pool
- Verified that all existing examples are working as expected
