### PR TITLE
Update React example to use OrganelleBox time metadata

### DIFF
--- a/packages/core/examples/image2d_from_omezarr4d_hcs/main.ts
+++ b/packages/core/examples/image2d_from_omezarr4d_hcs/main.ts
@@ -6,7 +6,7 @@ import {
   PanZoomControls,
   Region,
   loadOmeroChannels,
-  loadOmeroDefaultZ,
+  loadOmeroDefaults,
   loadOmeZarrPlate,
   loadOmeZarrWell,
 } from "@";
@@ -57,7 +57,8 @@ const onImageChange = async () => {
   const imageUrl =
     plateUrl + "/" + wellSelector.value + "/" + imageSelector.value;
   const source = new OmeZarrImageSource(imageUrl);
-  const omeroDefaultZ = await loadOmeroDefaultZ(source);
+  const omeroDefaults = await loadOmeroDefaults(source);
+  const omeroDefaultZ = omeroDefaults?.defaultZ ?? 0;
   region[2] = {
     dimension: "Z",
     index: {

--- a/packages/core/examples/layer_blending/main.ts
+++ b/packages/core/examples/layer_blending/main.ts
@@ -6,7 +6,7 @@ import {
   OmeZarrImageSource,
   OrthographicCamera,
   Region,
-  loadOmeroDefaultZ,
+  loadOmeroDefaults,
 } from "@";
 import { blendMode } from "@/core/layer";
 
@@ -21,7 +21,8 @@ const source = new OmeZarrImageSource(url);
 let zIndex = 0;
 (async () => {
   try {
-    zIndex = await loadOmeroDefaultZ(source);
+    const defaults = await loadOmeroDefaults(source);
+    zIndex = defaults?.defaultZ ?? 0;
   } catch (error) {
     console.error("Error loading default Z index:", error);
   }

--- a/packages/core/src/data/ome_zarr/metadata_loaders.ts
+++ b/packages/core/src/data/ome_zarr/metadata_loaders.ts
@@ -148,12 +148,12 @@ export async function loadOmeroChannels(
   return image.omero?.channels ?? [];
 }
 
-export async function loadOmeroDefaultZ(
+export async function loadOmeroDefaults(
   source: OmeZarrImageSource
-): Promise<number> {
+): Promise<OmeroMetadata["rdefs"]> {
   const group = await openGroup(source.location);
   const image = parseOmeZarrImage(group.attrs);
-  return image.omero?.rdefs?.defaultZ ?? 0;
+  return image.omero?.rdefs;
 }
 
 function adaptImageV04ToV05(imagev04: ImageV04): Image {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -28,7 +28,7 @@ export type { Region } from "./data/region";
 export type { Image as OmeZarrImage } from "./data/ome_zarr/0.4/image";
 export {
   loadOmeroChannels,
-  loadOmeroDefaultZ,
+  loadOmeroDefaults,
   loadOmeZarrPlate,
   loadOmeZarrWell,
 } from "./data/ome_zarr/metadata_loaders";

--- a/packages/react/examples/organelle-box-time/App.tsx
+++ b/packages/react/examples/organelle-box-time/App.tsx
@@ -121,7 +121,7 @@ export default function App() {
         sourceUrl={imageUrl}
         region={region}
         seriesDimensionName={timeDimension}
-        initialIndex="start"
+        initialIndex="omeroDefault"
         loadAllButtonText="Load entire duration (105MB)"
         classNames={{
           root: "bg-dark-sds-color-primitive-gray-100 flex-auto min-h-0",

--- a/packages/react/examples/organelle-box-time/App.tsx
+++ b/packages/react/examples/organelle-box-time/App.tsx
@@ -3,17 +3,101 @@ import { OmeZarrImageViewer } from "../../src/components/viewers/OmeZarrImageVie
 import { useState } from "react";
 
 const sourceUrl =
-  "https://public.czbiohub.org/organelle_box/datasets/A549/2024_11_07_A549_SEC61_DENV_cropped.zarr";
-const wellPath = "B/3";
+  "https://public.czbiohub.org/organelle_box/datasets/A549/organelle_box_crop_3fov_v2.zarr";
+const wellPath = "G3BP1/Mock";
+const timeDimension = "T";
 const region: Region = [
-  { dimension: "T", index: { type: "full" } },
+  { dimension: timeDimension, index: { type: "full" } },
   { dimension: "C", index: { type: "full" } },
   { dimension: "Z", index: { type: "point", value: 0 } },
   { dimension: "Y", index: { type: "full" } },
   { dimension: "X", index: { type: "full" } },
 ];
 
-const imagePaths = ["000000", "000001", "000002", "001000", "001001", "001002"];
+const imagePaths = ["000000", "000001", "001001"];
+
+const wellMetadataName = "time_metadata.json";
+const wellMetadataUrl = `${sourceUrl}/${wellPath}/${wellMetadataName}`;
+
+type TimeMetadata = {
+  origin: string;
+  start: number;
+  step: number;
+  unit: string;
+};
+
+async function loadTimeMetadata(): Promise<TimeMetadata> {
+  const response = await fetch(wellMetadataUrl);
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch well metadata from ${wellMetadataUrl}: ${response.status} ${response.statusText}`
+    );
+  }
+  const wellMetadata = await response.json();
+
+  if (!("time_metadata" in wellMetadata)) {
+    throw new Error(`No time metadata found in ${wellMetadataUrl}`);
+  }
+  const timeMetadata = wellMetadata["time_metadata"];
+
+  if (!("origin" in timeMetadata)) {
+    throw new Error(`No time origin found in ${JSON.stringify(timeMetadata)}`);
+  }
+  const origin = timeMetadata["origin"];
+  if (typeof origin !== "string") {
+    throw new Error(`Invalid time origin ${origin}`);
+  }
+  if (origin !== "infection") {
+    throw new Error(`Unsupported time origin ${origin}`);
+  }
+
+  if (!("unit" in timeMetadata)) {
+    throw new Error(`No time unit found in ${JSON.stringify(timeMetadata)}`);
+  }
+  const unit = timeMetadata["unit"];
+  if (typeof unit !== "string") {
+    throw new Error(`Invalid time unit ${unit}`);
+  }
+  if (unit !== "minute") {
+    throw new Error(`Unsupported time unit ${unit}`);
+  }
+
+  if (!("start_time" in timeMetadata)) {
+    throw new Error(`No start time found in ${JSON.stringify(timeMetadata)}`);
+  }
+  const start = timeMetadata["start_time"];
+  if (typeof start !== "number") {
+    throw new Error(`Invalid start time ${start}`);
+  }
+
+  if (!("time-gap" in timeMetadata)) {
+    throw new Error(`No time gap found in ${JSON.stringify(timeMetadata)}`);
+  }
+  const step = timeMetadata["time-gap"];
+  if (typeof step !== "number") {
+    throw new Error(`Invalid time gap ${step}`);
+  }
+
+  return {
+    origin,
+    start,
+    step,
+    unit,
+  };
+}
+
+function timeIndicatorText(
+  currentIndex: number,
+  totalIndexes: number,
+  timeMetadata: TimeMetadata | null
+): string {
+  if (timeMetadata === null) {
+    return `${currentIndex} / ${totalIndexes} frames`;
+  }
+  const currentTime = timeMetadata.start + currentIndex * timeMetadata.step;
+  const totalTime = timeMetadata.start + totalIndexes * timeMetadata.step;
+  return `${(currentTime / 60).toFixed(1)} / ${(totalTime / 60).toFixed(1)} HPI`;
+}
 
 /** Organelle Box time use case demo. */
 export default function App() {
@@ -22,19 +106,28 @@ export default function App() {
   const imagePath = imagePaths[imageIndex];
   const imageUrl = `${sourceUrl}/${wellPath}/${imagePath}`;
 
+  const [timeMetadata, setTimeMetadata] = useState<TimeMetadata | null>(null);
+  if (timeMetadata === null) {
+    loadTimeMetadata()
+      .then((tm) => setTimeMetadata(tm))
+      .catch((error) => {
+        console.error("Failed to load time metadata:", error);
+      });
+  }
+
   return (
     <div className="h-screen flex flex-col">
       <OmeZarrImageViewer
         sourceUrl={imageUrl}
         region={region}
-        seriesDimensionName="T"
+        seriesDimensionName={timeDimension}
         initialIndex="start"
-        loadAllButtonText="Load entire duration (230MB)"
+        loadAllButtonText="Load entire duration (105MB)"
         classNames={{
           root: "bg-dark-sds-color-primitive-gray-100 flex-auto min-h-0",
         }}
         indexIndicatorText={(currentIndex, totalIndexes) =>
-          `${Math.floor(currentIndex / 60)}m${currentIndex % 60}s of ${Math.floor(totalIndexes / 60)}m${totalIndexes % 60}s`
+          timeIndicatorText(currentIndex, totalIndexes, timeMetadata)
         }
       />
       <input

--- a/packages/react/examples/organelle-box-time/App.tsx
+++ b/packages/react/examples/organelle-box-time/App.tsx
@@ -36,7 +36,9 @@ async function loadTimeMetadata(): Promise<TimeMetadata> {
   const wellMetadata = await response.json();
 
   if (!("time_metadata" in wellMetadata)) {
-    throw new Error(`No time metadata found in ${wellMetadataUrl}`);
+    throw new Error(
+      `No time metadata found in ${JSON.stringify(wellMetadataUrl)}`
+    );
   }
   const timeMetadata = wellMetadata["time_metadata"];
 

--- a/packages/react/examples/organelle-box-time/App.tsx
+++ b/packages/react/examples/organelle-box-time/App.tsx
@@ -1,6 +1,6 @@
 import { Region } from "@idetik/core";
 import { OmeZarrImageViewer } from "../../src/components/viewers/OmeZarrImageViewer";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 const sourceUrl =
   "https://public.czbiohub.org/organelle_box/datasets/A549/organelle_box_crop_3fov_v2.zarr";
@@ -78,6 +78,8 @@ async function loadTimeMetadata(): Promise<TimeMetadata> {
     throw new Error(`Invalid time gap ${step}`);
   }
 
+  console.debug("Loaded time metadata:", timeMetadata);
+
   return {
     origin,
     start,
@@ -107,13 +109,14 @@ export default function App() {
   const imageUrl = `${sourceUrl}/${wellPath}/${imagePath}`;
 
   const [timeMetadata, setTimeMetadata] = useState<TimeMetadata | null>(null);
-  if (timeMetadata === null) {
+
+  useEffect(() => {
     loadTimeMetadata()
       .then((tm) => setTimeMetadata(tm))
       .catch((error) => {
         console.error("Failed to load time metadata:", error);
       });
-  }
+  }, []);
 
   return (
     <div className="h-screen flex flex-col">

--- a/packages/react/src/components/App.tsx
+++ b/packages/react/src/components/App.tsx
@@ -74,7 +74,7 @@ export default function App() {
         sourceUrl={imageUrl}
         region={region}
         seriesDimensionName="Z"
-        initialIndex="omeroDefaultZ"
+        initialIndex="omeroDefault"
         classNames={{
           root: "bg-dark-sds-color-primitive-gray-100 flex-auto min-h-0",
         }}

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
@@ -7,7 +7,7 @@ import {
   ImageSeriesLayer,
   Region,
   loadOmeroChannels,
-  loadOmeroDefaultZ,
+  loadOmeroDefaults,
   ChannelProps,
   Idetik,
   ImageLayer,
@@ -39,7 +39,7 @@ export interface OmeZarrImageViewerProps {
   resolutionLevel?: number;
   shouldAutoLoadAllSlices?: boolean;
   shouldLoadMiddleZ?: boolean;
-  initialIndex?: "start" | "middle" | "end" | "omeroDefaultZ";
+  initialIndex?: "start" | "middle" | "end" | "omeroDefault";
   indexIndicatorText?:
     | string
     | ((currentIndex: number, totalIndexes: number) => string);
@@ -77,7 +77,7 @@ export function OmeZarrImageViewer({
   resolutionLevel = 0,
   shouldAutoLoadAllSlices = false,
   shouldLoadMiddleZ = false,
-  initialIndex = "omeroDefaultZ",
+  initialIndex = "omeroDefault",
   loadAllButtonText,
   indexIndicatorText,
   scaleBar = {
@@ -464,7 +464,14 @@ async function loadImageMetadata(
       const zShape = attrsForLevel.shape[zIdx];
       initialZ = zShape - 1;
     } else {
-      initialZ = await loadOmeroDefaultZ(source);
+      const defaults = await loadOmeroDefaults(source);
+      if (seriesDimensionName.toUpperCase() == "Z") {
+        initialZ = defaults?.defaultZ ?? 0;
+      } else if (seriesDimensionName.toUpperCase() == "T") {
+        initialZ = defaults?.defaultT ?? 0;
+      } else {
+        initialZ = 0;
+      }
     }
   } else if (zRegion) {
     switch (zRegion.index?.type) {

--- a/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
+++ b/packages/react/src/components/viewers/OmeZarrImageViewer/OmeZarrImageViewer.tsx
@@ -465,9 +465,9 @@ async function loadImageMetadata(
       initialZ = zShape - 1;
     } else {
       const defaults = await loadOmeroDefaults(source);
-      if (seriesDimensionName.toUpperCase() == "Z") {
+      if (seriesDimensionName.toUpperCase() === "Z") {
         initialZ = defaults?.defaultZ ?? 0;
-      } else if (seriesDimensionName.toUpperCase() == "T") {
+      } else if (seriesDimensionName.toUpperCase() === "T") {
         initialZ = defaults?.defaultT ?? 0;
       } else {
         initialZ = 0;


### PR DESCRIPTION
### Summary
This change updates the React example to use the newly added time metadata that is planned to be added in the OrganelleBox.

https://github.com/user-attachments/assets/a016746c-4e72-414b-948f-982b586c5372

The motivation behind this change was to use those metadata and share with the OrganelleBox team to ensure this type of display is sufficient. The example should also serve as an integration example.

As part of these changes, I modified the name and return type of `loadOmeroDefaultZ`, so that we can also pull out `defaultT` as needed for this example. I updated the `initialIndex` prop of the `OmeZarrImageViewer` appropriately. I'd like to improve the state of accessing these metadata in the future (e.g. avoiding the need for loading/parsing the main OME-Zarr JSON multiple times), but did not attempt that in this change.

### Tests & Checks
I manually tested the React examples.
I manually tested the manual examples.