### PR TITLE
Add queue for cancellable limited concurrent fetches

### DIFF
--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -11,6 +11,7 @@ import { Box3 } from "../math/box3";
 import { almostEqual } from "../utilities/almost_equal";
 import { Logger } from "../utilities/logger";
 import { OrthographicCamera } from "../objects/cameras/orthographic_camera";
+import { ChunkQueue } from "@/utilities/chunk_queue";
 
 // Number of chunks to extend beyond the visible bounds in each direction (x/y/z)
 // These additional chunks are prefetched to improve responsiveness when panning.
@@ -149,8 +150,8 @@ export class ChunkManagerSource {
     return this.currentLOD_;
   }
 
-  public loadChunkData(chunk: Chunk) {
-    return this.loader_.loadChunkData(chunk, this.sliceCoords_);
+  public loadChunkData(chunk: Chunk, signal: AbortSignal) {
+    return this.loader_.loadChunkData(chunk, this.sliceCoords_, signal);
   }
 
   private setLOD(lodFactor: number): void {
@@ -348,11 +349,9 @@ export class ChunkManagerSource {
   }
 }
 
-type BucketItem = { source: ChunkManagerSource; chunk: Chunk };
-type Buckets = BucketItem[][];
-
 export class ChunkManager {
   private readonly sources_ = new Map<ChunkSource, ChunkManagerSource>();
+  private readonly queue_ = new ChunkQueue();
 
   public async addSource(source: ChunkSource, sliceCoords: SliceCoordinates) {
     let existing = this.sources_.get(source);
@@ -377,29 +376,16 @@ export class ChunkManager {
     const virtualUnitsPerScreenPixel = virtualWidth / bufferWidth;
     const lodFactor = Math.log2(1 / virtualUnitsPerScreenPixel);
 
-    const buckets: Buckets = [[], [], [], []];
-
     for (const [_, source] of this.sources_) {
       source.update(lodFactor, viewBounds2D);
       for (const chunk of source.chunks) {
-        if (chunk.state !== "queued" || chunk.priority === null) continue;
-        buckets[chunk.priority].push({ source, chunk });
-      }
-    }
-
-    for (const bucket of buckets) {
-      for (const { source, chunk } of bucket) {
-        if (chunk.state !== "queued") continue; // guard
-        chunk.state = "loading";
-        source
-          .loadChunkData(chunk)
-          .then(() => {
-            if (chunk.state === "loading") chunk.state = "loaded";
-          })
-          .catch((err) => {
-            Logger.error("ChunkManager", String(err));
-            if (chunk.state === "loading") chunk.state = "unloaded";
-          });
+        if (chunk.priority === null) {
+          this.queue_.cancel(chunk);
+        } else if (chunk.state === "queued") {
+          this.queue_.enqueue(chunk, (signal) =>
+            source.loadChunkData(chunk, signal)
+          );
+        }
       }
     }
   }

--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -11,7 +11,7 @@ import { Box3 } from "../math/box3";
 import { almostEqual } from "../utilities/almost_equal";
 import { Logger } from "../utilities/logger";
 import { OrthographicCamera } from "../objects/cameras/orthographic_camera";
-import { ChunkQueue } from "@/utilities/chunk_queue";
+import { ChunkQueue } from "../data/chunk_queue";
 
 // Number of chunks to extend beyond the visible bounds in each direction (x/y/z)
 // These additional chunks are prefetched to improve responsiveness when panning.
@@ -388,5 +388,7 @@ export class ChunkManager {
         }
       }
     }
+
+    this.queue_.flush();
   }
 }

--- a/packages/core/src/data/chunk.ts
+++ b/packages/core/src/data/chunk.ts
@@ -114,7 +114,11 @@ export type ChunkLoader = {
 
   getSourceDimensionMap(): SourceDimensionMap;
 
-  loadChunkData(chunk: Chunk, sliceCoords: SliceCoordinates): Promise<void>;
+  loadChunkData(
+    chunk: Chunk,
+    sliceCoords: SliceCoordinates,
+    signal: AbortSignal
+  ): Promise<void>;
 
   getAttributes(): ReadonlyArray<LoaderAttributes>;
 };

--- a/packages/core/src/data/chunk_queue.ts
+++ b/packages/core/src/data/chunk_queue.ts
@@ -1,5 +1,5 @@
-import { Chunk } from "@/data/chunk";
-import { Logger } from "./logger";
+import { Chunk } from "./chunk";
+import { Logger } from "../utilities/logger";
 
 const MAX_CONCURRENT = 8;
 
@@ -24,6 +24,9 @@ export class ChunkQueue {
     if (this.pending_.some((p) => p.chunk === chunk)) return;
 
     this.pending_.push({ chunk, fn });
+  }
+
+  flush() {
     this.pump();
   }
 
