### PR TITLE
Multiple Viewports: Move LOD calculation to Viewport

### DIFF
--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -129,7 +129,7 @@ export class ChunkManagerSource {
   public update(viewport: Viewport) {
     const lodFactor = viewport.getLodFactor();
     this.setLOD(lodFactor);
-    const viewBounds2D = viewport.getWorldViewRect();
+    const viewBounds2D = viewport.camera.getWorldViewRect();
     const zBounds = this.getZBounds();
 
     if (

--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -10,8 +10,8 @@ import { Box2 } from "../math/box2";
 import { Box3 } from "../math/box3";
 import { almostEqual } from "../utilities/almost_equal";
 import { Logger } from "../utilities/logger";
-import { OrthographicCamera } from "../objects/cameras/orthographic_camera";
 import { ChunkQueue } from "../data/chunk_queue";
+import { Viewport } from "./viewport";
 
 // Number of chunks to extend beyond the visible bounds in each direction (x/y/z)
 // These additional chunks are prefetched to improve responsiveness when panning.
@@ -126,8 +126,10 @@ export class ChunkManagerSource {
     return [...lowResChunks, ...currentLODChunks];
   }
 
-  public update(lodFactor: number, viewBounds2D: Box2) {
+  public update(viewport: Viewport) {
+    const lodFactor = viewport.getLodFactor();
     this.setLOD(lodFactor);
+    const viewBounds2D = viewport.getWorldViewRect();
     const zBounds = this.getZBounds();
 
     if (
@@ -396,21 +398,9 @@ export class ChunkManager {
     return existing;
   }
 
-  public update(camera: OrthographicCamera, bufferWidth: number) {
-    if (camera.type !== "OrthographicCamera") {
-      throw new Error(
-        "ChunkManager currently supports only orthographic cameras. " +
-          "Update the implementation before using a perspective camera."
-      );
-    }
-
-    const viewBounds2D = camera.getWorldViewRect();
-    const virtualWidth = Math.abs(viewBounds2D.max[0] - viewBounds2D.min[0]);
-    const virtualUnitsPerScreenPixel = virtualWidth / bufferWidth;
-    const lodFactor = Math.log2(1 / virtualUnitsPerScreenPixel);
-
+  public update(viewport: Viewport) {
     for (const [_, source] of this.sources_) {
-      source.update(lodFactor, viewBounds2D);
+      source.update(viewport);
       for (const chunk of source.chunks) {
         if (chunk.priority === null) {
           this.queue_.cancel(chunk);

--- a/packages/core/src/core/viewport.ts
+++ b/packages/core/src/core/viewport.ts
@@ -1,5 +1,4 @@
 import { Camera } from "../objects/cameras/camera";
-import { OrthographicCamera } from "../objects/cameras/orthographic_camera";
 import { Layer } from "./layer";
 import { LayerManager } from "./layer_manager";
 import { CameraControls } from "../objects/cameras/controls";
@@ -95,19 +94,8 @@ export class Viewport {
     );
   }
 
-  public getWorldViewRect(): Box2 {
-    if (this.camera.type !== "OrthographicCamera") {
-      throw new Error(
-        "ChunkManager currently supports only orthographic cameras. " +
-          "Update the implementation before using a perspective camera."
-      );
-    }
-    const camera = this.camera as OrthographicCamera;
-    return camera.getWorldViewRect();
-  }
-
   public getLodFactor(): number {
-    const viewBounds2D = this.getWorldViewRect();
+    const viewBounds2D = this.camera.getWorldViewRect();
     const virtualWidth = Math.abs(viewBounds2D.max[0] - viewBounds2D.min[0]);
     const bufferWidth = this.getBox().toRect().width;
     const virtualUnitsPerScreenPixel = virtualWidth / bufferWidth;

--- a/packages/core/src/core/viewport.ts
+++ b/packages/core/src/core/viewport.ts
@@ -1,4 +1,5 @@
 import { Camera } from "../objects/cameras/camera";
+import { OrthographicCamera } from "../objects/cameras/orthographic_camera";
 import { Layer } from "./layer";
 import { LayerManager } from "./layer_manager";
 import { CameraControls } from "../objects/cameras/controls";
@@ -94,9 +95,24 @@ export class Viewport {
     );
   }
 
-  public clientToWorld(position: vec2, depth: number = 0): vec3 {
-    const clipPos = this.clientToClip(position, depth);
-    return this.camera.clipToWorld(clipPos);
+  public getWorldViewRect(): Box2 {
+    if (this.camera.type !== "OrthographicCamera") {
+      throw new Error(
+        "ChunkManager currently supports only orthographic cameras. " +
+          "Update the implementation before using a perspective camera."
+      );
+    }
+    const camera = this.camera as OrthographicCamera;
+    return camera.getWorldViewRect();
+  }
+
+  public getLodFactor(): number {
+    const viewBounds2D = this.getWorldViewRect();
+    const virtualWidth = Math.abs(viewBounds2D.max[0] - viewBounds2D.min[0]);
+    const bufferWidth = this.getBox().toRect().width;
+    const virtualUnitsPerScreenPixel = virtualWidth / bufferWidth;
+
+    return Math.log2(1 / virtualUnitsPerScreenPixel);
   }
 
   private getBox(): Box2 {

--- a/packages/core/src/idetik.ts
+++ b/packages/core/src/idetik.ts
@@ -6,7 +6,6 @@ import { CameraControls } from "./objects/cameras/controls";
 import { Logger } from "./utilities/logger";
 import { ChunkManager } from "./core/chunk_manager";
 import { vec2, vec3 } from "gl-matrix";
-import { OrthographicCamera } from "./objects/cameras/orthographic_camera";
 import { createStats, type Stats } from "./utilities/stats";
 import {
   parseViewportConfigs,
@@ -132,12 +131,7 @@ export class Idetik {
       }
 
       for (const viewport of this.viewports_) {
-        if (viewport.camera.type === "OrthographicCamera") {
-          this.chunkManager_.update(
-            viewport.camera as OrthographicCamera,
-            viewport.getBoxRelativeTo(this.canvas).toRect().width
-          );
-        }
+        this.chunkManager_.update(viewport);
         this.renderer_.render(viewport);
       }
 

--- a/packages/core/src/objects/cameras/camera.ts
+++ b/packages/core/src/objects/cameras/camera.ts
@@ -1,5 +1,6 @@
 import { RenderableObject } from "../../core/renderable_object";
 import { mat4, vec3, vec4 } from "gl-matrix";
+import { Box2 } from "../../math/box2";
 
 export type CameraType = "OrthographicCamera" | "PerspectiveCamera";
 
@@ -54,5 +55,12 @@ export abstract class Camera extends RenderableObject {
       this.transform.matrix
     );
     return vec3.fromValues(worldPos[0], worldPos[1], worldPos[2]);
+  }
+
+  public getWorldViewRect(): Box2 {
+    throw new Error(
+      "getWorldViewRect is required by some camera-aware layer types" +
+        `, but is not supported by this camera type (${this.type})`
+    );
   }
 }


### PR DESCRIPTION
### Summary
This moves LOD calculation and world view bounds logic from `ChunkManager` to `Viewport` class. `ChunkManager.update()` and `ChunkManagerSource.update()` both now take a `Viewport` parameter instead of separate camera and buffer width parameters. This also consolidates the `OrthographicCamera`-specific type checking into the `Viewport`.

This improves separation of concerns by moving viewport-specific calculations into the `Viewport` class, making the `ChunkManager` API and main render loop cleaner. This also allows us to support different LODs in different viewports. The POC implementation just relied on the `ChunkManager` state switching rapidly as it rendered each viewport.

This is step four of the implementation plan in the [Multiple Viewports Tech Spec](https://docs.google.com/document/d/1OwGL7KW34hxFAENyOm2WiQ71E58XGu9Y7jKkJlyRx84/edit?tab=t.0).

### Related Issue
Closes N/A

### Tests & Checks
Tested existing examples work without changes
