### PR TITLE
Add an `EventDispatcher` to each `Viewport` for viewport-scoped events

### DIFF
--- a/packages/core/src/core/event_dispatcher.ts
+++ b/packages/core/src/core/event_dispatcher.ts
@@ -40,9 +40,9 @@ type Listener = (event: EventContext) => void;
 export class EventDispatcher {
   private readonly listeners_: Listener[] = [];
 
-  constructor(canvas: HTMLCanvasElement) {
+  constructor(element: HTMLElement) {
     eventTypes.forEach((type) => {
-      canvas.addEventListener(type, this.handleEvent, { passive: false });
+      element.addEventListener(type, this.handleEvent, { passive: false });
     });
   }
 

--- a/packages/core/src/core/viewport.ts
+++ b/packages/core/src/core/viewport.ts
@@ -6,6 +6,7 @@ import { Box2 } from "../math/box2";
 import { vec2, vec3 } from "gl-matrix";
 import { generateUUID } from "../utilities/uuid_generator";
 import { Logger } from "../utilities/logger";
+import { EventContext, EventDispatcher } from "./event_dispatcher";
 
 export interface ViewportConfig {
   id?: string;
@@ -20,6 +21,7 @@ export class Viewport {
   public readonly element: HTMLElement;
   public readonly camera: Camera;
   public readonly layerManager: LayerManager;
+  public readonly events: EventDispatcher;
   public cameraControls?: CameraControls;
 
   constructor(config: ViewportConfig, layerManager: LayerManager) {
@@ -29,6 +31,23 @@ export class Viewport {
     this.layerManager = layerManager;
     this.cameraControls = config.cameraControls;
     this.updateAspectRatio();
+    this.events = new EventDispatcher(this.element);
+    this.events.addEventListener((event: EventContext) => {
+      if (
+        event.event instanceof PointerEvent ||
+        event.event instanceof WheelEvent
+      ) {
+        const { clientX, clientY } = event.event;
+        const client = vec2.fromValues(clientX, clientY);
+        event.clipPos = this.clientToClip(client, 0);
+        event.worldPos = this.camera.clipToWorld(event.clipPos);
+      }
+      for (const layer of this.layerManager.layers) {
+        layer.onEvent(event);
+        if (event.propagationStopped) return;
+      }
+      this.cameraControls?.onEvent(event);
+    });
 
     for (const layer of config.layers ?? []) {
       this.layerManager.add(layer);

--- a/packages/core/src/idetik.ts
+++ b/packages/core/src/idetik.ts
@@ -1,7 +1,6 @@
 import { Camera } from "./objects/cameras/camera";
 import { Layer } from "./core/layer";
 import { LayerManager } from "./core/layer_manager";
-import { EventContext, EventDispatcher } from "./core/event_dispatcher";
 import { WebGLRenderer } from "./renderers/webgl_renderer";
 import { CameraControls } from "./objects/cameras/controls";
 import { Logger } from "./utilities/logger";
@@ -41,7 +40,6 @@ export class Idetik {
   private readonly renderer_: WebGLRenderer;
   private readonly viewports_: Viewport[];
   public readonly canvas: HTMLCanvasElement;
-  public readonly events: EventDispatcher;
   public readonly overlays: Overlay[];
   private readonly stats_?: Stats;
 
@@ -85,24 +83,6 @@ export class Idetik {
     this.overlays = params.overlays ?? [];
 
     if (params.showStats) this.stats_ = createStats();
-
-    this.events = new EventDispatcher(canvas);
-    this.events.addEventListener((event: EventContext) => {
-      if (
-        event.event instanceof PointerEvent ||
-        event.event instanceof WheelEvent
-      ) {
-        const { clientX, clientY } = event.event;
-        const client = vec2.fromValues(clientX, clientY);
-        event.clipPos = this.clientToClip(client, 0);
-        event.worldPos = this.camera.clipToWorld(event.clipPos);
-      }
-      for (const layer of this.layerManager.layers) {
-        layer.onEvent(event);
-        if (event.propagationStopped) return;
-      }
-      this.viewports_[0].cameraControls?.onEvent(event);
-    });
   }
 
   public get width() {
@@ -117,8 +97,12 @@ export class Idetik {
     return this.renderer_.textureInfo;
   }
 
-  // TEMP: backward-compatible getters/setter for camera, layerManager, and cameraControls
+  // TEMP: backward-compatible getters/setter for events, camera, layerManager, and cameraControls
   // to be removed on completion of multi-viewport implementation
+  public get events() {
+    return this.viewports_[0].events;
+  }
+
   public get camera() {
     return this.viewports_[0].camera;
   }


### PR DESCRIPTION
### Summary
This uses the existing `EventDispatcher` with very little modification, but adds one to each viewport (still currently only one).

### Related Issue
Obviates #434

### Tests & Checks
Current examples still work, including those that depend on events (value picking and controls)