### PR TITLE
Implement `ChannelsEnabled` for `ChunkedImageLayer`

### DIFF
--- a/packages/core/examples/chunk_streaming/main.ts
+++ b/packages/core/examples/chunk_streaming/main.ts
@@ -24,7 +24,23 @@ const sliceCoords = {
   c: 0,
 };
 
-const channelProps: ChannelProps = { contrastLimits: [0, 255] };
+// values copied from source
+const imageDataRange = { min: 0, max: 244 };
+const z = { translate: 0.0, scale: 1.24, shape: 448 };
+const min = z.translate;
+const max = z.translate + z.scale * z.shape - z.scale;
+const zRange = { min, max };
+
+const initialWindow = 50;
+const initialLevel = 25;
+const initialContrastLimits = windowLevelToContrastLimits(
+  initialWindow,
+  initialLevel
+);
+const channelProps: ChannelProps[] = [
+  { contrastLimits: initialContrastLimits },
+];
+
 const camera = new OrthographicCamera(left, right, top, bottom);
 const imageLayer = new ChunkedImageLayer({ source, sliceCoords, channelProps });
 imageLayer.debugMode = true;
@@ -48,13 +64,13 @@ const controls = {
   sliceCoords,
   showWireframes: true,
   showChunkInfoOverlay: true,
+  window: initialWindow,
+  level: initialLevel,
+  resetContrast: function () {
+    contrastFolder.reset();
+  },
 };
 
-// values copied from source
-const z = { translate: 0.0, scale: 1.24, shape: 448 };
-const min = z.translate;
-const max = z.translate + z.scale * z.shape - z.scale;
-const zRange = { min, max };
 const gui = new GUI({ width: 500 });
 
 gui
@@ -72,3 +88,37 @@ gui
   .onChange((show: boolean) => {
     overlaySelector.style.display = show ? "block" : "none";
   });
+
+const contrastFolder = gui.addFolder("Window/Level");
+contrastFolder
+  .add(controls, "window", 1, 100, 1)
+  .name("Window (%)")
+  .onChange(updateContrastLimits);
+
+contrastFolder
+  .add(controls, "level", 0, 100, 1)
+  .name("Level (%)")
+  .onChange(updateContrastLimits);
+
+contrastFolder.add(controls, "resetContrast").name("Reset");
+
+function updateContrastLimits() {
+  const contrastLimits = windowLevelToContrastLimits(
+    controls.window,
+    controls.level
+  );
+  const newChannelProps = [{ contrastLimits }];
+  imageLayer.setChannelProps(newChannelProps);
+}
+
+function windowLevelToContrastLimits(
+  window: number,
+  level: number
+): [number, number] {
+  return [
+    (imageDataRange.max - imageDataRange.min) *
+      (level / 100 - window / 100 / 2),
+    (imageDataRange.max - imageDataRange.min) *
+      (level / 100 + window / 100 / 2),
+  ];
+}

--- a/packages/core/examples/image_labels_overlay_with_value_picking/main.ts
+++ b/packages/core/examples/image_labels_overlay_with_value_picking/main.ts
@@ -84,7 +84,7 @@ const imageLayer = new ChunkedImageLayer({
   source: imageSource,
   sliceCoords,
   transparent: true,
-  channelProps: { contrastLimits: phaseContrastLimits },
+  channelProps: [{ contrastLimits: phaseContrastLimits }],
 });
 
 // Function to create label layer with current mode

--- a/packages/core/examples/ome_zarr_v05/main.ts
+++ b/packages/core/examples/ome_zarr_v05/main.ts
@@ -33,7 +33,7 @@ const yInfo = dimensionInfo("y");
 const xInfo = dimensionInfo("x");
 
 const sliceCoords = { z: zMidPoint };
-const channelProps: ChannelProps = { contrastLimits: [0, 200] };
+const channelProps: ChannelProps[] = [{ contrastLimits: [0, 200] }];
 
 const pickInfoDiv = document.querySelector<HTMLDivElement>("#pick-info")!;
 

