### PR TITLE
Don't include core-prerelease in rollup of react-prerelease

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@idetik/react-prerelease",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/react/vite.config.js
+++ b/packages/react/vite.config.js
@@ -57,7 +57,7 @@ export default defineConfig(() => {
             "react-dom/client": "ReactDOM.client",
             "@czi-sds/components": "SDS",
             "@mui/material": "MaterialUI",
-            "@idetik/core": "IdetikCore",
+            "@idetik/core-prerelease": "IdetikCorePre",
           },
         },
       },

--- a/packages/react/vite.config.js
+++ b/packages/react/vite.config.js
@@ -1,16 +1,16 @@
 /// <reference types="vitest" />
-import { defineConfig } from 'vite';
-import eslint from 'vite-plugin-eslint';
-import path from 'path';
+import { defineConfig } from "vite";
+import eslint from "vite-plugin-eslint";
+import path from "path";
 import react from "@vitejs/plugin-react";
-import typescript from '@rollup/plugin-typescript';
-import tailwindcss from 'tailwindcss';
-import autoprefixer from 'autoprefixer';
+import typescript from "@rollup/plugin-typescript";
+import tailwindcss from "tailwindcss";
+import autoprefixer from "autoprefixer";
 
 // __dirname is not available in ES6 modules
 // https://github.com/vitejs/vite/issues/6946#issuecomment-1041506056
-import { dirname } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
 const _dirname = dirname(fileURLToPath(import.meta.url));
 
 const plugins = [
@@ -27,60 +27,55 @@ const plugins = [
 export default defineConfig(() => {
   return {
     plugins,
-    root: '.',
-    publicDir: path.resolve(_dirname, 'public'),
+    root: ".",
+    publicDir: path.resolve(_dirname, "public"),
     build: {
-      outDir: 'dist',
+      outDir: "dist",
       // TODO: set these by build mode or something
       sourcemap: true,
       // minify: false,
       lib: {
-        entry: path.resolve(_dirname, 'src/index.ts'),
-        name: 'idetik-react',
+        entry: path.resolve(_dirname, "src/index.ts"),
+        name: "idetik-react",
         fileName: "index",
       },
       rollupOptions: {
         external: [
-          'react',
-          'react/jsx-runtime',
-          'react-dom',
-          'react-dom/client',
-          '@czi-sds/components',
-          '@mui/material',
-          '@idetik/core',
+          "react",
+          "react/jsx-runtime",
+          "react-dom",
+          "react-dom/client",
+          "@czi-sds/components",
+          "@mui/material",
+          "@idetik/core-prerelease",
         ],
         output: {
           globals: {
-            'react': 'React',
-            'react-dom': 'ReactDOM',
-            'react/jsx-runtime': 'React.jsxRuntime',
-            'react-dom/client': 'ReactDOM.client',
-            '@czi-sds/components': 'SDS',
-            '@mui/material': 'MaterialUI',
-            '@idetik/core': 'IdetikCore',
+            react: "React",
+            "react-dom": "ReactDOM",
+            "react/jsx-runtime": "React.jsxRuntime",
+            "react-dom/client": "ReactDOM.client",
+            "@czi-sds/components": "SDS",
+            "@mui/material": "MaterialUI",
+            "@idetik/core": "IdetikCore",
           },
         },
       },
     },
     css: {
       postcss: {
-        plugins: [
-          tailwindcss,
-          autoprefixer,
-        ],
+        plugins: [tailwindcss, autoprefixer],
       },
     },
     resolve: {
       alias: {
-        '@': path.resolve(_dirname, 'src'),
+        "@": path.resolve(_dirname, "src"),
       },
     },
     server: {
       watch: {
-        include: [
-          path.resolve(_dirname, 'src/**'),
-        ],
+        include: [path.resolve(_dirname, "src/**")],
       },
     },
-  }
+  };
 });


### PR DESCRIPTION
Find/replace was missed during the migration.

Tested that:
 - `yalc add @idetik/core-prerelease` works now.
 - VCP with `react-prerelease@1.1.1` works.