### PR TITLE
Load chunks center-out within each priority

### DIFF
--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -12,7 +12,7 @@ import { almostEqual } from "../utilities/almost_equal";
 import { Logger } from "../utilities/logger";
 import { OrthographicCamera } from "../objects/cameras/orthographic_camera";
 import { ChunkQueue } from "../data/chunk_queue";
-import { clamp } from "@/utilities/clamp";
+import { clamp } from "../utilities/clamp";
 
 // Number of chunks to extend beyond the visible bounds in each direction (x/y/z)
 // These additional chunks are prefetched to improve responsiveness when panning.
@@ -201,7 +201,7 @@ export class ChunkManagerSource {
     );
 
     const paddedBounds = this.getPaddedBounds(viewBounds3D);
-    const centerIndicies = this.getCenterIndices(viewBounds2D);
+    const centerIndices = this.getCenterIndices(viewBounds2D);
 
     for (const chunk of this.chunks_) {
       const isVisible = this.isChunkWithinBounds(chunk, viewBounds3D);
@@ -230,8 +230,8 @@ export class ChunkManagerSource {
 
       if (chunk.priority !== null) {
         chunk.orderKey = Math.max(
-          Math.abs(chunk.chunkIndex.x - centerIndicies[chunk.lod].x),
-          Math.abs(chunk.chunkIndex.y - centerIndicies[chunk.lod].y)
+          Math.abs(chunk.chunkIndex.x - centerIndices[chunk.lod].x),
+          Math.abs(chunk.chunkIndex.y - centerIndices[chunk.lod].y)
         );
       }
 
@@ -376,6 +376,8 @@ export class ChunkManagerSource {
 
   private getCenterIndices(bounds: Box2) {
     const output: { x: number; y: number }[] = [];
+    const cx = (bounds.min[0] + bounds.max[0]) / 2;
+    const cy = (bounds.min[1] + bounds.max[1]) / 2;
 
     for (let lod = 0; lod < this.lodCount; ++lod) {
       const xLod = this.dimensions_.x.lods[lod];
@@ -386,9 +388,6 @@ export class ChunkManagerSource {
 
       const chunksX = Math.ceil(xLod.size / xLod.chunkSize);
       const chunksY = Math.ceil(yLod.size / yLod.chunkSize);
-
-      const cx = (bounds.min[0] + bounds.max[0]) / 2;
-      const cy = (bounds.min[1] + bounds.max[1]) / 2;
 
       output[lod] = {
         x: clamp(

--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -5,14 +5,13 @@ import {
   ChunkSource,
   SliceCoordinates,
 } from "../data/chunk";
-import { vec2, vec3 } from "gl-matrix";
+import { ReadonlyVec2, vec2, vec3 } from "gl-matrix";
 import { Box2 } from "../math/box2";
 import { Box3 } from "../math/box3";
 import { almostEqual } from "../utilities/almost_equal";
 import { Logger } from "../utilities/logger";
 import { OrthographicCamera } from "../objects/cameras/orthographic_camera";
 import { ChunkQueue } from "../data/chunk_queue";
-import { clamp } from "../utilities/clamp";
 
 // Number of chunks to extend beyond the visible bounds in each direction (x/y/z)
 // These additional chunks are prefetched to improve responsiveness when panning.
@@ -201,7 +200,8 @@ export class ChunkManagerSource {
     );
 
     const paddedBounds = this.getPaddedBounds(viewBounds3D);
-    const centerIndices = this.getCenterIndices(viewBounds2D);
+    const center = vec2.create();
+    vec2.lerp(center, viewBounds2D.min, viewBounds2D.max, 0.5);
 
     for (const chunk of this.chunks_) {
       const isVisible = this.isChunkWithinBounds(chunk, viewBounds3D);
@@ -229,10 +229,7 @@ export class ChunkManagerSource {
       }
 
       if (chunk.priority !== null) {
-        chunk.orderKey = Math.max(
-          Math.abs(chunk.chunkIndex.x - centerIndices[chunk.lod].x),
-          Math.abs(chunk.chunkIndex.y - centerIndices[chunk.lod].y)
-        );
+        chunk.orderKey = this.orderKeyByDistance(chunk, center);
       }
 
       if (isLoaded && !isFallbackLOD) {
@@ -374,36 +371,14 @@ export class ChunkManagerSource {
     );
   }
 
-  private getCenterIndices(bounds: Box2) {
-    const output: { x: number; y: number }[] = [];
-    const cx = (bounds.min[0] + bounds.max[0]) / 2;
-    const cy = (bounds.min[1] + bounds.max[1]) / 2;
-
-    for (let lod = 0; lod < this.lodCount; ++lod) {
-      const xLod = this.dimensions_.x.lods[lod];
-      const yLod = this.dimensions_.y.lods[lod];
-
-      const chunkWorldSizeX = xLod.chunkSize * xLod.scale;
-      const chunkWorldSizeY = yLod.chunkSize * yLod.scale;
-
-      const chunksX = Math.ceil(xLod.size / xLod.chunkSize);
-      const chunksY = Math.ceil(yLod.size / yLod.chunkSize);
-
-      output[lod] = {
-        x: clamp(
-          Math.floor((cx - xLod.translation) / chunkWorldSizeX),
-          0,
-          chunksX - 1
-        ),
-        y: clamp(
-          Math.floor((cy - yLod.translation) / chunkWorldSizeY),
-          0,
-          chunksY - 1
-        ),
-      };
-    }
-
-    return output;
+  private orderKeyByDistance(chunk: Chunk, center: ReadonlyVec2): number {
+    const chunkCenter = {
+      x: chunk.offset.x + 0.5 * chunk.shape.x * chunk.scale.x,
+      y: chunk.offset.y + 0.5 * chunk.shape.y * chunk.scale.y,
+    };
+    const dx = chunkCenter.x - center[0];
+    const dy = chunkCenter.y - center[1];
+    return dx * dx + dy * dy;
   }
 }
 

--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -12,6 +12,7 @@ import { almostEqual } from "../utilities/almost_equal";
 import { Logger } from "../utilities/logger";
 import { OrthographicCamera } from "../objects/cameras/orthographic_camera";
 import { ChunkQueue } from "../data/chunk_queue";
+import { clamp } from "@/utilities/clamp";
 
 // Number of chunks to extend beyond the visible bounds in each direction (x/y/z)
 // These additional chunks are prefetched to improve responsiveness when panning.
@@ -76,6 +77,7 @@ export class ChunkManagerSource {
               visible: false,
               prefetch: false,
               priority: null,
+              orderKey: null,
               shape: {
                 x: chunkWidth,
                 y: chunkHeight,
@@ -199,6 +201,8 @@ export class ChunkManagerSource {
     );
 
     const paddedBounds = this.getPaddedBounds(viewBounds3D);
+    const centerIndicies = this.getCenterIndices(viewBounds2D);
+
     for (const chunk of this.chunks_) {
       const isVisible = this.isChunkWithinBounds(chunk, viewBounds3D);
       const eligibleForPrefetch =
@@ -221,6 +225,14 @@ export class ChunkManagerSource {
         chunk.state = "queued";
       } else if (chunk.priority === null && chunk.state === "queued") {
         chunk.state = "unloaded";
+        chunk.orderKey = null;
+      }
+
+      if (chunk.priority !== null) {
+        chunk.orderKey = Math.max(
+          Math.abs(chunk.chunkIndex.x - centerIndicies[chunk.lod].x),
+          Math.abs(chunk.chunkIndex.y - centerIndicies[chunk.lod].y)
+        );
       }
 
       if (isLoaded && !isFallbackLOD) {
@@ -231,6 +243,7 @@ export class ChunkManagerSource {
           chunk.data = undefined;
           chunk.state = "unloaded";
           chunk.priority = null;
+          chunk.orderKey = null;
           Logger.debug(
             "ChunkManagerSource",
             `Disposing chunk in LOD ${chunk.lod}`
@@ -359,6 +372,39 @@ export class ChunkManagerSource {
         bounds.max[2] + padZ
       )
     );
+  }
+
+  private getCenterIndices(bounds: Box2) {
+    const output: { x: number; y: number }[] = [];
+
+    for (let lod = 0; lod < this.lodCount; ++lod) {
+      const xLod = this.dimensions_.x.lods[lod];
+      const yLod = this.dimensions_.y.lods[lod];
+
+      const chunkWorldSizeX = xLod.chunkSize * xLod.scale;
+      const chunkWorldSizeY = yLod.chunkSize * yLod.scale;
+
+      const chunksX = Math.ceil(xLod.size / xLod.chunkSize);
+      const chunksY = Math.ceil(yLod.size / yLod.chunkSize);
+
+      const cx = (bounds.min[0] + bounds.max[0]) / 2;
+      const cy = (bounds.min[1] + bounds.max[1]) / 2;
+
+      output[lod] = {
+        x: clamp(
+          Math.floor((cx - xLod.translation) / chunkWorldSizeX),
+          0,
+          chunksX - 1
+        ),
+        y: clamp(
+          Math.floor((cy - yLod.translation) / chunkWorldSizeY),
+          0,
+          chunksY - 1
+        ),
+      };
+    }
+
+    return output;
   }
 }
 

--- a/packages/core/src/data/chunk.ts
+++ b/packages/core/src/data/chunk.ts
@@ -33,6 +33,7 @@ export type Chunk = {
   visible: boolean;
   prefetch: boolean;
   priority: number | null;
+  orderKey: number | null;
   shape: {
     x: number;
     y: number;

--- a/packages/core/src/data/chunk_queue.ts
+++ b/packages/core/src/data/chunk_queue.ts
@@ -62,10 +62,17 @@ export class ChunkQueue {
     }
 
     this.pending_.sort((a, b) => {
-      return (
-        (a.chunk.priority ?? Number.MAX_SAFE_INTEGER) -
-        (b.chunk.priority ?? Number.MAX_SAFE_INTEGER)
-      );
+      const priorityA = a.chunk.priority ?? Number.MAX_SAFE_INTEGER;
+      const priorityB = b.chunk.priority ?? Number.MAX_SAFE_INTEGER;
+
+      if (priorityA === priorityB) {
+        return (
+          (a.chunk.orderKey ?? Number.MAX_SAFE_INTEGER) -
+          (b.chunk.orderKey ?? Number.MAX_SAFE_INTEGER)
+        );
+      }
+
+      return priorityA - priorityB;
     });
 
     while (

--- a/packages/core/src/data/ome_zarr/image_loader.ts
+++ b/packages/core/src/data/ome_zarr/image_loader.ts
@@ -180,6 +180,7 @@ export class OmeZarrImageLoader {
       visible: true,
       prefetch: false,
       priority: null,
+      orderKey: null,
       data: subarray.data,
       shape: {
         x: subarray.shape[subarray.shape.length - 1],

--- a/packages/core/test/chunk_queue.test.ts
+++ b/packages/core/test/chunk_queue.test.ts
@@ -100,6 +100,37 @@ describe("ChunkQueue", () => {
     await expectCounts(queue, { pending: 0, running: 0 });
   });
 
+  test("tie-breaks by orderKey within equal priority", async () => {
+    const queue = new ChunkQueue();
+
+    const started: number[] = [];
+    const ctl2 = makeControllableLoader(() => started.push(2));
+    const ctl0 = makeControllableLoader(() => started.push(0));
+    const ctl1 = makeControllableLoader(() => started.push(1));
+
+    queue.enqueue(
+      makeChunk({ state: "queued", priority: 1, orderKey: 2 }),
+      ctl2.loader
+    );
+    queue.enqueue(
+      makeChunk({ state: "queued", priority: 1, orderKey: 0 }),
+      ctl0.loader
+    );
+    queue.enqueue(
+      makeChunk({ state: "queued", priority: 1, orderKey: 1 }),
+      ctl1.loader
+    );
+
+    queue.flush();
+    await expectCounts(queue, { pending: 0, running: 3 });
+    expect(started).toEqual([0, 1, 2]);
+
+    ctl0.resolve();
+    ctl1.resolve();
+    ctl2.resolve();
+    await expectCounts(queue, { pending: 0, running: 0 });
+  });
+
   test("does not process the same chunk twice", async () => {
     const queue = new ChunkQueue();
     const chunk = makeChunk({ state: "queued", priority: 0 });

--- a/packages/core/test/helpers.ts
+++ b/packages/core/test/helpers.ts
@@ -18,6 +18,7 @@ export function makeChunk(overrides: ChunkOverrides = {}): Chunk {
     visible: false,
     prefetch: false,
     priority: null,
+    orderKey: null,
     shape: { x: 256, y: 256, z: 256, c: 1 },
     rowStride: 256,
     rowAlignmentBytes: 1,


### PR DESCRIPTION
### Summary
This PR adds an `orderKey` to `Chunk`, computed each frame from the view
center to load chunks center-out within each priority.

### Tests & Checks

- Added an additional test for verifying sorting by `orderKey`.
- All existing examples are working as expected.
- Manual verification (see video below):
  - Change chunk queue capacity to 1
  - Order the view in LOD1 so it's centered
  - Zoom in from the center
  - Observe chunks in the middle are loaded first

https://github.com/user-attachments/assets/979f4ec8-adc0-485f-9c1f-e69c0a168b96


