### PR TITLE
Skip chunk manager update when not needed

### DIFF
--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -449,6 +449,8 @@ export class ChunkManager {
   }
 
   public update(camera: OrthographicCamera, bufferWidth: number) {
+    if (this.sources_.size === 0) return;
+
     if (camera.type !== "OrthographicCamera") {
       throw new Error(
         "ChunkManager currently supports only orthographic cameras. " +


### PR DESCRIPTION
### Summary
This skips `ChunkManager.update` when there are no sources. This avoids a small amount of unnecessary computation (e.g. some small matrix inversions and multiplications) on the CPU, but in a very simple way.

It's possible that all layers may use the `ChunkManager` in the future, but this can be removed when that's the case.

### Related Issue
Closes #313

### Tests & Checks
I manually tested all the core examples.
I manually tested the main React component.
