### PR TITLE
Prepare for npm prerelease version 5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "idetik",
+  "name": "idetik-release",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -8201,7 +8201,7 @@
     },
     "packages/core": {
       "name": "@idetik/core-prerelease",
-      "version": "4.0.0",
+      "version": "5.0.0",
       "license": "MIT",
       "dependencies": {
         "gl-matrix": "^3.4.3",
@@ -8215,7 +8215,7 @@
     },
     "packages/react": {
       "name": "@idetik/react-prerelease",
-      "version": "4.0.0",
+      "version": "5.0.0",
       "license": "MIT",
       "dependencies": {
         "@base-ui-components/react": "^1.0.0-beta.2",
@@ -8243,6 +8243,18 @@
         "@idetik/core-prerelease": "^4.0.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
+      }
+    },
+    "packages/react/node_modules/@idetik/core-prerelease": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@idetik/core-prerelease/-/core-prerelease-4.0.0.tgz",
+      "integrity": "sha512-0CTs5Z3M/u4JlN+sJNUtUHfbhLcq4lyrbyxFCypPKj+B/DKTnBofRmqTQ1ik3P+SfG9EUsZSTh4q8CTlOuqi+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "gl-matrix": "^3.4.3",
+        "zarrita": "^0.4.0-next.16",
+        "zod": "^3.24.1"
       }
     },
     "packages/react/node_modules/@mui/icons-material": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "idetik-release",
+  "name": "idetik",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -8231,7 +8231,7 @@
         "react-dom": "^18.3.1"
       },
       "devDependencies": {
-        "@idetik/core-prerelease": "^4.0.0",
+        "@idetik/core-prerelease": "^5.0.0",
         "@testing-library/react": "^16.3.0",
         "@types/classnames": "^2.3.0",
         "autoprefixer": "^10.4.20",
@@ -8243,18 +8243,6 @@
         "@idetik/core-prerelease": "^4.0.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
-      }
-    },
-    "packages/react/node_modules/@idetik/core-prerelease": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@idetik/core-prerelease/-/core-prerelease-4.0.0.tgz",
-      "integrity": "sha512-0CTs5Z3M/u4JlN+sJNUtUHfbhLcq4lyrbyxFCypPKj+B/DKTnBofRmqTQ1ik3P+SfG9EUsZSTh4q8CTlOuqi+w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "gl-matrix": "^3.4.3",
-        "zarrita": "^0.4.0-next.16",
-        "zod": "^3.24.1"
       }
     },
     "packages/react/node_modules/@mui/icons-material": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@idetik/core-prerelease",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@idetik/react-prerelease",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -52,7 +52,7 @@
     "idetik"
   ],
   "devDependencies": {
-    "@idetik/core-prerelease": "^4.0.0",
+    "@idetik/core-prerelease": "^5.0.0",
     "@testing-library/react": "^16.3.0",
     "@types/classnames": "^2.3.0",
     "autoprefixer": "^10.4.20",


### PR DESCRIPTION
### Summary
This was prepared according to the guide added in #477 

### Tests & Checks
This release was tested locally in VCP (CryoLens and HITL) using `yalc`
