### PR TITLE
Add assets for publishing to NPM

### DIFF
--- a/.github/workflows/lint-test-build.yml
+++ b/.github/workflows/lint-test-build.yml
@@ -29,14 +29,14 @@ jobs:
           npx playwright install chromium
 
       - name: Compile TypeScript
-        run: npm run compile --workspace=@idetik/core
+        run: npm run compile --workspace=@idetik/core-prerelease
 
       - name: Lint
         run: |
-          npm run lint --workspace=@idetik/core
-          npm run format-check --workspace=@idetik/core
-          npm run lint --workspace=@idetik/react
-          npm run format-check --workspace=@idetik/react
+          npm run lint --workspace=@idetik/core-prerelease
+          npm run format-check --workspace=@idetik/core-prerelease
+          npm run lint --workspace=@idetik/react-prerelease
+          npm run format-check --workspace=@idetik/react-prerelease
 
       - name: Run tests with coverage
         run: npm run test-with-coverage --workspace=@idetik/core

--- a/.github/workflows/lint-test-build.yml
+++ b/.github/workflows/lint-test-build.yml
@@ -39,7 +39,7 @@ jobs:
           npm run format-check --workspace=@idetik/react-prerelease
 
       - name: Run tests with coverage
-        run: npm run test-with-coverage --workspace=@idetik/core
+        run: npm run test-with-coverage --workspace=@idetik/core-prerelease
 
   build:
     needs: lint-and-test

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "idetik-review",
+  "name": "idetik",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -1504,7 +1504,11 @@
       "resolved": "packages/core",
       "link": true
     },
