### PR TITLE
Trim padding from edge chunks in OME-Zarr image loader

### DIFF
--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -68,9 +68,21 @@ export class ChunkManagerSource {
 
         for (let x = 0; x < chunksX; ++x) {
           const xOffset = xLod.translation + x * xLod.chunkSize * xLod.scale;
+          const actualChunkWidth = Math.min(
+            chunkWidth,
+            xLod.size - x * chunkWidth
+          );
           for (let y = 0; y < chunksY; ++y) {
+            const actualChunkHeight = Math.min(
+              chunkHeight,
+              yLod.size - y * chunkHeight
+            );
             const yOffset = yLod.translation + y * yLod.chunkSize * yLod.scale;
             for (let z = 0; z < chunksZ; ++z) {
+              const actualChunkDepth = Math.min(
+                chunkDepth,
+                (zLod?.size ?? 1) - z * chunkDepth
+              );
               const zOffset =
                 zLod !== undefined
                   ? zLod.translation + z * chunkDepth * zLod.scale
@@ -83,12 +95,12 @@ export class ChunkManagerSource {
                 priority: null,
                 orderKey: null,
                 shape: {
-                  x: chunkWidth,
-                  y: chunkHeight,
-                  z: chunkDepth,
+                  x: actualChunkWidth,
+                  y: actualChunkHeight,
+                  z: actualChunkDepth,
                   c: channels,
                 },
-                rowStride: chunkWidth,
+                rowStride: actualChunkWidth,
                 rowAlignmentBytes: 1,
                 chunkIndex: { x, y, z, t },
                 scale: {

--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -68,21 +68,10 @@ export class ChunkManagerSource {
 
         for (let x = 0; x < chunksX; ++x) {
           const xOffset = xLod.translation + x * xLod.chunkSize * xLod.scale;
-          const actualChunkWidth = Math.min(
-            chunkWidth,
-            xLod.size - x * chunkWidth
-          );
+          const rowStride = Math.min(chunkWidth, xLod.size - x * chunkWidth);
           for (let y = 0; y < chunksY; ++y) {
-            const actualChunkHeight = Math.min(
-              chunkHeight,
-              yLod.size - y * chunkHeight
-            );
             const yOffset = yLod.translation + y * yLod.chunkSize * yLod.scale;
             for (let z = 0; z < chunksZ; ++z) {
-              const actualChunkDepth = Math.min(
-                chunkDepth,
-                (zLod?.size ?? 1) - z * chunkDepth
-              );
               const zOffset =
                 zLod !== undefined
                   ? zLod.translation + z * chunkDepth * zLod.scale
@@ -95,12 +84,12 @@ export class ChunkManagerSource {
                 priority: null,
                 orderKey: null,
                 shape: {
-                  x: actualChunkWidth,
-                  y: actualChunkHeight,
-                  z: actualChunkDepth,
+                  x: Math.min(chunkWidth, xLod.size - x * chunkWidth),
+                  y: Math.min(chunkWidth, xLod.size - y * chunkWidth),
+                  z: Math.min(chunkDepth, (zLod?.size ?? 1) - z * chunkDepth),
                   c: channels,
                 },
-                rowStride: actualChunkWidth,
+                rowStride,
                 rowAlignmentBytes: 1,
                 chunkIndex: { x, y, z, t },
                 scale: {

--- a/packages/core/src/data/ome_zarr/image_loader.ts
+++ b/packages/core/src/data/ome_zarr/image_loader.ts
@@ -19,7 +19,6 @@ import { Image as OmeZarrImage } from "./0.5/image";
 import { Readable } from "@zarrita/storage";
 import { ZarrArrayParams } from "../zarr/open";
 import { getChunk } from "./worker_pool";
-import { Logger } from "../../utilities/logger";
 
 // Implements the interface required for getting array chunks in zarrita:
 // https://github.com/manzt/zarrita.js/blob/c15c1a14e42a83516972368ac962ebdf56a6dcdb/packages/indexing/src/types.ts#L52
@@ -95,62 +94,69 @@ export class OmeZarrImageLoader {
 
     const array = this.arrays_[chunk.lod];
     const arrayParams = this.arrayParams_[chunk.lod];
-    const subarray = await getChunk(array, arrayParams, chunkCoords, {
+    const receivedChunk = await getChunk(array, arrayParams, chunkCoords, {
       signal,
     });
 
-    this.assignChunkData(chunk, subarray);
+    this.assignChunkData(chunk, receivedChunk);
   }
 
-  private assignChunkData(chunk: Chunk, subarray: zarr.Chunk<zarr.DataType>) {
-    const wholeChunk = subarray.data;
+  private assignChunkData(
+    chunk: Chunk,
+    receivedChunk: zarr.Chunk<zarr.DataType>
+  ) {
+    const wholeChunk = receivedChunk.data;
 
     if (!isChunkData(wholeChunk)) {
       throw new Error(
-        `Subarray has an unsupported data type, data=${wholeChunk.constructor.name}`
+        `Received chunk has an unsupported data type, data=${wholeChunk.constructor.name}`
       );
     }
 
+    const receivedShape = {
+      x: receivedChunk.shape[this.dimensions_.x.index],
+      y: receivedChunk.shape[this.dimensions_.y.index],
+      z: this.dimensions_.z
+        ? receivedChunk.shape[this.dimensions_.z.index]
+        : chunk.shape.z,
+    };
+
     if (
-      subarray.shape[this.dimensions_.x.index] === chunk.shape.x &&
-      subarray.shape[this.dimensions_.y.index] === chunk.shape.y &&
-      (!this.dimensions_.z ||
-        subarray.shape[this.dimensions_.z.index] === chunk.shape.z)
+      receivedShape.x === chunk.shape.x &&
+      receivedShape.y === chunk.shape.y &&
+      receivedShape.z === chunk.shape.z
     ) {
       chunk.data = wholeChunk;
-      chunk.rowStride = subarray.stride[this.dimensions_.y.index];
+      chunk.rowStride = receivedChunk.stride[this.dimensions_.y.index];
     } else if (
-      subarray.shape[this.dimensions_.x.index] < chunk.shape.x ||
-      subarray.shape[this.dimensions_.y.index] < chunk.shape.y ||
-      (this.dimensions_.z &&
-        subarray.shape[this.dimensions_.z.index] < chunk.shape.z)
+      receivedShape.x < chunk.shape.x ||
+      receivedShape.y < chunk.shape.y ||
+      receivedShape.z < chunk.shape.z
     ) {
       throw new Error(
         `Received incompatible shape for chunkIndex ${JSON.stringify(chunk.chunkIndex)} at LOD ${chunk.lod}: ` +
-          `expected shape: ${JSON.stringify(chunk.shape)}, received shape: ${subarray.shape} (too small)`
+          `expected shape: ${JSON.stringify(chunk.shape)}, received shape: ${JSON.stringify(receivedShape)} (too small)`
       );
     } else {
-      Logger.debug(
-        "OmeZarrImageLoader",
-        `Removing padding from chunk with chunkIndex ${JSON.stringify(chunk.chunkIndex)} at LOD ${chunk.lod} (edge chunk): `,
-        `expected shape: ${JSON.stringify(chunk.shape)}, received shape: ${subarray.shape}`
-      );
-      // remove chunk padding in-place to avoid reallocation, discard unused space
+      // remove chunk padding, copying into a compact array
+      const compactSize = chunk.shape.x * chunk.shape.y * chunk.shape.z;
+      const compactData = wholeChunk.slice(0, compactSize);
+
       let offset = 0;
       const zStride = this.dimensions_.z
-        ? subarray.stride[this.dimensions_.z.index]
+        ? receivedChunk.stride[this.dimensions_.z.index]
         : 0;
-      const yStride = subarray.stride[this.dimensions_.y.index];
+      const yStride = receivedChunk.stride[this.dimensions_.y.index];
       for (let z = 0; z < chunk.shape.z; z++) {
         const zStart = z * zStride;
         for (let y = 0; y < chunk.shape.y; y++) {
           const srcStart = zStart + y * yStride;
           const srcEnd = srcStart + chunk.shape.x;
-          wholeChunk.set(wholeChunk.subarray(srcStart, srcEnd), offset);
+          compactData.set(wholeChunk.subarray(srcStart, srcEnd), offset);
           offset += chunk.shape.x;
         }
       }
-      chunk.data = wholeChunk.subarray(0, offset);
+      chunk.data = compactData;
       chunk.rowStride = chunk.shape.x;
     }
 

--- a/packages/core/src/data/ome_zarr/image_loader.ts
+++ b/packages/core/src/data/ome_zarr/image_loader.ts
@@ -19,6 +19,7 @@ import { Image as OmeZarrImage } from "./0.5/image";
 import { Readable } from "@zarrita/storage";
 import { ZarrArrayParams } from "../zarr/open";
 import { getChunk } from "./worker_pool";
+import { Logger } from "../../utilities/logger";
 
 // Implements the interface required for getting array chunks in zarrita:
 // https://github.com/manzt/zarrita.js/blob/c15c1a14e42a83516972368ac962ebdf56a6dcdb/packages/indexing/src/types.ts#L52
@@ -98,23 +99,68 @@ export class OmeZarrImageLoader {
       signal,
     });
 
-    const data = subarray.data;
-    if (!isChunkData(data)) {
+    this.assignChunkData(chunk, subarray);
+  }
+
+  private assignChunkData(chunk: Chunk, subarray: zarr.Chunk<zarr.DataType>) {
+    const wholeChunk = subarray.data;
+
+    if (!isChunkData(wholeChunk)) {
       throw new Error(
-        `Subarray has an unsupported data type, data=${data.constructor.name}`
+        `Subarray has an unsupported data type, data=${wholeChunk.constructor.name}`
       );
     }
 
-    const rowAlignment = data.BYTES_PER_ELEMENT;
+    if (
+      subarray.shape[this.dimensions_.x.index] === chunk.shape.x &&
+      subarray.shape[this.dimensions_.y.index] === chunk.shape.y &&
+      (!this.dimensions_.z ||
+        subarray.shape[this.dimensions_.z.index] === chunk.shape.z)
+    ) {
+      chunk.data = wholeChunk;
+      chunk.rowStride = subarray.stride[this.dimensions_.y.index];
+    } else if (
+      subarray.shape[this.dimensions_.x.index] < chunk.shape.x ||
+      subarray.shape[this.dimensions_.y.index] < chunk.shape.y ||
+      (this.dimensions_.z &&
+        subarray.shape[this.dimensions_.z.index] < chunk.shape.z)
+    ) {
+      throw new Error(
+        `Received incompatible shape for chunkIndex ${JSON.stringify(chunk.chunkIndex)} at LOD ${chunk.lod}: ` +
+          `expected shape: ${JSON.stringify(chunk.shape)}, received shape: ${subarray.shape} (too small)`
+      );
+    } else {
+      Logger.debug(
+        "OmeZarrImageLoader",
+        `Removing padding from chunk with chunkIndex ${JSON.stringify(chunk.chunkIndex)} at LOD ${chunk.lod} (edge chunk): `,
+        `expected shape: ${JSON.stringify(chunk.shape)}, received shape: ${subarray.shape}`
+      );
+      // remove chunk padding in-place to avoid reallocation, discard unused space
+      let offset = 0;
+      const zStride = this.dimensions_.z
+        ? subarray.stride[this.dimensions_.z.index]
+        : 0;
+      const yStride = subarray.stride[this.dimensions_.y.index];
+      for (let z = 0; z < chunk.shape.z; z++) {
+        const zStart = z * zStride;
+        for (let y = 0; y < chunk.shape.y; y++) {
+          const srcStart = zStart + y * yStride;
+          const srcEnd = srcStart + chunk.shape.x;
+          wholeChunk.set(wholeChunk.subarray(srcStart, srcEnd), offset);
+          offset += chunk.shape.x;
+        }
+      }
+      chunk.data = wholeChunk.subarray(0, offset);
+      chunk.rowStride = chunk.shape.x;
+    }
+
+    const rowAlignment = chunk.data.BYTES_PER_ELEMENT;
     if (!isTextureUnpackRowAlignment(rowAlignment)) {
       throw new Error(
         "Invalid row alignment value. Possible values are 1, 2, 4, or 8"
       );
     }
-
     chunk.rowAlignmentBytes = rowAlignment;
-    chunk.rowStride = subarray.stride[this.dimensions_.y.index];
-    chunk.data = data;
   }
 
   public async loadRegion(

--- a/packages/core/src/data/ome_zarr/image_loader.ts
+++ b/packages/core/src/data/ome_zarr/image_loader.ts
@@ -10,6 +10,7 @@ import {
   isChunkData,
   LoaderAttributes,
   SliceCoordinates,
+  ChunkData,
 } from "../chunk";
 import { isTextureUnpackRowAlignment } from "../../objects/textures/texture";
 import { PromiseScheduler } from "../promise_scheduler";
@@ -98,18 +99,9 @@ export class OmeZarrImageLoader {
       signal,
     });
 
-    this.assignChunkData(chunk, receivedChunk);
-  }
-
-  private assignChunkData(
-    chunk: Chunk,
-    receivedChunk: zarr.Chunk<zarr.DataType>
-  ) {
-    const wholeChunk = receivedChunk.data;
-
-    if (!isChunkData(wholeChunk)) {
+    if (!isChunkData(receivedChunk.data)) {
       throw new Error(
-        `Received chunk has an unsupported data type, data=${wholeChunk.constructor.name}`
+        `Received chunk has an unsupported data type, data=${receivedChunk.data.constructor.name}`
       );
     }
 
@@ -121,43 +113,28 @@ export class OmeZarrImageLoader {
         : chunk.shape.z,
     };
 
-    if (
-      receivedShape.x === chunk.shape.x &&
-      receivedShape.y === chunk.shape.y &&
-      receivedShape.z === chunk.shape.z
-    ) {
-      chunk.data = wholeChunk;
-      chunk.rowStride = receivedChunk.stride[this.dimensions_.y.index];
-    } else if (
+    const receivedChunkTooSmall =
       receivedShape.x < chunk.shape.x ||
       receivedShape.y < chunk.shape.y ||
-      receivedShape.z < chunk.shape.z
-    ) {
+      receivedShape.z < chunk.shape.z;
+
+    if (receivedChunkTooSmall) {
       throw new Error(
         `Received incompatible shape for chunkIndex ${JSON.stringify(chunk.chunkIndex)} at LOD ${chunk.lod}: ` +
           `expected shape: ${JSON.stringify(chunk.shape)}, received shape: ${JSON.stringify(receivedShape)} (too small)`
       );
-    } else {
-      // remove chunk padding, copying into a compact array
-      const compactSize = chunk.shape.x * chunk.shape.y * chunk.shape.z;
-      const compactData = wholeChunk.slice(0, compactSize);
+    }
 
-      let offset = 0;
-      const zStride = this.dimensions_.z
-        ? receivedChunk.stride[this.dimensions_.z.index]
-        : 0;
-      const yStride = receivedChunk.stride[this.dimensions_.y.index];
-      for (let z = 0; z < chunk.shape.z; z++) {
-        const zStart = z * zStride;
-        for (let y = 0; y < chunk.shape.y; y++) {
-          const srcStart = zStart + y * yStride;
-          const srcEnd = srcStart + chunk.shape.x;
-          compactData.set(wholeChunk.subarray(srcStart, srcEnd), offset);
-          offset += chunk.shape.x;
-        }
-      }
-      chunk.data = compactData;
-      chunk.rowStride = chunk.shape.x;
+    const receivedChunkHasPadding =
+      receivedShape.x > chunk.shape.x ||
+      receivedShape.y > chunk.shape.y ||
+      receivedShape.z > chunk.shape.z;
+
+    if (receivedChunkHasPadding) {
+      chunk.data = this.trimChunkPadding(chunk, receivedChunk);
+    } else {
+      chunk.data = receivedChunk.data;
+      chunk.rowStride = receivedChunk.stride[this.dimensions_.y.index];
     }
 
     const rowAlignment = chunk.data.BYTES_PER_ELEMENT;
@@ -167,6 +144,32 @@ export class OmeZarrImageLoader {
       );
     }
     chunk.rowAlignmentBytes = rowAlignment;
+  }
+
+  private trimChunkPadding(
+    chunk: Chunk,
+    receivedChunk: zarr.Chunk<zarr.DataType>
+  ): ChunkData {
+    // type assertion is safe because we check isChunkData(receivedChunk.data) in the caller
+    const receivedChunkData = receivedChunk.data as ChunkData;
+    const compactSize = chunk.shape.x * chunk.shape.y * chunk.shape.z;
+    const compactData = receivedChunkData.slice(0, compactSize);
+
+    let offset = 0;
+    const zStride = this.dimensions_.z
+      ? receivedChunk.stride[this.dimensions_.z.index]
+      : 0;
+    const yStride = receivedChunk.stride[this.dimensions_.y.index];
+    for (let z = 0; z < chunk.shape.z; z++) {
+      const zStart = z * zStride;
+      for (let y = 0; y < chunk.shape.y; y++) {
+        const srcStart = zStart + y * yStride;
+        const srcEnd = srcStart + chunk.shape.x;
+        compactData.set(receivedChunkData.subarray(srcStart, srcEnd), offset);
+        offset += chunk.shape.x;
+      }
+    }
+    return compactData;
   }
 
   public async loadRegion(

--- a/packages/core/src/data/ome_zarr/image_loader.ts
+++ b/packages/core/src/data/ome_zarr/image_loader.ts
@@ -11,6 +11,7 @@ import {
   LoaderAttributes,
   SliceCoordinates,
   ChunkData,
+  ChunkDataConstructor,
 } from "../chunk";
 import { isTextureUnpackRowAlignment } from "../../objects/textures/texture";
 import { PromiseScheduler } from "../promise_scheduler";
@@ -131,7 +132,11 @@ export class OmeZarrImageLoader {
       receivedShape.z > chunk.shape.z;
 
     if (receivedChunkHasPadding) {
-      chunk.data = this.trimChunkPadding(chunk, receivedChunk);
+      chunk.data = this.trimChunkPadding(
+        chunk,
+        receivedChunk.data,
+        receivedChunk.stride
+      );
     } else {
       chunk.data = receivedChunk.data;
       chunk.rowStride = receivedChunk.stride[this.dimensions_.y.index];
@@ -148,18 +153,18 @@ export class OmeZarrImageLoader {
 
   private trimChunkPadding(
     chunk: Chunk,
-    receivedChunk: zarr.Chunk<zarr.DataType>
+    receivedChunkData: ChunkData,
+    receivedChunkStride: number[]
   ): ChunkData {
-    // type assertion is safe because we check isChunkData(receivedChunk.data) in the caller
-    const receivedChunkData = receivedChunk.data as ChunkData;
     const compactSize = chunk.shape.x * chunk.shape.y * chunk.shape.z;
-    const compactData = receivedChunkData.slice(0, compactSize);
+    const compactData =
+      new (receivedChunkData.constructor as ChunkDataConstructor)(compactSize);
 
     let offset = 0;
     const zStride = this.dimensions_.z
-      ? receivedChunk.stride[this.dimensions_.z.index]
+      ? receivedChunkStride[this.dimensions_.z.index]
       : 0;
-    const yStride = receivedChunk.stride[this.dimensions_.y.index];
+    const yStride = receivedChunkStride[this.dimensions_.y.index];
     for (let z = 0; z < chunk.shape.z; z++) {
       const zStart = z * zStride;
       for (let y = 0; y < chunk.shape.y; y++) {

--- a/packages/core/src/utilities/logger.ts
+++ b/packages/core/src/utilities/logger.ts
@@ -29,6 +29,7 @@ type Module =
   | "LabelImageLayer"
   | "Layer"
   | "ZarrWorker"
+  | "OmeZarrImageLoader"
   | "RenderablePool"
   | "Viewport"
   | "WebGLRenderer"

--- a/packages/core/src/utilities/logger.ts
+++ b/packages/core/src/utilities/logger.ts
@@ -29,7 +29,6 @@ type Module =
   | "LabelImageLayer"
   | "Layer"
   | "ZarrWorker"
-  | "OmeZarrImageLoader"
   | "RenderablePool"
   | "Viewport"
   | "WebGLRenderer"


### PR DESCRIPTION
### Summary

This PR adds special chunk shape handling for edge chunks in OME-Zarr datasets. Previously, edge chunks (chunks at the boundaries of an image that don't align with full chunk dimensions) would receive padded data from zarrita, which resulted in (sometimes large) areas of zero-valued padding on the bottom/right of the image (viewing a z slice in standard orientation).

#### Changes
  - `ChunkManager`: Calculate actual chunk dimensions based on remaining image size for edge chunks
  - `OmeZarrImageLoader`: Detect when received chunk data is larger than expected and remove padding in-place by copying only the valid data rows
  
This does not handle similar issues chunking in `c` or `t`. It seems unlikely that channels would be chunked in such a way, though I'm not sure about time. This can also be handled later since the chunk manager already makes some assumptions about these dimensions.

https://github.com/user-attachments/assets/539e7bae-3094-4169-930b-f7c6061d35fc

### Related Issue
Closes #428

### Tests & Checks
Tested with chunk streaming and OME-Zarr v0.5 examples
Tested with `OmeZarrChunkedImageViewer` react example