### PR TITLE
Multiple Viewports: Introduce Viewport class and update Renderer.render() to take viewport

### DIFF
--- a/packages/core/src/core/renderer.ts
+++ b/packages/core/src/core/renderer.ts
@@ -1,15 +1,12 @@
-import { LayerManager } from "./layer_manager";
-import { Camera } from "../objects/cameras/camera";
 import { Color, ColorLike } from "./color";
 import { Layer } from "./layer";
-import { Box2 } from "../math/box2";
+import { Viewport } from "./viewport";
 
 export abstract class Renderer {
   private readonly canvas_: HTMLCanvasElement | null;
   private width_ = 0;
   private height_ = 0;
   private backgroundColor_: Color = new Color(0, 0, 0, 0);
-  private activeCamera_: Camera | null = null;
 
   protected abstract resize(width: number, height: number): void;
   protected abstract renderObject(layer: Layer, objectIndex: number): void;
@@ -20,19 +17,7 @@ export abstract class Renderer {
     this.updateRendererSize();
   }
 
-  protected set activeCamera(camera: Camera) {
-    if (this.activeCamera_ !== camera) {
-      this.activeCamera_ = camera;
-      this.updateActiveCamera();
-    }
-  }
-
-  // TODO: make this just take a Viewport instance once implemented
-  public abstract render(
-    layerManager: LayerManager,
-    camera: Camera,
-    viewportBox: Box2
-  ): void;
+  public abstract render(viewport: Viewport): void;
 
   public updateSize(): void {
     this.updateRendererSize();
@@ -45,15 +30,6 @@ export abstract class Renderer {
 
     if (this.canvas.width !== this.width_) this.canvas.width = this.width_;
     if (this.canvas.height !== this.height_) this.canvas.height = this.height_;
-
-    this.updateActiveCamera();
-  }
-
-  private updateActiveCamera() {
-    const canvasAspectRatio = this.width_ / this.height_;
-    if (this.activeCamera_) {
-      this.activeCamera_.setAspectRatio(canvasAspectRatio);
-    }
   }
 
   protected get canvas() {
@@ -74,14 +50,5 @@ export abstract class Renderer {
 
   public set backgroundColor(color: ColorLike) {
     this.backgroundColor_ = Color.from(color);
-  }
-
-  protected get activeCamera() {
-    if (this.activeCamera_ === null) {
-      throw new Error(
-        "Attempted to access the active camera before it was set."
-      );
-    }
-    return this.activeCamera_;
   }
 }

--- a/packages/core/src/core/renderer.ts
+++ b/packages/core/src/core/renderer.ts
@@ -1,3 +1,4 @@
+import { Camera } from "../objects/cameras/camera";
 import { Color, ColorLike } from "./color";
 import { Layer } from "./layer";
 import { Viewport } from "./viewport";
@@ -9,7 +10,11 @@ export abstract class Renderer {
   private backgroundColor_: Color = new Color(0, 0, 0, 0);
 
   protected abstract resize(width: number, height: number): void;
-  protected abstract renderObject(layer: Layer, objectIndex: number): void;
+  protected abstract renderObject(
+    layer: Layer,
+    objectIndex: number,
+    camera: Camera
+  ): void;
   protected abstract clear(): void;
 
   constructor(canvas: HTMLCanvasElement) {

--- a/packages/core/src/core/viewport.ts
+++ b/packages/core/src/core/viewport.ts
@@ -5,6 +5,7 @@ import { CameraControls } from "../objects/cameras/controls";
 import { Box2 } from "../math/box2";
 import { vec2, vec3 } from "gl-matrix";
 import { generateUUID } from "../utilities/uuid_generator";
+import { Logger } from "../utilities/logger";
 
 export interface ViewportConfig {
   id?: string;
@@ -104,6 +105,13 @@ export class Viewport {
 
   private updateAspectRatio(): void {
     const { width, height } = this.getBox().toRect();
+    if (width <= 0 || height <= 0) {
+      Logger.debug(
+        "Viewport",
+        `Skipping aspect ratio update for viewport ${this.id}: invalid dimensions ${width}x${height}`
+      );
+      return;
+    }
     const aspectRatio = width / height;
     this.camera.setAspectRatio(aspectRatio);
   }

--- a/packages/core/src/core/viewport.ts
+++ b/packages/core/src/core/viewport.ts
@@ -20,7 +20,7 @@ export class Viewport {
   public readonly element: HTMLElement;
   public readonly camera: Camera;
   public readonly layerManager: LayerManager;
-  public cameraControls: CameraControls | null = null;
+  public cameraControls?: CameraControls;
 
   private cachedViewportBox_: Box2 | null = null;
 
@@ -29,7 +29,7 @@ export class Viewport {
     this.element = config.element;
     this.camera = config.camera;
     this.layerManager = layerManager;
-    this.cameraControls = config.cameraControls ?? null;
+    this.cameraControls = config.cameraControls;
     this.updateAspectRatio();
 
     for (const layer of config.layers ?? []) {

--- a/packages/core/src/core/viewport.ts
+++ b/packages/core/src/core/viewport.ts
@@ -1,0 +1,154 @@
+import { Camera } from "../objects/cameras/camera";
+import { Layer } from "./layer";
+import { LayerManager } from "./layer_manager";
+import { CameraControls } from "../objects/cameras/controls";
+import { Box2 } from "../math/box2";
+import { vec2, vec3 } from "gl-matrix";
+import { generateUUID } from "../utilities/uuid_generator";
+
+export interface ViewportConfig {
+  id?: string;
+  element: HTMLElement;
+  camera: Camera;
+  layers?: Layer[];
+  cameraControls?: CameraControls;
+}
+
+export class Viewport {
+  public readonly id: string;
+  public readonly element: HTMLElement;
+  public readonly camera: Camera;
+  public cameraControls: CameraControls | null = null;
+
+  private readonly canvas_: HTMLCanvasElement;
+  private readonly layerManager_: LayerManager;
+  private cachedViewportBox_: Box2 | null = null;
+
+  constructor(
+    config: ViewportConfig,
+    layerManager: LayerManager,
+    canvas: HTMLCanvasElement
+  ) {
+    this.id = config.id || config.element.id || generateUUID();
+    this.element = config.element;
+    this.canvas_ = canvas;
+    this.camera = config.camera;
+    this.cameraControls = config.cameraControls ?? null;
+    this.layerManager_ = layerManager;
+    this.updateAspectRatio();
+
+    for (const layer of config.layers ?? []) {
+      this.layerManager_.add(layer);
+    }
+  }
+
+  public get layerManager(): LayerManager {
+    return this.layerManager_;
+  }
+
+  public updateSize(): void {
+    this.cachedViewportBox_ = null;
+    this.updateAspectRatio();
+  }
+
+  public getViewportBox(): Box2 {
+    if (this.cachedViewportBox_) {
+      return this.cachedViewportBox_;
+    }
+
+    const rect = this.element.getBoundingClientRect();
+    const canvasRect = this.canvas_.getBoundingClientRect();
+    const devicePixelRatio = window.devicePixelRatio || 1;
+
+    // Calculate viewport position relative to canvas in CSS pixels
+    const cssX = rect.left - canvasRect.left;
+    const cssY = rect.top - canvasRect.top;
+    const cssWidth = rect.width;
+    const cssHeight = rect.height;
+
+    // Convert to device pixels for WebGL viewport
+    // Note: WebGL Y coordinate is flipped, so we adjust the Y position
+    const x = Math.floor(cssX * devicePixelRatio);
+    const y = Math.floor(
+      (canvasRect.height - cssY - cssHeight) * devicePixelRatio
+    );
+    const width = Math.floor(cssWidth * devicePixelRatio);
+    const height = Math.floor(cssHeight * devicePixelRatio);
+
+    this.cachedViewportBox_ = new Box2(
+      vec2.fromValues(x, y),
+      vec2.fromValues(x + width, y + height)
+    );
+
+    return this.cachedViewportBox_;
+  }
+
+  public clientToClip(position: vec2, depth: number = 0): vec3 {
+    const [x, y] = position;
+    const rect = this.element.getBoundingClientRect();
+    return vec3.fromValues(
+      (2 * (x - rect.x)) / rect.width - 1,
+      (2 * (y - rect.y)) / rect.height - 1,
+      depth
+    );
+  }
+
+  public clientToWorld(position: vec2, depth: number = 0): vec3 {
+    const clipPos = this.clientToClip(position, depth);
+    return this.camera.clipToWorld(clipPos);
+  }
+
+  private updateAspectRatio(): void {
+    const { width, height } = this.getViewportBox().toRect();
+    const aspectRatio = width / height;
+    this.camera.setAspectRatio(aspectRatio);
+  }
+}
+
+function validateViewportConfigs(viewportConfigs: ViewportConfig[]): void {
+  const elementToViewportId = new Map<HTMLElement, string>();
+  const seenViewportIds = new Set<string>();
+
+  for (const config of viewportConfigs) {
+    const viewportId = config.id || config.element.id;
+
+    // check for duplicate viewport IDs if we have an explicit ID
+    // (viewports without IDs will get unique generated IDs)
+    if (viewportId && seenViewportIds.has(viewportId)) {
+      throw new Error(
+        `Duplicate viewport ID "${viewportId}". Each viewport must have a unique ID.`
+      );
+    }
+    if (viewportId) {
+      seenViewportIds.add(viewportId);
+    }
+
+    const newViewportId = viewportId || "unnamed-viewport";
+
+    // check for multiple viewports specified with the same element
+    if (elementToViewportId.has(config.element)) {
+      const existingViewportId = elementToViewportId.get(config.element)!;
+      const elementDescription =
+        config.element.tagName.toLowerCase() +
+        (config.element.id ? `#${config.element.id}` : "[element has no id]");
+      throw new Error(
+        `Multiple viewports cannot share the same HTML element: ` +
+          `viewports "${existingViewportId}" and "${newViewportId}" both use ${elementDescription}`
+      );
+    }
+    elementToViewportId.set(config.element, newViewportId);
+  }
+}
+
+export function parseViewportConfigs(
+  viewportConfigs: ViewportConfig[],
+  createLayerManager: () => LayerManager,
+  canvas: HTMLCanvasElement
+): Viewport[] {
+  validateViewportConfigs(viewportConfigs);
+
+  return viewportConfigs.map((config) => {
+    const layerManager = createLayerManager();
+    return new Viewport(config, layerManager, canvas);
+  });
+}

--- a/packages/core/src/core/viewport.ts
+++ b/packages/core/src/core/viewport.ts
@@ -18,10 +18,10 @@ export class Viewport {
   public readonly id: string;
   public readonly element: HTMLElement;
   public readonly camera: Camera;
+  public readonly layerManager: LayerManager;
   public cameraControls: CameraControls | null = null;
 
   private readonly canvas_: HTMLCanvasElement;
-  private readonly layerManager_: LayerManager;
   private cachedViewportBox_: Box2 | null = null;
 
   constructor(
@@ -33,18 +33,15 @@ export class Viewport {
     this.element = config.element;
     this.canvas_ = canvas;
     this.camera = config.camera;
+    this.layerManager = layerManager;
     this.cameraControls = config.cameraControls ?? null;
-    this.layerManager_ = layerManager;
     this.updateAspectRatio();
 
     for (const layer of config.layers ?? []) {
-      this.layerManager_.add(layer);
+      this.layerManager.add(layer);
     }
   }
 
-  public get layerManager(): LayerManager {
-    return this.layerManager_;
-  }
 
   public updateSize(): void {
     this.cachedViewportBox_ = null;

--- a/packages/core/src/core/viewport.ts
+++ b/packages/core/src/core/viewport.ts
@@ -42,7 +42,6 @@ export class Viewport {
     }
   }
 
-
   public updateSize(): void {
     this.cachedViewportBox_ = null;
     this.updateAspectRatio();

--- a/packages/core/src/core/viewport.ts
+++ b/packages/core/src/core/viewport.ts
@@ -47,7 +47,7 @@ export class Viewport {
     this.updateAspectRatio();
   }
 
-  public getViewportBox(): Box2 {
+  public getBoxRelativeToCanvas(): Box2 {
     if (this.cachedViewportBox_) {
       return this.cachedViewportBox_;
     }
@@ -95,7 +95,7 @@ export class Viewport {
   }
 
   private updateAspectRatio(): void {
-    const { width, height } = this.getViewportBox().toRect();
+    const { width, height } = this.getBoxRelativeToCanvas().toRect();
     const aspectRatio = width / height;
     this.camera.setAspectRatio(aspectRatio);
   }

--- a/packages/core/src/core/viewport.ts
+++ b/packages/core/src/core/viewport.ts
@@ -21,17 +21,11 @@ export class Viewport {
   public readonly layerManager: LayerManager;
   public cameraControls: CameraControls | null = null;
 
-  private readonly canvas_: HTMLCanvasElement;
   private cachedViewportBox_: Box2 | null = null;
 
-  constructor(
-    config: ViewportConfig,
-    layerManager: LayerManager,
-    canvas: HTMLCanvasElement
-  ) {
+  constructor(config: ViewportConfig, layerManager: LayerManager) {
     this.id = config.id || config.element.id || generateUUID();
     this.element = config.element;
-    this.canvas_ = canvas;
     this.camera = config.camera;
     this.layerManager = layerManager;
     this.cameraControls = config.cameraControls ?? null;
@@ -47,36 +41,30 @@ export class Viewport {
     this.updateAspectRatio();
   }
 
-  public getBoxRelativeToCanvas(): Box2 {
-    if (this.cachedViewportBox_) {
-      return this.cachedViewportBox_;
-    }
-
-    const rect = this.element.getBoundingClientRect();
-    const canvasRect = this.canvas_.getBoundingClientRect();
+  public getBoxRelativeTo(canvas: HTMLCanvasElement): Box2 {
+    const viewportRect = this.getBox().toRect();
+    const canvasRect = canvas.getBoundingClientRect();
     const devicePixelRatio = window.devicePixelRatio || 1;
 
-    // Calculate viewport position relative to canvas in CSS pixels
-    const cssX = rect.left - canvasRect.left;
-    const cssY = rect.top - canvasRect.top;
-    const cssWidth = rect.width;
-    const cssHeight = rect.height;
+    // convert canvas rect to device pixels
+    // viewport rect is already in device pixels
+    const canvasX = canvasRect.left * devicePixelRatio;
+    const canvasY = canvasRect.top * devicePixelRatio;
+    const canvasHeight = canvasRect.height * devicePixelRatio;
 
-    // Convert to device pixels for WebGL viewport
+    const relativeX = viewportRect.x - canvasX;
+    const relativeY = viewportRect.y - canvasY;
+
     // Note: WebGL Y coordinate is flipped, so we adjust the Y position
-    const x = Math.floor(cssX * devicePixelRatio);
-    const y = Math.floor(
-      (canvasRect.height - cssY - cssHeight) * devicePixelRatio
-    );
-    const width = Math.floor(cssWidth * devicePixelRatio);
-    const height = Math.floor(cssHeight * devicePixelRatio);
+    const x = Math.floor(relativeX);
+    const y = Math.floor(canvasHeight - relativeY - viewportRect.height);
+    const width = Math.floor(viewportRect.width);
+    const height = Math.floor(viewportRect.height);
 
-    this.cachedViewportBox_ = new Box2(
+    return new Box2(
       vec2.fromValues(x, y),
       vec2.fromValues(x + width, y + height)
     );
-
-    return this.cachedViewportBox_;
   }
 
   public clientToClip(position: vec2, depth: number = 0): vec3 {
@@ -94,8 +82,28 @@ export class Viewport {
     return this.camera.clipToWorld(clipPos);
   }
 
+  private getBox(): Box2 {
+    if (this.cachedViewportBox_) {
+      return this.cachedViewportBox_;
+    }
+    const viewportRect = this.element.getBoundingClientRect();
+    const devicePixelRatio = window.devicePixelRatio || 1;
+
+    const x = viewportRect.left * devicePixelRatio;
+    const y = viewportRect.top * devicePixelRatio;
+    const width = viewportRect.width * devicePixelRatio;
+    const height = viewportRect.height * devicePixelRatio;
+
+    this.cachedViewportBox_ = new Box2(
+      vec2.fromValues(x, y),
+      vec2.fromValues(x + width, y + height)
+    );
+
+    return this.cachedViewportBox_;
+  }
+
   private updateAspectRatio(): void {
-    const { width, height } = this.getBoxRelativeToCanvas().toRect();
+    const { width, height } = this.getBox().toRect();
     const aspectRatio = width / height;
     this.camera.setAspectRatio(aspectRatio);
   }
@@ -138,13 +146,12 @@ function validateViewportConfigs(viewportConfigs: ViewportConfig[]): void {
 
 export function parseViewportConfigs(
   viewportConfigs: ViewportConfig[],
-  createLayerManager: () => LayerManager,
-  canvas: HTMLCanvasElement
+  createLayerManager: () => LayerManager
 ): Viewport[] {
   validateViewportConfigs(viewportConfigs);
 
   return viewportConfigs.map((config) => {
     const layerManager = createLayerManager();
-    return new Viewport(config, layerManager, canvas);
+    return new Viewport(config, layerManager);
   });
 }

--- a/packages/core/src/idetik.ts
+++ b/packages/core/src/idetik.ts
@@ -161,7 +161,7 @@ export class Idetik {
         vec2.fromValues(this.renderer_.width, this.renderer_.height)
       );
       for (const viewport of this.viewports_) {
-        const viewportBox = viewport.getViewportBox();
+        const viewportBox = viewport.getBoxRelativeToCanvas();
         if (!Box2.intersects(rendererBox, viewportBox)) {
           Logger.debug(
             "Idetik",

--- a/packages/core/src/idetik.ts
+++ b/packages/core/src/idetik.ts
@@ -14,7 +14,6 @@ import {
   Viewport,
   ViewportConfig,
 } from "./core/viewport";
-import { Box2 } from "./math/box2";
 
 type Overlay = {
   update(idetik: Idetik, timestamp?: DOMHighResTimeStamp): void;
@@ -81,11 +80,7 @@ export class Idetik {
     // TEMP: pass closure to reuse the main LayerManager instead of creating new ones
     // This avoids circular import issues while maintaining shared context
     const createLayerManager = () => new LayerManager(this.context_);
-    this.viewports_ = parseViewportConfigs(
-      viewportConfigs,
-      createLayerManager,
-      canvas
-    );
+    this.viewports_ = parseViewportConfigs(viewportConfigs, createLayerManager);
 
     this.overlays = params.overlays ?? [];
 
@@ -156,24 +151,11 @@ export class Idetik {
         this.updateSize();
       }
 
-      const rendererBox = new Box2(
-        vec2.fromValues(0, 0),
-        vec2.fromValues(this.renderer_.width, this.renderer_.height)
-      );
       for (const viewport of this.viewports_) {
-        const viewportBox = viewport.getBoxRelativeToCanvas();
-        if (!Box2.intersects(rendererBox, viewportBox)) {
-          Logger.debug(
-            "Idetik",
-            `Viewport ${viewport.id} is entirely outside canvas bounds, skipping render`
-          );
-          continue;
-        }
         if (viewport.camera.type === "OrthographicCamera") {
-          const width = viewportBox.toRect().width;
           this.chunkManager_.update(
             viewport.camera as OrthographicCamera,
-            width
+            viewport.getBoxRelativeTo(this.canvas).toRect().width
           );
         }
         this.renderer_.render(viewport);

--- a/packages/core/src/idetik.ts
+++ b/packages/core/src/idetik.ts
@@ -9,6 +9,11 @@ import { ChunkManager } from "./core/chunk_manager";
 import { vec2, vec3 } from "gl-matrix";
 import { OrthographicCamera } from "./objects/cameras/orthographic_camera";
 import { createStats, type Stats } from "./utilities/stats";
+import {
+  parseViewportConfigs,
+  Viewport,
+  ViewportConfig,
+} from "./core/viewport";
 import { Box2 } from "./math/box2";
 
 type Overlay = {
@@ -30,14 +35,12 @@ export type IdetikContext = {
 };
 
 export class Idetik {
-  private cameraControls_?: CameraControls;
   private lastAnimationId_?: number;
   private needsResize_ = false;
   private readonly chunkManager_: ChunkManager;
   private readonly context_: IdetikContext;
   private readonly renderer_: WebGLRenderer;
-  public camera: Camera;
-  public layerManager: LayerManager;
+  private readonly viewports_: Viewport[];
   public readonly canvas: HTMLCanvasElement;
   public readonly events: EventDispatcher;
   public readonly overlays: Overlay[];
@@ -51,8 +54,6 @@ export class Idetik {
       throw new Error("Cannot provide both canvas and canvasSelector");
     }
 
-    this.camera = params.camera;
-    this.cameraControls_ = params.cameraControls;
     const canvas =
       params.canvas ??
       document.querySelector<HTMLCanvasElement>(params.canvasSelector!);
@@ -60,18 +61,31 @@ export class Idetik {
       throw new Error(`Canvas not found: ${params.canvasSelector}`);
     }
     this.canvas = canvas;
+
     this.renderer_ = new WebGLRenderer(canvas);
     this.chunkManager_ = new ChunkManager();
     this.context_ = {
       chunkManager: this.chunkManager_,
     };
-    this.layerManager = new LayerManager(this.context_);
 
-    if (params.layers) {
-      for (const layer of params.layers) {
-        this.layerManager.add(layer);
-      }
-    }
+    // TEMP: creating a single viewport for now to maintain the existing API
+    const viewportConfigs: ViewportConfig[] = [
+      {
+        id: "main",
+        element: canvas,
+        camera: params.camera,
+        layers: params.layers,
+        cameraControls: params.cameraControls,
+      },
+    ];
+    // TEMP: pass closure to reuse the main LayerManager instead of creating new ones
+    // This avoids circular import issues while maintaining shared context
+    const createLayerManager = () => new LayerManager(this.context_);
+    this.viewports_ = parseViewportConfigs(
+      viewportConfigs,
+      createLayerManager,
+      canvas
+    );
 
     this.overlays = params.overlays ?? [];
 
@@ -92,7 +106,7 @@ export class Idetik {
         layer.onEvent(event);
         if (event.propagationStopped) return;
       }
-      this.cameraControls_?.onEvent(event);
+      this.cameraControls?.onEvent(event);
     });
   }
 
@@ -108,57 +122,63 @@ export class Idetik {
     return this.renderer_.textureInfo;
   }
 
-  public set cameraControls(controls: CameraControls | undefined) {
-    this.cameraControls_ = controls;
+  // TEMP: backward-compatible getters/setter for camera, layerManager, and cameraControls
+  // to be removed on completion of multi-viewport implementation
+  public get camera() {
+    return this.viewports_[0].camera;
+  }
+
+  public get layerManager() {
+    return this.viewports_[0].layerManager;
+  }
+
+  public set cameraControls(controls: CameraControls | null) {
+    this.viewports_[0].cameraControls = controls;
+  }
+
+  public get cameraControls() {
+    return this.viewports_[0].cameraControls;
   }
 
   public clientToClip(position: vec2, depth: number = 0): vec3 {
-    const [x, y] = position;
-    const rect = this.canvas.getBoundingClientRect();
-    return vec3.fromValues(
-      (2 * (x - rect.x)) / this.canvas.clientWidth - 1,
-      (2 * (y - rect.y)) / this.canvas.clientHeight - 1,
-      depth
-    );
+    return this.viewports_[0].clientToClip(position, depth);
   }
 
   public start() {
     Logger.info("Idetik", "Idetik runtime started");
-    new ResizeObserver(() => {
-      this.needsResize_ = true;
-    }).observe(this.canvas);
+    this.startLayoutObservers();
 
     const render = (timestamp?: DOMHighResTimeStamp) => {
       if (this.stats_) this.stats_.begin();
 
-      if (!this.camera) {
-        Logger.warn(
-          "Idetik",
-          "A camera must be set before starting the Idetik runtime"
-        );
-        return;
-      }
-
-      if (this.camera.type === "OrthographicCamera") {
-        this.chunkManager_.update(
-          this.camera as OrthographicCamera,
-          this.renderer_.width
-        );
-      }
-
       // Must resize before render b/c changing canvas coordinate space clears it.
       if (this.needsResize_) {
-        this.renderer_.updateSize();
-        this.needsResize_ = false;
+        this.updateSize();
       }
 
-      // TEMP: in the future, the renderer will manage a list of dynamically-sized viewports
-      // instead of passing its own box to itself
-      const viewportBox = new Box2(
+      const rendererBox = new Box2(
         vec2.fromValues(0, 0),
         vec2.fromValues(this.renderer_.width, this.renderer_.height)
       );
-      this.renderer_.render(this.layerManager, this.camera, viewportBox);
+      for (const viewport of this.viewports_) {
+        const viewportBox = viewport.getViewportBox();
+        if (!Box2.intersects(rendererBox, viewportBox)) {
+          Logger.debug(
+            "Idetik",
+            `Viewport ${viewport.id} is entirely outside canvas bounds, skipping render`
+          );
+          continue;
+        }
+        if (viewport.camera.type === "OrthographicCamera") {
+          const width = viewportBox.toRect().width;
+          this.chunkManager_.update(
+            viewport.camera as OrthographicCamera,
+            width
+          );
+        }
+        this.renderer_.render(viewport);
+      }
+
       for (const overlay of this.overlays) {
         overlay.update(this, timestamp);
       }
@@ -174,5 +194,41 @@ export class Idetik {
     if (this.lastAnimationId_ !== undefined) {
       cancelAnimationFrame(this.lastAnimationId_);
     }
+  }
+
+  private startLayoutObservers() {
+    const resizeObserver = new ResizeObserver(() => {
+      this.needsResize_ = true;
+    });
+
+    resizeObserver.observe(this.canvas);
+    for (const viewport of this.viewports_) {
+      if (viewport.element !== this.canvas) {
+        resizeObserver.observe(viewport.element);
+      }
+    }
+
+    const startDevicePixelRatioObserver = () => {
+      const mediaQuery = matchMedia(
+        `(resolution: ${window.devicePixelRatio}dppx)`
+      );
+      mediaQuery.addEventListener(
+        "change",
+        () => {
+          this.needsResize_ = true;
+          startDevicePixelRatioObserver();
+        },
+        { once: true }
+      );
+    };
+    startDevicePixelRatioObserver();
+  }
+
+  private updateSize() {
+    this.renderer_.updateSize();
+    for (const viewport of this.viewports_) {
+      viewport.updateSize();
+    }
+    this.needsResize_ = false;
   }
 }

--- a/packages/core/src/idetik.ts
+++ b/packages/core/src/idetik.ts
@@ -187,6 +187,9 @@ export class Idetik {
     }
 
     const startDevicePixelRatioObserver = () => {
+      // this media query needs to be updated after a change is detected, so we use a one-time
+      // event listener that re-registers itself with the new value
+      // https://developer.mozilla.org/en-US/docs/Web/API/Window/devicePixelRatio#monitoring_screen_resolution_or_zoom_level_changes
       const mediaQuery = matchMedia(
         `(resolution: ${window.devicePixelRatio}dppx)`
       );

--- a/packages/core/src/idetik.ts
+++ b/packages/core/src/idetik.ts
@@ -101,7 +101,7 @@ export class Idetik {
         layer.onEvent(event);
         if (event.propagationStopped) return;
       }
-      this.cameraControls?.onEvent(event);
+      this.viewports_[0].cameraControls?.onEvent(event);
     });
   }
 
@@ -127,12 +127,8 @@ export class Idetik {
     return this.viewports_[0].layerManager;
   }
 
-  public set cameraControls(controls: CameraControls | null) {
+  public set cameraControls(controls: CameraControls | undefined) {
     this.viewports_[0].cameraControls = controls;
-  }
-
-  public get cameraControls() {
-    return this.viewports_[0].cameraControls;
   }
 
   public clientToClip(position: vec2, depth: number = 0): vec3 {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,6 +11,9 @@ export type { LayerState } from "./core/layer";
 export { LayerManager } from "./core/layer_manager";
 export type { EventContext } from "./core/event_dispatcher";
 
+export { Viewport, parseViewportConfigs } from "./core/viewport";
+export type { ViewportConfig } from "./core/viewport";
+
 export { AxesLayer } from "./layers/axes_layer";
 export { ProjectedLineLayer } from "./layers/projected_line_layer";
 export { TracksLayer } from "./layers/tracks_layer";

--- a/packages/core/src/renderers/webgl_renderer.ts
+++ b/packages/core/src/renderers/webgl_renderer.ts
@@ -69,7 +69,7 @@ export class WebGLRenderer extends Renderer {
       this.state_.setScissor(viewportBox);
       this.state_.setScissorTest(true);
     } else {
-      Logger.debug(
+      Logger.warn(
         "WebGLRenderer",
         `Viewport ${viewport.id} is entirely outside canvas bounds, skipping render`
       );

--- a/packages/core/src/renderers/webgl_renderer.ts
+++ b/packages/core/src/renderers/webgl_renderer.ts
@@ -7,12 +7,12 @@ import { WebGLBuffers } from "./webgl_buffers";
 import { WebGLTextures } from "./webgl_textures";
 
 import { Layer } from "../core/layer";
-import { LayerManager } from "../core/layer_manager";
-import { Camera } from "../objects/cameras/camera";
 import { WebGLState } from "./WebGLState";
 import { RenderableObject } from "../core/renderable_object";
 import { Geometry, Primitive } from "../core/geometry";
 import { Box2 } from "../math/box2";
+import { Viewport } from "../core/viewport";
+import { Camera } from "../objects/cameras/camera";
 
 import { mat4, vec2 } from "gl-matrix";
 
@@ -34,6 +34,7 @@ export class WebGLRenderer extends Renderer {
   private readonly bindings_: WebGLBuffers;
   private readonly textures_: WebGLTextures;
   private readonly state_: WebGLState;
+  private activeCamera_: Camera | null = null;
 
   constructor(canvas: HTMLCanvasElement) {
     super(canvas);
@@ -57,7 +58,8 @@ export class WebGLRenderer extends Renderer {
     this.resize(this.canvas.width, this.canvas.height);
   }
 
-  public render(layerManager: LayerManager, camera: Camera, viewportBox: Box2) {
+  public render(viewport: Viewport) {
+    const viewportBox = viewport.getViewportBox();
     const rendererBox = new Box2(
       vec2.fromValues(0, 0),
       vec2.fromValues(this.width, this.height)
@@ -71,9 +73,9 @@ export class WebGLRenderer extends Renderer {
     this.state_.setViewport(viewportBox);
 
     this.clear();
-    this.activeCamera = camera;
+    this.activeCamera_ = viewport.camera;
 
-    const { opaque, transparent } = layerManager.partitionLayers();
+    const { opaque, transparent } = viewport.layerManager.partitionLayers();
 
     this.state_.setDepthMask(true);
     for (const layer of opaque) {
@@ -133,15 +135,19 @@ export class WebGLRenderer extends Renderer {
     layer: Layer,
     program: WebGLShaderProgram
   ) {
+    if (!this.activeCamera_) {
+      throw new Error("No active camera set for rendering");
+    }
+
     const modelView = mat4.multiply(
       mat4.create(),
-      this.activeCamera.viewMatrix,
+      this.activeCamera_.viewMatrix,
       object.transform.matrix
     );
     const projection = mat4.multiply(
       mat4.create(),
       axisDirection,
-      this.activeCamera.projectionMatrix
+      this.activeCamera_.projectionMatrix
     );
     const resolution = [this.canvas.width, this.canvas.height];
 

--- a/packages/core/src/renderers/webgl_renderer.ts
+++ b/packages/core/src/renderers/webgl_renderer.ts
@@ -34,7 +34,6 @@ export class WebGLRenderer extends Renderer {
   private readonly bindings_: WebGLBuffers;
   private readonly textures_: WebGLTextures;
   private readonly state_: WebGLState;
-  private activeCamera_: Camera | null = null;
 
   constructor(canvas: HTMLCanvasElement) {
     super(canvas);
@@ -59,7 +58,7 @@ export class WebGLRenderer extends Renderer {
   }
 
   public render(viewport: Viewport) {
-    const viewportBox = viewport.getViewportBox();
+    const viewportBox = viewport.getBoxRelativeToCanvas();
     const rendererBox = new Box2(
       vec2.fromValues(0, 0),
       vec2.fromValues(this.width, this.height)
@@ -73,7 +72,6 @@ export class WebGLRenderer extends Renderer {
     this.state_.setViewport(viewportBox);
 
     this.clear();
-    this.activeCamera_ = viewport.camera;
 
     const { opaque, transparent } = viewport.layerManager.partitionLayers();
 
@@ -81,7 +79,7 @@ export class WebGLRenderer extends Renderer {
     for (const layer of opaque) {
       layer.update();
       if (layer.state === "ready") {
-        this.renderLayer(layer);
+        this.renderLayer(layer, viewport.camera);
       }
     }
 
@@ -89,7 +87,7 @@ export class WebGLRenderer extends Renderer {
     for (const layer of transparent) {
       layer.update();
       if (layer.state !== "ready") continue;
-      this.renderLayer(layer);
+      this.renderLayer(layer, viewport.camera);
     }
     this.state_.setDepthMask(true);
   }
@@ -98,12 +96,12 @@ export class WebGLRenderer extends Renderer {
     return this.textures_.textureInfo;
   }
 
-  private renderLayer(layer: Layer) {
+  private renderLayer(layer: Layer, camera: Camera) {
     this.state_.setBlendingMode(layer.transparent ? layer.blendMode : "none");
-    layer.objects.forEach((_, i) => this.renderObject(layer, i));
+    layer.objects.forEach((_, i) => this.renderObject(layer, i, camera));
   }
 
-  protected renderObject(layer: Layer, objectIndex: number) {
+  protected renderObject(layer: Layer, objectIndex: number, camera: Camera) {
     const object = layer.objects[objectIndex];
     this.bindings_.bindGeometry(object.geometry);
     object.popStaleTextures().forEach((texture) => {
@@ -114,7 +112,7 @@ export class WebGLRenderer extends Renderer {
     });
 
     const program = this.programs_.use(object.programName);
-    this.drawGeometry(object.geometry, object, layer, program);
+    this.drawGeometry(object.geometry, object, layer, program, camera);
 
     if (object.wireframeEnabled) {
       this.bindings_.bindGeometry(object.wireframeGeometry);
@@ -124,7 +122,8 @@ export class WebGLRenderer extends Renderer {
         object.wireframeGeometry,
         object,
         layer,
-        wireframeProgram
+        wireframeProgram,
+        camera
       );
     }
   }
@@ -133,21 +132,18 @@ export class WebGLRenderer extends Renderer {
     geometry: Geometry,
     object: RenderableObject,
     layer: Layer,
-    program: WebGLShaderProgram
+    program: WebGLShaderProgram,
+    camera: Camera
   ) {
-    if (!this.activeCamera_) {
-      throw new Error("No active camera set for rendering");
-    }
-
     const modelView = mat4.multiply(
       mat4.create(),
-      this.activeCamera_.viewMatrix,
+      camera.viewMatrix,
       object.transform.matrix
     );
     const projection = mat4.multiply(
       mat4.create(),
       axisDirection,
-      this.activeCamera_.projectionMatrix
+      camera.projectionMatrix
     );
     const resolution = [this.canvas.width, this.canvas.height];
 

--- a/packages/core/src/renderers/webgl_renderer.ts
+++ b/packages/core/src/renderers/webgl_renderer.ts
@@ -58,16 +58,22 @@ export class WebGLRenderer extends Renderer {
   }
 
   public render(viewport: Viewport) {
-    const viewportBox = viewport.getBoxRelativeToCanvas();
+    const viewportBox = viewport.getBoxRelativeTo(this.canvas);
     const rendererBox = new Box2(
       vec2.fromValues(0, 0),
       vec2.fromValues(this.width, this.height)
     );
     if (Box2.equals(viewportBox.floor(), rendererBox.floor())) {
       this.state_.setScissorTest(false);
-    } else {
+    } else if (Box2.intersects(viewportBox, rendererBox)) {
       this.state_.setScissor(viewportBox);
       this.state_.setScissorTest(true);
+    } else {
+      Logger.debug(
+        "WebGLRenderer",
+        `Viewport ${viewport.id} is entirely outside canvas bounds, skipping render`
+      );
+      return;
     }
     this.state_.setViewport(viewportBox);
 

--- a/packages/core/src/utilities/logger.ts
+++ b/packages/core/src/utilities/logger.ts
@@ -23,6 +23,7 @@ type Module =
   | "ImageLayer"
   | "LabelImageLayer"
   | "RenderablePool"
+  | "Viewport"
   | "WebGLRenderer"
   | "WebGLShaderProgram"
   | "WebGLTexture"

--- a/packages/core/test/viewport.test.ts
+++ b/packages/core/test/viewport.test.ts
@@ -14,11 +14,6 @@ function createTestElement(id: string): HTMLElement {
   return element;
 }
 
-function createTestCanvas(): HTMLCanvasElement {
-  const canvas = document.createElement("canvas");
-  return canvas;
-}
-
 function createTestCamera(): OrthographicCamera {
   return new OrthographicCamera(-1, 1, -1, 1);
 }
@@ -34,8 +29,7 @@ test("Viewport constructor uses provided ID", () => {
     camera,
   };
 
-  const canvas = createTestCanvas();
-  const viewport = new Viewport(config, layerManager, canvas);
+  const viewport = new Viewport(config, layerManager);
   expect(viewport.id).toBe("custom-viewport");
 });
 
@@ -49,8 +43,7 @@ test("Viewport constructor falls back to element ID", () => {
     camera,
   };
 
-  const canvas = createTestCanvas();
-  const viewport = new Viewport(config, layerManager, canvas);
+  const viewport = new Viewport(config, layerManager);
   expect(viewport.id).toBe("element-id");
 });
 
@@ -65,8 +58,7 @@ test("Viewport constructor generates a fallback ID when not provided or availabl
     camera,
   };
 
-  const canvas = createTestCanvas();
-  const viewport = new Viewport(config, layerManager, canvas);
+  const viewport = new Viewport(config, layerManager);
   expect(viewport.id).toBeDefined();
   expect(viewport.id.length).toBeGreaterThan(0);
 });
@@ -82,11 +74,7 @@ test("parseViewportConfigs creates viewports with validation", () => {
     { id: "viewport2", element: element2, camera: camera2 },
   ];
 
-  const viewports = parseViewportConfigs(
-    configs,
-    () => new LayerManager(),
-    createTestCanvas()
-  );
+  const viewports = parseViewportConfigs(configs, () => new LayerManager());
 
   expect(viewports).toHaveLength(2);
   expect(viewports[0].id).toBe("viewport1");
@@ -106,9 +94,9 @@ test("parseViewportConfigs throws on duplicate IDs", () => {
     { id: "duplicate", element: element2, camera: camera2 },
   ];
 
-  expect(() =>
-    parseViewportConfigs(configs, () => new LayerManager(), createTestCanvas())
-  ).toThrow('Duplicate viewport ID "duplicate"');
+  expect(() => parseViewportConfigs(configs, () => new LayerManager())).toThrow(
+    'Duplicate viewport ID "duplicate"'
+  );
 });
 
 test("parseViewportConfigs throws on shared elements", () => {
@@ -121,9 +109,9 @@ test("parseViewportConfigs throws on shared elements", () => {
     { id: "viewport2", element: sharedElement, camera: camera2 },
   ];
 
-  expect(() =>
-    parseViewportConfigs(configs, () => new LayerManager(), createTestCanvas())
-  ).toThrow("Multiple viewports cannot share the same HTML element");
+  expect(() => parseViewportConfigs(configs, () => new LayerManager())).toThrow(
+    "Multiple viewports cannot share the same HTML element"
+  );
 });
 
 test("parseViewportConfigs allows viewports without explicit IDs", () => {
@@ -137,11 +125,7 @@ test("parseViewportConfigs allows viewports without explicit IDs", () => {
     { element: element2, camera: camera2 },
   ];
 
-  const viewports = parseViewportConfigs(
-    configs,
-    () => new LayerManager(),
-    createTestCanvas()
-  );
+  const viewports = parseViewportConfigs(configs, () => new LayerManager());
 
   expect(viewports).toHaveLength(2);
   expect(viewports[0].id).toBe("element1");

--- a/packages/core/test/viewport.test.ts
+++ b/packages/core/test/viewport.test.ts
@@ -19,9 +19,13 @@ function createTestCanvas(): HTMLCanvasElement {
   return canvas;
 }
 
+function createTestCamera(): OrthographicCamera {
+  return new OrthographicCamera(-1, 1, -1, 1);
+}
+
 test("Viewport constructor uses provided ID", () => {
   const element = createTestElement("test-element");
-  const camera = new OrthographicCamera(-1, 1, -1, 1, 0.1, 1000);
+  const camera = createTestCamera();
   const layerManager = new LayerManager();
 
   const config: ViewportConfig = {
@@ -37,7 +41,7 @@ test("Viewport constructor uses provided ID", () => {
 
 test("Viewport constructor falls back to element ID", () => {
   const element = createTestElement("element-id");
-  const camera = new OrthographicCamera(-1, 1, -1, 1, 0.1, 1000);
+  const camera = createTestCamera();
   const layerManager = new LayerManager();
 
   const config: ViewportConfig = {
@@ -50,10 +54,10 @@ test("Viewport constructor falls back to element ID", () => {
   expect(viewport.id).toBe("element-id");
 });
 
-test("Viewport constructor generates UUID when no ID available", () => {
+test("Viewport constructor generates a fallback ID when not provided or available", () => {
   const element = createTestElement("");
   element.id = ""; // Ensure no ID
-  const camera = new OrthographicCamera(-1, 1, -1, 1, 0.1, 1000);
+  const camera = createTestCamera();
   const layerManager = new LayerManager();
 
   const config: ViewportConfig = {
@@ -70,8 +74,8 @@ test("Viewport constructor generates UUID when no ID available", () => {
 test("parseViewportConfigs creates viewports with validation", () => {
   const element1 = createTestElement("viewport1");
   const element2 = createTestElement("viewport2");
-  const camera1 = new OrthographicCamera(-1, 1, -1, 1, 0.1, 1000);
-  const camera2 = new OrthographicCamera(-1, 1, -1, 1, 0.1, 1000);
+  const camera1 = createTestCamera();
+  const camera2 = createTestCamera();
 
   const configs: ViewportConfig[] = [
     { id: "viewport1", element: element1, camera: camera1 },
@@ -94,8 +98,8 @@ test("parseViewportConfigs creates viewports with validation", () => {
 test("parseViewportConfigs throws on duplicate IDs", () => {
   const element1 = createTestElement("viewport1");
   const element2 = createTestElement("viewport2");
-  const camera1 = new OrthographicCamera(-1, 1, -1, 1, 0.1, 1000);
-  const camera2 = new OrthographicCamera(-1, 1, -1, 1, 0.1, 1000);
+  const camera1 = createTestCamera();
+  const camera2 = createTestCamera();
 
   const configs: ViewportConfig[] = [
     { id: "duplicate", element: element1, camera: camera1 },
@@ -109,8 +113,8 @@ test("parseViewportConfigs throws on duplicate IDs", () => {
 
 test("parseViewportConfigs throws on shared elements", () => {
   const sharedElement = createTestElement("shared");
-  const camera1 = new OrthographicCamera(-1, 1, -1, 1, 0.1, 1000);
-  const camera2 = new OrthographicCamera(-1, 1, -1, 1, 0.1, 1000);
+  const camera1 = createTestCamera();
+  const camera2 = createTestCamera();
 
   const configs: ViewportConfig[] = [
     { id: "viewport1", element: sharedElement, camera: camera1 },
@@ -125,8 +129,8 @@ test("parseViewportConfigs throws on shared elements", () => {
 test("parseViewportConfigs allows viewports without explicit IDs", () => {
   const element1 = createTestElement("element1");
   const element2 = createTestElement("element2");
-  const camera1 = new OrthographicCamera(-1, 1, -1, 1, 0.1, 1000);
-  const camera2 = new OrthographicCamera(-1, 1, -1, 1, 0.1, 1000);
+  const camera1 = createTestCamera();
+  const camera2 = createTestCamera();
 
   const configs: ViewportConfig[] = [
     { element: element1, camera: camera1 },

--- a/packages/core/test/viewport.test.ts
+++ b/packages/core/test/viewport.test.ts
@@ -1,0 +1,145 @@
+import { expect, test } from "vitest";
+
+import {
+  Viewport,
+  ViewportConfig,
+  parseViewportConfigs,
+  LayerManager,
+  OrthographicCamera,
+} from "@";
+
+function createTestElement(id: string): HTMLElement {
+  const element = document.createElement("div");
+  element.id = id;
+  return element;
+}
+
+function createTestCanvas(): HTMLCanvasElement {
+  const canvas = document.createElement("canvas");
+  return canvas;
+}
+
+test("Viewport constructor uses provided ID", () => {
+  const element = createTestElement("test-element");
+  const camera = new OrthographicCamera(-1, 1, -1, 1, 0.1, 1000);
+  const layerManager = new LayerManager();
+
+  const config: ViewportConfig = {
+    id: "custom-viewport",
+    element,
+    camera,
+  };
+
+  const canvas = createTestCanvas();
+  const viewport = new Viewport(config, layerManager, canvas);
+  expect(viewport.id).toBe("custom-viewport");
+});
+
+test("Viewport constructor falls back to element ID", () => {
+  const element = createTestElement("element-id");
+  const camera = new OrthographicCamera(-1, 1, -1, 1, 0.1, 1000);
+  const layerManager = new LayerManager();
+
+  const config: ViewportConfig = {
+    element,
+    camera,
+  };
+
+  const canvas = createTestCanvas();
+  const viewport = new Viewport(config, layerManager, canvas);
+  expect(viewport.id).toBe("element-id");
+});
+
+test("Viewport constructor generates UUID when no ID available", () => {
+  const element = createTestElement("");
+  element.id = ""; // Ensure no ID
+  const camera = new OrthographicCamera(-1, 1, -1, 1, 0.1, 1000);
+  const layerManager = new LayerManager();
+
+  const config: ViewportConfig = {
+    element,
+    camera,
+  };
+
+  const canvas = createTestCanvas();
+  const viewport = new Viewport(config, layerManager, canvas);
+  expect(viewport.id).toBeDefined();
+  expect(viewport.id.length).toBeGreaterThan(0);
+});
+
+test("parseViewportConfigs creates viewports with validation", () => {
+  const element1 = createTestElement("viewport1");
+  const element2 = createTestElement("viewport2");
+  const camera1 = new OrthographicCamera(-1, 1, -1, 1, 0.1, 1000);
+  const camera2 = new OrthographicCamera(-1, 1, -1, 1, 0.1, 1000);
+
+  const configs: ViewportConfig[] = [
+    { id: "viewport1", element: element1, camera: camera1 },
+    { id: "viewport2", element: element2, camera: camera2 },
+  ];
+
+  const viewports = parseViewportConfigs(
+    configs,
+    () => new LayerManager(),
+    createTestCanvas()
+  );
+
+  expect(viewports).toHaveLength(2);
+  expect(viewports[0].id).toBe("viewport1");
+  expect(viewports[1].id).toBe("viewport2");
+  expect(viewports[0].element).toBe(element1);
+  expect(viewports[1].element).toBe(element2);
+});
+
+test("parseViewportConfigs throws on duplicate IDs", () => {
+  const element1 = createTestElement("viewport1");
+  const element2 = createTestElement("viewport2");
+  const camera1 = new OrthographicCamera(-1, 1, -1, 1, 0.1, 1000);
+  const camera2 = new OrthographicCamera(-1, 1, -1, 1, 0.1, 1000);
+
+  const configs: ViewportConfig[] = [
+    { id: "duplicate", element: element1, camera: camera1 },
+    { id: "duplicate", element: element2, camera: camera2 },
+  ];
+
+  expect(() =>
+    parseViewportConfigs(configs, () => new LayerManager(), createTestCanvas())
+  ).toThrow('Duplicate viewport ID "duplicate"');
+});
+
+test("parseViewportConfigs throws on shared elements", () => {
+  const sharedElement = createTestElement("shared");
+  const camera1 = new OrthographicCamera(-1, 1, -1, 1, 0.1, 1000);
+  const camera2 = new OrthographicCamera(-1, 1, -1, 1, 0.1, 1000);
+
+  const configs: ViewportConfig[] = [
+    { id: "viewport1", element: sharedElement, camera: camera1 },
+    { id: "viewport2", element: sharedElement, camera: camera2 },
+  ];
+
+  expect(() =>
+    parseViewportConfigs(configs, () => new LayerManager(), createTestCanvas())
+  ).toThrow("Multiple viewports cannot share the same HTML element");
+});
+
+test("parseViewportConfigs allows viewports without explicit IDs", () => {
+  const element1 = createTestElement("element1");
+  const element2 = createTestElement("element2");
+  const camera1 = new OrthographicCamera(-1, 1, -1, 1, 0.1, 1000);
+  const camera2 = new OrthographicCamera(-1, 1, -1, 1, 0.1, 1000);
+
+  const configs: ViewportConfig[] = [
+    { element: element1, camera: camera1 },
+    { element: element2, camera: camera2 },
+  ];
+
+  const viewports = parseViewportConfigs(
+    configs,
+    () => new LayerManager(),
+    createTestCanvas()
+  );
+
+  expect(viewports).toHaveLength(2);
+  expect(viewports[0].id).toBe("element1");
+  expect(viewports[1].id).toBe("element2");
+});


### PR DESCRIPTION
### Summary

This PR introduces the Viewport abstraction and updates the Renderer API to accept viewport objects instead of separate parameters.

- Added `Viewport` class that encapsulates camera, HTML element, layer manager, and coordinate transformations
- Added `ViewportConfig` interface and `parseViewportConfigs()` utility function with validation
- Modified `Renderer.render()` interface from `render(layerManager, camera, viewportBox)` to `render(viewport)`
- Updated `WebGLRenderer` to implement the new render signature
- `activeCamera` removed from base `Renderer`, as viewports now handle resizing and camera updates
- Modified runtime to use viewport internally while maintaining backward compatibility through getter/setter proxies
- Modified runtime to start layout observers for resize events on all viewports and device pixel ratio

The runtime still operates with a single viewport only - this change is purely an API refactor to prepare for multiple viewport support. All existing applications and examples continue to work without modification.

This is step two of the implementation plan in the [Multiple Viewports Tech Spec](https://docs.google.com/document/d/1OwGL7KW34hxFAENyOm2WiQ71E58XGu9Y7jKkJlyRx84/edit?tab=t.0).

### Related Issue
N/A

### Tests & Checks
Manually tested examples
Added basic tests for viewport + instantiation