--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -10,7 +10,7 @@ import { Box2 } from "../math/box2";
 import { Box3 } from "../math/box3";
 import { almostEqual } from "../utilities/almost_equal";
 import { Logger } from "../utilities/logger";
-import { OrthographicCamera } from "@/objects/cameras/orthographic_camera";
+import { OrthographicCamera } from "../objects/cameras/orthographic_camera";
 
 // Number of chunks to extend beyond the visible bounds in each direction (x/y/z)
 // These additional chunks are prefetched to improve responsiveness when panning.

--- a/packages/core/src/layers/chunked_image_layer.ts
+++ b/packages/core/src/layers/chunked_image_layer.ts
@@ -167,7 +167,7 @@ export class ChunkedImageLayer extends Layer implements ChannelsEnabled {
     const image = new ImageRenderable(
       geometry,
       Texture2DArray.createWithChunk(chunk, this.getDataForImage(chunk)),
-      this.channelProps_
+      this.channelProps_ ?? [{}]
     );
     this.updateImageChunk(image, chunk);
     return image;

--- a/packages/core/src/layers/chunked_image_layer.ts
+++ b/packages/core/src/layers/chunked_image_layer.ts
@@ -31,7 +31,7 @@ export class ChunkedImageLayer extends Layer implements ChannelsEnabled {
   private readonly visibleChunks_: Map<Chunk, ImageRenderable> = new Map();
   private readonly pool_ = new RenderablePool<ImageRenderable>();
   private readonly initialChannelProps_?: ChannelProps[];
-  private readonly channelChangeCallbacks_: Array<() => void> = [];
+  private readonly channelChangeCallbacks_:  (() => void)[] = [];
   private channelProps_?: ChannelProps[];
   private chunkManagerSource_?: ChunkManagerSource;
   private pointerDownPos_: vec2 | null = null;

--- a/packages/core/src/layers/chunked_image_layer.ts
+++ b/packages/core/src/layers/chunked_image_layer.ts
@@ -31,7 +31,7 @@ export class ChunkedImageLayer extends Layer implements ChannelsEnabled {
   private readonly visibleChunks_: Map<Chunk, ImageRenderable> = new Map();
   private readonly pool_ = new RenderablePool<ImageRenderable>();
   private readonly initialChannelProps_?: ChannelProps[];
-  private readonly channelChangeCallbacks_:  (() => void)[] = [];
+  private readonly channelChangeCallbacks_: (() => void)[] = [];
   private channelProps_?: ChannelProps[];
   private chunkManagerSource_?: ChunkManagerSource;
   private pointerDownPos_: vec2 | null = null;

--- a/packages/core/src/layers/chunked_image_layer.ts
+++ b/packages/core/src/layers/chunked_image_layer.ts
@@ -2,7 +2,7 @@ import { Layer, LayerOptions } from "../core/layer";
 import { IdetikContext } from "../idetik";
 import { Chunk, ChunkSource, SliceCoordinates } from "../data/chunk";
 import { ChunkManagerSource } from "../core/chunk_manager";
-import { ChannelProps } from "../objects/textures/channel";
+import { ChannelProps, ChannelsEnabled } from "../objects/textures/channel";
 import { ImageRenderable } from "../objects/renderable/image_renderable";
 import { Texture2DArray } from "../objects/textures/texture_2d_array";
 import { PlaneGeometry } from "../objects/geometry/plane_geometry";
@@ -18,19 +18,21 @@ import { RenderablePool } from "../utilities/renderable_pool";
 export type ChunkedImageLayerProps = LayerOptions & {
   source: ChunkSource;
   sliceCoords: SliceCoordinates;
-  channelProps?: ChannelProps;
+  channelProps?: ChannelProps[];
   onPickValue?: (info: PointPickingResult) => void;
 };
 
-export class ChunkedImageLayer extends Layer {
+export class ChunkedImageLayer extends Layer implements ChannelsEnabled {
   public readonly type = "ChunkedImageLayer";
 
   private readonly source_: ChunkSource;
   private readonly sliceCoords_: SliceCoordinates;
   private readonly onPickValue_?: (info: PointPickingResult) => void;
   private readonly visibleChunks_: Map<Chunk, ImageRenderable> = new Map();
-  private readonly channelProps_?: ChannelProps;
   private readonly pool_ = new RenderablePool<ImageRenderable>();
+  private readonly initialChannelProps_?: ChannelProps[];
+  private readonly channelChangeCallbacks_: Array<() => void> = [];
+  private channelProps_?: ChannelProps[];
   private chunkManagerSource_?: ChunkManagerSource;
   private pointerDownPos_: vec2 | null = null;
   private zPrevPointWorld_?: number;
@@ -55,6 +57,7 @@ export class ChunkedImageLayer extends Layer {
     this.source_ = source;
     this.sliceCoords_ = sliceCoords;
     this.channelProps_ = channelProps;
+    this.initialChannelProps_ = channelProps;
     this.onPickValue_ = onPickValue;
   }
 
@@ -150,6 +153,9 @@ export class ChunkedImageLayer extends Layer {
       const texture = pooled.textures[0] as Texture2DArray;
       texture.updateWithChunk(chunk, this.getDataForImage(chunk));
       this.updateImageChunk(pooled, chunk);
+      if (this.channelProps_) {
+        pooled.setChannelProps(this.channelProps_);
+      }
       return pooled;
     }
 
@@ -161,7 +167,7 @@ export class ChunkedImageLayer extends Layer {
     const image = new ImageRenderable(
       geometry,
       Texture2DArray.createWithChunk(chunk, this.getDataForImage(chunk)),
-      this.channelProps_ ? [this.channelProps_] : [{}]
+      this.channelProps_
     );
     this.updateImageChunk(image, chunk);
     return image;
@@ -251,6 +257,38 @@ export class ChunkedImageLayer extends Layer {
           this.wireframeColors_[chunk.lod % this.wireframeColors_.length];
       }
     });
+  }
+
+  public get channelProps(): ChannelProps[] | undefined {
+    return this.channelProps_;
+  }
+
+  public setChannelProps(channelProps: ChannelProps[]) {
+    this.channelProps_ = channelProps;
+    this.visibleChunks_.forEach((image) => {
+      image.setChannelProps(channelProps);
+    });
+    this.channelChangeCallbacks_.forEach((callback) => {
+      callback();
+    });
+  }
+
+  public resetChannelProps(): void {
+    if (this.initialChannelProps_ !== undefined) {
+      this.setChannelProps(this.initialChannelProps_);
+    }
+  }
+
+  public addChannelChangeCallback(callback: () => void): void {
+    this.channelChangeCallbacks_.push(callback);
+  }
+
+  public removeChannelChangeCallback(callback: () => void): void {
+    const index = this.channelChangeCallbacks_.indexOf(callback);
+    if (index === -1) {
+      throw new Error(`Callback to remove could not be found: ${callback}`);
+    }
+    this.channelChangeCallbacks_.splice(index, 1);
   }
 }
 


### PR DESCRIPTION
### Summary
Our current method for integrating with channel controls relies on implementing the `ChannelsEnabled` interface. `ChunkedImageLayer` currently only supports a single-channel (see #372), but implementing this interface allows us to add dynamic contrast limit (window/level) controls for these layers. This is needed for porting some existing applications (Try Cryolens, Tomogram Quality) to use the `ChunkedImagelayer` for progressive chunk streaming.

It's a little weird to have to pass a list of channel props when the limit is 1. So we may want to change the interface later if we decide to only support single-channel images in this layer (relying instead on layer blending for multiple channels). I think this can be revisited when we are ready to remove `ImageLayer` and `ImageSeriesLayer`.

Tagging @phoenixAja for review, since I think this is needed for porting the Tomogram Quality app to use `ChunkedImageLayer`.

### Related Issue
#372 (does not close)

### Tests & Checks
Tested with current examples
Added window/level controls to chunk streaming example