-    "node_modules/@idetik/react": {
+    "node_modules/@idetik/core-prerelease": {
+      "resolved": "packages/core",
+      "link": true
+    },
+    "node_modules/@idetik/react-prerelease": {
       "resolved": "packages/react",
       "link": true
     },
@@ -8156,7 +8160,7 @@
       }
     },
     "packages/core": {
-      "name": "@idetik/core",
+      "name": "@idetik/core-prerelease",
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
@@ -8170,8 +8174,8 @@
       }
     },
     "packages/react": {
-      "name": "@idetik/react",
-      "version": "0.0.1",
+      "name": "@idetik/react-prerelease",
+      "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
         "@base-ui-components/react": "^1.0.0-beta.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8157,7 +8157,7 @@
     },
     "packages/core": {
       "name": "@idetik/core-prerelease",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "gl-matrix": "^3.4.3",
@@ -8171,7 +8171,7 @@
     },
     "packages/react": {
       "name": "@idetik/react-prerelease",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "@base-ui-components/react": "^1.0.0-beta.2",
@@ -8187,7 +8187,7 @@
         "react-dom": "^18.3.1"
       },
       "devDependencies": {
-        "@idetik/core-prerelease": "^0.0.1",
+        "@idetik/core-prerelease": "^2.0.0",
         "@types/classnames": "^2.3.0",
         "autoprefixer": "^10.4.20",
         "classnames": "^2.5.1",
@@ -8195,21 +8195,9 @@
       },
       "peerDependencies": {
         "@czi-sds/components": "^22.3.0",
-        "@idetik/core-prerelease": "^1.0.0",
+        "@idetik/core-prerelease": "^2.0.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
-      }
-    },
-    "packages/react/node_modules/@idetik/core-prerelease": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@idetik/core-prerelease/-/core-prerelease-0.0.1.tgz",
-      "integrity": "sha512-A9HLw3zTqgweIAijnOlaXX+P9zMndu7vRzuWoixtBtaYLy68nXn7CnFonUO8oJ4IbVdui0xnja+6E1fmVnSKng==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "gl-matrix": "^3.4.3",
-        "zarrita": "^0.4.0-next.16",
-        "zod": "^3.24.1"
       }
     },
     "packages/react/node_modules/@mui/icons-material": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8171,7 +8171,7 @@
     },
     "packages/react": {
       "name": "@idetik/react-prerelease",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@base-ui-components/react": "^1.0.0-beta.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1500,10 +1500,6 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
-    "node_modules/@idetik/core": {
-      "resolved": "packages/core",
-      "link": true
-    },
     "node_modules/@idetik/core-prerelease": {
       "resolved": "packages/core",
       "link": true
@@ -8161,7 +8157,7 @@
     },
     "packages/core": {
       "name": "@idetik/core-prerelease",
-      "version": "0.0.1",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "gl-matrix": "^3.4.3",
@@ -8175,7 +8171,7 @@
     },
     "packages/react": {
       "name": "@idetik/react-prerelease",
-      "version": "0.0.0",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@base-ui-components/react": "^1.0.0-beta.2",
@@ -8191,7 +8187,7 @@
         "react-dom": "^18.3.1"
       },
       "devDependencies": {
-        "@idetik/core": "^0.0.1",
+        "@idetik/core-prerelease": "^0.0.1",
         "@types/classnames": "^2.3.0",
         "autoprefixer": "^10.4.20",
         "classnames": "^2.5.1",
@@ -8199,9 +8195,21 @@
       },
       "peerDependencies": {
         "@czi-sds/components": "^22.3.0",
-        "@idetik/core": "^0.0.1",
+        "@idetik/core-prerelease": "^1.0.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
+      }
+    },
+    "packages/react/node_modules/@idetik/core-prerelease": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@idetik/core-prerelease/-/core-prerelease-0.0.1.tgz",
+      "integrity": "sha512-A9HLw3zTqgweIAijnOlaXX+P9zMndu7vRzuWoixtBtaYLy68nXn7CnFonUO8oJ4IbVdui0xnja+6E1fmVnSKng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "gl-matrix": "^3.4.3",
+        "zarrita": "^0.4.0-next.16",
+        "zod": "^3.24.1"
       }
     },
     "packages/react/node_modules/@mui/icons-material": {

--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
     "packages/react"
   ],
   "scripts": {
-    "build": "npm run build --workspace=@idetik/core",
+    "build": "npm run build --workspace=@idetik/core-prerelease",
     "build:all": "npm run build --workspaces",
-    "examples": "npm run dev --workspace=@idetik/core",
-    "components": "npm run dev --workspace=@idetik/react",
+    "examples": "npm run dev --workspace=@idetik/core-prerelease",
+    "components": "npm run dev --workspace=@idetik/react-prerelease",
     "format:all": "npm run format --workspaces"
   },
   "devDependencies": {

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,6 +1,6 @@
 # @idetik/core-prerelease
 
-🚨 **This package is under active development and is subject to frequent changes.** Use at your own risk in production environments.
+🚨 **This package is under active development.** Use at your own risk in production environments.
 
 A layer-based visualization abstraction for interactive rendering of large datasets, with particular focus on scientific imaging and bioinformatics data formats.
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,53 @@
+# @idetik/core-prerelease
+
+🚨 **This package is under active development and is subject to frequent changes.** Use at your own risk in production environments.
+
+A layer-based visualization abstraction for interactive rendering of large datasets, with particular focus on scientific imaging and bioinformatics data formats.
+
+## Key Components
+
+### Core Architecture
+- `Idetik`: Main runtime
+- `LayerManager`: Manages layer composition and rendering order
+- `WebGLRenderer`: GPU-accelerated rendering engine
+- `Layer`: Base class for all visualization layers
+
+### Layer Types
+- `ImageLayer`: Static image rendering
+- `ChunkedImageLayer`: Streaming large image data
+- `ImageSeriesLayer`: Time-series and multi-dimensional images
+- `LabelImageLayer`: Segmentation masks and labels
+- `TracksLayer`: Object tracking visualization
+- `ProjectedLineLayer`: Line and curve rendering
+- `AxesLayer`: Coordinate system visualization
+
+## Examples
+
+The `/examples` directory contains comprehensive demonstrations:
+
+- **Basic image visualization**: 2D image rendering from OME-Zarr
+- **Multi-dimensional data**: 5D datasets (x, y, z, channel, time)
+- **High Content Screening**: Plate/well data visualization  
+- **Label overlays**: Segmentation masks with value picking
+- **Image series**: Time-lapse and z-stack navigation
+- **Streaming data**: Chunk-based loading for large datasets
+- **Layer composition**: Blending multiple visualization layers
+- **Interactive features**: Point selection and data sampling
+
+## Development
+
+### Building
+```bash
+npm run build  # Compile TypeScript and bundle
+```
+
+### Testing
+```bash
+npm test              # Run tests with watch mode
+npm run test-with-coverage  # Generate coverage report
+```
+
+### Development Server
+```bash
+npm run dev           # Start development server with examples
+```

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -4,36 +4,6 @@
 
 A layer-based visualization abstraction for interactive rendering of large datasets, with particular focus on scientific imaging and bioinformatics data formats.
 
-## Key Components
-
-### Core Architecture
-- `Idetik`: Main runtime
-- `LayerManager`: Manages layer composition and rendering order
-- `WebGLRenderer`: GPU-accelerated rendering engine
-- `Layer`: Base class for all visualization layers
-
-### Layer Types
-- `ImageLayer`: Static image rendering
-- `ChunkedImageLayer`: Streaming large image data
-- `ImageSeriesLayer`: Time-series and multi-dimensional images
-- `LabelImageLayer`: Segmentation masks and labels
-- `TracksLayer`: Object tracking visualization
-- `ProjectedLineLayer`: Line and curve rendering
-- `AxesLayer`: Coordinate system visualization
-
-## Examples
-
-The `/examples` directory contains comprehensive demonstrations:
-
-- **Basic image visualization**: 2D image rendering from OME-Zarr
-- **Multi-dimensional data**: 5D datasets (x, y, z, channel, time)
-- **High Content Screening**: Plate/well data visualization  
-- **Label overlays**: Segmentation masks with value picking
-- **Image series**: Time-lapse and z-stack navigation
-- **Streaming data**: Chunk-based loading for large datasets
-- **Layer composition**: Blending multiple visualization layers
-- **Interactive features**: Point selection and data sampling
-
 ## Development
 
 ### Building

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,4 +1,4 @@
-# @idetik/core-prerelease
+# @idetik/core
 
 🚨 **This package is under active development.** Use at your own risk in production environments.
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@idetik/core-prerelease",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@idetik/core-prerelease",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,7 +11,7 @@
     "format": "prettier --write './**/*.{ts,tsx,html,json}'",
     "format-check": "prettier --check './**/*.{ts,tsx,html,json}'",
     "lint": "eslint .",
-    "pub": "npm publish --access=public"
+    "pub": "npm run build; npm publish --access=public"
   },
   "dependencies": {
     "gl-matrix": "^3.4.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,5 @@
 {
-  "name": "@idetik/core",
-  "private": true,
+  "name": "@idetik/core-prerelease",
   "version": "0.0.1",
   "type": "module",
   "scripts": {
@@ -11,7 +10,8 @@
     "test-with-coverage": "vitest run --coverage",
     "format": "prettier --write './**/*.{ts,tsx,html,json}'",
     "format-check": "prettier --check './**/*.{ts,tsx,html,json}'",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "pub": "npm publish --access=public"
   },
   "dependencies": {
     "gl-matrix": "^3.4.3",
@@ -40,6 +40,9 @@
   },
   "author": "",
   "license": "MIT",
+  "keywords": [
+    "idetik"
+  ],
   "devDependencies": {
     "@apidevtools/json-schema-ref-parser": "^14.1.1",
     "json-schema-to-zod": "^2.6.1"

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,4 +1,4 @@
-# @idetik/react
+# @idetik/react-prerelease
 
 🚨 **This package is under active development.** Use at your own risk in production environments.
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,4 +1,4 @@
-# @idetik/react-prerelease
+# @idetik/react
 
 🚨 **This package is under active development.** Use at your own risk in production environments.
 
@@ -8,13 +8,19 @@ React components for interactive visualization of large datasets, built on the I
 
 ### Installation
 
+NPM
 ```bash
-npm install @idetik/react-prerelease
+npm i @idetik/react@npm:@idetik/react-prerelease @idetik/core@npm:@idetik/core-prerelease
+```
+
+Yarn
+```bash
+yarn add @idetik/react@npm:@idetik/react-prerelease@latest @idetik/core@npm:@idetik/core-prerelease@latest
 ```
 
 Add
 ```css
-@import "@idetik/react-prerelease/style.css";
+@import "@idetik/react/style.css";
 ```
 to you global CSS file.
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -16,7 +16,7 @@ Add
 ```css
 @import "@idetik/react-prerelease/style.css";
 ```
-to you global CSS file.
+to your global CSS file.
 
 ### Basic Usage: OmeZarrImageViewer (Reference Viewer)
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,6 +1,6 @@
 # @idetik/react
 
-🚨 **This package is under active development and is subject to frequent changes.** Use at your own risk in production environments.
+🚨 **This package is under active development.** Use at your own risk in production environments.
 
 React components for interactive visualization of large datasets, built on the Idetik runtime.
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -182,8 +182,8 @@ No need to host any data locally to start development.
 ### Development with Core Package
 
 If you make changes to the `@idetik/core` package, you'll need to:
-1. Rebuild the core package: `npm run build --workspace=@idetik/core`
-2. Rebuild this package: `npm run build --workspace=@idetik/react`
+1. Rebuild the core package: `npm run build --workspace=@idetik/core-prerelease`
+2. Rebuild this package: `npm run build --workspace=@idetik/react-prerelease`
 
 This ensures your React components use the latest version of the core package.
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,5 +1,7 @@
 # @idetik/react
 
+🚨 **This package is under active development and is subject to frequent changes.** Use at your own risk in production environments.
+
 React components for interactive visualization of large datasets, built on the Idetik runtime.
 
 ## For Integrators: Using @idetik/react Components

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -9,8 +9,14 @@ React components for interactive visualization of large datasets, built on the I
 ### Installation
 
 ```bash
-npm install @idetik/react @idetik/core
+npm install @idetik/react-prerelease
 ```
+
+Add
+```css
+@import "@idetik/react-prerelease/style.css";
+```
+to you global CSS file.
 
 ### Basic Usage: OmeZarrImageViewer (Reference Viewer)
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -8,19 +8,13 @@ React components for interactive visualization of large datasets, built on the I
 
 ### Installation
 
-NPM
 ```bash
-npm i @idetik/react@npm:@idetik/react-prerelease @idetik/core@npm:@idetik/core-prerelease
-```
-
-Yarn
-```bash
-yarn add @idetik/react@npm:@idetik/react-prerelease@latest @idetik/core@npm:@idetik/core-prerelease@latest
+npm i @idetik/react-prerelease @idetik/core-prerelease
 ```
 
 Add
 ```css
-@import "@idetik/react/style.css";
+@import "@idetik/react-prerelease/style.css";
 ```
 to you global CSS file.
 

--- a/packages/react/examples/local-files/App.tsx
+++ b/packages/react/examples/local-files/App.tsx
@@ -1,4 +1,4 @@
-import { Region } from "@idetik/core";
+import { Region } from "@idetik/core-prerelease";
 import { OmeZarrImageViewer } from "../../src/components/viewers/OmeZarrImageViewer";
 import { useState } from "react";
 

--- a/packages/react/examples/organelle-box-time/App.tsx
+++ b/packages/react/examples/organelle-box-time/App.tsx
@@ -1,4 +1,4 @@
-import { Region } from "@idetik/core";
+import { Region } from "@idetik/core-prerelease";
 import { OmeZarrImageViewer } from "../../src/components/viewers/OmeZarrImageViewer";
 import { useEffect, useState } from "react";
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@idetik/react-prerelease",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@idetik/react-prerelease",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -9,7 +9,7 @@
     "format": "prettier --write './**/*.{ts,tsx,html,json}'",
     "format-check": "prettier --check './**/*.{ts,tsx,html,json}'",
     "lint": "eslint .",
-    "pub": "npm publish --access=public"
+    "pub": "npm run build; npm publish --access=public"
   },
   "dependencies": {
     "@base-ui-components/react": "^1.0.0-beta.2",
@@ -58,7 +58,7 @@
   },
   "peerDependencies": {
     "@czi-sds/components": "^22.3.0",
-    "@idetik/core-prerelease": "^0.0.1",
+    "@idetik/core": "npm:@idetik/core-prerelease@^0.0.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -58,7 +58,7 @@
   },
   "peerDependencies": {
     "@czi-sds/components": "^22.3.0",
-    "@idetik/core": "npm:@idetik/core-prerelease@^0.0.1",
+    "@idetik/core-prerelease": "^0.0.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -50,7 +50,7 @@
     "idetik"
   ],
   "devDependencies": {
-    "@idetik/core-prerelease": "^0.0.1",
+    "@idetik/core-prerelease": "^1.0.0",
     "@types/classnames": "^2.3.0",
     "autoprefixer": "^10.4.20",
     "classnames": "^2.5.1",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@idetik/react-prerelease",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@idetik/react-prerelease",
-  "version": "0.0.3",
+  "version": "1.0.0",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -58,7 +58,7 @@
   },
   "peerDependencies": {
     "@czi-sds/components": "^22.3.0",
-    "@idetik/core-prerelease": "^0.0.1",
+    "@idetik/core-prerelease": "^1.0.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@idetik/react",
+  "name": "@idetik/react-prerelease",
   "version": "0.0.0",
   "type": "module",
   "scripts": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@idetik/react-prerelease",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -50,7 +50,7 @@
     "idetik"
   ],
   "devDependencies": {
-    "@idetik/core-prerelease": "^1.0.0",
+    "@idetik/core-prerelease": "^2.0.0",
     "@types/classnames": "^2.3.0",
     "autoprefixer": "^10.4.20",
     "classnames": "^2.5.1",
@@ -58,7 +58,7 @@
   },
   "peerDependencies": {
     "@czi-sds/components": "^22.3.0",
-    "@idetik/core-prerelease": "^1.0.0",
+    "@idetik/core-prerelease": "^2.0.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@idetik/react",
-  "private": true,
-  "version": "0.0.1",
+  "version": "0.0.0",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -9,7 +8,8 @@
     "build": "vite build && tsc && rollup -c rollup.config.js",
     "format": "prettier --write './**/*.{ts,tsx,html,json}'",
     "format-check": "prettier --check './**/*.{ts,tsx,html,json}'",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "pub": "npm publish --access=public"
   },
   "dependencies": {
     "@base-ui-components/react": "^1.0.0-beta.2",
@@ -46,6 +46,9 @@
   ],
   "author": "",
   "license": "MIT",
+  "keywords": [
+    "idetik"
+  ],
   "devDependencies": {
     "@idetik/core": "^0.0.1",
     "@types/classnames": "^2.3.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@idetik/react-prerelease",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -50,7 +50,7 @@
     "idetik"
   ],
   "devDependencies": {
-    "@idetik/core": "^0.0.1",
+    "@idetik/core-prerelease": "^0.0.1",
     "@types/classnames": "^2.3.0",
     "autoprefixer": "^10.4.20",
     "classnames": "^2.5.1",
@@ -58,7 +58,7 @@
   },
   "peerDependencies": {
     "@czi-sds/components": "^22.3.0",
-    "@idetik/core": "^0.0.1",
+    "@idetik/core-prerelease": "^0.0.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   }

--- a/packages/react/src/components/App.tsx
+++ b/packages/react/src/components/App.tsx
@@ -1,4 +1,4 @@
-import { Region } from "@idetik/core";
+import { Region } from "@idetik/core-prerelease";
 import { OmeZarrImageViewer } from "./viewers/OmeZarrImageViewer";
 import { useCallback, useRef, useState } from "react";
 

--- a/packages/react/src/components/providers/IdetikProvider.tsx
+++ b/packages/react/src/components/providers/IdetikProvider.tsx
@@ -1,6 +1,10 @@
 "use client";
 
-import { Idetik, OrthographicCamera, PanZoomControls } from "@idetik/core";
+import {
+  Idetik,
+  OrthographicCamera,
+  PanZoomControls,
+} from "@idetik/core-prerelease";
 import { PropsWithChildren, useState } from "react";
 import { IdetikContext, IdetikContextValue } from "../../hooks/useIdetik";
 

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
@@ -11,7 +11,7 @@ import {
   ChannelProps,
   Idetik,
   ImageLayer,
-} from "@idetik/core";
+} from "@idetik/core-prerelease";
 import { useIdetik } from "../../../hooks/useIdetik";
 import { IdetikCanvas } from "../../IdetikCanvas";
 import { Button, InputSlider, LoadingIndicator } from "@czi-sds/components";

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/components/ChannelControlsList/ChannelControlsList.tsx
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/components/ChannelControlsList/ChannelControlsList.tsx
@@ -6,7 +6,11 @@ import {
 } from "@czi-sds/components";
 import cns from "classnames";
 import { ChannelControl } from "./components/ChannelControl";
-import { ChannelProps, ColorLike, ChannelsEnabled } from "@idetik/core";
+import {
+  ChannelProps,
+  ColorLike,
+  ChannelsEnabled,
+} from "@idetik/core-prerelease";
 import { useSyncExternalStore } from "react";
 import { ExtraControlProps } from "../../utils";
 

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/components/ChannelControlsList/components/ChannelControl/ChannelControl.tsx
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/components/ChannelControlsList/components/ChannelControl/ChannelControl.tsx
@@ -1,4 +1,4 @@
-import { ColorLike } from "@idetik/core";
+import { ColorLike } from "@idetik/core-prerelease";
 import { VisibilityToggle } from "./components/VisibilityToggle";
 import { ColorPicker } from "./components/ColorPicker";
 import { ContrastSlider } from "./components/ContrastSlider";

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/components/ChannelControlsList/components/ChannelControl/components/ColorPicker/ColorPicker.tsx
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/components/ChannelControlsList/components/ChannelControl/components/ColorPicker/ColorPicker.tsx
@@ -1,4 +1,4 @@
-import { Color, ColorLike } from "@idetik/core";
+import { Color, ColorLike } from "@idetik/core-prerelease";
 
 interface ColorPickerProps {
   color: ColorLike;

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/components/ScaleBar/ScaleBar.tsx
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/components/ScaleBar/ScaleBar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useRef } from "react";
-import { Idetik, OrthographicCamera } from "@idetik/core";
+import { Idetik, OrthographicCamera } from "@idetik/core-prerelease";
 import cns from "classnames";
 import { useIdetik } from "hooks";
 

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/utils.ts
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/utils.ts
@@ -1,4 +1,4 @@
-import { OmeroChannel, ChannelProps, Color } from "@idetik/core";
+import { OmeroChannel, ChannelProps, Color } from "@idetik/core-prerelease";
 
 // these are the "extra" properties we need for rendering
 // the *control* that core does not track

--- a/packages/react/src/hooks/useIdetik.ts
+++ b/packages/react/src/hooks/useIdetik.ts
@@ -1,4 +1,4 @@
-import { Idetik } from "@idetik/core";
+import { Idetik } from "@idetik/core-prerelease";
 import { createContext, useContext } from "react";
 
 export type IdetikContextValue =


### PR DESCRIPTION
https://www.npmjs.com/package/@idetik/core-prerelease
https://www.npmjs.com/package/@idetik/react-prerelease

- The packages for now are called `[core|react]-prerelease` so that current clients can have some degree of safety with semver while allowing us to reserve `@idetik/[core|react]@1.0.0` for our true launch (at which point we can delete these temporary packages).
- Next step: Split the repos and delete the top-level NPM project.
- Added a Claude-generated README.md to `core` so that something shows up on the NPM page, but I could delete that if we don't think it helps.
- Adds disclaimers that the packages are under active development.