### PR TITLE
Fix chunk height in chunk manager initialization

### DIFF
--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -107,7 +107,7 @@ export class ChunkManagerSource {
                 orderKey: null,
                 shape: {
                   x: Math.min(chunkWidth, xLod.size - x * chunkWidth),
-                  y: Math.min(chunkWidth, xLod.size - y * chunkWidth),
+                  y: Math.min(chunkHeight, yLod.size - y * chunkHeight),
                   z: Math.min(chunkDepth, (zLod?.size ?? 1) - z * chunkDepth),
                   c: channels,
                 },


### PR DESCRIPTION
### Summary
This changes fixes setting the chunk height, which was broken in https://github.com/chanzuckerberg/idetik/pull/470.

### Tests & Checks
I tested the main chunk streaming example.