@@ -43,16 +46,24 @@ export class ChunkQueue {
   }
 
   private pump() {
+    if (
+      this.running_.size >= this.maxConcurrent_ ||
+      this.pending_.length === 0
+    ) {
+      return;
+    }
+
+    this.pending_.sort((a, b) => {
+      return (
+        (a.chunk.priority ?? Number.MAX_SAFE_INTEGER) -
+        (b.chunk.priority ?? Number.MAX_SAFE_INTEGER)
+      );
+    });
+
     while (
       this.running_.size < this.maxConcurrent_ &&
       this.pending_.length > 0
     ) {
-      this.pending_.sort((a, b) => {
-        return (
-          (a.chunk.priority ?? Number.MAX_SAFE_INTEGER) -
-          (b.chunk.priority ?? Number.MAX_SAFE_INTEGER)
-        );
-      });
       this.start(this.pending_.shift()!);
     }
   }
@@ -67,18 +78,18 @@ export class ChunkQueue {
       .then(
         () => {
           if (chunk.state === "loading") chunk.state = "loaded";
-          this.running_.delete(chunk);
-          this.pump();
         },
         (err) => {
           if (chunk.state === "loading") chunk.state = "unloaded";
-          this.running_.delete(chunk);
-          this.pump();
           if (err.name !== "AbortError") {
             Logger.error("ChunkQueue", String(err));
           }
         }
-      );
+      )
+      .finally(() => {
+        this.running_.delete(chunk);
+        this.pump();
+      });
 
     this.running_.set(chunk, { controller, promise });
   }

--- a/packages/core/src/data/chunk_queue.ts
+++ b/packages/core/src/data/chunk_queue.ts
@@ -19,18 +19,18 @@ export class ChunkQueue {
     this.maxConcurrent_ = Math.max(1, maxConcurrent);
   }
 
