### PR TITLE
Prevent flickering in the chunked image layer when changing the time point

### DIFF
--- a/packages/core/examples/chunk_streaming/index.html
+++ b/packages/core/examples/chunk_streaming/index.html
@@ -44,12 +44,23 @@
         background-color: rgba(0, 0, 0, 0.5);
         user-select: none;
       }
+
+      #time-point {
+        position: absolute;
+        bottom: 0.5em;
+        left: 0.3em;
+        margin: 1em;
+        padding: 1em;
+        color: white;
+        background-color: rgba(0, 0, 0, 0.5);
+      }
     </style>
   </head>
 
   <body>
     <canvas id="canvas"></canvas>
     <div id="chunk-info">Chunks: Loading...</div>
+    <div id="time-point"></div>
     <script type="module" src="./main.ts"></script>
   </body>
 </html>

--- a/packages/core/examples/chunk_streaming/main.ts
+++ b/packages/core/examples/chunk_streaming/main.ts
@@ -95,12 +95,21 @@ gui
   .add(controls.sliceCoords, "t", tRange.min, tRange.max, t.scale)
   .name("T-point");
 
-gui
+const overlaysFolder = gui.addFolder("Overlays");
+
+overlaysFolder
+  .add(controls, "showTimePointOverlay")
+  .name("Show time point overlay")
+  .onChange((show: boolean) => {
+    timePointDiv.style.display = show ? "block" : "none";
+  });
+
+overlaysFolder
   .add(controls, "showWireframes")
   .name("Show tile wireframes")
   .onChange((show: boolean) => (imageLayer.debugMode = show));
 
