### PR TITLE
Adjust LOD factor based on source data scale

### DIFF
--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -28,6 +28,9 @@ export class ChunkManagerSource {
   private readonly sliceCoords_: SliceCoordinates;
   private readonly dimensions_: SourceDimensionMap;
   private currentLOD_: number = 0;
+  // TODO: make LOD bias configurable per-source or per-layer
+  // positive values nudge towards coarser resolution (higher LOD number)
+  private lodBias_: number = 0.5;
   private lastViewBounds2D_: Box2 | null = null;
   private lastZBounds_?: [number, number];
 
@@ -154,10 +157,13 @@ export class ChunkManagerSource {
   }
 
   private setLOD(lodFactor: number): void {
+    const sourceAdjustment =
+      this.lodBias_ - Math.log2(this.dimensions_.x.lods[0].scale);
+    const sourceAdjustedLodFactor = sourceAdjustment - lodFactor;
     const maxLOD = this.lowestResLOD_;
     const targetLOD = Math.max(
       0,
-      Math.min(maxLOD, Math.floor(maxLOD - lodFactor))
+      Math.min(maxLOD, Math.floor(sourceAdjustedLodFactor))
     );
 
     if (targetLOD !== this.currentLOD_) {

--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -157,6 +157,13 @@ export class ChunkManagerSource {
   }
 
   private setLOD(lodFactor: number): void {
+    // `scale` here is the x-width of an image pixel in virtual units at LOD 0.
+    // So (ignoring the bias term) subtracting `lodFactor` from `Math.log2(scale)`
+    // is effectively `Math.log2(virtualUnitsPerScreenPixel / xScale)`.
+    // That is, `adjustedLodFactor = Math.log2(imagePixelsPerScreenPixel)`;
+    // or in other words, how many image pixels (LOD 0) fit in a screen pixel.
+    // Use of log2 here and in ChunkManager relies on the assumption that
+    // each LOD is downsampled by a factor of 2 in X and Y.
     const sourceAdjustment =
       this.lodBias_ - Math.log2(this.dimensions_.x.lods[0].scale);
     const sourceAdjustedLodFactor = sourceAdjustment - lodFactor;


### PR DESCRIPTION
### Summary
This PR updates the LOD calculation system to incorporate the image scale (per-source).

This also introduces an LOD "bias" term on the source, that can be used to nudge the calculation towards more or less LOD. It's currently hard-coded to 0.5, which nudges to a slightly lower-resolution than "necessary". This PR does not currently add an API to change this bias, so I added a TODO comment. I'm not sure if this bias should be per-source, per-layer, or perhaps per-viewport, and what the user API should look like.

Note: all our LOD calculation is currently based on width/x. We will need to make this more general for anisotropic resolutions and additional slice orientations.

### Related Issue
Closes #426 

### Tests & Checks
I tested by making a custom example page that syncs cameras, and loads test zarr files with three different scales: 10, 1, and 0.1. All three have the exact same image content with a 4-level pyramid from 2048x2048 to 256x256 (chunk size 512x512, or 256x256 at LOD3).

On `main` you can see the images display at different LODs even though they are the same underlying number of pixels shown at the same size (canvases are about 600px square):

https://github.com/user-attachments/assets/e7ec0b64-3202-42eb-80bb-4c98246c9925

With these proposed changes, you can see the LOD is kept in sync across images with different scales:

https://github.com/user-attachments/assets/5976ff13-41b8-4b05-a139-93da6c27951e


