### PR TITLE
(SMALL) Move geometry instancing into renderables

### DIFF
--- a/packages/core/src/layers/chunked_image_layer.ts
+++ b/packages/core/src/layers/chunked_image_layer.ts
@@ -5,7 +5,6 @@ import { ChunkManagerSource } from "../core/chunk_manager_source";
 import { ChannelProps, ChannelsEnabled } from "../objects/textures/channel";
 import { ImageRenderable } from "../objects/renderable/image_renderable";
 import { Texture2DArray } from "../objects/textures/texture_2d_array";
-import { PlaneGeometry } from "../objects/geometry/plane_geometry";
 import { Logger } from "../utilities/logger";
 import { Color } from "../core/color";
 import { EventContext } from "../core/event_dispatcher";
@@ -192,9 +191,9 @@ export class ChunkedImageLayer extends Layer implements ChannelsEnabled {
   }
 
   private createImage(chunk: Chunk) {
-    const geometry = new PlaneGeometry(chunk.shape.x, chunk.shape.y, 1, 1);
     const image = new ImageRenderable(
-      geometry,
+      chunk.shape.x,
+      chunk.shape.y,
       Texture2DArray.createWithChunk(chunk, this.getDataForImage(chunk)),
       this.channelProps_ ?? [{}]
     );

--- a/packages/core/src/layers/image_layer.ts
+++ b/packages/core/src/layers/image_layer.ts
@@ -4,7 +4,6 @@ import { Chunk, ChunkSource } from "../data/chunk";
 import { ChannelProps, ChannelsEnabled } from "../objects/textures/channel";
 import { ImageRenderable } from "../objects/renderable/image_renderable";
 import { Texture2DArray } from "../objects/textures/texture_2d_array";
-import { PlaneGeometry } from "../objects/geometry/plane_geometry";
 import { EventContext } from "../core/event_dispatcher";
 import { vec2, vec3 } from "gl-matrix";
 import { handlePointPickingEvent, PointPickingResult } from "./point_picking";
@@ -134,9 +133,9 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
   }
 
   private createImage(chunk: Chunk) {
-    const geometry = new PlaneGeometry(chunk.shape.x, chunk.shape.y, 1, 1);
     const image = new ImageRenderable(
-      geometry,
+      chunk.shape.x,
+      chunk.shape.y,
       Texture2DArray.createWithChunk(chunk),
       this.channelProps
     );

--- a/packages/core/src/layers/image_series_layer.ts
+++ b/packages/core/src/layers/image_series_layer.ts
@@ -4,7 +4,6 @@ import { Chunk, ChunkSource } from "../data/chunk";
 import { Texture2DArray } from "../objects/textures/texture_2d_array";
 import { ChannelProps, ChannelsEnabled } from "../objects/textures/channel";
 import { ImageRenderable } from "../objects/renderable/image_renderable";
-import { PlaneGeometry } from "../objects/geometry/plane_geometry";
 import { ImageSeriesLoader, SetIndexResult } from "./image_series_loader";
 
 export type ImageSeriesLayerProps = LayerOptions & {
@@ -133,8 +132,12 @@ export class ImageSeriesLayer extends Layer implements ChannelsEnabled {
     texture: Texture2DArray,
     channelProps?: ChannelProps[]
   ) {
-    const geometry = new PlaneGeometry(chunk.shape.x, chunk.shape.y, 1, 1);
-    const image = new ImageRenderable(geometry, texture, channelProps);
+    const image = new ImageRenderable(
+      chunk.shape.x,
+      chunk.shape.y,
+      texture,
+      channelProps
+    );
     image.transform.setScale([chunk.scale.x, chunk.scale.y, 1]);
     image.transform.setTranslation([chunk.offset.x, chunk.offset.y, 0]);
     return image;

--- a/packages/core/src/layers/label_image_layer.ts
+++ b/packages/core/src/layers/label_image_layer.ts
@@ -2,7 +2,6 @@ import { Layer, LayerOptions } from "../core/layer";
 import { Region } from "../data/region";
 import { Chunk, ChunkSource } from "../data/chunk";
 import { Texture2D } from "../objects/textures/texture_2d";
-import { PlaneGeometry } from "../objects/geometry/plane_geometry";
 import {
   LabelColorMap,
   LabelColorMapProps,
@@ -117,9 +116,9 @@ export class LabelImageLayer extends Layer {
 
   private createImage(chunk: Chunk) {
     this.imageChunk_ = chunk; // Store chunk for value picking
-    const geometry = new PlaneGeometry(chunk.shape.x, chunk.shape.y, 1, 1);
     const image = new LabelImageRenderable({
-      geometry,
+      width: chunk.shape.x,
+      height: chunk.shape.y,
       imageData: Texture2D.createWithChunk(chunk),
       colorMap: this.colorMap_,
       outlineSelected: this.outlineSelected_,

--- a/packages/core/src/layers/label_image_series_layer.ts
+++ b/packages/core/src/layers/label_image_series_layer.ts
@@ -3,7 +3,6 @@ import { Region } from "../data/region";
 import { Chunk, ChunkSource } from "../data/chunk";
 import { Texture2D } from "../objects/textures/texture_2d";
 import { LabelImageRenderable } from "../objects/renderable/label_image_renderable";
-import { PlaneGeometry } from "../objects/geometry/plane_geometry";
 import {
   LabelColorMap,
   LabelColorMapProps,
@@ -110,9 +109,9 @@ export class LabelImageSeriesLayer extends Layer {
   }
 
   private createImage(chunk: Chunk, texture: Texture2D) {
-    const geometry = new PlaneGeometry(chunk.shape.x, chunk.shape.y, 1, 1);
     const image = new LabelImageRenderable({
-      geometry,
+      width: chunk.shape.x,
+      height: chunk.shape.y,
       imageData: texture,
       colorMap: this.colorMap_,
     });

--- a/packages/core/src/objects/renderable/image_renderable.ts
+++ b/packages/core/src/objects/renderable/image_renderable.ts
@@ -1,5 +1,5 @@
 import { RenderableObject } from "../../core/renderable_object";
-import { Geometry } from "../../core/geometry";
+import { PlaneGeometry } from "../../objects/geometry/plane_geometry";
 import { Texture, TextureDataType } from "../../objects/textures/texture";
 import {
   Channel,
@@ -29,12 +29,13 @@ export class ImageRenderable extends RenderableObject {
   private channels_: Required<Channel>[];
 
   constructor(
-    geometry: Geometry,
+    width: number,
+    height: number,
     texture: Texture,
     channels: ChannelProps[] = []
   ) {
     super();
-    this.geometry = geometry;
+    this.geometry = new PlaneGeometry(width, height, 1, 1);
     this.setTexture(0, texture);
     this.channels_ = validateChannels(texture, channels);
     this.programName = textureToShader(texture);

--- a/packages/core/src/objects/renderable/label_image_renderable.ts
+++ b/packages/core/src/objects/renderable/label_image_renderable.ts
@@ -1,12 +1,13 @@
 import { RenderableObject } from "../../core/renderable_object";
-import { Geometry } from "../../core/geometry";
+import { PlaneGeometry } from "../../objects/geometry/plane_geometry";
 import { Texture, TextureDataType } from "../../objects/textures/texture";
 import { Color } from "../../core/color";
 import { Texture2D } from "../textures/texture_2d";
 import { LabelColorMap } from "./label_color_map";
 
 type LabelImageRenderableProps = {
-  geometry: Geometry;
+  width: number;
+  height: number;
   imageData: Texture;
   colorMap: LabelColorMap;
   outlineSelected?: boolean;
@@ -39,7 +40,7 @@ export class LabelImageRenderable extends RenderableObject {
 
   constructor(props: LabelImageRenderableProps) {
     super();
-    this.geometry = props.geometry;
+    this.geometry = new PlaneGeometry(props.width, props.height, 1, 1);
     this.setTexture(0, validateImageData(props.imageData));
     const colorCycleTexture = this.makeColorCycleTexture(props.colorMap.cycle);
     this.setTexture(1, colorCycleTexture);


### PR DESCRIPTION
### Summary

This PR moves plane geometry instancing from layers into renderable objects.
I noticed this while reviewing code, and it seemed to me that it breaks the
renderable abstraction. IMO the only type of renderable that should receive
geometry spec is a triangulated mesh (including instanced and multi-resolution).

### Tests & Checks

- All checks have passed