### PR TITLE
Fix react example style and simplify z-index

### DIFF
--- a/packages/react/examples/ome-zarr-chunked-image-viewer/App.tsx
+++ b/packages/react/examples/ome-zarr-chunked-image-viewer/App.tsx
@@ -96,6 +96,7 @@ function ChunkedImageViewerDemo() {
           Z-Slice Navigation:
         </label>
         <InputSlider
+          disabled={!zSliderConfig}
           value={
             zSliderConfig
               ? Math.round(

--- a/packages/react/examples/ome-zarr-chunked-image-viewer/App.tsx
+++ b/packages/react/examples/ome-zarr-chunked-image-viewer/App.tsx
@@ -1,18 +1,11 @@
 import { InputSlider } from "@czi-sds/components";
-import {
-  SliceCoordinates,
-  ChunkedImageLayer,
-  ChunkLoader,
-} from "@idetik/core-prerelease";
+import { ChunkedImageLayer, ChunkLoader } from "@idetik/core-prerelease";
 import { OmeZarrChunkedImageViewer } from "../../src";
 import { useCallback, useRef, useState } from "react";
 
 const sourceUrl =
   "https://czii-onsite.czbiohub.org/krios1.processing/aretomo3/25jul30a/run002/vol003/Position_1_Vol.zarr";
-const initialSliceCoordinates: SliceCoordinates = {
-  t: 0,
-  z: 296,
-};
+const initZCoord = 296;
 
 const fallbackContrastLimits: [number, number] = [-0.0008789, 0.0052775];
 
@@ -21,62 +14,47 @@ const viewerClassNames = {
 };
 
 function ChunkedImageViewerDemo() {
-  const [sliceCoordinates, setSliceCoordinates] = useState<SliceCoordinates>(
-    initialSliceCoordinates
-  );
-  const updateZSliceRef = useRef<((zValue: number) => void) | null>(null);
-  const [zSliderConfig, setZSliderConfig] = useState<{
-    min: number;
-    max: number;
-    step: number;
-    scale: number;
-    translation: number;
-    hasMetadata: boolean;
-  }>({
-    min: 0,
-    max: 591,
-    step: 1,
-    scale: 1,
-    translation: 0,
-    hasMetadata: false,
-  }); // Default values, will be updated when metadata is loaded
+  const [zCoord, setZCoord] = useState<number>(initZCoord);
+  const [zSliderConfig, setZSliderConfig] = useState<
+    | {
+        min: number;
+        max: number;
+        step: number;
+        scale: number;
+        translation: number;
+      }
+    | undefined
+  >(undefined);
 
   const layerCreatedTime = useRef<number | undefined>(undefined);
 
   const handleLayerCreated = useCallback(
-    (layer?: ChunkedImageLayer, updateZSlice?: (zValue: number) => void) => {
+    (layer: ChunkedImageLayer) => {
+      console.debug("layer", layer);
       layerCreatedTime.current = performance.now();
-      updateZSliceRef.current = updateZSlice || null;
 
       // Update z-slider configuration based on loaded metadata
-      if (layer?.source) {
-        layer.source
-          .open()
-          .then((loader: ChunkLoader) => {
-            const dimensionMap = loader.getSourceDimensionMap();
-            const zDimension = dimensionMap.z;
-
-            if (zDimension && zDimension.lods.length > 0) {
-              // Use LOD 0 (highest resolution) as reference for slider bounds
-              const zLod0 = zDimension.lods[0];
-              const actualZSliceCount = zLod0.size;
-
-              setZSliderConfig({
-                min: 0,
-                max: actualZSliceCount - 1, // Last slice index (0-indexed)
-                step: 1,
-                scale: zLod0.scale,
-                translation: zLod0.translation,
-                hasMetadata: true,
-              });
-            }
-          })
-          .catch((error: unknown) => {
-            console.error("Failed to load z-dimension metadata:", error);
-          });
-      }
+      layer.source
+        .open()
+        .then((loader: ChunkLoader) => {
+          // Use LOD 0 (highest resolution) as reference for slider bounds
+          const zLod0 = loader.getSourceDimensionMap().z?.lods[0];
+          if (zLod0) {
+            const actualZSliceCount = zLod0.size;
+            setZSliderConfig({
+              min: 0,
+              max: actualZSliceCount - 1, // Last slice index (0-indexed)
+              step: 1,
+              scale: zLod0.scale,
+              translation: zLod0.translation,
+            });
+          }
+        })
+        .catch((error: unknown) => {
+          console.error("Failed to load z-dimension metadata:", error);
+        });
     },
-    []
+    [setZSliderConfig]
   );
 
   const handleFirstSliceLoaded = useCallback(() => {
@@ -90,30 +68,24 @@ function ChunkedImageViewerDemo() {
 
   const handleZSliceChange = useCallback(
     (_event: Event, newZ: number | number[]) => {
-      const sliderValue = Array.isArray(newZ) ? newZ[0] : newZ;
-      if (typeof sliderValue === "number" && !isNaN(sliderValue)) {
-        // Convert slider index to physical coordinate
-        const physicalZ = zSliderConfig.hasMetadata
-          ? zSliderConfig.translation + sliderValue * zSliderConfig.scale
-          : sliderValue; // Fallback to direct value if no metadata yet
-
-        setSliceCoordinates((prev: SliceCoordinates) => ({
-          ...prev,
-          z: physicalZ,
-        }));
-        if (updateZSliceRef.current) {
-          updateZSliceRef.current(physicalZ);
-        }
-      }
+      if (!zSliderConfig) return;
+      if (typeof newZ !== "number") return;
+      if (isNaN(newZ)) return;
+      // Convert slider index to physical coordinate
+      const physicalZ = zSliderConfig
+        ? zSliderConfig.translation + newZ * zSliderConfig.scale
+        : newZ; // Fallback to direct value if no metadata yet
+      setZCoord(physicalZ);
     },
-    [zSliderConfig]
+    [zSliderConfig, setZCoord]
   );
 
   return (
     <div className="h-screen flex flex-col">
       <OmeZarrChunkedImageViewer
         sourceUrl={sourceUrl}
-        sliceCoordinates={sliceCoordinates}
+        initZCoord={initZCoord}
+        zCoord={zCoord}
         fallbackContrastLimits={fallbackContrastLimits}
         classNames={viewerClassNames}
         onLayerCreated={handleLayerCreated}
@@ -125,21 +97,22 @@ function ChunkedImageViewerDemo() {
         </label>
         <InputSlider
           value={
-            zSliderConfig.hasMetadata && sliceCoordinates.z !== undefined
+            zSliderConfig
               ? Math.round(
-                  (sliceCoordinates.z - zSliderConfig.translation) /
-                    zSliderConfig.scale
+                  (zCoord - zSliderConfig.translation) / zSliderConfig.scale
                 )
-              : (sliceCoordinates.z ?? zSliderConfig.min)
+              : zCoord
           }
-          min={zSliderConfig.min}
-          max={zSliderConfig.max}
-          step={zSliderConfig.step}
+          min={zSliderConfig?.min}
+          max={zSliderConfig?.max}
+          step={zSliderConfig?.step}
           onChange={handleZSliceChange}
           className="flex-1"
         />
         <span className="text-white min-w-fit">
-          Slice {sliceCoordinates.z ?? zSliderConfig.min} of {zSliderConfig.max}
+          {zSliderConfig
+            ? `Slice ${zCoord} of ${zSliderConfig?.max}`
+            : "Loading..."}
         </span>
       </div>
     </div>

--- a/packages/react/examples/ome-zarr-chunked-image-viewer/App.tsx
+++ b/packages/react/examples/ome-zarr-chunked-image-viewer/App.tsx
@@ -1,11 +1,10 @@
 import { InputSlider } from "@czi-sds/components";
-import { ChunkedImageLayer, ChunkLoader } from "@idetik/core-prerelease";
 import { OmeZarrChunkedImageViewer } from "../../src";
 import { useCallback, useRef, useState } from "react";
 
 const sourceUrl =
   "https://czii-onsite.czbiohub.org/krios1.processing/aretomo3/25jul30a/run002/vol003/Position_1_Vol.zarr";
-const initZCoord = 296;
+const initZIndex = 296;
 
 const fallbackContrastLimits: [number, number] = [-0.0008789, 0.0052775];
 
@@ -14,48 +13,10 @@ const viewerClassNames = {
 };
 
 function ChunkedImageViewerDemo() {
-  const [zCoord, setZCoord] = useState<number>(initZCoord);
-  const [zSliderConfig, setZSliderConfig] = useState<
-    | {
-        min: number;
-        max: number;
-        step: number;
-        scale: number;
-        translation: number;
-      }
-    | undefined
-  >(undefined);
+  const [zIndex, setZIndex] = useState<number>(initZIndex);
+  const [zMaxIndex, setZMaxIndex] = useState<number | undefined>(undefined);
 
   const layerCreatedTime = useRef<number | undefined>(undefined);
-
-  const handleLayerCreated = useCallback(
-    (layer: ChunkedImageLayer) => {
-      console.debug("layer", layer);
-      layerCreatedTime.current = performance.now();
-
-      // Update z-slider configuration based on loaded metadata
-      layer.source
-        .open()
-        .then((loader: ChunkLoader) => {
-          // Use LOD 0 (highest resolution) as reference for slider bounds
-          const zLod0 = loader.getSourceDimensionMap().z?.lods[0];
-          if (zLod0) {
-            const actualZSliceCount = zLod0.size;
-            setZSliderConfig({
-              min: 0,
-              max: actualZSliceCount - 1, // Last slice index (0-indexed)
-              step: 1,
-              scale: zLod0.scale,
-              translation: zLod0.translation,
-            });
-          }
-        })
-        .catch((error: unknown) => {
-          console.error("Failed to load z-dimension metadata:", error);
-        });
-    },
-    [setZSliderConfig]
-  );
 
   const handleFirstSliceLoaded = useCallback(() => {
     if (layerCreatedTime.current !== undefined) {
@@ -68,27 +29,23 @@ function ChunkedImageViewerDemo() {
 
   const handleZSliceChange = useCallback(
     (_event: Event, newZ: number | number[]) => {
-      if (!zSliderConfig) return;
+      if (!zMaxIndex) return;
       if (typeof newZ !== "number") return;
       if (isNaN(newZ)) return;
-      // Convert slider index to physical coordinate
-      const physicalZ = zSliderConfig
-        ? zSliderConfig.translation + newZ * zSliderConfig.scale
-        : newZ; // Fallback to direct value if no metadata yet
-      setZCoord(physicalZ);
+      setZIndex(newZ);
     },
-    [zSliderConfig, setZCoord]
+    [zMaxIndex, setZIndex]
   );
 
   return (
     <div className="h-screen flex flex-col">
       <OmeZarrChunkedImageViewer
         sourceUrl={sourceUrl}
-        initZCoord={initZCoord}
-        zCoord={zCoord}
+        initZIndex={initZIndex}
+        zIndex={zIndex}
+        setZMaxIndex={setZMaxIndex}
         fallbackContrastLimits={fallbackContrastLimits}
         classNames={viewerClassNames}
-        onLayerCreated={handleLayerCreated}
         onFirstSliceLoaded={handleFirstSliceLoaded}
       />
       <div className="flex h-16 shrink-0 bg-dark-sds-color-primitive-gray-200 p-4 items-center gap-4">
@@ -96,23 +53,16 @@ function ChunkedImageViewerDemo() {
           Z-Slice Navigation:
         </label>
         <InputSlider
-          disabled={!zSliderConfig}
-          value={
-            zSliderConfig
-              ? Math.round(
-                  (zCoord - zSliderConfig.translation) / zSliderConfig.scale
-                )
-              : zCoord
-          }
-          min={zSliderConfig?.min}
-          max={zSliderConfig?.max}
-          step={zSliderConfig?.step}
+          disabled={zMaxIndex === undefined}
+          value={zIndex}
+          min={0}
+          max={zMaxIndex}
           onChange={handleZSliceChange}
           className="flex-1"
         />
         <span className="text-white min-w-fit">
-          {zSliderConfig
-            ? `Slice ${zCoord} of ${zSliderConfig?.max}`
+          {zMaxIndex !== undefined
+            ? `Slice ${zIndex} of ${zMaxIndex}`
             : "Loading..."}
         </span>
       </div>

--- a/packages/react/examples/ome-zarr-chunked-image-viewer/App.tsx
+++ b/packages/react/examples/ome-zarr-chunked-image-viewer/App.tsx
@@ -29,12 +29,11 @@ function ChunkedImageViewerDemo() {
 
   const handleZSliceChange = useCallback(
     (_event: Event, newZ: number | number[]) => {
-      if (!zMaxIndex) return;
       if (typeof newZ !== "number") return;
       if (isNaN(newZ)) return;
       setZIndex(newZ);
     },
-    [zMaxIndex, setZIndex]
+    [setZIndex]
   );
 
   return (

--- a/packages/react/examples/ome-zarr-chunked-image-viewer/App.tsx
+++ b/packages/react/examples/ome-zarr-chunked-image-viewer/App.tsx
@@ -1,14 +1,10 @@
-import { ThemeProvider as EmotionThemeProvider } from "@emotion/react";
-import { StyledEngineProvider, ThemeProvider } from "@mui/material/styles";
-import { Theme, InputSlider } from "@czi-sds/components";
-import CssBaseline from "@mui/material/CssBaseline";
-import useMediaQuery from "@mui/material/useMediaQuery";
+import { InputSlider } from "@czi-sds/components";
 import {
   SliceCoordinates,
   ChunkedImageLayer,
   ChunkLoader,
 } from "@idetik/core-prerelease";
-import { IdetikProvider, OmeZarrChunkedImageViewer } from "../../src";
+import { OmeZarrChunkedImageViewer } from "../../src";
 import { useCallback, useRef, useState } from "react";
 
 const sourceUrl =
@@ -47,7 +43,6 @@ function ChunkedImageViewerDemo() {
 
   const layerCreatedTime = useRef<number | undefined>(undefined);
 
-  console.log("Rendering App with sourceUrl:", sourceUrl);
   const handleLayerCreated = useCallback(
     (layer?: ChunkedImageLayer, updateZSlice?: (zValue: number) => void) => {
       layerCreatedTime.current = performance.now();
@@ -152,19 +147,9 @@ function ChunkedImageViewerDemo() {
 }
 
 export default function App() {
-  const prefersDarkMode = useMediaQuery("(prefers-color-scheme: dark)");
-  const theme = prefersDarkMode ? Theme("dark") : Theme("light");
-
   return (
-    <StyledEngineProvider injectFirst>
-      <ThemeProvider theme={theme}>
-        <EmotionThemeProvider theme={theme}>
-          <CssBaseline />
-          <IdetikProvider>
-            <ChunkedImageViewerDemo />
-          </IdetikProvider>
-        </EmotionThemeProvider>
-      </ThemeProvider>
-    </StyledEngineProvider>
+    <div className="h-screen flex flex-col">
+      <ChunkedImageViewerDemo />
+    </div>
   );
 }

--- a/packages/react/examples/organelle-box-time/App.tsx
+++ b/packages/react/examples/organelle-box-time/App.tsx
@@ -121,7 +121,7 @@ export default function App() {
   }, []);
 
   return (
-    <div className="h-full flex flex-col">
+    <div className="h-screen flex flex-col">
       <OmeZarrImageViewer
         sourceUrl={imageUrl}
         region={region}

--- a/packages/react/examples/organelle-box-time/index.html
+++ b/packages/react/examples/organelle-box-time/index.html
@@ -4,13 +4,6 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Organelle Box Time</title>
-    <style>
-      html,
-      body {
-        margin: 0;
-        padding: 0;
-      }
-    </style>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/packages/react/src/components/viewers/OmeZarrChunkedImageViewer/OmeZarrChunkedImageViewer.tsx
+++ b/packages/react/src/components/viewers/OmeZarrChunkedImageViewer/OmeZarrChunkedImageViewer.tsx
@@ -150,9 +150,7 @@ export function OmeZarrChunkedImageViewer({
     if (zIndex === undefined) return;
     const sliceCoords = sliceCoordsRef.current;
     if (!sliceCoords) return;
-    const dimensionMap = dimensionMapRef.current;
-    if (!dimensionMap) return;
-    const zLod0 = dimensionMap.z?.lods[0];
+    const zLod0 = dimensionMapRef.current?.z?.lods[0];
     if (!zLod0) return;
     sliceCoords.z = zLod0.translation + zIndex * zLod0.scale;
   }, [zIndex]);

--- a/packages/react/src/components/viewers/OmeZarrChunkedImageViewer/OmeZarrChunkedImageViewer.tsx
+++ b/packages/react/src/components/viewers/OmeZarrChunkedImageViewer/OmeZarrChunkedImageViewer.tsx
@@ -27,7 +27,8 @@ export interface OmeZarrChunkedImageViewerProps {
     directory: FileSystemDirectoryHandle;
     path?: `/${string}`;
   };
-  sliceCoordinates: SliceCoordinates;
+  initZCoord?: number;
+  zCoord?: number;
   fallbackContrastLimits?: [number, number];
   classNames?: {
     root?: string;
@@ -36,17 +37,15 @@ export interface OmeZarrChunkedImageViewerProps {
     visible?: boolean;
     align?: "start" | "end" | "center";
   };
-  onLayerCreated?: (
-    layer?: ChunkedImageLayer,
-    updateZSlice?: (zValue: number) => void
-  ) => void;
+  onLayerCreated?: (layer: ChunkedImageLayer) => void;
   onFirstSliceLoaded?: () => void;
 }
 
 export function OmeZarrChunkedImageViewer({
   sourceUrl,
   sourceLocalDirectory,
-  sliceCoordinates,
+  initZCoord,
+  zCoord,
   fallbackContrastLimits,
   classNames,
   onLayerCreated,
@@ -98,24 +97,17 @@ export function OmeZarrChunkedImageViewer({
       setUnit(xUnit);
       const { layer, sliceCoords } = createLayer(
         source,
-        sliceCoordinates,
+        initZCoord,
         channelProps
       );
       imageLayerRef.current = layer;
       sliceCoordsRef.current = sliceCoords;
 
-      // Create updateZSlice function for external control
-      const updateZSlice = (zValue: number) => {
-        if (sliceCoords) {
-          sliceCoords.z = zValue;
-        }
-      };
-
-      onLayerCreated?.(layer, updateZSlice);
+      runtime.layerManager.add(layer);
+      onLayerCreated?.(layer);
       if (sourceRef.current !== source) {
         return;
       }
-      runtime.layerManager.add(layer);
       zoomToFit(xCoordRange, yCoordRange, runtime);
       setLoading(false);
       onFirstSliceLoaded?.();
@@ -129,9 +121,25 @@ export function OmeZarrChunkedImageViewer({
         runtime.layerManager.remove(imageLayerRef.current);
         imageLayerRef.current = null;
       }
+      sliceCoordsRef.current = null;
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- Only props that trigger reinitialize
-  }, [sourceUrl, fallbackContrastLimits, directory, path, runtime]);
+  }, [
+    sourceUrl,
+    initZCoord,
+    fallbackContrastLimits,
+    directory,
+    path,
+    runtime,
+    onFirstSliceLoaded,
+    onLayerCreated,
+  ]);
+
+  useEffect(() => {
+    const sliceCoords = sliceCoordsRef.current;
+    if (sliceCoords !== null) {
+      sliceCoords.z = zCoord;
+    }
+  }, [zCoord]);
 
   return (
     <div className={cns("w-full", "h-full", "relative", classNames?.root)}>
@@ -159,14 +167,14 @@ export function OmeZarrChunkedImageViewer({
 
 function createLayer(
   source: OmeZarrImageSource,
-  sliceCoordinates: SliceCoordinates,
+  initZCoord: number | undefined,
   channelProps: ChannelProps[]
 ): { layer: ChunkedImageLayer; sliceCoords: SliceCoordinates } {
+  const sliceCoords = { z: initZCoord };
   const layer = new ChunkedImageLayer({
     source,
-    sliceCoords: sliceCoordinates,
+    sliceCoords,
     channelProps,
   });
-
-  return { layer, sliceCoords: sliceCoordinates };
+  return { layer, sliceCoords };
 }

--- a/packages/react/src/components/viewers/OmeZarrChunkedImageViewer/OmeZarrChunkedImageViewer.tsx
+++ b/packages/react/src/components/viewers/OmeZarrChunkedImageViewer/OmeZarrChunkedImageViewer.tsx
@@ -5,6 +5,7 @@ import {
   OmeZarrImageSource,
   SliceCoordinates,
   ChannelProps,
+  ChunkLoader,
   ChunkedImageLayer,
 } from "@idetik/core-prerelease";
 import { useIdetik } from "../../../hooks/useIdetik";
@@ -27,8 +28,9 @@ export interface OmeZarrChunkedImageViewerProps {
     directory: FileSystemDirectoryHandle;
     path?: `/${string}`;
   };
-  initZCoord?: number;
-  zCoord?: number;
+  initZIndex?: number;
+  zIndex?: number;
+  setZMaxIndex?: (max?: number) => void;
   fallbackContrastLimits?: [number, number];
   classNames?: {
     root?: string;
@@ -44,8 +46,9 @@ export interface OmeZarrChunkedImageViewerProps {
 export function OmeZarrChunkedImageViewer({
   sourceUrl,
   sourceLocalDirectory,
-  initZCoord,
-  zCoord,
+  initZIndex,
+  zIndex,
+  setZMaxIndex,
   fallbackContrastLimits,
   classNames,
   onLayerCreated,
@@ -69,6 +72,9 @@ export function OmeZarrChunkedImageViewer({
   const sourceRef = useRef<OmeZarrImageSource | null>(null);
   const imageLayerRef = useRef<ChunkedImageLayer | null>(null);
   const sliceCoordsRef = useRef<SliceCoordinates | null>(null);
+  const dimensionMapRef = useRef<ReturnType<
+    ChunkLoader["getSourceDimensionMap"]
+  > | null>(null);
 
   const { directory, path } = sourceLocalDirectory ?? {};
   useEffect(() => {
@@ -80,11 +86,13 @@ export function OmeZarrChunkedImageViewer({
       }
       sourceRef.current = source;
       setLoading(true);
+      const openPromise = source.open();
       const loadChannelMetadataPromise = loadChannelMetadata(
         source,
         fallbackContrastLimits
       );
       const loadImageMetadataPromise = loadImageMetadata(source);
+      const loader = await openPromise;
       const { channelProps, extraControlProps } =
         await loadChannelMetadataPromise;
       const { xUnit, yCoordRange, xCoordRange } =
@@ -97,11 +105,14 @@ export function OmeZarrChunkedImageViewer({
       setUnit(xUnit);
       const { layer, sliceCoords } = createLayer(
         source,
-        initZCoord,
+        initZIndex,
         channelProps
       );
       imageLayerRef.current = layer;
       sliceCoordsRef.current = sliceCoords;
+      dimensionMapRef.current = loader.getSourceDimensionMap();
+
+      setZMaxIndex?.(dimensionMapRef.current.z?.lods[0]?.size);
 
       runtime.layerManager.add(layer);
       onLayerCreated?.(layer);
@@ -125,7 +136,7 @@ export function OmeZarrChunkedImageViewer({
     };
   }, [
     sourceUrl,
-    initZCoord,
+    initZIndex,
     fallbackContrastLimits,
     directory,
     path,
@@ -135,11 +146,15 @@ export function OmeZarrChunkedImageViewer({
   ]);
 
   useEffect(() => {
+    if (zIndex === undefined) return;
     const sliceCoords = sliceCoordsRef.current;
-    if (sliceCoords !== null) {
-      sliceCoords.z = zCoord;
-    }
-  }, [zCoord]);
+    if (!sliceCoords) return;
+    const dimensionMap = dimensionMapRef.current;
+    if (!dimensionMap) return;
+    const zLod0 = dimensionMap.z?.lods[0];
+    if (!zLod0) return;
+    sliceCoords.z = zLod0.translation + zIndex * zLod0.scale;
+  }, [zIndex]);
 
   return (
     <div className={cns("w-full", "h-full", "relative", classNames?.root)}>

--- a/packages/react/src/components/viewers/OmeZarrChunkedImageViewer/OmeZarrChunkedImageViewer.tsx
+++ b/packages/react/src/components/viewers/OmeZarrChunkedImageViewer/OmeZarrChunkedImageViewer.tsx
@@ -114,11 +114,11 @@ export function OmeZarrChunkedImageViewer({
 
       setZMaxIndex?.(dimensionMapRef.current.z?.lods[0]?.size);
 
-      runtime.layerManager.add(layer);
       onLayerCreated?.(layer);
       if (sourceRef.current !== source) {
         return;
       }
+      runtime.layerManager.add(layer);
       zoomToFit(xCoordRange, yCoordRange, runtime);
       setLoading(false);
       onFirstSliceLoaded?.();
@@ -143,6 +143,7 @@ export function OmeZarrChunkedImageViewer({
     runtime,
     onFirstSliceLoaded,
     onLayerCreated,
+    setZMaxIndex,
   ]);
 
   useEffect(() => {

--- a/packages/react/tailwind.config.js
+++ b/packages/react/tailwind.config.js
@@ -5,6 +5,7 @@ export default {
   content: [
     "./index.html",
     "./src/**/*.{ts,tsx,css}",
+    "./examples/**/*.{ts,tsx,css}",
   ],
   theme: {
     extend: sds,


### PR DESCRIPTION
This does two things to hopefully improve https://github.com/chanzuckerberg/idetik/pull/464

1. Fix the style issues with the react example.
This fix works by including the examples directory in the tailwind config, and then making some other changes so that the examples are relatively consistent.

2. Simplify the handling the z-coordinate.
This works by allowing the app to use an integer z-index, and forcing the viewer to do the conversion. I think this conversion from LOD0-index to physical value should really be handled by Idetik core, in which case it could be moved off this component.
