### PR TITLE
Updates to layer attachment lifecycle

### DIFF
--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -35,8 +35,9 @@ export class ChunkManager {
       return chunkManagerSource;
     };
 
-    this.pendingSources_.set(source, initializeSource());
-    return this.pendingSources_.get(source)!;
+    const pending = initializeSource();
+    this.pendingSources_.set(source, pending);
+    return pending;
   }
 
   public update(camera: OrthographicCamera, bufferWidth: number) {

--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -6,6 +6,10 @@ import { ImageSourcePolicy } from "./image_source_policy";
 
 export class ChunkManager {
   private readonly sources_ = new Map<ChunkSource, ChunkManagerSource>();
+  private readonly pendingSources_ = new Map<
+    ChunkSource,
+    Promise<ChunkManagerSource>
+  >();
   private readonly queue_ = new ChunkQueue();
 
   public async addSource(
@@ -13,13 +17,26 @@ export class ChunkManager {
     sliceCoords: SliceCoordinates,
     policy: ImageSourcePolicy
   ) {
-    let existing = this.sources_.get(source);
-    if (!existing) {
-      const loader = await source.open();
-      existing = new ChunkManagerSource(loader, sliceCoords, policy);
-      this.sources_.set(source, existing);
+    const existingOrPending =
+      this.sources_.get(source) ?? this.pendingSources_.get(source);
+    if (existingOrPending) {
+      return existingOrPending;
     }
-    return existing;
+
+    const initializeSource = async () => {
+      const loader = await source.open();
+      const chunkManagerSource = new ChunkManagerSource(
+        loader,
+        sliceCoords,
+        policy
+      );
+      this.sources_.set(source, chunkManagerSource);
+      this.pendingSources_.delete(source);
+      return chunkManagerSource;
+    };
+
+    this.pendingSources_.set(source, initializeSource());
+    return this.pendingSources_.get(source)!;
   }
 
   public update(camera: OrthographicCamera, bufferWidth: number) {

--- a/packages/core/src/core/layer.ts
+++ b/packages/core/src/core/layer.ts
@@ -3,7 +3,6 @@ import { RenderableObject } from "./renderable_object";
 import { clamp } from "../utilities/clamp";
 import { Logger } from "../utilities/logger";
 import { EventContext } from "./event_dispatcher";
-import { Viewport } from "./viewport";
 
 export type LayerState = "initialized" | "loading" | "ready";
 export type blendMode = "normal" | "additive" | "subtractive" | "multiply";
@@ -18,10 +17,6 @@ export interface LayerOptions {
   opacity?: number;
   blendMode?: blendMode;
 }
-
-export type RenderContext = {
-  viewport: Viewport;
-};
 
 export abstract class Layer {
   public abstract readonly type: string;
@@ -64,7 +59,7 @@ export abstract class Layer {
     this.opacity_ = clamp(value, 0.0, 1.0);
   }
 
-  public abstract update(context?: RenderContext): void;
+  public abstract update(): void;
 
   public onEvent(_: EventContext): void {}
 

--- a/packages/core/src/core/layer.ts
+++ b/packages/core/src/core/layer.ts
@@ -3,6 +3,7 @@ import { RenderableObject } from "./renderable_object";
 import { clamp } from "../utilities/clamp";
 import { Logger } from "../utilities/logger";
 import { EventContext } from "./event_dispatcher";
+import { Viewport } from "./viewport";
 
 export type LayerState = "initialized" | "loading" | "ready";
 export type blendMode = "normal" | "additive" | "subtractive" | "multiply";
@@ -17,6 +18,10 @@ export interface LayerOptions {
   opacity?: number;
   blendMode?: blendMode;
 }
+
+export type RenderContext = {
+  viewport: Viewport;
+};
 
 export abstract class Layer {
   public abstract readonly type: string;
@@ -59,7 +64,7 @@ export abstract class Layer {
     this.opacity_ = clamp(value, 0.0, 1.0);
   }
 
-  public abstract update(): void;
+  public abstract update(context?: RenderContext): void;
 
   public onEvent(_: EventContext): void {}
 
@@ -68,6 +73,8 @@ export abstract class Layer {
   // manager, but for now, we allow optional overrides to avoid requiring
   // placeholder implementations.
   public async onAttached(_context: IdetikContext) {}
+
+  public onDetached(): void {}
 
   public get objects() {
     return this.objects_;

--- a/packages/core/src/core/layer_manager.ts
+++ b/packages/core/src/core/layer_manager.ts
@@ -30,10 +30,10 @@ export class LayerManager {
     return { opaque, transparent };
   }
 
-  public async add(layer: Layer) {
+  public add(layer: Layer) {
     this.layers_ = [...this.layers_, layer];
     if (this.context_) {
-      await layer.onAttached(this.context_);
+      layer.onAttached(this.context_);
     }
     this.notifyLayersChanged();
   }

--- a/packages/core/src/core/layer_manager.ts
+++ b/packages/core/src/core/layer_manager.ts
@@ -30,10 +30,10 @@ export class LayerManager {
     return { opaque, transparent };
   }
 
-  public add(layer: Layer) {
+  public async add(layer: Layer) {
     this.layers_ = [...this.layers_, layer];
     if (this.context_) {
-      layer.onAttached(this.context_);
+      await layer.onAttached(this.context_);
     }
     this.notifyLayersChanged();
   }
@@ -47,11 +47,18 @@ export class LayerManager {
   }
 
   public removeByIndex(index: number) {
+    const layer = this.layers_[index];
+    if (layer) {
+      layer.onDetached();
+    }
     this.layers_ = this.layers_.filter((_, i) => i !== index);
     this.notifyLayersChanged();
   }
 
   public removeAll() {
+    for (const layer of this.layers_) {
+      layer.onDetached();
+    }
     this.layers_ = [];
     this.notifyLayersChanged();
   }

--- a/packages/core/src/layers/chunked_image_layer.ts
+++ b/packages/core/src/layers/chunked_image_layer.ts
@@ -73,11 +73,24 @@ export class ChunkedImageLayer extends Layer implements ChannelsEnabled {
   }
 
   public async onAttached(context: IdetikContext) {
+    if (this.chunkManagerSource_) {
+      throw new Error(
+        `ChunkedImageLayer cannot be attached to multiple viewports. ` +
+          `Layer is already attached. ` +
+          `Create separate layer instances for each viewport.`
+      );
+    }
     this.chunkManagerSource_ = await context.chunkManager.addSource(
       this.source_,
       this.sliceCoords_,
       this.policy_
     );
+  }
+
+  public onDetached(): void {
+    this.chunkManagerSource_ = undefined;
+    this.visibleChunks_.clear();
+    this.clearObjects();
   }
 
   public update() {

--- a/packages/core/src/layers/chunked_image_layer.ts
+++ b/packages/core/src/layers/chunked_image_layer.ts
@@ -75,9 +75,8 @@ export class ChunkedImageLayer extends Layer implements ChannelsEnabled {
   public async onAttached(context: IdetikContext) {
     if (this.chunkManagerSource_) {
       throw new Error(
-        `ChunkedImageLayer cannot be attached to multiple viewports. ` +
-          `Layer is already attached. ` +
-          `Create separate layer instances for each viewport.`
+        "ChunkedImageLayer is already attached. " +
+          "A layer cannot be attached to multiple LayerManagers simultaneously."
       );
     }
     this.chunkManagerSource_ = await context.chunkManager.addSource(
@@ -89,7 +88,7 @@ export class ChunkedImageLayer extends Layer implements ChannelsEnabled {
 
   public onDetached(): void {
     this.chunkManagerSource_ = undefined;
-    this.visibleChunks_.clear();
+    this.releaseAndRemoveChunks(this.visibleChunks_.keys());
     this.clearObjects();
   }
 
@@ -114,12 +113,10 @@ export class ChunkedImageLayer extends Layer implements ChannelsEnabled {
 
     const orderedByLOD = this.chunkManagerSource_.getChunks();
     const current = new Set(orderedByLOD);
-    this.visibleChunks_.forEach((image, chunk) => {
-      if (!current.has(chunk)) {
-        this.visibleChunks_.delete(chunk);
-        this.pool_.release(poolKeyForImageRenderable(chunk), image);
-      }
-    });
+    const nonVisibleChunks = Array.from(this.visibleChunks_.keys()).filter(
+      (chunk) => !current.has(chunk)
+    );
+    this.releaseAndRemoveChunks(nonVisibleChunks);
 
     this.clearObjects();
     for (const chunk of orderedByLOD) {
@@ -359,6 +356,16 @@ export class ChunkedImageLayer extends Layer implements ChannelsEnabled {
       throw new Error(`Callback to remove could not be found: ${callback}`);
     }
     this.channelChangeCallbacks_.splice(index, 1);
+  }
+
+  private releaseAndRemoveChunks(chunks: Iterable<Chunk>): void {
+    for (const chunk of chunks) {
+      const image = this.visibleChunks_.get(chunk);
+      if (image) {
+        this.pool_.release(poolKeyForImageRenderable(chunk), image);
+        this.visibleChunks_.delete(chunk);
+      }
+    }
   }
 }
 

--- a/packages/core/src/renderers/webgl_renderer.ts
+++ b/packages/core/src/renderers/webgl_renderer.ts
@@ -83,7 +83,7 @@ export class WebGLRenderer extends Renderer {
 
     this.state_.setDepthMask(true);
     for (const layer of opaque) {
-      layer.update();
+      layer.update({ viewport });
       if (layer.state === "ready") {
         this.renderLayer(layer, viewport.camera);
       }
@@ -91,7 +91,7 @@ export class WebGLRenderer extends Renderer {
 
     this.state_.setDepthMask(false);
     for (const layer of transparent) {
-      layer.update();
+      layer.update({ viewport });
       if (layer.state !== "ready") continue;
       this.renderLayer(layer, viewport.camera);
     }

--- a/packages/core/src/renderers/webgl_renderer.ts
+++ b/packages/core/src/renderers/webgl_renderer.ts
@@ -83,7 +83,7 @@ export class WebGLRenderer extends Renderer {
 
     this.state_.setDepthMask(true);
     for (const layer of opaque) {
-      layer.update({ viewport });
+      layer.update();
       if (layer.state === "ready") {
         this.renderLayer(layer, viewport.camera);
       }
@@ -91,7 +91,7 @@ export class WebGLRenderer extends Renderer {
 
     this.state_.setDepthMask(false);
     for (const layer of transparent) {
-      layer.update({ viewport });
+      layer.update();
       if (layer.state !== "ready") continue;
       this.renderLayer(layer, viewport.camera);
     }


### PR DESCRIPTION
### Summary
This fixes a race condition where multiple layers simultaneously requesting the same data source can create duplicate ChunkManagerSource instances (see #399).

This also adds an additional `onDetached` method for layers to implement cleanup on removal, and uses it to clear some state from the `ChunkedImageLayer`. Finally, this adds a guard to the `ChunkedImageLayer` to prevent unsupported attachment to multiple `LayerManager`s (in effect, simultaneous attachment to multiple viewports).

### Related Issue
related to #399 but may not close - the method still hides async behavior, this just fixes the immediate problem it was causing
[Doc with thoughts on Idetik layers](https://docs.google.com/document/d/1TSdHHSB0fq5dbbmeWIMSalwF-fZHWndTYcIZy2mhrIM/edit?usp=sharing)

### Tests & Checks
All existing tests pass
Manually verified race condition fix by checking that concurrent layer additions return the same `ChunkManagerSource` promise