### PR TITLE
Inline WebWorker for use downstream (i.e. in the react workspace)

### DIFF
--- a/packages/core/src/data/ome_zarr/worker_pool.ts
+++ b/packages/core/src/data/ome_zarr/worker_pool.ts
@@ -3,6 +3,10 @@ import { Readable } from "@zarrita/storage";
 import { Logger } from "../../utilities/logger";
 import { ZarrArrayParams } from "../zarr/open";
 import { ZarrWorkerRequest, ZarrWorkerResponse } from "./worker_kernel";
+// "inline" import to ensure worker code works in dependent projects
+// this is a workaround for a vite limitation when building a library
+// see https://github.com/vitejs/vite/issues/11672
+import WorkerKernel from "./worker_kernel.ts?worker&inline";
 
 type PendingGetChunkRequest = {
   resolve: (value: zarr.Chunk<zarr.DataType>) => void;
@@ -127,9 +131,7 @@ function handleWorkerError(
 }
 
 function createWorker(): Worker {
-  const worker = new Worker(new URL("./worker_kernel.ts", import.meta.url), {
-    type: "module",
-  });
+  const worker = new WorkerKernel();
 
   worker.addEventListener("message", (e) => handleWorkerMessage(e, worker));
   worker.addEventListener("error", (error) => handleWorkerError(error, worker));

--- a/packages/core/vite.config.js
+++ b/packages/core/vite.config.js
@@ -77,8 +77,10 @@ export default defineConfig(({ mode }) => {
       format: 'es',
       rollupOptions: {
         output: {
-          format: 'es'
-        }
+          format: 'es',
+          inlineDynamicImports: true,
+        },
+        external: []  // Bundle all dependencies for inline workers
       }
     },
     resolve: {


### PR DESCRIPTION
### Summary
This is a (hopefully temporary) workaround for a limitation of Vite when bundling WebWorker code. The workaround here is to "inline" the worker code, including its dependencies. Unfortunately this represents a pretty big increase in the bundle size (see below). I think this is mostly the effect of including `blosc` and `zstd` (our largest dependencies) twice.

My initial instinct is that the performance benefit of the WebWorkers is worth the added bundle size, and we can work to optimize that later.

#### Build output on `main`
```
vite v6.3.4 building for production...
✓ 124 modules transformed.
dist/assets/gzip-DchmmbTG.js              0.50 kB
dist/assets/zlib-Din1wO0I.js              0.50 kB
dist/assets/chunk-INHXZS53-DiyuLb3Z.js    0.61 kB
dist/assets/browser-D0q2hNGi.js          16.14 kB
dist/assets/worker_kernel-DM8-UwpE.js    26.32 kB
dist/assets/lz4-DUlZKApi.js              43.67 kB
dist/assets/blosc-BOWv2fO7.js           611.44 kB
dist/assets/zstd-DnzmycJs.js            754.13 kB
dist/gzip-DchmmbTG.js                     0.50 kB │ gzip:   0.33 kB │ map:   1.28 kB
dist/zlib-Din1wO0I.js                     0.50 kB │ gzip:   0.33 kB │ map:   1.28 kB
dist/chunk-INHXZS53-DiyuLb3Z.js           0.61 kB │ gzip:   0.37 kB │ map:   1.69 kB
dist/browser-D0q2hNGi.js                 16.14 kB │ gzip:   5.90 kB │ map: 116.58 kB
dist/lz4-DUlZKApi.js                     43.67 kB │ gzip:  16.85 kB │ map:  73.44 kB
dist/index.js                           270.34 kB │ gzip:  63.37 kB │ map: 909.44 kB
dist/blosc-BOWv2fO7.js                  611.44 kB │ gzip: 205.60 kB │ map: 644.00 kB
dist/zstd-DnzmycJs.js                   754.13 kB │ gzip: 242.59 kB │ map: 783.47 kB
dist/index.umd.cjs  1,591.69 kB │ gzip: 520.49 kB │ map: 2,497.04 kB
✓ built in 4.46s
dist/types/src/index.d.ts → dist/index.d.ts...
created dist/index.d.ts in 142ms
```
#### Build output on this branch
```
vite v6.3.4 building for production...
✓ 125 modules transformed.
dist/gzip-DchmmbTG.js                0.50 kB │ gzip:   0.33 kB │ map:   1.28 kB
dist/zlib-Din1wO0I.js                0.50 kB │ gzip:   0.33 kB │ map:   1.28 kB
dist/chunk-INHXZS53-DiyuLb3Z.js      0.61 kB │ gzip:   0.37 kB │ map:   1.69 kB
dist/browser-D0q2hNGi.js            16.14 kB │ gzip:   5.90 kB │ map: 116.58 kB
dist/lz4-DUlZKApi.js                43.67 kB │ gzip:  16.85 kB │ map:  73.44 kB
dist/blosc-BOWv2fO7.js             611.44 kB │ gzip: 205.60 kB │ map: 644.00 kB
dist/zstd-DnzmycJs.js              754.13 kB │ gzip: 242.59 kB │ map: 783.47 kB
dist/index.js                    1,724.92 kB │ gzip: 541.08 kB │ map: 913.15 kB
dist/index.umd.cjs  3,045.90 kB │ gzip: 996.69 kB │ map: 2,500.50 kB
✓ built in 4.30s

dist/types/src/index.d.ts → dist/index.d.ts...
created dist/index.d.ts in 145ms
```

The other workaround I've seen mentioned requires changes in the _downstream_ project build config to exclude Idetik from `optimizeDeps`. I could not get this to work, but excluding from `optimizeDeps` suggests to me it has additional drawbacks (likely again affecting bundle size) so I'm not sure it would be better even if it did work.

Obviously we need to avoid a rash decision, but I see a lot of recommendations for [parcel](https://parceljs.org/) for building libraries as opposed to apps, with some indication that it does not suffer from this problem.

### Related Issues
https://github.com/vitejs/vite/issues/11672
https://github.com/vitejs/vite/issues/8427
https://github.com/vitejs/vite/issues/15618

### Tests & Checks
Tested on a merged branch with #464, `OmeZarrChunkedImageLoader` example worked properly 