-  enqueue(chunk: Chunk, fn: LoaderFn) {
+  public enqueue(chunk: Chunk, fn: LoaderFn) {
     if (this.running_.has(chunk)) return;
     if (this.pending_.some((p) => p.chunk === chunk)) return;
 
     this.pending_.push({ chunk, fn });
   }
 
-  flush() {
+  public flush() {
     this.pump();
   }
 
-  cancel(chunk: Chunk) {
+  public cancel(chunk: Chunk) {
     const idx = this.pending_.findIndex((p) => p.chunk === chunk);
     if (idx >= 0) {
       this.pending_.splice(idx, 1);
@@ -43,6 +43,14 @@ export class ChunkQueue {
       running.controller.abort();
       Logger.debug("ChunkQueue", "Cancelled fetch request");
     }
+  }
+
+  public get pendingCount() {
+    return this.pending_.length;
+  }
+
+  public get runningCount() {
+    return this.running_.size;
   }
 
   private pump() {

--- a/packages/core/src/data/ome_zarr/image_loader.ts
+++ b/packages/core/src/data/ome_zarr/image_loader.ts
@@ -61,7 +61,11 @@ export class OmeZarrImageLoader {
     return this.dimensions_;
   }
 
-  public async loadChunkData(chunk: Chunk, sliceCoords: SliceCoordinates) {
+  public async loadChunkData(
+    chunk: Chunk,
+    sliceCoords: SliceCoordinates,
+    signal: AbortSignal
+  ) {
     const chunkCoords: number[] = [];
     chunkCoords[this.dimensions_.x.index] = chunk.chunkIndex.x;
     chunkCoords[this.dimensions_.y.index] = chunk.chunkIndex.y;
@@ -92,7 +96,7 @@ export class OmeZarrImageLoader {
     }
 
     const array = this.arrays_[chunk.lod];
-    const subarray = await array.getChunk(chunkCoords);
+    const subarray = await array.getChunk(chunkCoords, { signal });
 
     const data = subarray.data;
     if (!isChunkData(data)) {

--- a/packages/core/src/utilities/chunk_queue.ts
+++ b/packages/core/src/utilities/chunk_queue.ts
@@ -1,0 +1,80 @@
+import { Chunk } from "@/data/chunk";
+import { Logger } from "./logger";
+
+const MAX_CONCURRENT = 8;
+
+type LoaderFn = (signal: AbortSignal) => Promise<void>;
+
+type PendingItem = { chunk: Chunk; fn: LoaderFn };
+
+export class ChunkQueue {
+  private readonly pending_: PendingItem[] = [];
+  private readonly running_ = new Map<
+    Chunk,
+    { controller: AbortController; promise: Promise<void> }
+  >();
+
+  enqueue(chunk: Chunk, fn: LoaderFn) {
+    if (this.running_.has(chunk)) return;
+    if (this.pending_.some((p) => p.chunk === chunk)) return;
+
+    this.pending_.push({ chunk, fn });
+    this.pump();
+  }
+
+  cancel(chunk: Chunk) {
+    const idx = this.pending_.findIndex((p) => p.chunk === chunk);
+    if (idx >= 0) {
+      this.pending_.splice(idx, 1);
+      Logger.debug("ChunkQueue", "Cancelled pending request");
+      return;
+    }
+
+    const running = this.running_.get(chunk);
+    if (running) {
+      running.controller.abort();
+      Logger.debug("ChunkQueue", "Cancelled fetch request");
+    }
+  }
+
+  private pump() {
+    while (this.running_.size < MAX_CONCURRENT && this.pending_.length > 0) {
+      this.pending_.sort((a, b) => {
+        return (
+          (a.chunk.priority ?? Number.MAX_SAFE_INTEGER) -
+          (b.chunk.priority ?? Number.MAX_SAFE_INTEGER)
+        );
+      });
+      this.start(this.pending_.shift()!);
+    }
+  }
+
+  private start(item: PendingItem) {
+    const { chunk, fn } = item;
+    chunk.state = "loading";
+
+    const controller = new AbortController();
+    const promise = Promise.resolve()
+      .then(() => fn(controller.signal))
+      .then(
+        () => {
+          if (chunk.state === "loading") chunk.state = "loaded";
+          this.running_.delete(chunk);
+          this.pump();
+        },
+        (err) => {
+          if (chunk.state === "loading") chunk.state = "unloaded";
+          this.running_.delete(chunk);
+          this.pump();
+
+          const isAbort =
+            err instanceof DOMException && err.name === "AbortError";
+          if (!isAbort) {
+            Logger.error("ChunkQueue", String(err));
+          }
+        }
+      );
+
+    this.running_.set(chunk, { controller, promise });
+  }
+}

--- a/packages/core/src/utilities/chunk_queue.ts
+++ b/packages/core/src/utilities/chunk_queue.ts
@@ -8,11 +8,16 @@ type LoaderFn = (signal: AbortSignal) => Promise<void>;
 type PendingItem = { chunk: Chunk; fn: LoaderFn };
 
 export class ChunkQueue {
+  private readonly maxConcurrent_: number;
   private readonly pending_: PendingItem[] = [];
   private readonly running_ = new Map<
     Chunk,
     { controller: AbortController; promise: Promise<void> }
   >();
+
+  constructor(maxConcurrent = MAX_CONCURRENT) {
+    this.maxConcurrent_ = Math.max(1, maxConcurrent);
+  }
 
   enqueue(chunk: Chunk, fn: LoaderFn) {
     if (this.running_.has(chunk)) return;
@@ -38,7 +43,10 @@ export class ChunkQueue {
   }
 
   private pump() {
-    while (this.running_.size < MAX_CONCURRENT && this.pending_.length > 0) {
+    while (
+      this.running_.size < this.maxConcurrent_ &&
+      this.pending_.length > 0
+    ) {
       this.pending_.sort((a, b) => {
         return (
           (a.chunk.priority ?? Number.MAX_SAFE_INTEGER) -
@@ -66,10 +74,7 @@ export class ChunkQueue {
           if (chunk.state === "loading") chunk.state = "unloaded";
           this.running_.delete(chunk);
           this.pump();
-
-          const isAbort =
-            err instanceof DOMException && err.name === "AbortError";
-          if (!isAbort) {
+          if (err.name !== "AbortError") {
             Logger.error("ChunkQueue", String(err));
           }
         }

--- a/packages/core/src/utilities/logger.ts
+++ b/packages/core/src/utilities/logger.ts
@@ -18,6 +18,7 @@ const Colors = {
 type Module =
   | "ChunkManager"
   | "ChunkManagerSource"
+  | "ChunkQueue"
   | "ChunkedImageLayer"
   | "EventDispatcher"
   | "Idetik"

--- a/packages/core/test/chunk_queue.test.ts
+++ b/packages/core/test/chunk_queue.test.ts
@@ -2,42 +2,52 @@ import { describe, expect, test } from "vitest";
 import { ChunkQueue } from "@/data/chunk_queue";
 import { makeChunk, makeControllableLoader, waitFor } from "./helpers";
 
+async function expectCounts(
+  queue: ChunkQueue,
+  count: { pending: number; running: number }
+) {
+  await waitFor(
+    () =>
+      queue.pendingCount === count.pending &&
+      queue.runningCount === count.running
+  );
+  expect(queue.pendingCount).toBe(count.pending);
+  expect(queue.runningCount).toBe(count.running);
+}
+
 describe("ChunkQueue", () => {
   test("successful load sets state to loaded", async () => {
     const queue = new ChunkQueue();
     const ctl = makeControllableLoader();
-    const chunk = makeChunk({
-      state: "queued",
-      priority: 0,
-    });
+    const chunk = makeChunk({ state: "queued", priority: 0 });
 
     queue.enqueue(chunk, ctl.loader);
+    expect(queue.pendingCount).toBe(1);
 
     queue.flush();
-    await waitFor(() => chunk.state === "loading");
+    await expectCounts(queue, { pending: 0, running: 1 });
+    expect(chunk.state).toBe("loading");
 
     ctl.resolve();
-    await waitFor(() => chunk.state === "loaded");
+    await expectCounts(queue, { pending: 0, running: 0 });
+    expect(chunk.state).toBe("loaded");
   });
 
   test("starts up to max concurrent tasks and queues the rest", async () => {
-    const queue = new ChunkQueue();
-
-    let started = 0;
-    const ctls = Array.from({ length: 10 }, () =>
-      makeControllableLoader(() => (started += 1))
-    );
-
+    const maxConcurrent = 8;
+    const queue = new ChunkQueue(maxConcurrent);
+    const ctls = Array.from({ length: 10 }, () => makeControllableLoader());
     Array.from({ length: 10 }, () => makeChunk({ state: "queued" })).forEach(
       (chunk, i) => queue.enqueue(chunk, ctls[i].loader)
     );
 
-    queue.flush();
-    await waitFor(() => started === 8);
+    expect(queue.pendingCount).toBe(10);
 
-    // free one slot and ensure exactly one more starts
+    queue.flush();
+    await expectCounts(queue, { pending: 2, running: maxConcurrent });
+
     ctls[0].resolve();
-    await waitFor(() => started === 9);
+    await expectCounts(queue, { pending: 1, running: maxConcurrent });
   });
 
   test("respects priority ordering when starting", async () => {
@@ -53,70 +63,101 @@ describe("ChunkQueue", () => {
     queue.enqueue(makeChunk({ state: "queued", priority: 0 }), ctl0.loader);
 
     queue.flush();
-    await waitFor(() => started.length === 3);
-
+    await expectCounts(queue, { pending: 0, running: 3 });
     expect(started).toEqual([0, 1, 5]);
+
+    ctl0.resolve();
+    ctl1.resolve();
+    ctl5.resolve();
+    await expectCounts(queue, { pending: 0, running: 0 });
+  });
+
+  test("backfills by priority when slots free up", async () => {
+    const queue = new ChunkQueue(1);
+
+    const started: number[] = [];
+    const ctl0 = makeControllableLoader(() => started.push(0));
+    const ctl1 = makeControllableLoader(() => started.push(1));
+    const ctl5 = makeControllableLoader(() => started.push(5));
+
+    queue.enqueue(makeChunk({ state: "queued", priority: 5 }), ctl5.loader);
+    queue.enqueue(makeChunk({ state: "queued", priority: 1 }), ctl1.loader);
+    queue.enqueue(makeChunk({ state: "queued", priority: 0 }), ctl0.loader);
+
+    queue.flush();
+    await expectCounts(queue, { pending: 2, running: 1 });
+    expect(started).toEqual([0]);
+
+    ctl0.resolve();
+    await expectCounts(queue, { pending: 1, running: 1 });
+    expect(started).toEqual([0, 1]);
+
+    ctl1.resolve();
+    await expectCounts(queue, { pending: 0, running: 1 });
+    expect(started).toEqual([0, 1, 5]);
+
+    ctl5.resolve();
+    await expectCounts(queue, { pending: 0, running: 0 });
   });
 
   test("does not process the same chunk twice", async () => {
     const queue = new ChunkQueue();
     const chunk = makeChunk({ state: "queued", priority: 0 });
 
-    let started = 0;
-    const ctl = makeControllableLoader(() => (started += 1));
+    const ctl = makeControllableLoader();
+    queue.enqueue(chunk, ctl.loader);
+    queue.enqueue(chunk, ctl.loader);
+    queue.enqueue(chunk, ctl.loader);
 
-    queue.enqueue(chunk, ctl.loader);
-    queue.enqueue(chunk, ctl.loader);
-    queue.enqueue(chunk, ctl.loader);
+    expect(queue.pendingCount).toBe(1);
 
     queue.flush();
-    await waitFor(() => chunk.state === "loading");
-    expect(started).toBe(1);
+    await expectCounts(queue, { pending: 0, running: 1 });
   });
 
   test("cancel pending request prevents it from starting", async () => {
     const queue = new ChunkQueue(1);
 
-    const blockerCtl = makeControllableLoader();
-    const blockerChunk = makeChunk({ state: "queued", priority: 0 });
-    queue.enqueue(blockerChunk, blockerCtl.loader);
-
-    let pendingStarted = false;
-    const pendingCtl = makeControllableLoader(() => (pendingStarted = true));
     const pendingChunk = makeChunk({ state: "queued", priority: 0 });
-    queue.enqueue(pendingChunk, pendingCtl.loader);
+    const blockerChunk = makeChunk({ state: "queued", priority: 0 });
+    const blockerCtl = makeControllableLoader();
+
+    queue.enqueue(blockerChunk, blockerCtl.loader);
+    queue.enqueue(pendingChunk, makeControllableLoader().loader);
+    expect(queue.pendingCount).toBe(2);
 
     queue.flush();
-    await waitFor(() => blockerChunk.state === "loading");
+    await expectCounts(queue, { pending: 1, running: 1 });
 
     queue.cancel(pendingChunk);
 
     blockerCtl.resolve();
-    await waitFor(() => blockerChunk.state === "loaded");
-    await Promise.resolve(); // microtask tick
-
-    expect(pendingStarted).toBe(false);
+    await expectCounts(queue, { pending: 0, running: 0 });
     expect(pendingChunk.state).toBe("queued");
   });
 
   test("cancel running request aborts and resets", async () => {
     const queue = new ChunkQueue();
     const ctl = makeControllableLoader();
-    const chunk = makeChunk({ state: "queued", priority: 0 });
+    const chunk = makeChunk({ state: "queued" });
 
     queue.enqueue(chunk, ctl.loader);
     queue.flush();
 
-    await waitFor(() => chunk.state === "loading");
+    await expectCounts(queue, { pending: 0, running: 1 });
+    expect(chunk.state).toBe("loading");
 
     queue.cancel(chunk);
 
-    await waitFor(() => chunk.state === "unloaded");
+    await expectCounts(queue, { pending: 0, running: 0 });
+    expect(chunk.state).toBe("unloaded");
 
     // verify it can run again after cancel
     chunk.state = "queued";
     queue.enqueue(chunk, ctl.loader);
     queue.flush();
-    await waitFor(() => chunk.state === "loading");
+
+    await expectCounts(queue, { pending: 0, running: 1 });
+    expect(chunk.state).toBe("loading");
   });
 });

--- a/packages/core/test/chunk_queue.test.ts
+++ b/packages/core/test/chunk_queue.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { ChunkQueue } from "@/utilities/chunk_queue";
+import { ChunkQueue } from "@/data/chunk_queue";
 import { makeChunk, makeControllableLoader, waitFor } from "./helpers";
 
 describe("ChunkQueue", () => {
@@ -12,6 +12,8 @@ describe("ChunkQueue", () => {
     });
 
     queue.enqueue(chunk, ctl.loader);
+
+    queue.flush();
     await waitFor(() => chunk.state === "loading");
 
     ctl.resolve();
@@ -26,10 +28,11 @@ describe("ChunkQueue", () => {
       makeControllableLoader(() => (started += 1))
     );
 
-    const chunks = Array.from({ length: 10 }, () =>
-      makeChunk({ state: "queued" })
+    Array.from({ length: 10 }, () => makeChunk({ state: "queued" })).forEach(
+      (chunk, i) => queue.enqueue(chunk, ctls[i].loader)
     );
-    chunks.forEach((chunk, i) => queue.enqueue(chunk, ctls[i].loader));
+
+    queue.flush();
     await waitFor(() => started === 8);
 
     // free one slot and ensure exactly one more starts
@@ -38,34 +41,20 @@ describe("ChunkQueue", () => {
   });
 
   test("respects priority ordering when starting", async () => {
-    const queue = new ChunkQueue(1); // only one request can run at a time
-
-    const blocker = makeControllableLoader();
-    const blockerChunk = makeChunk({ state: "queued", priority: 10 });
-    queue.enqueue(blockerChunk, blocker.loader);
-    await waitFor(() => blockerChunk.state === "loading");
+    const queue = new ChunkQueue();
 
     const started: number[] = [];
     const ctl0 = makeControllableLoader(() => started.push(0));
     const ctl1 = makeControllableLoader(() => started.push(1));
     const ctl5 = makeControllableLoader(() => started.push(5));
 
+    queue.enqueue(makeChunk({ state: "queued", priority: 5 }), ctl5.loader);
     queue.enqueue(makeChunk({ state: "queued", priority: 1 }), ctl1.loader);
     queue.enqueue(makeChunk({ state: "queued", priority: 0 }), ctl0.loader);
-    queue.enqueue(makeChunk({ state: "queued", priority: 5 }), ctl5.loader);
 
-    expect(started).toEqual([]);
-
-    blocker.resolve(); // frees the slot
-    await waitFor(() => started.length === 1);
-    expect(started).toEqual([0]);
-
-    ctl0.resolve();
-    await waitFor(() => started.length === 2);
-    expect(started).toEqual([0, 1]);
-
-    ctl1.resolve();
+    queue.flush();
     await waitFor(() => started.length === 3);
+
     expect(started).toEqual([0, 1, 5]);
   });
 
@@ -79,6 +68,8 @@ describe("ChunkQueue", () => {
     queue.enqueue(chunk, ctl.loader);
     queue.enqueue(chunk, ctl.loader);
     queue.enqueue(chunk, ctl.loader);
+
+    queue.flush();
     await waitFor(() => chunk.state === "loading");
     expect(started).toBe(1);
   });
@@ -86,21 +77,25 @@ describe("ChunkQueue", () => {
   test("cancel pending request prevents it from starting", async () => {
     const queue = new ChunkQueue(1);
 
-    const blocker = makeControllableLoader();
+    const blockerCtl = makeControllableLoader();
     const blockerChunk = makeChunk({ state: "queued", priority: 0 });
-    queue.enqueue(blockerChunk, blocker.loader);
+    queue.enqueue(blockerChunk, blockerCtl.loader);
+
+    let pendingStarted = false;
+    const pendingCtl = makeControllableLoader(() => (pendingStarted = true));
+    const pendingChunk = makeChunk({ state: "queued", priority: 0 });
+    queue.enqueue(pendingChunk, pendingCtl.loader);
+
+    queue.flush();
     await waitFor(() => blockerChunk.state === "loading");
 
-    let started = false;
-    const pendingCtl = makeControllableLoader(() => (started = true));
-    const pendingChunk = makeChunk({ state: "queued", priority: 0 });
-
-    queue.enqueue(pendingChunk, pendingCtl.loader);
     queue.cancel(pendingChunk);
-    blocker.resolve();
 
+    blockerCtl.resolve();
     await waitFor(() => blockerChunk.state === "loaded");
-    expect(started).toBe(false);
+    await Promise.resolve(); // microtask tick
+
+    expect(pendingStarted).toBe(false);
     expect(pendingChunk.state).toBe("queued");
   });
 
@@ -110,14 +105,18 @@ describe("ChunkQueue", () => {
     const chunk = makeChunk({ state: "queued", priority: 0 });
 
     queue.enqueue(chunk, ctl.loader);
+    queue.flush();
+
     await waitFor(() => chunk.state === "loading");
 
     queue.cancel(chunk);
+
     await waitFor(() => chunk.state === "unloaded");
 
     // verify it can run again after cancel
     chunk.state = "queued";
     queue.enqueue(chunk, ctl.loader);
+    queue.flush();
     await waitFor(() => chunk.state === "loading");
   });
 });

--- a/packages/core/test/chunk_queue.test.ts
+++ b/packages/core/test/chunk_queue.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, test } from "vitest";
+import { ChunkQueue } from "@/utilities/chunk_queue";
+import { makeChunk, makeControllableLoader, waitFor } from "./helpers";
+
+describe("ChunkQueue", () => {
+  test("successful load sets state to loaded", async () => {
+    const queue = new ChunkQueue();
+    const ctl = makeControllableLoader();
+    const chunk = makeChunk({
+      state: "queued",
+      priority: 0,
+    });
+
+    queue.enqueue(chunk, ctl.loader);
+    await waitFor(() => chunk.state === "loading");
+
+    ctl.resolve();
+    await waitFor(() => chunk.state === "loaded");
+  });
+
+  test("starts up to max concurrent tasks and queues the rest", async () => {
+    const queue = new ChunkQueue();
+
+    let started = 0;
+    const ctls = Array.from({ length: 10 }, () =>
+      makeControllableLoader(() => (started += 1))
+    );
+
+    const chunks = Array.from({ length: 10 }, () =>
+      makeChunk({ state: "queued" })
+    );
+    chunks.forEach((chunk, i) => queue.enqueue(chunk, ctls[i].loader));
+    await waitFor(() => started === 8);
+
+    // free one slot and ensure exactly one more starts
+    ctls[0].resolve();
+    await waitFor(() => started === 9);
+  });
+
+  test("respects priority ordering when starting", async () => {
+    const queue = new ChunkQueue(1); // only one request can run at a time
+
+    const blocker = makeControllableLoader();
+    const blockerChunk = makeChunk({ state: "queued", priority: 10 });
+    queue.enqueue(blockerChunk, blocker.loader);
+    await waitFor(() => blockerChunk.state === "loading");
+
+    const started: number[] = [];
+    const ctl0 = makeControllableLoader(() => started.push(0));
+    const ctl1 = makeControllableLoader(() => started.push(1));
+    const ctl5 = makeControllableLoader(() => started.push(5));
+
+    queue.enqueue(makeChunk({ state: "queued", priority: 1 }), ctl1.loader);
+    queue.enqueue(makeChunk({ state: "queued", priority: 0 }), ctl0.loader);
+    queue.enqueue(makeChunk({ state: "queued", priority: 5 }), ctl5.loader);
+
+    expect(started).toEqual([]);
+
+    blocker.resolve(); // frees the slot
+    await waitFor(() => started.length === 1);
+    expect(started).toEqual([0]);
+
+    ctl0.resolve();
+    await waitFor(() => started.length === 2);
+    expect(started).toEqual([0, 1]);
+
+    ctl1.resolve();
+    await waitFor(() => started.length === 3);
+    expect(started).toEqual([0, 1, 5]);
+  });
+
+  test("does not process the same chunk twice", async () => {
+    const queue = new ChunkQueue();
+    const chunk = makeChunk({ state: "queued", priority: 0 });
+
+    let started = 0;
+    const ctl = makeControllableLoader(() => (started += 1));
+
+    queue.enqueue(chunk, ctl.loader);
+    queue.enqueue(chunk, ctl.loader);
+    queue.enqueue(chunk, ctl.loader);
+    await waitFor(() => chunk.state === "loading");
+    expect(started).toBe(1);
+  });
+
+  test("cancel pending request prevents it from starting", async () => {
+    const queue = new ChunkQueue(1);
+
+    const blocker = makeControllableLoader();
+    const blockerChunk = makeChunk({ state: "queued", priority: 0 });
+    queue.enqueue(blockerChunk, blocker.loader);
+    await waitFor(() => blockerChunk.state === "loading");
+
+    let started = false;
+    const pendingCtl = makeControllableLoader(() => (started = true));
+    const pendingChunk = makeChunk({ state: "queued", priority: 0 });
+
+    queue.enqueue(pendingChunk, pendingCtl.loader);
+    queue.cancel(pendingChunk);
+    blocker.resolve();
+
+    await waitFor(() => blockerChunk.state === "loaded");
+    expect(started).toBe(false);
+    expect(pendingChunk.state).toBe("queued");
+  });
+
+  test("cancel running request aborts and resets", async () => {
+    const queue = new ChunkQueue();
+    const ctl = makeControllableLoader();
+    const chunk = makeChunk({ state: "queued", priority: 0 });
+
+    queue.enqueue(chunk, ctl.loader);
+    await waitFor(() => chunk.state === "loading");
+
+    queue.cancel(chunk);
+    await waitFor(() => chunk.state === "unloaded");
+
+    // verify it can run again after cancel
+    chunk.state = "queued";
+    queue.enqueue(chunk, ctl.loader);
+    await waitFor(() => chunk.state === "loading");
+  });
+});

--- a/packages/core/test/helpers.ts
+++ b/packages/core/test/helpers.ts
@@ -1,0 +1,37 @@
+import type { Chunk } from "@/data/chunk";
+
+type ChunkOverrides = Partial<
+  Omit<Chunk, "shape" | "chunkIndex" | "scale" | "offset">
+> & {
+  shape?: Partial<Chunk["shape"]>;
+  chunkIndex?: Partial<Chunk["chunkIndex"]>;
+  scale?: Partial<Chunk["scale"]>;
+  offset?: Partial<Chunk["offset"]>;
+};
+
+export function makeChunk(overrides: ChunkOverrides = {}): Chunk {
+  const { shape, chunkIndex, scale, offset, ...rest } = overrides;
+
+  const defaultChunk: Chunk = {
+    state: "unloaded",
+    lod: 0,
+    visible: false,
+    prefetch: false,
+    priority: null,
+    shape: { x: 256, y: 256, z: 256, c: 1 },
+    rowStride: 256,
+    rowAlignmentBytes: 1,
+    chunkIndex: { x: 0, y: 0, z: 0 },
+    scale: { x: 1, y: 1, z: 1 },
+    offset: { x: 0, y: 0, z: 0 },
+  };
+
+  return {
+    ...defaultChunk,
+    ...rest,
+    shape: { ...defaultChunk.shape, ...(shape ?? {}) },
+    chunkIndex: { ...defaultChunk.chunkIndex, ...(chunkIndex ?? {}) },
+    scale: { ...defaultChunk.scale, ...(scale ?? {}) },
+    offset: { ...defaultChunk.offset, ...(offset ?? {}) },
+  };
+}

--- a/packages/core/test/helpers.ts
+++ b/packages/core/test/helpers.ts
@@ -35,3 +35,47 @@ export function makeChunk(overrides: ChunkOverrides = {}): Chunk {
     offset: { ...defaultChunk.offset, ...(offset ?? {}) },
   };
 }
+
+export function makeControllableLoader(onStart?: () => void) {
+  const createAbortError = () => {
+    const e = new Error("Cancelled");
+    e.name = "AbortError";
+    return e;
+  };
+
+  let _resolve: () => void;
+  let _reject: (e: unknown) => void;
+
+  const loader = (signal: AbortSignal) =>
+    new Promise<void>((resolve, reject) => {
+      _resolve = resolve;
+      _reject = reject;
+      onStart?.();
+
+      const abort = () => reject(createAbortError());
+
+      if (signal.aborted) {
+        abort();
+      } else {
+        signal.addEventListener("abort", abort, { once: true });
+      }
+    });
+
+  return {
+    loader,
+    resolve: () => _resolve?.(),
+    reject: (e?: unknown) => _reject?.(e ?? new Error("test rejection")),
+  };
+}
+
+export async function waitFor(
+  check: () => boolean,
+  { timeout = 500, interval = 5 } = {}
+) {
+  const start = Date.now();
+  while (true) {
+    if (check()) return;
+    if (Date.now() - start > timeout) throw new Error("waitFor timeout");
+    await new Promise((r) => setTimeout(r, interval));
+  }
+}

--- a/packages/core/test/helpers.ts
+++ b/packages/core/test/helpers.ts
@@ -1,7 +1,7 @@
 import type { Chunk } from "@/data/chunk";
 
 type ChunkOverrides = Partial<
-  Omit<Chunk, "shape" | "chunkIndex" | "scale" | "offset">
+  Omit<Chunk, "shape" | "chunkIndex" | "scale" | "offset" | "rowStride">
 > & {
   shape?: Partial<Chunk["shape"]>;
   chunkIndex?: Partial<Chunk["chunkIndex"]>;
@@ -26,13 +26,16 @@ export function makeChunk(overrides: ChunkOverrides = {}): Chunk {
     offset: { x: 0, y: 0, z: 0 },
   };
 
+  const mergedShape = { ...defaultChunk.shape, ...(shape ?? {}) };
+
   return {
     ...defaultChunk,
     ...rest,
-    shape: { ...defaultChunk.shape, ...(shape ?? {}) },
+    shape: mergedShape,
     chunkIndex: { ...defaultChunk.chunkIndex, ...(chunkIndex ?? {}) },
     scale: { ...defaultChunk.scale, ...(scale ?? {}) },
     offset: { ...defaultChunk.offset, ...(offset ?? {}) },
+    rowStride: mergedShape.x,
   };
 }
 

--- a/packages/core/test/renderable_pool.test.ts
+++ b/packages/core/test/renderable_pool.test.ts
@@ -72,7 +72,6 @@ describe("poolKeyForImageRenderable", () => {
       makeChunk({
         lod: 2,
         shape: { x: 256, y: 128 },
-        rowStride: 256,
         rowAlignmentBytes: 4,
       })
     );

--- a/packages/core/test/renderable_pool.test.ts
+++ b/packages/core/test/renderable_pool.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test, vi, beforeEach } from "vitest";
 import { RenderablePool } from "@/utilities/renderable_pool";
 import { RenderableObject } from "@/core/renderable_object";
 import { poolKeyForImageRenderable } from "@/layers/chunked_image_layer";
+import { makeChunk } from "./helpers";
 
 class RenderableStub extends RenderableObject {
   public readonly type = "RenderableStub";
@@ -67,14 +68,15 @@ describe("RenderablePool", () => {
 
 describe("poolKeyForImageRenderable", () => {
   test("builds a stable key string from chunk layout fields", () => {
-    const chunk = {
-      lod: 2,
-      shape: { x: 256, y: 128 },
-      rowStride: 256,
-      rowAlignmentBytes: 4,
-    } as unknown as import("../src/data/chunk").Chunk;
+    const key = poolKeyForImageRenderable(
+      makeChunk({
+        lod: 2,
+        shape: { x: 256, y: 128 },
+        rowStride: 256,
+        rowAlignmentBytes: 4,
+      })
+    );
 
-    const key = poolKeyForImageRenderable(chunk);
     expect(key).toBe("lod2:shape256x128:stride256:align4");
   });
 });


### PR DESCRIPTION
### Summary

This PR adds a chunk-aware fetch queue that:
- Limits concurrent requests
- Aborts in-flight requests if chunks become unnecessary
- Respects priority
- Keeps chunk state transitions consistent

### Notes

- This implementation doesn't respect sequencing within the same priority. I will need to address this when implementing loading order.

### Tests & Checks

- All existing examples are working as expected
- Added test suite for the chunk queue
- Manual verification:
  - Use the console log, filter `ChunkQueue` logs to verify cancellations
  - Change `MAX_CONCURRENT` in the `ChunkQueue` + throttling to verify concurrent connection limit
  - See how chunks are loaded top left in a linear progression