### PR TITLE
Add event dispatcher connect/disconnect in runtime start/stop

### DIFF
--- a/packages/core/src/core/event_dispatcher.ts
+++ b/packages/core/src/core/event_dispatcher.ts
@@ -52,7 +52,7 @@ export class EventDispatcher {
 
   public connect() {
     if (this.isConnected_) {
-      Logger.debug(
+      Logger.warn(
         "EventDispatcher",
         "Attempted to connect already connected event dispatcher",
         `element id: ${this.element_.id}`

--- a/packages/core/src/core/event_dispatcher.ts
+++ b/packages/core/src/core/event_dispatcher.ts
@@ -39,15 +39,47 @@ type Listener = (event: EventContext) => void;
 
 export class EventDispatcher {
   private readonly listeners_: Listener[] = [];
+  private readonly element_: HTMLElement;
+  private isConnected_ = false;
 
   constructor(element: HTMLElement) {
-    eventTypes.forEach((type) => {
-      element.addEventListener(type, this.handleEvent, { passive: false });
-    });
+    this.element_ = element;
   }
 
   public addEventListener(listener: Listener) {
     this.listeners_.push(listener);
+  }
+
+  public connect() {
+    if (this.isConnected_) {
+      Logger.debug(
+        "EventDispatcher",
+        "Attempted to connect already connected event dispatcher",
+        `element id: ${this.element_.id}`
+      );
+      return;
+    }
+    this.isConnected_ = true;
+    eventTypes.forEach((type) => {
+      this.element_.addEventListener(type, this.handleEvent, {
+        passive: false,
+      });
+    });
+  }
+
+  public disconnect() {
+    if (!this.isConnected_) {
+      Logger.debug(
+        "EventDispatcher",
+        "Attempted to disconnect already disconnected event dispatcher",
+        `element id: ${this.element_.id}`
+      );
+      return;
+    }
+    this.isConnected_ = false;
+    eventTypes.forEach((type) => {
+      this.element_.removeEventListener(type, this.handleEvent);
+    });
   }
 
   private readonly handleEvent = (e: Event) => {

--- a/packages/core/src/idetik.ts
+++ b/packages/core/src/idetik.ts
@@ -130,6 +130,7 @@ export class Idetik {
         if (viewport.element !== this.canvas) {
           elements.push(viewport.element);
         }
+        viewport.events.connect();
       }
       this.pixelSizeObserver_.start(elements);
       this.animate();
@@ -174,6 +175,9 @@ export class Idetik {
       Logger.warn("Idetik", "Idetik runtime not started");
     } else {
       this.pixelSizeObserver_.stop();
+      for (const viewport of this.viewports_) {
+        viewport.events.disconnect();
+      }
       cancelAnimationFrame(this.lastAnimationId_);
       this.lastAnimationId_ = undefined;
     }


### PR DESCRIPTION
### Summary
I attempted to update Idetik in the VCP project in preparation of the CryoLens release. Unfortunately this broke the HITL app, which is now tied to the same Idetik dependency version. The previous version did not include #394, and the HITL app behavior changed without long-lived Idetik runtime(s).

I was able to work around some of the issues there, but duplicate event observers are still interfering. I was able to test a local build with these changes and it fixes some of the issues.