### PR TITLE
Try to fix the examples build again 

### DIFF
--- a/.github/workflows/deploy-examples.yml
+++ b/.github/workflows/deploy-examples.yml
@@ -36,7 +36,7 @@ jobs:
         run: npm run build --workspace=@idetik/core-prerelease
 
       - name: Build examples for production
-        run: npm run build:examples --workspace=@idetik/core-prerelease -- --base=/idetik/
+        run: npm run build:examples --workspace=@idetik/core-prerelease
 
       - name: Setup Pages
         uses: actions/configure-pages@v4

--- a/packages/core/vite-plugin-examples-nav.js
+++ b/packages/core/vite-plugin-examples-nav.js
@@ -43,7 +43,8 @@ function examplesManifestPlugin() {
 
       try {
         generateExamplesManifest();
-        console.log("Examples manifest generated");
+        copyManifestToPublic();
+        console.log("Examples manifest generated and copied to public");
       } catch (error) {
         console.error("Failed to generate examples manifest:", error);
       }

--- a/packages/core/vite-plugin-examples-nav.js
+++ b/packages/core/vite-plugin-examples-nav.js
@@ -26,18 +26,20 @@ function copyManifestToPublic() {
 }
 
 function examplesManifestPlugin() {
+  let isExamplesBuild = false;
+
   return {
     name: "examples-navigation",
     config(config, { command, mode }) {
-      // Configure build inputs for examples mode
       if (command === "build" && mode === "examples") {
+        isExamplesBuild = true;
         config.build = config.build || {};
         config.build.rollupOptions = config.build.rollupOptions || {};
         config.build.rollupOptions.input = getExampleInputs();
       }
     },
-    buildStart(options) {
-      if (options.command !== "build" || options.mode !== "examples") {
+    buildStart(_options) {
+      if (!isExamplesBuild) {
         return;
       }
 

--- a/packages/core/vite.config.js
+++ b/packages/core/vite.config.js
@@ -71,7 +71,6 @@ export default defineConfig(({ mode }) => {
     build: {
       outDir: 'dist',
       target: 'es2022',
-      copyPublicDir: true,
       ...(mode === 'production' ? productionBuildOptions : {}),
     },
     resolve: {

--- a/packages/core/vite.config.js
+++ b/packages/core/vite.config.js
@@ -71,6 +71,7 @@ export default defineConfig(({ mode }) => {
     build: {
       outDir: 'dist',
       target: 'es2022',
+      copyPublicDir: true,
       ...(mode === 'production' ? productionBuildOptions : {}),
     },
     resolve: {


### PR DESCRIPTION
### Summary
I see 404s for various assets in the gh pages deployment:

> `GET https://vigilant-adventure-prk33kk.pages.github.io/idetik/assets/main-WkhCYxyw.js net::ERR_ABORTED 404 (Not Found)`

I think the issue here is the extra `/idetik` in the URL that was being specified in the workflow file.