### PR TITLE
Prepare for latest npm package versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,8 @@
         "vite-plugin-eslint": "^1.8.1",
         "vite-plugin-glsl": "^1.3.0",
         "vitest": "^3.0.9"
-      }
+      },
+      "version": "1.0.0"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -8516,5 +8517,6 @@
         "node": ">=14.0.0"
       }
     }
-  }
+  },
+  "version": "1.0.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "1.0.0",
       "workspaces": [
         "packages/core",
         "packages/react"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,5 @@
 {
   "name": "idetik",
-  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,11 @@
 {
   "name": "idetik",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
+      "version": "1.0.0",
       "workspaces": [
         "packages/core",
         "packages/react"
@@ -33,8 +35,7 @@
         "vite-plugin-eslint": "^1.8.1",
         "vite-plugin-glsl": "^1.3.0",
         "vitest": "^3.0.9"
-      },
-      "version": "1.0.0"
+      }
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -8202,7 +8203,7 @@
     },
     "packages/core": {
       "name": "@idetik/core-prerelease",
-      "version": "2.0.0",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "gl-matrix": "^3.4.3",
@@ -8216,7 +8217,7 @@
     },
     "packages/react": {
       "name": "@idetik/react-prerelease",
-      "version": "1.1.1",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@base-ui-components/react": "^1.0.0-beta.2",
@@ -8232,7 +8233,7 @@
         "react-dom": "^18.3.1"
       },
       "devDependencies": {
-        "@idetik/core-prerelease": "^2.0.0",
+        "@idetik/core-prerelease": "^3.0.0",
         "@testing-library/react": "^16.3.0",
         "@types/classnames": "^2.3.0",
         "autoprefixer": "^10.4.20",
@@ -8241,7 +8242,7 @@
       },
       "peerDependencies": {
         "@czi-sds/components": "^22.11.4",
-        "@idetik/core-prerelease": "^2.0.0",
+        "@idetik/core-prerelease": "^3.0.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       }
@@ -8517,6 +8518,5 @@
         "node": ">=14.0.0"
       }
     }
-  },
-  "version": "1.0.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -37,5 +37,6 @@
     "vite-plugin-eslint": "^1.8.1",
     "vite-plugin-glsl": "^1.3.0",
     "vitest": "^3.0.9"
-  }
+  },
+  "version": "1.0.0"
 }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,5 @@
     "vite-plugin-eslint": "^1.8.1",
     "vite-plugin-glsl": "^1.3.0",
     "vitest": "^3.0.9"
-  },
-  "version": "1.0.0"
+  }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@idetik/core-prerelease",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@idetik/react-prerelease",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -52,7 +52,7 @@
     "idetik"
   ],
   "devDependencies": {
-    "@idetik/core-prerelease": "^2.0.0",
+    "@idetik/core-prerelease": "^3.0.0",
     "@testing-library/react": "^16.3.0",
     "@types/classnames": "^2.3.0",
     "autoprefixer": "^10.4.20",
@@ -61,7 +61,7 @@
   },
   "peerDependencies": {
     "@czi-sds/components": "^22.11.4",
-    "@idetik/core-prerelease": "^2.0.0",
+    "@idetik/core-prerelease": "^3.0.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   }


### PR DESCRIPTION
### Summary
This change is the result of running `npm version major` in both the core and react packages.

I decided to bump the major version because this is a pre-release. I'm not sure if there are breaking changes in either package and very few apps depend on either of these packages, but this offers some protection for them.

### Tests & Checks
I ran `npm install` to check that nothing changes after these bumps.
Then I ran `npm run build:all` to check that both packages build.
Then I ran `npm run examples` to check that the core examples work.
Then I ran `npm run components` to check that the react example works.
