### PR TITLE
Fix examples build for GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy-examples.yml
+++ b/.github/workflows/deploy-examples.yml
@@ -2,7 +2,7 @@ name: Deploy Examples to GitHub Pages
 
 on:
   push:
-    branches: [main, '*-deploy-examples']
+    branches: [main]
   pull_request:
     branches: [main]
   workflow_dispatch:

--- a/packages/core/vite.config.js
+++ b/packages/core/vite.config.js
@@ -71,6 +71,7 @@ export default defineConfig(({ mode }) => {
     build: {
       outDir: 'dist',
       target: 'es2022',
+      copyPublicDir: true,
       ...(mode === 'production' ? productionBuildOptions : {}),
     },
     resolve: {


### PR DESCRIPTION
### Summary
`copyPublicDir` is meant to be `true` by default, but removing this broke the static build.

See https://github.com/chanzuckerberg/idetik/pull/423#discussion_r2341714792

Also removing the trigger on `*-deploy-examples` that was used to bootstrap the workflow.

### Related Issue
N/A

### Tests & Checks
Tested with python server and build:examples locally