### PR TITLE
Use preventDefault to prevent page scroll on zoom

### DIFF
--- a/packages/core/src/objects/cameras/controls.ts
+++ b/packages/core/src/objects/cameras/controls.ts
@@ -39,6 +39,9 @@ export class PanZoomControls implements CameraControls {
     if (!event.worldPos || !event.clipPos) return;
     const e = event.event as WheelEvent;
 
+    // Prevent the page from scrolling, the default action for wheel events.
+    e.preventDefault();
+
     const posBeforeZoom = vec3.clone(event.worldPos);
     const zoomFactor = e.deltaY < 0 ? 1.05 : 0.95;
 


### PR DESCRIPTION
### Summary
When the Idetik canvas is within a page that has a vertical scroll bar, the mouse wheel event can both zoom Idetik and scroll the page, which is jarring and almost definitely undesirable. This change prevents the default page scroll action.

### Related Issue
Closes #440 

### Tests & Checks
I temporarily manually modified navigation.css to use `150%` height for the body, which adds a vertical scrollbar. I then used the HCS example as the canvas does not cover the whole page in that case, so I can zoom in/out with the mouse wheel on the canvas, and scroll the page up/down on the left side.