-gui
+overlaysFolder
   .add(controls, "showChunkInfoOverlay")
   .name("Show chunk information overlay")
   .onChange((show: boolean) => {

--- a/packages/core/examples/chunk_streaming/main.ts
+++ b/packages/core/examples/chunk_streaming/main.ts
@@ -56,12 +56,20 @@ const chunkInfoOverlay = new ChunkInfoOverlay({
   imageLayer: imageLayer,
 });
 
+const timePointDiv = document.querySelector<HTMLDivElement>("#time-point")!;
+const timePointOverlay = {
+  update(_idetik: Idetik, _timestamp?: DOMHighResTimeStamp) {
+    const time = imageLayer.lastPresentationTimeCoord;
+    timePointDiv.textContent = `t = ${time}`;
+  },
+};
+
 new Idetik({
   canvas: document.querySelector<HTMLCanvasElement>("#canvas")!,
   camera,
   cameraControls: new PanZoomControls(camera),
   layers: [imageLayer],
-  overlays: [chunkInfoOverlay],
+  overlays: [chunkInfoOverlay, timePointOverlay],
   showStats: true,
 }).start();
 
@@ -69,6 +77,7 @@ const controls = {
   sliceCoords,
   showWireframes: true,
   showChunkInfoOverlay: true,
+  showTimePointOverlay: true,
   window: initialWindow,
   level: initialLevel,
   resetContrast: function () {

--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -36,6 +36,7 @@ export class ChunkManagerSource {
   private lastViewBounds2D_: Box2 | null = null;
   private lastZBounds_?: [number, number];
   private lastTCoord_?: number;
+  private fetchedTCoords_: Set<number> = new Set();
 
   constructor(loader: ChunkLoader, sliceCoords: SliceCoordinates) {
     this.loader_ = loader;
@@ -137,6 +138,12 @@ export class ChunkManagerSource {
     return this.chunks_[this.sliceCoords_.t ?? 0];
   }
 
+  public allVisibleLowestLODLoaded(): boolean {
+    return this.getChunksAtCurrentTime()
+      .filter((c) => c.visible && c.lod === this.lowestResLOD_)
+      .every((c) => c.state === "loaded");
+  }
+
   public updateAndCollectChunkChanges(lodFactor: number, viewBounds2D: Box2) {
     this.setLOD(lodFactor);
     const zBounds = this.getZBounds();
@@ -223,6 +230,7 @@ export class ChunkManagerSource {
     const updatedChunks = this.updatePreviousTimeChunks();
 
     const currentTimeChunks = this.chunks_[this.sliceCoords_.t ?? 0];
+    this.fetchedTCoords_.add(this.sliceCoords_.t ?? 0);
     for (const chunk of currentTimeChunks) {
       const isVisible = this.isChunkWithinBounds(chunk, viewBounds3D);
       const eligibleForPrefetch =

--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -36,7 +36,6 @@ export class ChunkManagerSource {
   private lastViewBounds2D_: Box2 | null = null;
   private lastZBounds_?: [number, number];
   private lastTCoord_?: number;
-  private fetchedTCoords_: Set<number> = new Set();
 
   constructor(loader: ChunkLoader, sliceCoords: SliceCoordinates) {
     this.loader_ = loader;
@@ -230,7 +229,6 @@ export class ChunkManagerSource {
     const updatedChunks = this.updatePreviousTimeChunks();
 
     const currentTimeChunks = this.chunks_[this.sliceCoords_.t ?? 0];
-    this.fetchedTCoords_.add(this.sliceCoords_.t ?? 0);
     for (const chunk of currentTimeChunks) {
       const isVisible = this.isChunkWithinBounds(chunk, viewBounds3D);
       const eligibleForPrefetch =

--- a/packages/core/src/layers/chunked_image_layer.ts
+++ b/packages/core/src/layers/chunked_image_layer.ts
@@ -37,6 +37,7 @@ export class ChunkedImageLayer extends Layer implements ChannelsEnabled {
   private pointerDownPos_: vec2 | null = null;
   private zPrevPointWorld_?: number;
   private debugMode_ = false;
+  public lastPresentationTimeCoord?: number;
 
   private readonly wireframeColors_ = [
     new Color(0.6, 0.3, 0.3),

--- a/packages/core/src/layers/chunked_image_layer.ts
+++ b/packages/core/src/layers/chunked_image_layer.ts
@@ -79,7 +79,6 @@ export class ChunkedImageLayer extends Layer implements ChannelsEnabled {
 
   private updateChunks() {
     if (!this.chunkManagerSource_) return;
-    if (this.state !== "ready") this.setState("ready");
 
     if (
       this.visibleChunks_.size > 0 &&
@@ -89,10 +88,13 @@ export class ChunkedImageLayer extends Layer implements ChannelsEnabled {
       return;
     }
 
-    this.lastPresentationTimeStamp_ = performance.now();
     const orderedByLOD = this.chunkManagerSource_.getChunks();
+    if (orderedByLOD.length === 0) return;
+
+    this.lastPresentationTimeStamp_ = performance.now();
     this.lastPresentationTimeCoord_ = this.sliceCoords_.t;
 
+    if (this.state !== "ready") this.setState("ready");
     const current = new Set(orderedByLOD);
     this.visibleChunks_.forEach((image, chunk) => {
       if (!current.has(chunk)) {
@@ -114,7 +116,7 @@ export class ChunkedImageLayer extends Layer implements ChannelsEnabled {
     return this.lastPresentationTimeCoord_;
   }
 
-  private isPresentationStale() {
+  private isPresentationStale(): boolean {
     if (this.lastPresentationTimeStamp_ === undefined) return false;
     return (
       performance.now() - this.lastPresentationTimeStamp_ >

--- a/packages/core/src/layers/chunked_image_layer.ts
+++ b/packages/core/src/layers/chunked_image_layer.ts
@@ -38,7 +38,7 @@ export class ChunkedImageLayer extends Layer implements ChannelsEnabled {
   private zPrevPointWorld_?: number;
   private debugMode_ = false;
 
-  private static readonly STALE_PRESENTATION_MS_ = 2000;
+  private static readonly STALE_PRESENTATION_MS_ = 1000;
   private lastPresentationTimeStamp_?: DOMHighResTimeStamp;
   public lastPresentationTimeCoord?: number;
 
@@ -84,14 +84,14 @@ export class ChunkedImageLayer extends Layer implements ChannelsEnabled {
     if (
       this.visibleChunks_.size > 0 &&
       !this.chunkManagerSource_.allVisibleLowestLODLoaded() &&
-      !this.presentationTimedOut()
+      !this.isPresentationStale()
     ) {
       return;
     }
 
     this.lastPresentationTimeStamp_ = performance.now();
     const orderedByLOD = this.chunkManagerSource_.getChunks();
-    this.lastPresentationTimeCoord = orderedByLOD[0]?.chunkIndex.t;
+    this.lastPresentationTimeCoord = this.sliceCoords_.t;
 
     const current = new Set(orderedByLOD);
     this.visibleChunks_.forEach((image, chunk) => {
@@ -110,7 +110,7 @@ export class ChunkedImageLayer extends Layer implements ChannelsEnabled {
     }
   }
 
-  private presentationTimedOut() {
+  private isPresentationStale() {
     if (this.lastPresentationTimeStamp_ === undefined) return false;
     return (
       performance.now() - this.lastPresentationTimeStamp_ >

--- a/packages/core/src/layers/chunked_image_layer.ts
+++ b/packages/core/src/layers/chunked_image_layer.ts
@@ -79,6 +79,7 @@ export class ChunkedImageLayer extends Layer implements ChannelsEnabled {
 
   private updateChunks() {
     if (!this.chunkManagerSource_) return;
+    if (this.state !== "ready") this.setState("ready");
 
     if (
       this.visibleChunks_.size > 0 &&
@@ -94,7 +95,6 @@ export class ChunkedImageLayer extends Layer implements ChannelsEnabled {
     this.lastPresentationTimeStamp_ = performance.now();
     this.lastPresentationTimeCoord_ = this.sliceCoords_.t;
 
-    if (this.state !== "ready") this.setState("ready");
     const current = new Set(orderedByLOD);
     this.visibleChunks_.forEach((image, chunk) => {
       if (!current.has(chunk)) {

--- a/packages/core/src/layers/chunked_image_layer.ts
+++ b/packages/core/src/layers/chunked_image_layer.ts
@@ -40,7 +40,7 @@ export class ChunkedImageLayer extends Layer implements ChannelsEnabled {
 
   private static readonly STALE_PRESENTATION_MS_ = 1000;
   private lastPresentationTimeStamp_?: DOMHighResTimeStamp;
-  public lastPresentationTimeCoord?: number;
+  private lastPresentationTimeCoord_?: number;
 
   private readonly wireframeColors_ = [
     new Color(0.6, 0.3, 0.3),
@@ -91,7 +91,7 @@ export class ChunkedImageLayer extends Layer implements ChannelsEnabled {
 
     this.lastPresentationTimeStamp_ = performance.now();
     const orderedByLOD = this.chunkManagerSource_.getChunks();
-    this.lastPresentationTimeCoord = this.sliceCoords_.t;
+    this.lastPresentationTimeCoord_ = this.sliceCoords_.t;
 
     const current = new Set(orderedByLOD);
     this.visibleChunks_.forEach((image, chunk) => {
@@ -108,6 +108,10 @@ export class ChunkedImageLayer extends Layer implements ChannelsEnabled {
       this.visibleChunks_.set(chunk, image);
       this.addObject(image);
     }
+  }
+
+  public get lastPresentationTimeCoord(): number | undefined {
+    return this.lastPresentationTimeCoord_;
   }
 
   private isPresentationStale() {

--- a/packages/core/src/layers/chunked_image_layer.ts
+++ b/packages/core/src/layers/chunked_image_layer.ts
@@ -88,13 +88,10 @@ export class ChunkedImageLayer extends Layer implements ChannelsEnabled {
     ) {
       return;
     }
-
-    const orderedByLOD = this.chunkManagerSource_.getChunks();
-    if (orderedByLOD.length === 0) return;
-
     this.lastPresentationTimeStamp_ = performance.now();
     this.lastPresentationTimeCoord_ = this.sliceCoords_.t;
 
+    const orderedByLOD = this.chunkManagerSource_.getChunks();
     const current = new Set(orderedByLOD);
     this.visibleChunks_.forEach((image, chunk) => {
       if (!current.has(chunk)) {

--- a/packages/core/src/layers/chunked_image_layer.ts
+++ b/packages/core/src/layers/chunked_image_layer.ts
@@ -95,6 +95,8 @@ export class ChunkedImageLayer extends Layer implements ChannelsEnabled {
       this.visibleChunks_.set(chunk, image);
       this.addObject(image);
     }
+  
+    this.lastPresentationTimeCoord = orderedByLOD[0]?.chunkIndex.t;
   }
 
   private resliceIfZChanged() {

--- a/packages/core/src/layers/chunked_image_layer.ts
+++ b/packages/core/src/layers/chunked_image_layer.ts
@@ -37,6 +37,9 @@ export class ChunkedImageLayer extends Layer implements ChannelsEnabled {
   private pointerDownPos_: vec2 | null = null;
   private zPrevPointWorld_?: number;
   private debugMode_ = false;
+
+  private static readonly STALE_PRESENTATION_MS_ = 2000;
+  private lastPresentationTimeStamp_?: DOMHighResTimeStamp;
   public lastPresentationTimeCoord?: number;
 
   private readonly wireframeColors_ = [
@@ -78,9 +81,19 @@ export class ChunkedImageLayer extends Layer implements ChannelsEnabled {
     if (!this.chunkManagerSource_) return;
     if (this.state !== "ready") this.setState("ready");
 
-    const orderedByLOD = this.chunkManagerSource_.getChunks();
-    const current = new Set(orderedByLOD);
+    if (
+      this.visibleChunks_.size > 0 &&
+      !this.chunkManagerSource_.allVisibleLowestLODLoaded() &&
+      !this.presentationTimedOut()
+    ) {
+      return;
+    }
 
+    this.lastPresentationTimeStamp_ = performance.now();
+    const orderedByLOD = this.chunkManagerSource_.getChunks();
+    this.lastPresentationTimeCoord = orderedByLOD[0]?.chunkIndex.t;
+
+    const current = new Set(orderedByLOD);
     this.visibleChunks_.forEach((image, chunk) => {
       if (!current.has(chunk)) {
         this.visibleChunks_.delete(chunk);
@@ -95,8 +108,14 @@ export class ChunkedImageLayer extends Layer implements ChannelsEnabled {
       this.visibleChunks_.set(chunk, image);
       this.addObject(image);
     }
-  
-    this.lastPresentationTimeCoord = orderedByLOD[0]?.chunkIndex.t;
+  }
+
+  private presentationTimedOut() {
+    if (this.lastPresentationTimeStamp_ === undefined) return false;
+    return (
+      performance.now() - this.lastPresentationTimeStamp_ >
+      ChunkedImageLayer.STALE_PRESENTATION_MS_
+    );
   }
 
   private resliceIfZChanged() {


### PR DESCRIPTION
### Summary
This introduces some logic in the `ChunkedImageLayer` to show chunks at a previously loaded time point until all the visible chunks at the lowest LOD are loaded. This prevents those previously loaded chunks being immediately hidden, which can cause flickering in some cases of scrubbing through time.

This also exposes the most recently presented time coordinate in the `ChunkedImageLayer`, which is used in an overlay in the chunk streaming example.

### Related Issue
Closes #452 

### Tests & Checks
I manually tested the chunk streaming example.
