### PR TITLE
Multiple Viewports: Viewport-scoped events

### DIFF
--- a/packages/core/src/core/event_dispatcher.ts
+++ b/packages/core/src/core/event_dispatcher.ts
@@ -19,14 +19,20 @@ function isEventType(type: string): type is EventType {
 function hasClientCoordinates(
   event: Event
 ): event is Event & { clientX: number; clientY: number } {
-  return "clientX" in event && "clientY" in event;
+  const mouseEvent = event as Event & { clientX?: number; clientY?: number };
+  return (
+    typeof mouseEvent.clientX === "number" &&
+    typeof mouseEvent.clientY === "number" &&
+    !Number.isNaN(mouseEvent.clientX) &&
+    !Number.isNaN(mouseEvent.clientY)
+  );
 }
 
 export class EventContext {
   private propagationStopped_: boolean = false;
   public readonly type: EventType;
   public readonly event: Event;
-  public readonly clientPos: vec2;
+  public readonly clientPos?: vec2;
   public readonly worldPos?: vec3;
   public readonly clipPos?: vec3;
   public readonly source?: EventProvider;
@@ -34,7 +40,7 @@ export class EventContext {
   constructor(
     type: EventType,
     event: Event,
-    clientPos: vec2,
+    clientPos?: vec2,
     worldPos?: vec3,
     clipPos?: vec3,
     source?: EventProvider
@@ -65,7 +71,7 @@ export class EventContext {
     }
     const clientPos = hasClientCoordinates(domEvent)
       ? vec2.fromValues(domEvent.clientX, domEvent.clientY)
-      : vec2.fromValues(0, 0);
+      : undefined;
     return new EventContext(domEvent.type, domEvent, clientPos);
   }
 }

--- a/packages/core/src/core/event_dispatcher.ts
+++ b/packages/core/src/core/event_dispatcher.ts
@@ -74,7 +74,7 @@ export interface EventProvider {
   processEvent(eventContext: EventContext): EventContext;
 }
 
-class CanvasEventProvider implements EventProvider {
+export class CanvasEventProvider implements EventProvider {
   public readonly element: HTMLCanvasElement;
 
   constructor(element: HTMLCanvasElement) {
@@ -97,11 +97,6 @@ export class EventDispatcher {
   private readonly listeners_: Listener[] = [];
   private readonly domListeners_: Map<EventProvider, DOMEventListener> =
     new Map();
-
-  constructor(canvas: HTMLCanvasElement) {
-    const canvasProvider = new CanvasEventProvider(canvas);
-    this.addProvider(canvasProvider);
-  }
 
   public addEventListener(listener: Listener) {
     this.listeners_.push(listener);

--- a/packages/core/src/core/event_dispatcher.ts
+++ b/packages/core/src/core/event_dispatcher.ts
@@ -1,6 +1,5 @@
 import { vec2, vec3 } from "gl-matrix";
 import { Logger } from "../utilities/logger";
-import { Viewport } from "./viewport";
 
 const eventTypes = [
   "pointerdown",
@@ -17,6 +16,12 @@ function isEventType(type: string): type is EventType {
   return (eventTypes as readonly string[]).includes(type);
 }
 
+function hasClientCoordinates(
+  event: Event
+): event is Event & { clientX: number; clientY: number } {
+  return "clientX" in event && "clientY" in event;
+}
+
 export class EventContext {
   private propagationStopped_: boolean = false;
   public readonly type: EventType;
@@ -24,7 +29,7 @@ export class EventContext {
   public readonly clientPos: vec2;
   public readonly worldPos?: vec3;
   public readonly clipPos?: vec3;
-  public readonly sourceViewport?: Viewport;
+  public readonly source?: EventProvider;
 
   constructor(
     type: EventType,
@@ -32,14 +37,14 @@ export class EventContext {
     clientPos: vec2,
     worldPos?: vec3,
     clipPos?: vec3,
-    sourceViewport?: Viewport
+    source?: EventProvider
   ) {
     this.type = type;
     this.event = event;
     this.clientPos = clientPos;
     this.worldPos = worldPos;
     this.clipPos = clipPos;
-    this.sourceViewport = sourceViewport;
+    this.source = source;
   }
 
   get propagationStopped() {
@@ -49,143 +54,109 @@ export class EventContext {
   stopPropagation() {
     this.propagationStopped_ = true;
   }
+
+  public static fromDOMEvent(domEvent: Event): EventContext | null {
+    if (!isEventType(domEvent.type)) {
+      return null;
+    }
+    const clientPos = hasClientCoordinates(domEvent)
+      ? vec2.fromValues(domEvent.clientX, domEvent.clientY)
+      : vec2.fromValues(0, 0);
+    return new EventContext(domEvent.type, domEvent, clientPos);
+  }
 }
 
 type Listener = (event: EventContext) => void;
+type DOMEventListener = (e: Event) => void;
+
+export interface EventProvider {
+  readonly element: HTMLElement;
+  processEvent(eventContext: EventContext): EventContext;
+}
+
+class CanvasEventProvider implements EventProvider {
+  public readonly element: HTMLCanvasElement;
+
+  constructor(element: HTMLCanvasElement) {
+    this.element = element;
+  }
+
+  processEvent(eventContext: EventContext): EventContext {
+    return new EventContext(
+      eventContext.type,
+      eventContext.event,
+      eventContext.clientPos,
+      eventContext.worldPos,
+      eventContext.clipPos,
+      this
+    );
+  }
+}
 
 export class EventDispatcher {
   private readonly listeners_: Listener[] = [];
-  private readonly viewportEventHandlers_: Map<Viewport, (e: Event) => void> =
+  private readonly domListeners_: Map<EventProvider, DOMEventListener> =
     new Map();
 
   constructor(canvas: HTMLCanvasElement) {
-    eventTypes.forEach((type) => {
-      canvas.addEventListener(type, this.handleEvent, { passive: false });
-    });
+    const canvasProvider = new CanvasEventProvider(canvas);
+    this.addProvider(canvasProvider);
   }
 
   public addEventListener(listener: Listener) {
     this.listeners_.push(listener);
   }
 
-  public addViewport(viewport: Viewport) {
-    if (this.viewportEventHandlers_.has(viewport)) {
+  public addProvider(provider: EventProvider) {
+    if (this.domListeners_.has(provider)) {
+      Logger.warn("EventDispatcher", `Provider ${provider} already registered`);
+      return;
+    }
+
+    const domHandler = this.createHandler(provider);
+    this.domListeners_.set(provider, domHandler);
+
+    eventTypes.forEach((type) => {
+      provider.element.addEventListener(type, domHandler, { passive: false });
+    });
+  }
+
+  public removeProvider(provider: EventProvider) {
+    if (!this.domListeners_.has(provider)) {
       Logger.warn(
         "EventDispatcher",
-        `Viewport ${viewport.id} already registered`
+        `Provider ${provider} not found for removal`
       );
       return;
     }
 
-    const handler = this.createViewportEventHandler(viewport);
-    this.viewportEventHandlers_.set(viewport, handler);
-
-    eventTypes.forEach((type) => {
-      viewport.element.addEventListener(type, handler, { passive: false });
-    });
-  }
-
-  public removeViewport(viewport: Viewport) {
-    const handler = this.viewportEventHandlers_.get(viewport);
-    if (!handler) {
-      Logger.warn(
-        "EventDispatcher",
-        `Viewport ${viewport.id} not found for removal`
-      );
-      return;
-    }
-
-    eventTypes.forEach((type) => {
-      viewport.element.removeEventListener(type, handler);
-    });
-    this.viewportEventHandlers_.delete(viewport);
-  }
-
-  public setViewports(viewports: Viewport[]) {
-    for (const viewport of this.viewportEventHandlers_.keys()) {
-      this.removeViewport(viewport);
-    }
-
-    for (const viewport of viewports) {
-      this.addViewport(viewport);
+    const domHandler = this.domListeners_.get(provider);
+    if (domHandler) {
+      eventTypes.forEach((type) => {
+        provider.element.removeEventListener(type, domHandler);
+      });
+      this.domListeners_.delete(provider);
     }
   }
 
-  private createViewportEventHandler(viewport: Viewport): (e: Event) => void {
+  private createHandler(provider: EventProvider): DOMEventListener {
     return (e: Event) => {
-      if (!isEventType(e.type)) {
-        Logger.error("EventDispatcher", `Unsupported event type ${e.type}`);
+      const baseEventContext = EventContext.fromDOMEvent(e);
+      if (!baseEventContext) {
         return;
       }
 
-      const clientPos = this.extractClientPos(e);
-
-      const { worldPos, clipPos } = this.getWorldPosition(e, viewport);
-      const event = new EventContext(
-        e.type,
-        e,
-        clientPos,
-        worldPos,
-        clipPos,
-        viewport
-      );
-
-      // pass viewport events to their own layers first
-      for (const layer of viewport.layerManager.layers) {
-        layer.onEvent(event);
-        if (event.propagationStopped) return;
+      // let provider process the context (augment + handle internal distribution) first
+      const eventContext = provider.processEvent(baseEventContext);
+      if (eventContext.propagationStopped) {
+        return;
       }
 
-      viewport.cameraControls?.onEvent(event);
-      if (event.propagationStopped) return;
-
+      // distribute provider-augmented context to global listeners if not stopped
       for (const listener of this.listeners_) {
-        listener(event);
-        if (event.propagationStopped) return;
+        listener(eventContext);
+        if (eventContext.propagationStopped) return;
       }
     };
   }
-
-  private extractClientPos(event: Event): vec2 {
-    if (this.hasClientCoordinates(event)) {
-      return vec2.fromValues(event.clientX, event.clientY);
-    }
-    return vec2.fromValues(0, 0);
-  }
-
-  private getWorldPosition(
-    event: Event,
-    viewport: Viewport
-  ): { worldPos?: vec3; clipPos?: vec3 } {
-    if (this.hasClientCoordinates(event)) {
-      const clipPos = viewport.clientToClip([event.clientX, event.clientY], 0);
-      const worldPos = viewport.camera.clipToWorld(clipPos);
-      return { worldPos, clipPos };
-    } else {
-      return {};
-    }
-  }
-
-  private hasClientCoordinates(
-    event: Event
-  ): event is Event & { clientX: number; clientY: number } {
-    return "clientX" in event && "clientY" in event;
-  }
-
-  private readonly handleEvent = (e: Event) => {
-    if (!isEventType(e.type)) {
-      Logger.error("EventDispatcher", `Unsupported event type ${e.type}`);
-      return;
-    }
-
-    const clientPos = this.extractClientPos(e);
-
-    // base canvas event - no viewport context
-    const event = new EventContext(e.type, e, clientPos);
-
-    for (const listener of this.listeners_) {
-      listener(event);
-      if (event.propagationStopped) return;
-    }
-  };
 }

--- a/packages/core/src/core/event_dispatcher.ts
+++ b/packages/core/src/core/event_dispatcher.ts
@@ -57,6 +57,10 @@ export class EventContext {
 
   public static fromDOMEvent(domEvent: Event): EventContext | null {
     if (!isEventType(domEvent.type)) {
+      Logger.error(
+        "EventDispatcher",
+        `Unsupported event type ${domEvent.type}`
+      );
       return null;
     }
     const clientPos = hasClientCoordinates(domEvent)

--- a/packages/core/src/core/event_dispatcher.ts
+++ b/packages/core/src/core/event_dispatcher.ts
@@ -1,5 +1,6 @@
-import { vec3 } from "gl-matrix";
+import { vec2, vec3 } from "gl-matrix";
 import { Logger } from "../utilities/logger";
+import { Viewport } from "./viewport";
 
 const eventTypes = [
   "pointerdown",
@@ -7,6 +8,8 @@ const eventTypes = [
   "pointerup",
   "pointercancel",
   "wheel",
+  "mouseenter",
+  "mouseleave",
 ] as const;
 
 type EventType = (typeof eventTypes)[number];
@@ -17,13 +20,26 @@ function isEventType(type: string): type is EventType {
 export class EventContext {
   private propagationStopped_: boolean = false;
   public readonly type: EventType;
-  public readonly event?: Event;
-  public worldPos?: vec3;
-  public clipPos?: vec3;
+  public readonly event: Event;
+  public readonly clientPos: vec2;
+  public readonly worldPos?: vec3;
+  public readonly clipPos?: vec3;
+  public readonly sourceViewport?: Viewport;
 
-  constructor(type: EventType, event?: Event) {
+  constructor(
+    type: EventType,
+    event: Event,
+    clientPos: vec2,
+    worldPos?: vec3,
+    clipPos?: vec3,
+    sourceViewport?: Viewport
+  ) {
     this.type = type;
     this.event = event;
+    this.clientPos = clientPos;
+    this.worldPos = worldPos;
+    this.clipPos = clipPos;
+    this.sourceViewport = sourceViewport;
   }
 
   get propagationStopped() {
@@ -39,6 +55,8 @@ type Listener = (event: EventContext) => void;
 
 export class EventDispatcher {
   private readonly listeners_: Listener[] = [];
+  private readonly viewportEventHandlers_: Map<Viewport, (e: Event) => void> =
+    new Map();
 
   constructor(canvas: HTMLCanvasElement) {
     eventTypes.forEach((type) => {
@@ -50,16 +68,124 @@ export class EventDispatcher {
     this.listeners_.push(listener);
   }
 
+  public addViewport(viewport: Viewport) {
+    if (this.viewportEventHandlers_.has(viewport)) {
+      Logger.warn(
+        "EventDispatcher",
+        `Viewport ${viewport.id} already registered`
+      );
+      return;
+    }
+
+    const handler = this.createViewportEventHandler(viewport);
+    this.viewportEventHandlers_.set(viewport, handler);
+
+    eventTypes.forEach((type) => {
+      viewport.element.addEventListener(type, handler, { passive: false });
+    });
+  }
+
+  public removeViewport(viewport: Viewport) {
+    const handler = this.viewportEventHandlers_.get(viewport);
+    if (!handler) {
+      Logger.warn(
+        "EventDispatcher",
+        `Viewport ${viewport.id} not found for removal`
+      );
+      return;
+    }
+
+    eventTypes.forEach((type) => {
+      viewport.element.removeEventListener(type, handler);
+    });
+    this.viewportEventHandlers_.delete(viewport);
+  }
+
+  public setViewports(viewports: Viewport[]) {
+    for (const viewport of this.viewportEventHandlers_.keys()) {
+      this.removeViewport(viewport);
+    }
+
+    for (const viewport of viewports) {
+      this.addViewport(viewport);
+    }
+  }
+
+  private createViewportEventHandler(viewport: Viewport): (e: Event) => void {
+    return (e: Event) => {
+      if (!isEventType(e.type)) {
+        Logger.error("EventDispatcher", `Unsupported event type ${e.type}`);
+        return;
+      }
+
+      const clientPos = this.extractClientPos(e);
+
+      const { worldPos, clipPos } = this.getWorldPosition(e, viewport);
+      const event = new EventContext(
+        e.type,
+        e,
+        clientPos,
+        worldPos,
+        clipPos,
+        viewport
+      );
+
+      // pass viewport events to their own layers first
+      for (const layer of viewport.layerManager.layers) {
+        layer.onEvent(event);
+        if (event.propagationStopped) return;
+      }
+
+      viewport.cameraControls?.onEvent(event);
+      if (event.propagationStopped) return;
+
+      for (const listener of this.listeners_) {
+        listener(event);
+        if (event.propagationStopped) return;
+      }
+    };
+  }
+
+  private extractClientPos(event: Event): vec2 {
+    if (this.hasClientCoordinates(event)) {
+      return vec2.fromValues(event.clientX, event.clientY);
+    }
+    return vec2.fromValues(0, 0);
+  }
+
+  private getWorldPosition(
+    event: Event,
+    viewport: Viewport
+  ): { worldPos?: vec3; clipPos?: vec3 } {
+    if (this.hasClientCoordinates(event)) {
+      const clipPos = viewport.clientToClip([event.clientX, event.clientY], 0);
+      const worldPos = viewport.camera.clipToWorld(clipPos);
+      return { worldPos, clipPos };
+    } else {
+      return {};
+    }
+  }
+
+  private hasClientCoordinates(
+    event: Event
+  ): event is Event & { clientX: number; clientY: number } {
+    return "clientX" in event && "clientY" in event;
+  }
+
   private readonly handleEvent = (e: Event) => {
     if (!isEventType(e.type)) {
       Logger.error("EventDispatcher", `Unsupported event type ${e.type}`);
       return;
     }
 
-    const event = new EventContext(e.type, e);
+    const clientPos = this.extractClientPos(e);
+
+    // base canvas event - no viewport context
+    const event = new EventContext(e.type, e, clientPos);
+
     for (const listener of this.listeners_) {
       listener(event);
-      if (event.propagationStopped) break;
+      if (event.propagationStopped) return;
     }
   };
 }

--- a/packages/core/src/core/event_dispatcher.ts
+++ b/packages/core/src/core/event_dispatcher.ts
@@ -84,25 +84,6 @@ export interface EventProvider {
   processEvent(eventContext: EventContext): EventContext;
 }
 
-export class CanvasEventProvider implements EventProvider {
-  public readonly element: HTMLCanvasElement;
-
-  constructor(element: HTMLCanvasElement) {
-    this.element = element;
-  }
-
-  processEvent(eventContext: EventContext): EventContext {
-    return new EventContext(
-      eventContext.type,
-      eventContext.event,
-      eventContext.clientPos,
-      eventContext.worldPos,
-      eventContext.clipPos,
-      this
-    );
-  }
-}
-
 export class EventDispatcher {
   private readonly listeners_: Listener[] = [];
   private readonly domListeners_: Map<EventProvider, DOMEventListener> =

--- a/packages/core/src/core/viewport.ts
+++ b/packages/core/src/core/viewport.ts
@@ -6,6 +6,7 @@ import { Box2 } from "../math/box2";
 import { vec2, vec3 } from "gl-matrix";
 import { generateUUID } from "../utilities/uuid_generator";
 import { Logger } from "../utilities/logger";
+import { EventContext, EventProvider } from "./event_dispatcher";
 
 export interface ViewportConfig {
   id?: string;
@@ -15,7 +16,7 @@ export interface ViewportConfig {
   cameraControls?: CameraControls;
 }
 
-export class Viewport {
+export class Viewport implements EventProvider {
   public readonly id: string;
   public readonly element: HTMLElement;
   public readonly camera: Camera;
@@ -81,6 +82,30 @@ export class Viewport {
   public clientToWorld(position: vec2, depth: number = 0): vec3 {
     const clipPos = this.clientToClip(position, depth);
     return this.camera.clipToWorld(clipPos);
+  }
+
+  public processEvent(eventContext: EventContext): EventContext {
+    const clipPos = this.clientToClip(eventContext.clientPos, 0);
+    const worldPos = this.camera.clipToWorld(clipPos);
+    const augmentedContext = new EventContext(
+      eventContext.type,
+      eventContext.event,
+      eventContext.clientPos,
+      worldPos,
+      clipPos,
+      this
+    );
+
+    for (const layer of this.layerManager.layers) {
+      layer.onEvent(augmentedContext);
+      if (augmentedContext.propagationStopped) break;
+    }
+
+    if (!augmentedContext.propagationStopped) {
+      this.cameraControls?.onEvent(augmentedContext);
+    }
+
+    return augmentedContext;
   }
 
   private getBox(): Box2 {

--- a/packages/core/src/core/viewport.ts
+++ b/packages/core/src/core/viewport.ts
@@ -80,8 +80,10 @@ export class Viewport implements EventProvider {
   }
 
   public processEvent(eventContext: EventContext): EventContext {
-    const clipPos = this.clientToClip(eventContext.clientPos, 0);
-    const worldPos = this.camera.clipToWorld(clipPos);
+    const clipPos = eventContext.clientPos
+      ? this.clientToClip(eventContext.clientPos, 0)
+      : undefined;
+    const worldPos = clipPos ? this.camera.clipToWorld(clipPos) : undefined;
     const augmentedContext = new EventContext(
       eventContext.type,
       eventContext.event,

--- a/packages/core/src/core/viewport.ts
+++ b/packages/core/src/core/viewport.ts
@@ -79,11 +79,6 @@ export class Viewport implements EventProvider {
     );
   }
 
-  public clientToWorld(position: vec2, depth: number = 0): vec3 {
-    const clipPos = this.clientToClip(position, depth);
-    return this.camera.clipToWorld(clipPos);
-  }
-
   public processEvent(eventContext: EventContext): EventContext {
     const clipPos = this.clientToClip(eventContext.clientPos, 0);
     const worldPos = this.camera.clipToWorld(clipPos);

--- a/packages/core/src/idetik.ts
+++ b/packages/core/src/idetik.ts
@@ -17,6 +17,7 @@ import {
 
 type Overlay = {
   update(idetik: Idetik, timestamp?: DOMHighResTimeStamp): void;
+  onEvent?(event: EventContext): void;
 };
 
 type IdetikParams = {
@@ -87,22 +88,15 @@ export class Idetik {
     if (params.showStats) this.stats_ = createStats();
 
     this.events = new EventDispatcher(canvas);
-    this.events.addEventListener((event: EventContext) => {
-      if (
-        event.event instanceof PointerEvent ||
-        event.event instanceof WheelEvent
-      ) {
-        const { clientX, clientY } = event.event;
-        const client = vec2.fromValues(clientX, clientY);
-        event.clipPos = this.clientToClip(client, 0);
-        event.worldPos = this.camera.clipToWorld(event.clipPos);
+    for (const viewport of this.viewports_) {
+      this.events.addViewport(viewport);
+    }
+
+    for (const overlay of this.overlays) {
+      if (overlay.onEvent) {
+        this.events.addEventListener(overlay.onEvent.bind(overlay));
       }
-      for (const layer of this.layerManager.layers) {
-        layer.onEvent(event);
-        if (event.propagationStopped) return;
-      }
-      this.viewports_[0].cameraControls?.onEvent(event);
-    });
+    }
   }
 
   public get width() {

--- a/packages/core/src/idetik.ts
+++ b/packages/core/src/idetik.ts
@@ -1,11 +1,7 @@
 import { Camera } from "./objects/cameras/camera";
 import { Layer } from "./core/layer";
 import { LayerManager } from "./core/layer_manager";
-import {
-  EventContext,
-  EventDispatcher,
-  CanvasEventProvider,
-} from "./core/event_dispatcher";
+import { EventDispatcher } from "./core/event_dispatcher";
 import { WebGLRenderer } from "./renderers/webgl_renderer";
 import { CameraControls } from "./objects/cameras/controls";
 import { Logger } from "./utilities/logger";
@@ -21,7 +17,6 @@ import {
 
 type Overlay = {
   update(idetik: Idetik, timestamp?: DOMHighResTimeStamp): void;
-  onEvent?(event: EventContext): void;
 };
 
 type IdetikParams = {
@@ -92,22 +87,7 @@ export class Idetik {
     if (params.showStats) this.stats_ = createStats();
 
     this.events = new EventDispatcher();
-    for (const viewport of this.viewports_) {
-      this.events.addProvider(viewport);
-    }
-
-    // add canvas provider if no viewport uses the canvas as its element
-    // this handles multi-viewport cases where canvas background might be exposed
-    // i.e. when viewports don't cover the entire canvas
-    if (!this.viewports_.some((v) => v.element === canvas)) {
-      this.events.addProvider(new CanvasEventProvider(canvas));
-    }
-
-    for (const overlay of this.overlays) {
-      if (overlay.onEvent) {
-        this.events.addEventListener(overlay.onEvent.bind(overlay));
-      }
-    }
+    this.events.addProvider(this.viewports_[0]);
   }
 
   public get width() {

--- a/packages/core/src/idetik.ts
+++ b/packages/core/src/idetik.ts
@@ -89,7 +89,7 @@ export class Idetik {
 
     this.events = new EventDispatcher(canvas);
     for (const viewport of this.viewports_) {
-      this.events.addViewport(viewport);
+      this.events.addProvider(viewport);
     }
 
     for (const overlay of this.overlays) {

--- a/packages/core/src/idetik.ts
+++ b/packages/core/src/idetik.ts
@@ -1,7 +1,11 @@
 import { Camera } from "./objects/cameras/camera";
 import { Layer } from "./core/layer";
 import { LayerManager } from "./core/layer_manager";
-import { EventContext, EventDispatcher } from "./core/event_dispatcher";
+import {
+  EventContext,
+  EventDispatcher,
+  CanvasEventProvider,
+} from "./core/event_dispatcher";
 import { WebGLRenderer } from "./renderers/webgl_renderer";
 import { CameraControls } from "./objects/cameras/controls";
 import { Logger } from "./utilities/logger";
@@ -87,9 +91,16 @@ export class Idetik {
 
     if (params.showStats) this.stats_ = createStats();
 
-    this.events = new EventDispatcher(canvas);
+    this.events = new EventDispatcher();
     for (const viewport of this.viewports_) {
       this.events.addProvider(viewport);
+    }
+
+    // add canvas provider if no viewport uses the canvas as its element
+    // this handles multi-viewport cases where canvas background might be exposed
+    // i.e. when viewports don't cover the entire canvas
+    if (!this.viewports_.some((v) => v.element === canvas)) {
+      this.events.addProvider(new CanvasEventProvider(canvas));
     }
 
     for (const overlay of this.overlays) {

--- a/packages/core/test/event_provider.test.ts
+++ b/packages/core/test/event_provider.test.ts
@@ -87,7 +87,16 @@ describe("EventProvider architecture", () => {
   it("viewport provider adds coordinate transformations", () => {
     const canvas = document.createElement("canvas");
     Object.defineProperty(canvas, "getBoundingClientRect", {
-      value: () => ({ left: 0, top: 0, width: 800, height: 600 }),
+      value: () => ({
+        left: 0,
+        top: 0,
+        width: 800,
+        height: 600,
+        x: 0,
+        y: 0,
+        right: 800,
+        bottom: 600,
+      }),
     });
 
     const camera = new OrthographicCamera(0, 800, 0, 600);
@@ -143,10 +152,11 @@ describe("EventProvider architecture", () => {
     expect(receivedEvent!.clipPos).toBeUndefined();
 
     // Ensure client coordinates are preserved and valid
-    expect(Number.isNaN(receivedEvent!.clientPos[0])).toBe(false);
-    expect(Number.isNaN(receivedEvent!.clientPos[1])).toBe(false);
-    expect(receivedEvent!.clientPos[0]).toBe(150);
-    expect(receivedEvent!.clientPos[1]).toBe(250);
+    expect(receivedEvent!.clientPos).toBeDefined();
+    expect(Number.isNaN(receivedEvent!.clientPos![0])).toBe(false);
+    expect(Number.isNaN(receivedEvent!.clientPos![1])).toBe(false);
+    expect(receivedEvent!.clientPos![0]).toBe(150);
+    expect(receivedEvent!.clientPos![1]).toBe(250);
   });
 
   it("layers can stop propagation", () => {
@@ -162,5 +172,29 @@ describe("EventProvider architecture", () => {
     canvas.dispatchEvent(new PointerEvent("pointerdown"));
 
     expect(globalListener).not.toHaveBeenCalled();
+  });
+
+  it("handles events without client coordinates", () => {
+    const canvas = document.createElement("canvas");
+    const dispatcher = new EventDispatcher();
+
+    const canvasProvider = new CanvasEventProvider(canvas);
+    dispatcher.addProvider(canvasProvider);
+
+    let receivedEvent: EventContext | null = null;
+    dispatcher.addEventListener((event) => {
+      receivedEvent = event;
+    });
+
+    // Create a wheel event explicitly without clientX/clientY
+    const wheelEvent = new WheelEvent("wheel");
+    Object.defineProperty(wheelEvent, "clientX", { value: undefined });
+    Object.defineProperty(wheelEvent, "clientY", { value: undefined });
+    canvas.dispatchEvent(wheelEvent);
+
+    expect(receivedEvent).not.toBeNull();
+    expect(receivedEvent!.clientPos).toBeUndefined();
+    expect(receivedEvent!.worldPos).toBeUndefined();
+    expect(receivedEvent!.clipPos).toBeUndefined();
   });
 });

--- a/packages/core/test/event_provider.test.ts
+++ b/packages/core/test/event_provider.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  EventDispatcher,
+  EventContext,
+  EventProvider,
+  CanvasEventProvider,
+} from "../src/core/event_dispatcher";
+import { OrthographicCamera } from "../src/objects/cameras/orthographic_camera";
+import { Layer } from "../src/core/layer";
+import { Idetik } from "../src/idetik";
+import { vec2, vec3 } from "gl-matrix";
+
+class TestLayer extends Layer {
+  public readonly type = "test";
+  private shouldStopPropagation_ = false;
+
+  constructor(shouldStop = false) {
+    super({});
+    this.shouldStopPropagation_ = shouldStop;
+  }
+
+  public update() {}
+
+  public onEvent(event: EventContext) {
+    if (this.shouldStopPropagation_) {
+      event.stopPropagation();
+    }
+  }
+}
+
+class TestEventProvider implements EventProvider {
+  public eventProcessed = false;
+  public stopsPropagation = false;
+  public readonly element: HTMLElement;
+
+  constructor(element: HTMLElement) {
+    this.element = element;
+  }
+
+  processEvent(eventContext: EventContext): EventContext {
+    this.eventProcessed = true;
+    const augmented = new EventContext(
+      eventContext.type,
+      eventContext.event,
+      eventContext.clientPos,
+      eventContext.worldPos,
+      eventContext.clipPos,
+      this
+    );
+    augmented.stopPropagation();
+    return augmented;
+  }
+}
+
+describe("EventProvider architecture", () => {
+  it("EventProvider can stop propagation to prevent global listeners", () => {
+    const testDiv = document.createElement("div");
+    const dispatcher = new EventDispatcher();
+
+    const stoppingProvider = new TestEventProvider(testDiv);
+    stoppingProvider.stopsPropagation = true;
+    dispatcher.addProvider(stoppingProvider);
+
+    const globalListener = vi.fn();
+    dispatcher.addEventListener(globalListener);
+
+    const pointerEvent = new PointerEvent("pointerdown", {
+      clientX: 100,
+      clientY: 200,
+    });
+    testDiv.dispatchEvent(pointerEvent);
+
+    expect(stoppingProvider.eventProcessed).toBe(true);
+    expect(globalListener).not.toHaveBeenCalled();
+  });
+
+  it("Multiple EventProviders process events independently", () => {
+    const div1 = document.createElement("div");
+    const div2 = document.createElement("div");
+    const dispatcher = new EventDispatcher();
+
+    const provider1 = new TestEventProvider(div1);
+    const provider2 = new TestEventProvider(div2);
+
+    dispatcher.addProvider(provider1);
+    dispatcher.addProvider(provider2);
+
+    const pointerEvent = new PointerEvent("pointerdown", {
+      clientX: 50,
+      clientY: 75,
+    });
+    div1.dispatchEvent(pointerEvent);
+
+    expect(provider1.eventProcessed).toBe(true);
+    expect(provider2.eventProcessed).toBe(false);
+  });
+
+  it("Viewport provider adds world/clip coordinates", () => {
+    const canvas = document.createElement("canvas");
+    // Mock getBoundingClientRect to return specific dimensions
+    Object.defineProperty(canvas, "getBoundingClientRect", {
+      value: () => ({
+        left: 0,
+        top: 0,
+        width: 800,
+        height: 600,
+        x: 0,
+        y: 0,
+        right: 800,
+        bottom: 600,
+      }),
+    });
+
+    const camera = new OrthographicCamera(0, 800, 0, 600, 0, 100);
+    const idetik = new Idetik({ canvas, camera });
+
+    // add a global event listener
+    let receivedEvent: EventContext | null = null;
+    idetik.events.addEventListener((event) => {
+      receivedEvent = event;
+    });
+
+    const pointerEvent = new PointerEvent("pointerdown", {
+      clientX: 400,
+      clientY: 300,
+    });
+    canvas.dispatchEvent(pointerEvent);
+
+    expect(receivedEvent).not.toBeNull();
+    expect(receivedEvent!.clientPos).toEqual(vec2.fromValues(400, 300));
+    // default clip depth for events is 0 (no picking is done by default)
+    expect(receivedEvent!.clipPos).toEqual(vec3.fromValues(0, 0, 0));
+    // -50 is the center of the orthographic camera near/far range
+    expect(receivedEvent!.worldPos).toEqual(vec3.fromValues(400, 300, -50));
+  });
+
+  it("Fallback canvas provider does not add clip/world coordinates", () => {
+    const canvas = document.createElement("canvas");
+    const dispatcher = new EventDispatcher();
+
+    const canvasProvider = new CanvasEventProvider(canvas);
+    dispatcher.addProvider(canvasProvider);
+
+    let receivedEvent: EventContext | null = null;
+    dispatcher.addEventListener((event) => {
+      receivedEvent = event;
+    });
+
+    const pointerEvent = new PointerEvent("pointerdown", {
+      clientX: 150,
+      clientY: 250,
+    });
+    canvas.dispatchEvent(pointerEvent);
+
+    expect(receivedEvent).not.toBeNull();
+    expect(receivedEvent!.source).toBeDefined();
+    expect(receivedEvent!.source?.element).toBe(canvas);
+    expect(receivedEvent!.worldPos).toBeUndefined();
+    expect(receivedEvent!.clipPos).toBeUndefined();
+    expect(receivedEvent!.clientPos).toEqual(vec2.fromValues(150, 250));
+  });
+
+  it("Layer can stop propagation within viewport processing", () => {
+    const canvas = document.createElement("canvas");
+    const camera = new OrthographicCamera(0, 800, 0, 600);
+
+    const stoppingLayer = new TestLayer(true);
+    const idetik = new Idetik({
+      canvas,
+      camera,
+      layers: [stoppingLayer],
+    });
+
+    // global listener should not be called due to layer stopping propagation
+    const globalListener = vi.fn();
+    idetik.events.addEventListener(globalListener);
+
+    const pointerEvent = new PointerEvent("pointerdown", {
+      clientX: 400,
+      clientY: 300,
+    });
+    canvas.dispatchEvent(pointerEvent);
+
+    expect(globalListener).not.toHaveBeenCalled();
+  });
+
+  it("EventContext.fromDOMEvent creates valid context for supported event", () => {
+    const pointerEvent = new PointerEvent("pointermove", {
+      clientX: 123,
+      clientY: 456,
+    });
+
+    const context = EventContext.fromDOMEvent(pointerEvent);
+
+    expect(context).not.toBeNull();
+    expect(context!.type).toBe("pointermove");
+    expect(context!.event).toBe(pointerEvent);
+    expect(context!.clientPos).toEqual(vec2.fromValues(123, 456));
+    expect(context!.worldPos).toBeUndefined();
+    expect(context!.clipPos).toBeUndefined();
+    expect(context!.source).toBeUndefined();
+    expect(context!.propagationStopped).toBe(false);
+  });
+
+  it("EventContext.fromDOMEvent returns null for unsupported event types", () => {
+    const customEvent = new CustomEvent("unsupported");
+    const context = EventContext.fromDOMEvent(customEvent);
+    expect(context).toBeNull();
+  });
+
+  it("EventContext handles events without client coordinates", () => {
+    const wheelEvent = new WheelEvent("wheel", {
+      // a supported event type, but explicitly not setting clientX/clientY
+    });
+
+    const context = EventContext.fromDOMEvent(wheelEvent);
+
+    expect(context).not.toBeNull();
+
+    // Should default to (0, 0) when no client coordinates
+    expect(context!.clientPos).toEqual(vec2.fromValues(0, 0));
+  });
+});

--- a/packages/core/test/event_provider.test.ts
+++ b/packages/core/test/event_provider.test.ts
@@ -3,7 +3,6 @@ import {
   EventDispatcher,
   EventContext,
   EventProvider,
-  CanvasEventProvider,
 } from "../src/core/event_dispatcher";
 import { OrthographicCamera } from "../src/objects/cameras/orthographic_camera";
 import { Layer } from "../src/core/layer";
@@ -127,38 +126,6 @@ describe("EventProvider architecture", () => {
     expect(Number.isNaN(receivedEvent!.clipPos![2])).toBe(false);
   });
 
-  it("canvas provider works without coordinate transforms", () => {
-    const canvas = document.createElement("canvas");
-    const dispatcher = new EventDispatcher();
-
-    const canvasProvider = new CanvasEventProvider(canvas);
-    dispatcher.addProvider(canvasProvider);
-
-    let receivedEvent: EventContext | null = null;
-    dispatcher.addEventListener((event) => {
-      receivedEvent = event;
-    });
-
-    canvas.dispatchEvent(
-      new PointerEvent("pointerdown", {
-        clientX: 150,
-        clientY: 250,
-      })
-    );
-
-    expect(receivedEvent).not.toBeNull();
-    expect(receivedEvent!.source).toBe(canvasProvider);
-    expect(receivedEvent!.worldPos).toBeUndefined();
-    expect(receivedEvent!.clipPos).toBeUndefined();
-
-    // Ensure client coordinates are preserved and valid
-    expect(receivedEvent!.clientPos).toBeDefined();
-    expect(Number.isNaN(receivedEvent!.clientPos![0])).toBe(false);
-    expect(Number.isNaN(receivedEvent!.clientPos![1])).toBe(false);
-    expect(receivedEvent!.clientPos![0]).toBe(150);
-    expect(receivedEvent!.clientPos![1]).toBe(250);
-  });
-
   it("layers can stop propagation", () => {
     const canvas = document.createElement("canvas");
     const camera = new OrthographicCamera(0, 800, 0, 600);
@@ -172,29 +139,5 @@ describe("EventProvider architecture", () => {
     canvas.dispatchEvent(new PointerEvent("pointerdown"));
 
     expect(globalListener).not.toHaveBeenCalled();
-  });
-
-  it("handles events without client coordinates", () => {
-    const canvas = document.createElement("canvas");
-    const dispatcher = new EventDispatcher();
-
-    const canvasProvider = new CanvasEventProvider(canvas);
-    dispatcher.addProvider(canvasProvider);
-
-    let receivedEvent: EventContext | null = null;
-    dispatcher.addEventListener((event) => {
-      receivedEvent = event;
-    });
-
-    // Create a wheel event explicitly without clientX/clientY
-    const wheelEvent = new WheelEvent("wheel");
-    Object.defineProperty(wheelEvent, "clientX", { value: undefined });
-    Object.defineProperty(wheelEvent, "clientY", { value: undefined });
-    canvas.dispatchEvent(wheelEvent);
-
-    expect(receivedEvent).not.toBeNull();
-    expect(receivedEvent!.clientPos).toBeUndefined();
-    expect(receivedEvent!.worldPos).toBeUndefined();
-    expect(receivedEvent!.clipPos).toBeUndefined();
   });
 });

--- a/packages/core/test/event_provider.test.ts
+++ b/packages/core/test/event_provider.test.ts
@@ -8,7 +8,6 @@ import {
 import { OrthographicCamera } from "../src/objects/cameras/orthographic_camera";
 import { Layer } from "../src/core/layer";
 import { Idetik } from "../src/idetik";
-import { vec2, vec3 } from "gl-matrix";
 
 class TestLayer extends Layer {
   public readonly type = "test";
@@ -30,7 +29,6 @@ class TestLayer extends Layer {
 
 class TestEventProvider implements EventProvider {
   public eventProcessed = false;
-  public stopsPropagation = false;
   public readonly element: HTMLElement;
 
   constructor(element: HTMLElement) {
@@ -53,28 +51,23 @@ class TestEventProvider implements EventProvider {
 }
 
 describe("EventProvider architecture", () => {
-  it("EventProvider can stop propagation to prevent global listeners", () => {
+  it("providers can stop propagation to prevent global listeners", () => {
     const testDiv = document.createElement("div");
     const dispatcher = new EventDispatcher();
 
     const stoppingProvider = new TestEventProvider(testDiv);
-    stoppingProvider.stopsPropagation = true;
     dispatcher.addProvider(stoppingProvider);
 
     const globalListener = vi.fn();
     dispatcher.addEventListener(globalListener);
 
-    const pointerEvent = new PointerEvent("pointerdown", {
-      clientX: 100,
-      clientY: 200,
-    });
-    testDiv.dispatchEvent(pointerEvent);
+    testDiv.dispatchEvent(new PointerEvent("pointerdown"));
 
     expect(stoppingProvider.eventProcessed).toBe(true);
     expect(globalListener).not.toHaveBeenCalled();
   });
 
-  it("Multiple EventProviders process events independently", () => {
+  it("providers handle events independently", () => {
     const div1 = document.createElement("div");
     const div2 = document.createElement("div");
     const dispatcher = new EventDispatcher();
@@ -85,56 +78,47 @@ describe("EventProvider architecture", () => {
     dispatcher.addProvider(provider1);
     dispatcher.addProvider(provider2);
 
-    const pointerEvent = new PointerEvent("pointerdown", {
-      clientX: 50,
-      clientY: 75,
-    });
-    div1.dispatchEvent(pointerEvent);
+    div1.dispatchEvent(new PointerEvent("pointerdown"));
 
     expect(provider1.eventProcessed).toBe(true);
     expect(provider2.eventProcessed).toBe(false);
   });
 
-  it("Viewport provider adds world/clip coordinates", () => {
+  it("viewport provider adds coordinate transformations", () => {
     const canvas = document.createElement("canvas");
-    // Mock getBoundingClientRect to return specific dimensions
     Object.defineProperty(canvas, "getBoundingClientRect", {
-      value: () => ({
-        left: 0,
-        top: 0,
-        width: 800,
-        height: 600,
-        x: 0,
-        y: 0,
-        right: 800,
-        bottom: 600,
-      }),
+      value: () => ({ left: 0, top: 0, width: 800, height: 600 }),
     });
 
-    const camera = new OrthographicCamera(0, 800, 0, 600, 0, 100);
+    const camera = new OrthographicCamera(0, 800, 0, 600);
     const idetik = new Idetik({ canvas, camera });
 
-    // add a global event listener
     let receivedEvent: EventContext | null = null;
     idetik.events.addEventListener((event) => {
       receivedEvent = event;
     });
 
-    const pointerEvent = new PointerEvent("pointerdown", {
-      clientX: 400,
-      clientY: 300,
-    });
-    canvas.dispatchEvent(pointerEvent);
+    canvas.dispatchEvent(
+      new PointerEvent("pointerdown", {
+        clientX: 400,
+        clientY: 300,
+      })
+    );
 
     expect(receivedEvent).not.toBeNull();
-    expect(receivedEvent!.clientPos).toEqual(vec2.fromValues(400, 300));
-    // default clip depth for events is 0 (no picking is done by default)
-    expect(receivedEvent!.clipPos).toEqual(vec3.fromValues(0, 0, 0));
-    // -50 is the center of the orthographic camera near/far range
-    expect(receivedEvent!.worldPos).toEqual(vec3.fromValues(400, 300, -50));
+    expect(receivedEvent!.worldPos).toBeDefined();
+    expect(receivedEvent!.clipPos).toBeDefined();
+
+    // Ensure coordinates are valid numbers, not NaN
+    expect(Number.isNaN(receivedEvent!.worldPos![0])).toBe(false);
+    expect(Number.isNaN(receivedEvent!.worldPos![1])).toBe(false);
+    expect(Number.isNaN(receivedEvent!.worldPos![2])).toBe(false);
+    expect(Number.isNaN(receivedEvent!.clipPos![0])).toBe(false);
+    expect(Number.isNaN(receivedEvent!.clipPos![1])).toBe(false);
+    expect(Number.isNaN(receivedEvent!.clipPos![2])).toBe(false);
   });
 
-  it("Fallback canvas provider does not add clip/world coordinates", () => {
+  it("canvas provider works without coordinate transforms", () => {
     const canvas = document.createElement("canvas");
     const dispatcher = new EventDispatcher();
 
@@ -146,78 +130,37 @@ describe("EventProvider architecture", () => {
       receivedEvent = event;
     });
 
-    const pointerEvent = new PointerEvent("pointerdown", {
-      clientX: 150,
-      clientY: 250,
-    });
-    canvas.dispatchEvent(pointerEvent);
+    canvas.dispatchEvent(
+      new PointerEvent("pointerdown", {
+        clientX: 150,
+        clientY: 250,
+      })
+    );
 
     expect(receivedEvent).not.toBeNull();
-    expect(receivedEvent!.source).toBeDefined();
-    expect(receivedEvent!.source?.element).toBe(canvas);
+    expect(receivedEvent!.source).toBe(canvasProvider);
     expect(receivedEvent!.worldPos).toBeUndefined();
     expect(receivedEvent!.clipPos).toBeUndefined();
-    expect(receivedEvent!.clientPos).toEqual(vec2.fromValues(150, 250));
+
+    // Ensure client coordinates are preserved and valid
+    expect(Number.isNaN(receivedEvent!.clientPos[0])).toBe(false);
+    expect(Number.isNaN(receivedEvent!.clientPos[1])).toBe(false);
+    expect(receivedEvent!.clientPos[0]).toBe(150);
+    expect(receivedEvent!.clientPos[1]).toBe(250);
   });
 
-  it("Layer can stop propagation within viewport processing", () => {
+  it("layers can stop propagation", () => {
     const canvas = document.createElement("canvas");
     const camera = new OrthographicCamera(0, 800, 0, 600);
 
     const stoppingLayer = new TestLayer(true);
-    const idetik = new Idetik({
-      canvas,
-      camera,
-      layers: [stoppingLayer],
-    });
+    const idetik = new Idetik({ canvas, camera, layers: [stoppingLayer] });
 
-    // global listener should not be called due to layer stopping propagation
     const globalListener = vi.fn();
     idetik.events.addEventListener(globalListener);
 
-    const pointerEvent = new PointerEvent("pointerdown", {
-      clientX: 400,
-      clientY: 300,
-    });
-    canvas.dispatchEvent(pointerEvent);
+    canvas.dispatchEvent(new PointerEvent("pointerdown"));
 
     expect(globalListener).not.toHaveBeenCalled();
-  });
-
-  it("EventContext.fromDOMEvent creates valid context for supported event", () => {
-    const pointerEvent = new PointerEvent("pointermove", {
-      clientX: 123,
-      clientY: 456,
-    });
-
-    const context = EventContext.fromDOMEvent(pointerEvent);
-
-    expect(context).not.toBeNull();
-    expect(context!.type).toBe("pointermove");
-    expect(context!.event).toBe(pointerEvent);
-    expect(context!.clientPos).toEqual(vec2.fromValues(123, 456));
-    expect(context!.worldPos).toBeUndefined();
-    expect(context!.clipPos).toBeUndefined();
-    expect(context!.source).toBeUndefined();
-    expect(context!.propagationStopped).toBe(false);
-  });
-
-  it("EventContext.fromDOMEvent returns null for unsupported event types", () => {
-    const customEvent = new CustomEvent("unsupported");
-    const context = EventContext.fromDOMEvent(customEvent);
-    expect(context).toBeNull();
-  });
-
-  it("EventContext handles events without client coordinates", () => {
-    const wheelEvent = new WheelEvent("wheel", {
-      // a supported event type, but explicitly not setting clientX/clientY
-    });
-
-    const context = EventContext.fromDOMEvent(wheelEvent);
-
-    expect(context).not.toBeNull();
-
-    // Should default to (0, 0) when no client coordinates
-    expect(context!.clientPos).toEqual(vec2.fromValues(0, 0));
   });
 });


### PR DESCRIPTION
### Summary
This adds the concept of an `EventProvider` for the `EventDispatcher` instead of expecting all events to come directly from the canvas element. This allows for events to be scoped to a specific viewport, for example to allow each viewport to have separate camera controls.

I also added an optional `onEvent` to the `Overlay` type, so overlays can also respond to events. For example this would allow a global overlay to update depending on the which viewport has the mouse over it. We may also want to enable viewport-specific overlays at some point.

The `Viewport` class implements `EventProvider`, adding a `processEvent` method that:
* augments the event with viewport-specific information (source viewport, clipPos, and worldPos if the event has clientPos)
* dispatches the event first to viewport-specific listeners (layers and camera controls)
* dispatches the event to any global event listeners (overlays)

I also added support for `mouseenter` and `mouseleave` events. This lets the global event listeners to keep track of which viewport was last hovered, clicked, etc.

This is step three of the implementation plan in the [Multiple Viewports Tech Spec](https://docs.google.com/document/d/1OwGL7KW34hxFAENyOm2WiQ71E58XGu9Y7jKkJlyRx84/edit?tab=t.0).

### Related Issue
N/A

### Tests & Checks
Tested current examples work without modification
Added some tests for the event provider interface