### PR TITLE
Use clamp_to_edge instead of repeat as default texture wrap mode

### DIFF
--- a/packages/core/src/objects/textures/texture.ts
+++ b/packages/core/src/objects/textures/texture.ts
@@ -83,9 +83,9 @@ export abstract class Texture extends Node {
   public mipmapLevels = 1;
   public unpackAlignment: TextureUnpackRowAlignment = 4;
   public unpackRowLength = 0;
-  public wrapR: TextureWrapMode = "repeat";
-  public wrapS: TextureWrapMode = "repeat";
-  public wrapT: TextureWrapMode = "repeat";
+  public wrapR: TextureWrapMode = "clamp_to_edge";
+  public wrapS: TextureWrapMode = "clamp_to_edge";
+  public wrapT: TextureWrapMode = "clamp_to_edge";
   public needsUpdate = true;
 
   public abstract get width(): number;

--- a/packages/core/src/renderers/webgl_renderer.ts
+++ b/packages/core/src/renderers/webgl_renderer.ts
@@ -40,7 +40,7 @@ export class WebGLRenderer extends Renderer {
 
     this.gl_ = this.canvas.getContext("webgl2", {
       depth: true,
-      antialias: false,
+      antialias: true,
     });
     if (!this.gl_) {
       throw new Error(`Failed to initialize WebGL2 context`);


### PR DESCRIPTION
### Summary
This uses "clamp_to_edge" instead of "repeat" as the default wrap mode for textures, which prevents tile rendering artifacts seen in the OME-Zarr v0.5 example.

This change also allows us to explicitly enable anti-aliasing, which was previously explicitly disabled in #302 to fix a similar tile rendering artifact seen in other/older examples.

### Tests & Checks
I manually tested all the core examples.
I manually tested all the React examples.
