### PR TITLE
Add image source loading policies

### DIFF
--- a/packages/core/examples/ca_wave_dynamics/main.ts
+++ b/packages/core/examples/ca_wave_dynamics/main.ts
@@ -5,6 +5,8 @@ import {
   OmeZarrImageSource,
   OrthographicCamera,
   Color,
+  createExplorationPolicy,
+  createPlaybackPolicy,
 } from "@";
 import { PanZoomControls } from "@/objects/cameras/controls";
 import { addDimensionSlider } from "../lil_gui_utils";
@@ -43,7 +45,12 @@ const channelProps: ChannelProps[] = [
 ];
 
 const camera = new OrthographicCamera(left, right, top, bottom);
-const imageLayer = new ChunkedImageLayer({ source, sliceCoords, channelProps });
+const imageLayer = new ChunkedImageLayer({
+  source,
+  sliceCoords,
+  policy: createExplorationPolicy(),
+  channelProps,
+});
 imageLayer.debugMode = true;
 
 const timePointDiv = document.querySelector<HTMLDivElement>("#time-point")!;
@@ -81,7 +88,8 @@ addDimensionSlider({
     onRateChange: (rateHz: number) => {
       const source = imageLayer.chunkManagerSource;
       if (source) {
-        source.prioritizePrefetchTime = rateHz > 0;
+        source.imageSourcePolicy =
+          rateHz > 0 ? createPlaybackPolicy() : createExplorationPolicy();
       }
     },
   },

--- a/packages/core/examples/ca_wave_dynamics/main.ts
+++ b/packages/core/examples/ca_wave_dynamics/main.ts
@@ -86,11 +86,8 @@ addDimensionSlider({
   stepValue: t.scale,
   playback: {
     onRateChange: (rateHz: number) => {
-      const source = imageLayer.chunkManagerSource;
-      if (source) {
-        source.imageSourcePolicy =
-          rateHz > 0 ? createPlaybackPolicy() : createExplorationPolicy();
-      }
+      imageLayer.imageSourcePolicy =
+        rateHz > 0 ? createPlaybackPolicy() : createExplorationPolicy();
     },
   },
 });

--- a/packages/core/examples/chunk_streaming/main.ts
+++ b/packages/core/examples/chunk_streaming/main.ts
@@ -8,6 +8,11 @@ import {
 import { PanZoomControls } from "@/objects/cameras/controls";
 import { ChunkInfoOverlay } from "./chunk_info_overlay";
 import { addDimensionSlider } from "../lil_gui_utils";
+import {
+  createExplorationPolicy,
+  createPlaybackPolicy,
+} from "@/core/image_source_policy";
+
 import GUI from "lil-gui";
 
 const url =
@@ -48,7 +53,12 @@ const channelProps: ChannelProps[] = [
 ];
 
 const camera = new OrthographicCamera(left, right, top, bottom);
-const imageLayer = new ChunkedImageLayer({ source, sliceCoords, channelProps });
+const imageLayer = new ChunkedImageLayer({
+  source,
+  sliceCoords,
+  policy: createExplorationPolicy(),
+  channelProps,
+});
 imageLayer.debugMode = true;
 
 const overlaySelector = document.querySelector<HTMLDivElement>("#chunk-info")!;
@@ -108,7 +118,8 @@ addDimensionSlider({
     onRateChange: (rateHz: number) => {
       const source = imageLayer.chunkManagerSource;
       if (source) {
-        source.prioritizePrefetchTime = rateHz > 0;
+        source.imageSourcePolicy =
+          rateHz > 0 ? createPlaybackPolicy() : createExplorationPolicy();
       }
     },
   },

--- a/packages/core/examples/chunk_streaming/main.ts
+++ b/packages/core/examples/chunk_streaming/main.ts
@@ -116,11 +116,8 @@ addDimensionSlider({
   stepValue: t.scale,
   playback: {
     onRateChange: (rateHz: number) => {
-      const source = imageLayer.chunkManagerSource;
-      if (source) {
-        source.imageSourcePolicy =
-          rateHz > 0 ? createPlaybackPolicy() : createExplorationPolicy();
-      }
+      imageLayer.imageSourcePolicy =
+        rateHz > 0 ? createPlaybackPolicy() : createExplorationPolicy();
     },
   },
 });

--- a/packages/core/examples/image_labels_overlay_with_value_picking/main.ts
+++ b/packages/core/examples/image_labels_overlay_with_value_picking/main.ts
@@ -9,6 +9,7 @@ import {
 import { LabelImageLayer } from "@/layers/label_image_layer";
 import { PointPickingResult } from "@/layers/point_picking";
 import { PanZoomControls } from "@/objects/cameras/controls";
+import { createExplorationPolicy } from "@/core/image_source_policy";
 
 // These roughly correspond in terms of content and the number of time-points.
 // But the image is smaller in XY than the labels, and has a Z-stack, so it
@@ -83,6 +84,7 @@ infoBox.appendChild(toggleDiv);
 const imageLayer = new ChunkedImageLayer({
   source: imageSource,
   sliceCoords,
+  policy: createExplorationPolicy(),
   transparent: true,
   channelProps: [{ contrastLimits: phaseContrastLimits }],
 });

--- a/packages/core/examples/ome_zarr_v05/main.ts
+++ b/packages/core/examples/ome_zarr_v05/main.ts
@@ -9,6 +9,7 @@ import {
 import { AxesLayer } from "@/layers/axes_layer";
 import { PanZoomControls } from "@/objects/cameras/controls";
 import { addDimensionSlider } from "../lil_gui_utils";
+import { createExplorationPolicy } from "@/core/image_source_policy";
 import GUI from "lil-gui";
 
 const url =
@@ -51,6 +52,7 @@ const onPickValue = (info: PointPickingResult) => {
 const layer = new ChunkedImageLayer({
   source,
   sliceCoords,
+  policy: createExplorationPolicy(),
   channelProps,
   onPickValue,
 });

--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -2,16 +2,21 @@ import { ChunkSource, SliceCoordinates } from "../data/chunk";
 import { OrthographicCamera } from "../objects/cameras/orthographic_camera";
 import { ChunkQueue } from "../data/chunk_queue";
 import { ChunkManagerSource } from "./chunk_manager_source";
+import { ImageSourcePolicy } from "./image_source_policy";
 
 export class ChunkManager {
   private readonly sources_ = new Map<ChunkSource, ChunkManagerSource>();
   private readonly queue_ = new ChunkQueue();
 
-  public async addSource(source: ChunkSource, sliceCoords: SliceCoordinates) {
+  public async addSource(
+    source: ChunkSource,
+    sliceCoords: SliceCoordinates,
+    policy: ImageSourcePolicy
+  ) {
     let existing = this.sources_.get(source);
     if (!existing) {
       const loader = await source.open();
-      existing = new ChunkManagerSource(loader, sliceCoords);
+      existing = new ChunkManagerSource(loader, sliceCoords, policy);
       this.sources_.set(source, existing);
     }
     return existing;

--- a/packages/core/src/core/chunk_manager_source.ts
+++ b/packages/core/src/core/chunk_manager_source.ts
@@ -13,21 +13,28 @@ import { almostEqual } from "../utilities/almost_equal";
 import { Logger } from "../utilities/logger";
 import { clamp } from "../utilities/clamp";
 
+/*
+Unique symbol used as a capability token to allow internal modules to update
+the image source policy. Only code that imports this symbol can call
+setImageSourcePolicy; all other callers will be rejected. Acts like a "friend"
+access key, preventing accidental external mutation.
+*/
+export const INTERNAL_POLICY_KEY = Symbol("INTERNAL_POLICY_KEY");
+
 export class ChunkManagerSource {
   private readonly chunks_: Chunk[][];
   private readonly loader_;
   private readonly lowestResLOD_: number;
   private readonly sliceCoords_: SliceCoordinates;
   private readonly dimensions_: SourceDimensionMap;
+  private readonly tIndicesWithQueuedChunks_: Set<number> = new Set();
+  private readonly sourceMaxSquareDistance2D_: number;
   private policy_: ImageSourcePolicy;
   private policyChanged_ = false;
   private currentLOD_: number = 0;
   private lastViewBounds2D_: Box2 | null = null;
   private lastZBounds_?: [number, number];
   private lastTCoord_?: number;
-
-  private tIndicesWithQueuedChunks_: Set<number> = new Set();
-  private sourceMaxSquareDistance2D_: number;
 
   constructor(
     loader: ChunkLoader,
@@ -194,14 +201,14 @@ export class ChunkManagerSource {
     return this.currentLOD_;
   }
 
-  public get imageSourcePolicy(): Readonly<ImageSourcePolicy> {
-    return this.policy_;
-  }
+  public setImageSourcePolicy(newPolicy: ImageSourcePolicy, key: symbol) {
+    if (key !== INTERNAL_POLICY_KEY) {
+      throw new Error("Unauthorized policy mutation");
+    }
 
-  public set imageSourcePolicy(policy: ImageSourcePolicy) {
-    if (this.policy_ !== policy) {
+    if (this.policy_ !== newPolicy) {
+      this.policy_ = newPolicy;
       this.policyChanged_ = true;
-      this.policy_ = policy;
 
       Logger.info(
         "ChunkManagerSource",
@@ -235,13 +242,8 @@ export class ChunkManagerSource {
       Math.min(this.lowestResLOD_, this.policy_.lod.max)
     );
 
-    const target = Math.max(minPolicyLOD, Math.min(maxPolicyLOD, desiredLOD));
-
+    const target = clamp(desiredLOD, minPolicyLOD, maxPolicyLOD);
     if (target !== this.currentLOD_) {
-      Logger.debug(
-        "ChunkManagerSource",
-        `LOD changed from ${this.currentLOD_} to ${target}`
-      );
       this.currentLOD_ = target;
     }
   }
@@ -428,10 +430,6 @@ export class ChunkManagerSource {
     chunk.priority = null;
     chunk.orderKey = null;
     chunk.prefetch = false;
-    Logger.debug(
-      "ChunkManagerSource",
-      `Disposing chunk ${JSON.stringify(chunk.chunkIndex)} in LOD ${chunk.lod}`
-    );
   }
 
   private computePriority(

--- a/packages/core/src/core/chunk_manager_source.ts
+++ b/packages/core/src/core/chunk_manager_source.ts
@@ -196,13 +196,15 @@ export class ChunkManagerSource {
   }
 
   public set imageSourcePolicy(policy: ImageSourcePolicy) {
-    this.policy_ = policy;
+    if (this.policy_ != policy) {
+      this.policy_ = policy;
 
-    Logger.info(
-      "ChunkManagerSource",
-      "Using image source policy:",
-      this.policy_.profile
-    );
+      Logger.info(
+        "ChunkManagerSource",
+        "Using image source policy:",
+        this.policy_.profile
+      );
+    }
   }
 
   public loadChunkData(chunk: Chunk, signal: AbortSignal) {

--- a/packages/core/src/core/chunk_manager_source.ts
+++ b/packages/core/src/core/chunk_manager_source.ts
@@ -5,6 +5,7 @@ import {
   SliceCoordinates,
   coordToIndex,
 } from "../data/chunk";
+import { ImageSourcePolicy } from "./image_source_policy";
 import { ReadonlyVec2, vec2, vec3 } from "gl-matrix";
 import { Box2 } from "../math/box2";
 import { Box3 } from "../math/box3";
@@ -12,58 +13,45 @@ import { almostEqual } from "../utilities/almost_equal";
 import { Logger } from "../utilities/logger";
 import { clamp } from "../utilities/clamp";
 
-// Number of chunks to extend beyond the visible bounds in each direction (x/y/z)
-// These additional chunks are prefetched to improve responsiveness when panning.
-const PREFETCH_PADDING_CHUNKS = 0;
-
-// Fetch some number of time points ahead of current time.
-const PREFETCH_TIME_POINTS = 10;
-
-// Visible chunks at the fallback LOD.
-const PRI_FALLBACK_VISIBLE = 0;
-// Prioritized prefetch chunks not at the current time (e.g. during playback).
-const PRI_PREFETCH_TIME_HIGH = 1;
-// Visible chunks at the current LOD.
-const PRI_VISIBLE_CURRENT = 2;
-// Non-prioritized prefetch chunks not at the current time.
-const PRI_PREFETCH_TIME_LOW = 3;
-// Non-visible chunks at the fallback LOD.
-const PRI_FALLBACK_BACKGROUND = 4;
-// Prefetch non-visible chunks at the current time.
-const PRI_PREFETCH_SPACE = 5;
-
 export class ChunkManagerSource {
-  // First dimension of the array is time, the others cover LOD, x, y, z, c.
   private readonly chunks_: Chunk[][];
   private readonly loader_;
   private readonly lowestResLOD_: number;
   private readonly sliceCoords_: SliceCoordinates;
   private readonly dimensions_: SourceDimensionMap;
+  private policy_: ImageSourcePolicy;
   private currentLOD_: number = 0;
-  // TODO: make LOD bias configurable per-source or per-layer
-  // positive values nudge towards coarser resolution (higher LOD number)
-  private lodBias_: number = 0.5;
   private lastViewBounds2D_: Box2 | null = null;
   private lastZBounds_?: [number, number];
   private lastTCoord_?: number;
 
-  public prioritizePrefetchTime: boolean = false;
   private tIndicesWithQueuedChunks_: Set<number> = new Set();
   private sourceMaxSquareDistance2D_: number;
 
-  constructor(loader: ChunkLoader, sliceCoords: SliceCoordinates) {
+  constructor(
+    loader: ChunkLoader,
+    sliceCoords: SliceCoordinates,
+    policy: ImageSourcePolicy
+  ) {
     this.loader_ = loader;
+    this.policy_ = policy;
     this.dimensions_ = this.loader_.getSourceDimensionMap();
     this.lowestResLOD_ = this.dimensions_.numLods - 1;
     this.currentLOD_ = 0;
     this.sliceCoords_ = sliceCoords;
 
+    Logger.info(
+      "ChunkManagerSource",
+      "Using image source policy:",
+      this.policy_.profile
+    );
+
     this.validateXYScaleRatios();
     const { size: chunksT } = this.getAndValidateTimeDimension();
     const { size: chunksC } = this.getAndValidateChannelDimension();
 
-    const xLod0 = this.dimensions.x.lods[0];
-    const yLod0 = this.dimensions.y.lods[0];
+    const xLod0 = this.dimensions_.x.lods[0];
+    const yLod0 = this.dimensions_.y.lods[0];
     this.sourceMaxSquareDistance2D_ = vec2.squaredLength(
       vec2.fromValues(xLod0.size * xLod0.scale, yLod0.size * yLod0.scale)
     );
@@ -203,33 +191,52 @@ export class ChunkManagerSource {
     return this.currentLOD_;
   }
 
+  public get imageSourcePolicy(): Readonly<ImageSourcePolicy> {
+    return this.policy_;
+  }
+
+  public set imageSourcePolicy(policy: ImageSourcePolicy) {
+    this.policy_ = policy;
+
+    Logger.info(
+      "ChunkManagerSource",
+      "Using image source policy:",
+      this.policy_.profile
+    );
+  }
+
   public loadChunkData(chunk: Chunk, signal: AbortSignal) {
     return this.loader_.loadChunkData(chunk, signal);
   }
 
   private setLOD(lodFactor: number): void {
-    // `scale` here is the x-width of an image pixel in virtual units at LOD 0.
-    // So (ignoring the bias term) subtracting `lodFactor` from `Math.log2(scale)`
-    // is effectively `Math.log2(virtualUnitsPerScreenPixel / xScale)`.
-    // That is, `adjustedLodFactor = Math.log2(imagePixelsPerScreenPixel)`;
-    // or in other words, how many image pixels (LOD 0) fit in a screen pixel.
-    // Use of log2 here and in ChunkManager relies on the assumption that
-    // each LOD is downsampled by a factor of 2 in X and Y.
-    const sourceAdjustment =
-      this.lodBias_ - Math.log2(this.dimensions_.x.lods[0].scale);
-    const sourceAdjustedLodFactor = sourceAdjustment - lodFactor;
-    const maxLOD = this.lowestResLOD_;
-    const targetLOD = Math.max(
+    // `scale0` is the x pixel size (world units) at LOD 0.
+    // With 2x downsampling per LOD, selection happens in log2 space.
+    const scale0 = this.dimensions_.x.lods[0].scale;
+    const bias = this.policy_.lod.bias;
+
+    // How many LOD 0 pixels per screen pixel, normalized by source scale and bias.
+    const sourceAdjusted = bias - Math.log2(scale0) - lodFactor;
+    const desiredLOD = Math.floor(sourceAdjusted);
+
+    // Intersect dataset bounds with policy bounds.
+    const minPolicyLOD = Math.max(
       0,
-      Math.min(maxLOD, Math.floor(sourceAdjustedLodFactor))
+      Math.min(this.lowestResLOD_, this.policy_.lod.min)
+    );
+    const maxPolicyLOD = Math.max(
+      minPolicyLOD,
+      Math.min(this.lowestResLOD_, this.policy_.lod.max)
     );
 
-    if (targetLOD !== this.currentLOD_) {
+    const target = Math.max(minPolicyLOD, Math.min(maxPolicyLOD, desiredLOD));
+
+    if (target !== this.currentLOD_) {
       Logger.debug(
         "ChunkManagerSource",
-        `LOD changed from ${this.currentLOD_} to ${targetLOD}`
+        `LOD changed from ${this.currentLOD_} to ${target}`
       );
-      this.currentLOD_ = targetLOD;
+      this.currentLOD_ = target;
     }
   }
 
@@ -285,7 +292,7 @@ export class ChunkManagerSource {
     const disposedChunks: Chunk[] = [];
     for (const t of this.tIndicesWithQueuedChunks_) {
       const delta = t - currentTimeIndex;
-      if (delta >= 0 && delta <= PREFETCH_TIME_POINTS) continue;
+      if (delta >= 0 && delta <= this.policy_.prefetch.t) continue;
       const chunks = this.chunks_[t];
       for (const chunk of chunks) {
         this.disposeChunk(chunk);
@@ -361,7 +368,7 @@ export class ChunkManagerSource {
   ): Chunk[] {
     const tEnd = Math.min(
       this.chunks_.length - 1,
-      currentTimeIndex + PREFETCH_TIME_POINTS
+      currentTimeIndex + this.policy_.prefetch.t
     );
     const prefetchedChunks: Chunk[] = [];
     for (let t = currentTimeIndex + 1; t <= tEnd; ++t) {
@@ -371,9 +378,7 @@ export class ChunkManagerSource {
         if (!this.isChunkChannelInSlice(chunk)) continue;
         if (!this.isChunkWithinBounds(chunk, viewBounds3D)) continue;
         chunk.prefetch = true;
-        chunk.priority = this.prioritizePrefetchTime
-          ? PRI_PREFETCH_TIME_HIGH
-          : PRI_PREFETCH_TIME_LOW;
+        chunk.priority = this.policy_.priorityMap["prefetchTime"];
         const squareDistance = this.squareDistance2D(chunk, viewBoundsCenter2D);
         const normalizedDistance = clamp(
           squareDistance / this.sourceMaxSquareDistance2D_,
@@ -431,10 +436,13 @@ export class ChunkManagerSource {
     isChannelInSlice: boolean
   ) {
     if (!isChannelInSlice) return null;
-    if (isFallbackLOD && isVisible) return PRI_FALLBACK_VISIBLE;
-    if (isCurrentLOD && isVisible) return PRI_VISIBLE_CURRENT;
-    if (isFallbackLOD) return PRI_FALLBACK_BACKGROUND;
-    if (isCurrentLOD && isPrefetch) return PRI_PREFETCH_SPACE;
+
+    const m = this.policy_.priorityMap;
+    if (isFallbackLOD && isVisible) return m["fallbackVisible"];
+    if (isCurrentLOD && isVisible) return m["visibleCurrent"];
+    if (isFallbackLOD) return m["fallbackBackground"];
+    if (isCurrentLOD && isPrefetch) return m["prefetchSpace"];
+
     return null;
   }
 
@@ -565,12 +573,15 @@ export class ChunkManagerSource {
   private getPaddedBounds(bounds: Box3): Box3 {
     const xLod = this.dimensions_.x.lods[this.currentLOD_];
     const yLod = this.dimensions_.y.lods[this.currentLOD_];
+    const zLod = this.dimensions_.z?.lods[this.currentLOD_];
 
-    const padX = xLod.chunkSize * xLod.scale * PREFETCH_PADDING_CHUNKS;
-    const padY = yLod.chunkSize * yLod.scale * PREFETCH_PADDING_CHUNKS;
+    const padX = xLod.chunkSize * xLod.scale * this.policy_.prefetch.x;
+    const padY = yLod.chunkSize * yLod.scale * this.policy_.prefetch.y;
 
-    // Disable prefetching in Z until chunk prioritization exists.
-    const padZ = 0;
+    let padZ = 0;
+    if (zLod) {
+      padZ = zLod.chunkSize * zLod.scale * this.policy_.prefetch.z;
+    }
 
     return new Box3(
       vec3.fromValues(

--- a/packages/core/src/core/chunk_manager_source.ts
+++ b/packages/core/src/core/chunk_manager_source.ts
@@ -20,6 +20,7 @@ export class ChunkManagerSource {
   private readonly sliceCoords_: SliceCoordinates;
   private readonly dimensions_: SourceDimensionMap;
   private policy_: ImageSourcePolicy;
+  private policyChanged_ = false;
   private currentLOD_: number = 0;
   private lastViewBounds2D_: Box2 | null = null;
   private lastZBounds_?: [number, number];
@@ -161,21 +162,23 @@ export class ChunkManagerSource {
 
   public updateAndCollectChunkChanges(lodFactor: number, viewBounds2D: Box2) {
     this.setLOD(lodFactor);
-    const zBounds = this.getZBounds();
-    let updatedChunks: Chunk[] = [];
 
-    if (
+    const zBounds = this.getZBounds();
+    const changed =
+      this.policyChanged_ ||
       this.viewBounds2DChanged(viewBounds2D) ||
       this.zBoundsChanged(zBounds) ||
-      this.lastTCoord_ !== this.sliceCoords_.t
-    ) {
-      updatedChunks =
-        this.updateAndCollectChunkChangesForCurrentLod(viewBounds2D);
-    }
+      this.lastTCoord_ !== this.sliceCoords_.t;
 
+    const updatedChunks = changed
+      ? this.updateAndCollectChunkChangesForCurrentLod(viewBounds2D)
+      : [];
+
+    this.policyChanged_ = false;
     this.lastViewBounds2D_ = viewBounds2D.clone();
     this.lastZBounds_ = zBounds;
     this.lastTCoord_ = this.sliceCoords_.t;
+
     return updatedChunks;
   }
 
@@ -196,7 +199,8 @@ export class ChunkManagerSource {
   }
 
   public set imageSourcePolicy(policy: ImageSourcePolicy) {
-    if (this.policy_ != policy) {
+    if (this.policy_ !== policy) {
+      this.policyChanged_ = true;
       this.policy_ = policy;
 
       Logger.info(

--- a/packages/core/src/core/image_source_policy.ts
+++ b/packages/core/src/core/image_source_policy.ts
@@ -1,0 +1,150 @@
+const ALL_CATEGORIES = [
+  "fallbackVisible",
+  "prefetchTime",
+  "visibleCurrent",
+  "fallbackBackground",
+  "prefetchSpace",
+] as const;
+
+type PriorityCategory = (typeof ALL_CATEGORIES)[number];
+
+export type ImageSourcePolicyConfig = {
+  profile?: string;
+  prefetch: {
+    x: number;
+    y: number;
+    z?: number;
+    t?: number;
+  };
+  priorityOrder: PriorityCategory[];
+  lod?: {
+    min?: number;
+    max?: number;
+    bias?: number;
+  };
+};
+
+export type ImageSourcePolicy = Readonly<{
+  profile: string;
+  prefetch: {
+    x: number;
+    y: number;
+    z: number;
+    t: number;
+  };
+  priorityOrder: readonly PriorityCategory[];
+  priorityMap: Readonly<Record<PriorityCategory, number>>;
+  lod: {
+    min: number;
+    max: number;
+    bias: number;
+  };
+}>;
+
+export function createImageSourcePolicy(
+  config: ImageSourcePolicyConfig
+): ImageSourcePolicy {
+  validatePolicyConfig(config);
+
+  const prefetch = {
+    x: config.prefetch.x,
+    y: config.prefetch.y,
+    z: config.prefetch.z ?? 0,
+    t: config.prefetch.t ?? 0,
+  };
+
+  const priorityMap: Readonly<Record<PriorityCategory, number>> = Object.freeze(
+    ALL_CATEGORIES.reduce<Record<PriorityCategory, number>>(
+      (acc, cat) => {
+        const idx = config.priorityOrder.indexOf(cat);
+        acc[cat] = idx;
+        return acc;
+      },
+      {} as Record<PriorityCategory, number>
+    )
+  );
+
+  const lod = {
+    min: config.lod?.min ?? 0,
+    max: config.lod?.max ?? Number.MAX_SAFE_INTEGER,
+    bias: config.lod?.bias ?? 0.5,
+  };
+
+  const resolved: ImageSourcePolicy = {
+    profile: config.profile ?? "custom",
+    prefetch,
+    priorityOrder: Object.freeze([...config.priorityOrder]),
+    priorityMap,
+    lod,
+  };
+
+  return Object.freeze(resolved);
+}
+
+function validatePolicyConfig(config: ImageSourcePolicyConfig) {
+  for (const [k, v] of Object.entries(config.prefetch)) {
+    if (v === null) continue; // z/t may be omitted
+    if (v < 0) {
+      throw new Error(`prefetch.${k} must be a non-negative number`);
+    }
+  }
+
+  const lod = config.lod;
+  if (lod?.min != null && lod?.max != null && lod.min > lod.max) {
+    throw new Error(`lod.min must be <= lod.max`);
+  }
+
+  const order = config.priorityOrder;
+  if (
+    order.length !== ALL_CATEGORIES.length ||
+    new Set(order).size !== order.length
+  ) {
+    throw new Error(`priorityOrder must include all categories exactly once`);
+  }
+}
+
+function mergeConfig(
+  base: ImageSourcePolicyConfig,
+  overrides: Partial<ImageSourcePolicyConfig> = {}
+): ImageSourcePolicyConfig {
+  return {
+    profile: overrides.profile ?? base.profile,
+    prefetch: { ...base.prefetch, ...(overrides.prefetch ?? {}) },
+    lod: { ...base.lod, ...(overrides.lod ?? {}) },
+    priorityOrder: overrides.priorityOrder ?? base.priorityOrder,
+  };
+}
+
+export function createExplorationPolicy(
+  overrides: Partial<ImageSourcePolicyConfig> = {}
+): ImageSourcePolicy {
+  const base: ImageSourcePolicyConfig = {
+    profile: "exploration",
+    prefetch: { x: 1, y: 1, z: 1, t: 0 },
+    priorityOrder: [
+      "fallbackVisible",
+      "visibleCurrent",
+      "prefetchSpace",
+      "prefetchTime",
+      "fallbackBackground",
+    ],
+  };
+  return createImageSourcePolicy(mergeConfig(base, overrides));
+}
+
+export function createPlaybackPolicy(
+  overrides: Partial<ImageSourcePolicyConfig> = {}
+): ImageSourcePolicy {
+  const base: ImageSourcePolicyConfig = {
+    profile: "playback",
+    prefetch: { x: 0, y: 0, z: 0, t: 20 },
+    priorityOrder: [
+      "fallbackVisible",
+      "prefetchTime",
+      "visibleCurrent",
+      "fallbackBackground",
+      "prefetchSpace",
+    ],
+  };
+  return createImageSourcePolicy(mergeConfig(base, overrides));
+}

--- a/packages/core/src/core/image_source_policy.ts
+++ b/packages/core/src/core/image_source_policy.ts
@@ -6,7 +6,7 @@ const ALL_CATEGORIES = [
   "prefetchSpace",
 ] as const;
 
-type PriorityCategory = (typeof ALL_CATEGORIES)[number];
+export type PriorityCategory = (typeof ALL_CATEGORIES)[number];
 
 export type ImageSourcePolicyConfig = {
   profile?: string;
@@ -81,40 +81,6 @@ export function createImageSourcePolicy(
   return Object.freeze(resolved);
 }
 
-function validatePolicyConfig(config: ImageSourcePolicyConfig) {
-  for (const [k, v] of Object.entries(config.prefetch)) {
-    if (v === null) continue; // z/t may be omitted
-    if (v < 0) {
-      throw new Error(`prefetch.${k} must be a non-negative number`);
-    }
-  }
-
-  const lod = config.lod;
-  if (lod?.min != null && lod?.max != null && lod.min > lod.max) {
-    throw new Error(`lod.min must be <= lod.max`);
-  }
-
-  const order = config.priorityOrder;
-  if (
-    order.length !== ALL_CATEGORIES.length ||
-    new Set(order).size !== order.length
-  ) {
-    throw new Error(`priorityOrder must include all categories exactly once`);
-  }
-}
-
-function mergeConfig(
-  base: ImageSourcePolicyConfig,
-  overrides: Partial<ImageSourcePolicyConfig> = {}
-): ImageSourcePolicyConfig {
-  return {
-    profile: overrides.profile ?? base.profile,
-    prefetch: { ...base.prefetch, ...(overrides.prefetch ?? {}) },
-    lod: { ...base.lod, ...(overrides.lod ?? {}) },
-    priorityOrder: overrides.priorityOrder ?? base.priorityOrder,
-  };
-}
-
 export function createExplorationPolicy(
   overrides: Partial<ImageSourcePolicyConfig> = {}
 ): ImageSourcePolicy {
@@ -147,4 +113,38 @@ export function createPlaybackPolicy(
     ],
   };
   return createImageSourcePolicy(mergeConfig(base, overrides));
+}
+
+function validatePolicyConfig(config: ImageSourcePolicyConfig) {
+  for (const [k, v] of Object.entries(config.prefetch)) {
+    if (v === null) continue; // z/t may be omitted
+    if (v < 0) {
+      throw new Error(`prefetch.${k} must be a non-negative number`);
+    }
+  }
+
+  const lod = config.lod;
+  if (lod?.min != null && lod?.max != null && lod.min > lod.max) {
+    throw new Error(`lod.min must be <= lod.max`);
+  }
+
+  const order = config.priorityOrder;
+  if (
+    order.length !== ALL_CATEGORIES.length ||
+    new Set(order).size !== order.length
+  ) {
+    throw new Error(`priorityOrder must include all categories exactly once`);
+  }
+}
+
+function mergeConfig(
+  base: ImageSourcePolicyConfig,
+  overrides: Partial<ImageSourcePolicyConfig> = {}
+): ImageSourcePolicyConfig {
+  return {
+    profile: overrides.profile ?? base.profile,
+    prefetch: { ...base.prefetch, ...(overrides.prefetch ?? {}) },
+    lod: { ...base.lod, ...(overrides.lod ?? {}) },
+    priorityOrder: overrides.priorityOrder ?? base.priorityOrder,
+  };
 }

--- a/packages/core/src/core/image_source_policy.ts
+++ b/packages/core/src/core/image_source_policy.ts
@@ -115,16 +115,33 @@ export function createPlaybackPolicy(
   return createImageSourcePolicy(mergeConfig(base, overrides));
 }
 
+export function createNoPrefetchPolicy(
+  overrides: Partial<ImageSourcePolicyConfig> = {}
+): ImageSourcePolicy {
+  const base: ImageSourcePolicyConfig = {
+    profile: "no-prefetch",
+    prefetch: { x: 0, y: 0, z: 0, t: 0 },
+    priorityOrder: [
+      "fallbackVisible",
+      "visibleCurrent",
+      "fallbackBackground",
+      "prefetchSpace",
+      "prefetchTime",
+    ],
+  };
+  return createImageSourcePolicy(mergeConfig(base, overrides));
+}
+
 function validatePolicyConfig(config: ImageSourcePolicyConfig) {
   for (const [k, v] of Object.entries(config.prefetch)) {
-    if (v === null) continue; // z/t may be omitted
+    if (v === undefined) continue; // z/t may be omitted
     if (v < 0) {
       throw new Error(`prefetch.${k} must be a non-negative number`);
     }
   }
 
   const lod = config.lod;
-  if (lod?.min != null && lod?.max != null && lod.min > lod.max) {
+  if (lod?.min !== undefined && lod?.max !== undefined && lod.min > lod.max) {
     throw new Error(`lod.min must be <= lod.max`);
   }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -33,6 +33,7 @@ export type {
 export {
   createImageSourcePolicy,
   createExplorationPolicy,
+  createNoPrefetchPolicy,
   createPlaybackPolicy,
 } from "./core/image_source_policy";
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -25,6 +25,13 @@ export type { PointPickingResult } from "./layers/point_picking";
 export { ImageSeriesLayer } from "./layers/image_series_layer";
 export { OmeZarrImageSource } from "./data/ome_zarr/image_source";
 
+export type { ImageSourcePolicyConfig } from "./core/image_source_policy";
+export {
+  createImageSourcePolicy,
+  createExplorationPolicy,
+  createPlaybackPolicy,
+} from "./core/image_source_policy";
+
 export { Box2 } from "./math/box2";
 export { Box3 } from "./math/box3";
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -25,7 +25,11 @@ export type { PointPickingResult } from "./layers/point_picking";
 export { ImageSeriesLayer } from "./layers/image_series_layer";
 export { OmeZarrImageSource } from "./data/ome_zarr/image_source";
 
-export type { ImageSourcePolicyConfig } from "./core/image_source_policy";
+export type {
+  PriorityCategory,
+  ImageSourcePolicyConfig,
+} from "./core/image_source_policy";
+
 export {
   createImageSourcePolicy,
   createExplorationPolicy,

--- a/packages/core/src/layers/chunked_image_layer.ts
+++ b/packages/core/src/layers/chunked_image_layer.ts
@@ -2,6 +2,7 @@ import { Layer, LayerOptions } from "../core/layer";
 import { IdetikContext } from "../idetik";
 import { Chunk, ChunkSource, SliceCoordinates } from "../data/chunk";
 import { ChunkManagerSource } from "../core/chunk_manager_source";
+import { ImageSourcePolicy } from "../core/image_source_policy";
 import { ChannelProps, ChannelsEnabled } from "../objects/textures/channel";
 import { ImageRenderable } from "../objects/renderable/image_renderable";
 import { Texture2DArray } from "../objects/textures/texture_2d_array";
@@ -18,6 +19,7 @@ import { RenderablePool } from "../utilities/renderable_pool";
 export type ChunkedImageLayerProps = LayerOptions & {
   source: ChunkSource;
   sliceCoords: SliceCoordinates;
+  policy: ImageSourcePolicy;
   channelProps?: ChannelProps[];
   onPickValue?: (info: PointPickingResult) => void;
 };
@@ -25,6 +27,7 @@ export type ChunkedImageLayerProps = LayerOptions & {
 export class ChunkedImageLayer extends Layer implements ChannelsEnabled {
   public readonly type = "ChunkedImageLayer";
 
+  private readonly policy_: ImageSourcePolicy;
   private readonly source_: ChunkSource;
   private readonly sliceCoords_: SliceCoordinates;
   private readonly onPickValue_?: (info: PointPickingResult) => void;
@@ -52,6 +55,7 @@ export class ChunkedImageLayer extends Layer implements ChannelsEnabled {
   constructor({
     source,
     sliceCoords,
+    policy,
     channelProps,
     onPickValue,
     ...layerOptions
@@ -59,6 +63,7 @@ export class ChunkedImageLayer extends Layer implements ChannelsEnabled {
     super(layerOptions);
     this.setState("initialized");
     this.source_ = source;
+    this.policy_ = policy;
     this.sliceCoords_ = sliceCoords;
     this.channelProps_ = channelProps;
     this.initialChannelProps_ = channelProps;
@@ -68,7 +73,8 @@ export class ChunkedImageLayer extends Layer implements ChannelsEnabled {
   public async onAttached(context: IdetikContext) {
     this.chunkManagerSource_ = await context.chunkManager.addSource(
       this.source_,
-      this.sliceCoords_
+      this.sliceCoords_,
+      this.policy_
     );
   }
 

--- a/packages/core/src/layers/chunked_image_layer.ts
+++ b/packages/core/src/layers/chunked_image_layer.ts
@@ -1,7 +1,10 @@
 import { Layer, LayerOptions } from "../core/layer";
 import { IdetikContext } from "../idetik";
 import { Chunk, ChunkSource, SliceCoordinates } from "../data/chunk";
-import { ChunkManagerSource } from "../core/chunk_manager_source";
+import {
+  ChunkManagerSource,
+  INTERNAL_POLICY_KEY,
+} from "../core/chunk_manager_source";
 import { ImageSourcePolicy } from "../core/image_source_policy";
 import { ChannelProps, ChannelsEnabled } from "../objects/textures/channel";
 import { ImageRenderable } from "../objects/renderable/image_renderable";
@@ -27,7 +30,6 @@ export type ChunkedImageLayerProps = LayerOptions & {
 export class ChunkedImageLayer extends Layer implements ChannelsEnabled {
   public readonly type = "ChunkedImageLayer";
 
-  private readonly policy_: ImageSourcePolicy;
   private readonly source_: ChunkSource;
   private readonly sliceCoords_: SliceCoordinates;
   private readonly onPickValue_?: (info: PointPickingResult) => void;
@@ -35,6 +37,7 @@ export class ChunkedImageLayer extends Layer implements ChannelsEnabled {
   private readonly pool_ = new RenderablePool<ImageRenderable>();
   private readonly initialChannelProps_?: ChannelProps[];
   private readonly channelChangeCallbacks_: (() => void)[] = [];
+  private policy_: ImageSourcePolicy;
   private channelProps_?: ChannelProps[];
   private chunkManagerSource_?: ChunkManagerSource;
   private pointerDownPos_: vec2 | null = null;
@@ -160,6 +163,22 @@ export class ChunkedImageLayer extends Layer implements ChannelsEnabled {
 
   public get source(): ChunkSource {
     return this.source_;
+  }
+
+  public get imageSourcePolicy(): Readonly<ImageSourcePolicy> {
+    return this.policy_;
+  }
+
+  public set imageSourcePolicy(newPolicy: ImageSourcePolicy) {
+    if (this.policy_ !== newPolicy) {
+      this.policy_ = newPolicy;
+      if (this.chunkManagerSource_) {
+        this.chunkManagerSource_.setImageSourcePolicy(
+          newPolicy,
+          INTERNAL_POLICY_KEY
+        );
+      }
+    }
   }
 
   private slicePlane(chunk: Chunk, zValue: number) {

--- a/packages/core/test/image_source_policy.test.ts
+++ b/packages/core/test/image_source_policy.test.ts
@@ -1,0 +1,106 @@
+import { expect, test } from "vitest";
+import {
+  PriorityCategory,
+  createImageSourcePolicy,
+  createExplorationPolicy,
+  createPlaybackPolicy,
+} from "@";
+
+const VALID_PRIORITY_ORDER: PriorityCategory[] = [
+  "fallbackVisible",
+  "prefetchTime",
+  "visibleCurrent",
+  "fallbackBackground",
+  "prefetchSpace",
+];
+
+test("createImageSourcePolicy fills defaults for optional fields", () => {
+  const p = createImageSourcePolicy({
+    prefetch: { x: 1, y: 2 },
+    priorityOrder: VALID_PRIORITY_ORDER,
+  });
+
+  expect(p.profile).toBe("custom");
+  expect(p.prefetch).toEqual({ x: 1, y: 2, z: 0, t: 0 });
+  expect(p.lod).toEqual({ min: 0, max: Number.MAX_SAFE_INTEGER, bias: 0.5 });
+  expect(Object.keys(p.priorityMap)).toHaveLength(5);
+  expect(Object.isFrozen(p.priorityMap)).toBe(true);
+});
+
+test("createExplorationPolicy sets exploration defaults", () => {
+  const p = createExplorationPolicy();
+
+  expect(p.profile).toBe("exploration");
+  expect(p.prefetch).toEqual({ x: 1, y: 1, z: 1, t: 0 });
+  expect(Object.keys(p.priorityMap)).toHaveLength(5);
+  expect(p.priorityMap).toEqual({
+    fallbackVisible: 0,
+    visibleCurrent: 1,
+    prefetchSpace: 2,
+    prefetchTime: 3,
+    fallbackBackground: 4,
+  });
+});
+
+test("createPlaybackPolicy sets playback defaults", () => {
+  const p = createPlaybackPolicy();
+
+  expect(p.profile).toBe("playback");
+  expect(p.prefetch).toEqual({ x: 0, y: 0, z: 0, t: 20 });
+  expect(Object.keys(p.priorityMap)).toHaveLength(5);
+  expect(p.priorityMap).toEqual({
+    fallbackVisible: 0,
+    prefetchTime: 1,
+    visibleCurrent: 2,
+    fallbackBackground: 3,
+    prefetchSpace: 4,
+  });
+});
+
+test("throws on negative prefetch values", () => {
+  expect(() =>
+    createImageSourcePolicy({
+      prefetch: { x: -1, y: 0 },
+      priorityOrder: VALID_PRIORITY_ORDER,
+    })
+  ).toThrow("prefetch.x must be a non-negative number");
+});
+
+test("throws when lod.min > lod.max", () => {
+  expect(() =>
+    createImageSourcePolicy({
+      prefetch: { x: 0, y: 0 },
+      priorityOrder: VALID_PRIORITY_ORDER,
+      lod: { min: 10, max: 5 },
+    })
+  ).toThrow("lod.min must be <= lod.max");
+});
+
+test("throws if priorityOrder misses a category", () => {
+  expect(() =>
+    createImageSourcePolicy({
+      prefetch: { x: 0, y: 0 },
+      priorityOrder: [
+        "fallbackVisible",
+        "prefetchTime",
+        "visibleCurrent",
+        "fallbackBackground",
+      ],
+    })
+  ).toThrow("priorityOrder must include all categories exactly once");
+});
+
+test("throws if priorityOrder contains duplicates", () => {
+  expect(() =>
+    createImageSourcePolicy({
+      prefetch: { x: 0, y: 0 },
+      priorityOrder: [
+        "fallbackVisible",
+        "prefetchTime",
+        "visibleCurrent",
+        "fallbackBackground",
+        "fallbackVisible", // duplicate
+      ],
+    })
+  ).toThrow("priorityOrder must include all categories exactly once");
+});

--- a/packages/core/test/image_source_policy.test.ts
+++ b/packages/core/test/image_source_policy.test.ts
@@ -3,6 +3,7 @@ import {
   PriorityCategory,
   createImageSourcePolicy,
   createExplorationPolicy,
+  createNoPrefetchPolicy,
   createPlaybackPolicy,
 } from "@";
 
@@ -39,6 +40,21 @@ test("createExplorationPolicy sets exploration defaults", () => {
     prefetchSpace: 2,
     prefetchTime: 3,
     fallbackBackground: 4,
+  });
+});
+
+test("createNoPrefetchPolicy sets playback defaults", () => {
+  const p = createNoPrefetchPolicy();
+
+  expect(p.profile).toBe("no-prefetch");
+  expect(p.prefetch).toEqual({ x: 0, y: 0, z: 0, t: 0 });
+  expect(Object.keys(p.priorityMap)).toHaveLength(5);
+  expect(p.priorityMap).toEqual({
+    fallbackVisible: 0,
+    visibleCurrent: 1,
+    fallbackBackground: 2,
+    prefetchSpace: 3,
+    prefetchTime: 4,
   });
 });
 

--- a/packages/react/src/components/viewers/OmeZarrChunkedImageViewer/OmeZarrChunkedImageViewer.tsx
+++ b/packages/react/src/components/viewers/OmeZarrChunkedImageViewer/OmeZarrChunkedImageViewer.tsx
@@ -7,7 +7,7 @@ import {
   ChannelProps,
   ChunkLoader,
   ChunkedImageLayer,
-  createExplorationPolicy,
+  createNoPrefetchPolicy,
 } from "@idetik/core-prerelease";
 import { useIdetik } from "../../../hooks/useIdetik";
 import { IdetikCanvas } from "../../IdetikCanvas";
@@ -190,7 +190,7 @@ function createLayer(
   const layer = new ChunkedImageLayer({
     source,
     sliceCoords,
-    policy: createExplorationPolicy(),
+    policy: createNoPrefetchPolicy(),
     channelProps,
   });
   return { layer, sliceCoords };

--- a/packages/react/src/components/viewers/OmeZarrChunkedImageViewer/OmeZarrChunkedImageViewer.tsx
+++ b/packages/react/src/components/viewers/OmeZarrChunkedImageViewer/OmeZarrChunkedImageViewer.tsx
@@ -7,6 +7,7 @@ import {
   ChannelProps,
   ChunkLoader,
   ChunkedImageLayer,
+  createExplorationPolicy,
 } from "@idetik/core-prerelease";
 import { useIdetik } from "../../../hooks/useIdetik";
 import { IdetikCanvas } from "../../IdetikCanvas";
@@ -189,6 +190,7 @@ function createLayer(
   const layer = new ChunkedImageLayer({
     source,
     sliceCoords,
+    policy: createExplorationPolicy(),
     channelProps,
   });
   return { layer, sliceCoords };


### PR DESCRIPTION
### Summary

This PR introduces an image source policy object and related helpers used to
configure loading behavior for a given `ChunkManagerSource`. It replaces the
previous hard-coded constants with a structured policy definition. The only new
feature added in this change is support for specifying an LOD range, allowing
users to skip certain LOD levels for a given image.

### Related Issue
The next task for #487 is adding a config object to the runtime that handles memory and network properties.

### Tests & Checks

- All existing checks have passed.
- Added basic unit tests.