### PR TITLE
Add orbit controls for perspective camera

### DIFF
--- a/packages/core/src/core/transforms.ts
+++ b/packages/core/src/core/transforms.ts
@@ -1,4 +1,6 @@
-import { mat4, vec3, quat } from "gl-matrix";
+import { mat4, mat3, vec3, quat } from "gl-matrix";
+
+const WORLD_UP = vec3.fromValues(0, 1, 0);
 
 export class TrsTransform {
   private dirty_ = true;
@@ -42,6 +44,21 @@ export class TrsTransform {
 
   public setScale(vec: vec3) {
     vec3.copy(this.scale_, vec);
+    this.dirty_ = true;
+  }
+
+  public targetTo(target: vec3) {
+    // Avoid zero-length forward vector
+    if (vec3.equals(this.translation_, target)) {
+      target = vec3.clone(target);
+      target[2] += 1e-3;
+    }
+
+    const m = mat4.targetTo(mat4.create(), this.translation_, target, WORLD_UP);
+    const rotation = mat3.fromMat4(mat3.create(), m);
+    quat.fromMat3(this.rotation_, rotation);
+    quat.normalize(this.rotation_, this.rotation_);
+
     this.dirty_ = true;
   }
 

--- a/packages/core/src/core/transforms.ts
+++ b/packages/core/src/core/transforms.ts
@@ -1,5 +1,6 @@
-import { mat4, mat3, vec3, quat } from "gl-matrix";
+import { mat4, mat3, vec3, quat, glMatrix } from "gl-matrix";
 
+// +Y is world up to match gl-matrix
 const WORLD_UP = vec3.fromValues(0, 1, 0);
 
 export class TrsTransform {
@@ -48,10 +49,11 @@ export class TrsTransform {
   }
 
   public targetTo(target: vec3) {
-    // Avoid zero-length forward vector
+    // Prevent zero-length forward vector by nudging
+    // target slightly along +Z
     if (vec3.equals(this.translation_, target)) {
       target = vec3.clone(target);
-      target[2] += 1e-3;
+      target[2] += glMatrix.EPSILON;
     }
 
     const m = mat4.targetTo(mat4.create(), this.translation_, target, WORLD_UP);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -39,6 +39,7 @@ export {
 
 export { Box2 } from "./math/box2";
 export { Box3 } from "./math/box3";
+export { Spherical } from "./math/spherical";
 
 export type { Region } from "./data/region";
 export type { Image as OmeZarrImage } from "./data/ome_zarr/0.4/image";

--- a/packages/core/src/math/spherical.ts
+++ b/packages/core/src/math/spherical.ts
@@ -1,4 +1,3 @@
-import { clamp } from "@/utilities/clamp";
 import { vec3 } from "gl-matrix";
 
 export class Spherical {
@@ -10,12 +9,6 @@ export class Spherical {
     this.radius = radius;
     this.phi = phi;
     this.theta = theta;
-  }
-
-  public makeSafe() {
-    const ε = 1e-3;
-    const limit = Math.PI / 2 - ε;
-    this.theta = clamp(this.theta, -limit, limit);
   }
 
   public toVec3() {

--- a/packages/core/src/math/spherical.ts
+++ b/packages/core/src/math/spherical.ts
@@ -1,0 +1,29 @@
+import { clamp } from "@/utilities/clamp";
+import { vec3 } from "gl-matrix";
+
+export class Spherical {
+  public radius;
+  public phi;
+  public theta;
+
+  constructor(radius: number, phi: number, theta: number) {
+    this.radius = radius;
+    this.phi = phi;
+    this.theta = theta;
+  }
+
+  public makeSafe() {
+    const ε = 1e-3;
+    const limit = Math.PI / 2 - ε;
+    this.theta = clamp(this.theta, -limit, limit);
+  }
+
+  public toVec3() {
+    const c = Math.cos(this.theta);
+    return vec3.fromValues(
+      this.radius * Math.sin(this.phi) * c,
+      -this.radius * Math.sin(this.theta),
+      this.radius * Math.cos(this.phi) * c
+    );
+  }
+}

--- a/packages/core/src/objects/cameras/camera.ts
+++ b/packages/core/src/objects/cameras/camera.ts
@@ -24,6 +24,16 @@ export abstract class Camera extends RenderableObject {
     return this.transform.inverse;
   }
 
+  get right() {
+    const m = this.transform.matrix;
+    return vec3.fromValues(m[0], m[1], m[2]);
+  }
+
+  get up() {
+    const m = this.transform.matrix;
+    return vec3.fromValues(m[4], m[5], m[6]);
+  }
+
   public abstract setAspectRatio(aspectRatio: number): void;
   public abstract zoom(factor: number): void;
 

--- a/packages/core/src/objects/cameras/orbit_controls.ts
+++ b/packages/core/src/objects/cameras/orbit_controls.ts
@@ -1,9 +1,10 @@
 import { CameraControls } from "./controls";
 import { EventContext } from "../../core/event_dispatcher";
 import { PerspectiveCamera } from "./perspective_camera";
-import { Spherical } from "@/math/spherical";
+import { Spherical } from "../../math/spherical";
 
-import { vec3 } from "gl-matrix";
+import { glMatrix, vec3 } from "gl-matrix";
+import { clamp } from "../../utilities/clamp";
 
 const MOUSE_BUTTON_NONE = -1;
 const MOUSE_BUTTON_LEFT = 0;
@@ -15,14 +16,14 @@ const ZOOM_SPEED = 0.0009;
 
 export class OrbitControls implements CameraControls {
   private readonly camera_: PerspectiveCamera;
-  private readonly spherical_: Spherical;
+  private readonly sphericalPos_: Spherical;
   private readonly target_ = vec3.create();
 
   private currMouseButton_ = MOUSE_BUTTON_NONE;
 
   constructor(camera: PerspectiveCamera, radius = 1, yaw = 0, pitch = 0) {
     this.camera_ = camera;
-    this.spherical_ = new Spherical(radius, yaw, pitch);
+    this.sphericalPos_ = new Spherical(radius, yaw, pitch);
     this.update();
   }
 
@@ -58,11 +59,10 @@ export class OrbitControls implements CameraControls {
     const dx = e.movementX ?? 0;
     const dy = e.movementY ?? 0;
 
-    const m = e.shiftKey;
-    const b = this.currMouseButton_;
-
-    const doOrbit = b === MOUSE_BUTTON_LEFT && !m;
-    const doPan = (b === MOUSE_BUTTON_LEFT && m) || b === MOUSE_BUTTON_MIDDLE;
+    const doOrbit = this.currMouseButton_ === MOUSE_BUTTON_LEFT && !e.shiftKey;
+    const doPan =
+      (this.currMouseButton_ === MOUSE_BUTTON_LEFT && e.shiftKey) ||
+      this.currMouseButton_ === MOUSE_BUTTON_MIDDLE;
 
     if (doOrbit) this.orbit(dx, dy);
     if (doPan) this.pan(dx, dy);
@@ -71,7 +71,6 @@ export class OrbitControls implements CameraControls {
   }
 
   private onWheel(event: EventContext) {
-    if (!event.worldPos || !event.clipPos) return;
     const e = event.event as WheelEvent;
     e.preventDefault(); // prevent the page from scrolling
 
@@ -89,14 +88,20 @@ export class OrbitControls implements CameraControls {
   }
 
   private orbit(dx: number, dy: number) {
-    this.spherical_.phi -= dx * ORBIT_SPEED;
-    this.spherical_.theta += dy * ORBIT_SPEED;
-    this.spherical_.makeSafe();
+    this.sphericalPos_.phi -= dx * ORBIT_SPEED;
+    this.sphericalPos_.theta += dy * ORBIT_SPEED;
+
+    // Prevent the camera from reaching the poles (±π/2), where
+    // the view direction would flip and orbit controls would invert.
+    // We clamp the elevation angle slightly before ±π/2 to maintain
+    // stable rotation and avoid gimbal-like artifacts.
+    const limit = Math.PI / 2 - glMatrix.EPSILON;
+    this.sphericalPos_.theta = clamp(this.sphericalPos_.theta, -limit, limit);
   }
 
   private pan(dx: number, dy: number) {
     // Scale pan speed by distance so movement feels consistent
-    const speed = this.spherical_.radius * PAN_SPEED;
+    const speed = this.sphericalPos_.radius * PAN_SPEED;
     const delta = vec3.create();
 
     vec3.scaleAndAdd(delta, delta, this.camera_.right, dx);
@@ -109,11 +114,18 @@ export class OrbitControls implements CameraControls {
   private zoom(dy: number) {
     // Exponential for smooth, distance-independent zoom
     const scale = Math.exp(dy * ZOOM_SPEED);
-    this.spherical_.radius = Math.max(0.01, this.spherical_.radius * scale);
+    this.sphericalPos_.radius = Math.max(
+      0.01,
+      this.sphericalPos_.radius * scale
+    );
   }
 
   private update() {
-    const p = vec3.add(vec3.create(), this.target_, this.spherical_.toVec3());
+    const p = vec3.add(
+      vec3.create(),
+      this.target_,
+      this.sphericalPos_.toVec3()
+    );
     this.camera_.transform.setTranslation(p);
     this.camera_.transform.targetTo(this.target_);
   }

--- a/packages/core/src/objects/cameras/orbit_controls.ts
+++ b/packages/core/src/objects/cameras/orbit_controls.ts
@@ -1,0 +1,120 @@
+import { CameraControls } from "./controls";
+import { EventContext } from "../../core/event_dispatcher";
+import { PerspectiveCamera } from "./perspective_camera";
+import { Spherical } from "@/math/spherical";
+
+import { vec3 } from "gl-matrix";
+
+const MOUSE_BUTTON_NONE = -1;
+const MOUSE_BUTTON_LEFT = 0;
+const MOUSE_BUTTON_MIDDLE = 1;
+
+const ORBIT_SPEED = 0.009;
+const PAN_SPEED = 0.001;
+const ZOOM_SPEED = 0.0009;
+
+export class OrbitControls implements CameraControls {
+  private readonly camera_: PerspectiveCamera;
+  private readonly spherical_: Spherical;
+  private readonly target_ = vec3.create();
+
+  private currMouseButton_ = MOUSE_BUTTON_NONE;
+
+  constructor(camera: PerspectiveCamera, radius = 1, yaw = 0, pitch = 0) {
+    this.camera_ = camera;
+    this.spherical_ = new Spherical(radius, yaw, pitch);
+    this.update();
+  }
+
+  public onEvent(event: EventContext): void {
+    switch (event.type) {
+      case "pointerdown":
+        this.onPointerDown(event);
+        break;
+      case "pointermove":
+        this.onPointerMove(event);
+        break;
+      case "wheel":
+        this.onWheel(event);
+        break;
+      case "pointerup":
+      case "pointercancel":
+        this.onPointerEnd(event);
+        break;
+    }
+  }
+
+  private onPointerDown(event: EventContext) {
+    const e = event.event as PointerEvent;
+    this.currMouseButton_ = e.button;
+
+    (e.target as Element)?.setPointerCapture?.(e.pointerId);
+  }
+
+  private onPointerMove(event: EventContext) {
+    if (this.currMouseButton_ == MOUSE_BUTTON_NONE) return;
+
+    const e = event.event as PointerEvent;
+    const dx = e.movementX ?? 0;
+    const dy = e.movementY ?? 0;
+
+    const m = e.shiftKey;
+    const b = this.currMouseButton_;
+
+    const doOrbit = b === MOUSE_BUTTON_LEFT && !m;
+    const doPan = (b === MOUSE_BUTTON_LEFT && m) || b === MOUSE_BUTTON_MIDDLE;
+
+    if (doOrbit) this.orbit(dx, dy);
+    if (doPan) this.pan(dx, dy);
+
+    this.update();
+  }
+
+  private onWheel(event: EventContext) {
+    if (!event.worldPos || !event.clipPos) return;
+    const e = event.event as WheelEvent;
+    e.preventDefault(); // prevent the page from scrolling
+
+    const dy = e.deltaY ?? 0;
+    this.zoom(dy);
+
+    this.update();
+  }
+
+  private onPointerEnd(event: EventContext) {
+    this.currMouseButton_ = MOUSE_BUTTON_NONE;
+
+    const e = event.event as PointerEvent;
+    (e.target as Element)?.releasePointerCapture?.(e.pointerId);
+  }
+
+  private orbit(dx: number, dy: number) {
+    this.spherical_.phi -= dx * ORBIT_SPEED;
+    this.spherical_.theta += dy * ORBIT_SPEED;
+    this.spherical_.makeSafe();
+  }
+
+  private pan(dx: number, dy: number) {
+    // Scale pan speed by distance so movement feels consistent
+    const speed = this.spherical_.radius * PAN_SPEED;
+    const delta = vec3.create();
+
+    vec3.scaleAndAdd(delta, delta, this.camera_.right, dx);
+    vec3.scaleAndAdd(delta, delta, this.camera_.up, dy);
+    vec3.scale(delta, delta, speed);
+
+    vec3.sub(this.target_, this.target_, delta);
+  }
+
+  private zoom(dy: number) {
+    // Exponential for smooth, distance-independent zoom
+    const scale = Math.exp(dy * ZOOM_SPEED);
+    this.spherical_.radius = Math.max(0.01, this.spherical_.radius * scale);
+  }
+
+  private update() {
+    const p = vec3.add(vec3.create(), this.target_, this.spherical_.toVec3());
+    this.camera_.transform.setTranslation(p);
+    this.camera_.transform.targetTo(this.target_);
+  }
+}

--- a/packages/core/test/spherical.test.ts
+++ b/packages/core/test/spherical.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "vitest";
-import { glMatrix, vec3 } from "gl-matrix";
+import { vec3 } from "gl-matrix";
 
 import { Spherical } from "@";
 
@@ -12,44 +12,6 @@ function expectVec3Close(v: vec3, [x, y, z]: [number, number, number]) {
   expect(v[1]).toBeCloseTo(y);
   expect(v[2]).toBeCloseTo(z);
 }
-
-test("makeSafe clamps when theta > +π/2", () => {
-  const phi = glMatrix.toRadian(30);
-  const theta = PI_OVER_2 + Number.EPSILON;
-  const s = new Spherical(2, phi, theta);
-
-  s.makeSafe();
-  const expected = PI_OVER_2 - Number.EPSILON;
-
-  expect(s.phi).toBe(glMatrix.toRadian(30));
-  expect(s.theta).toBeCloseTo(expected);
-  expect(s.radius).toBe(2);
-});
-
-test("makeSafe clamps when theta < -π/2", () => {
-  const phi = glMatrix.toRadian(30);
-  const theta = -PI_OVER_2 - Number.EPSILON;
-  const s = new Spherical(2, phi, theta);
-
-  s.makeSafe();
-  const expected = -PI_OVER_2 + Number.EPSILON;
-
-  expect(s.phi).toBeCloseTo(glMatrix.toRadian(30));
-  expect(s.theta).toBeCloseTo(expected);
-  expect(s.radius).toBeCloseTo(2);
-});
-
-test("makeSafe leaves theta unchanged when already in range", () => {
-  const phi = glMatrix.toRadian(30);
-  const theta = glMatrix.toRadian(30);
-  const s = new Spherical(2, phi, theta);
-
-  s.makeSafe();
-
-  expect(s.phi).toBe(glMatrix.toRadian(30));
-  expect(s.theta).toBe(glMatrix.toRadian(30));
-  expect(s.radius).toBe(2);
-});
 
 test("toVec3 basic", () => {
   const phi = PI_OVER_4;

--- a/packages/core/test/spherical.test.ts
+++ b/packages/core/test/spherical.test.ts
@@ -1,0 +1,92 @@
+import { expect, test } from "vitest";
+import { glMatrix, vec3 } from "gl-matrix";
+
+import { Spherical } from "@";
+
+const PI = Math.PI;
+const PI_OVER_2 = PI / 2;
+const PI_OVER_4 = PI / 4;
+
+function expectVec3Close(v: vec3, [x, y, z]: [number, number, number]) {
+  expect(v[0]).toBeCloseTo(x);
+  expect(v[1]).toBeCloseTo(y);
+  expect(v[2]).toBeCloseTo(z);
+}
+
+test("makeSafe clamps when theta > +π/2", () => {
+  const phi = glMatrix.toRadian(30);
+  const theta = PI_OVER_2 + Number.EPSILON;
+  const s = new Spherical(2, phi, theta);
+
+  s.makeSafe();
+  const expected = PI_OVER_2 - Number.EPSILON;
+
+  expect(s.phi).toBe(glMatrix.toRadian(30));
+  expect(s.theta).toBeCloseTo(expected);
+  expect(s.radius).toBe(2);
+});
+
+test("makeSafe clamps when theta < -π/2", () => {
+  const phi = glMatrix.toRadian(30);
+  const theta = -PI_OVER_2 - Number.EPSILON;
+  const s = new Spherical(2, phi, theta);
+
+  s.makeSafe();
+  const expected = -PI_OVER_2 + Number.EPSILON;
+
+  expect(s.phi).toBeCloseTo(glMatrix.toRadian(30));
+  expect(s.theta).toBeCloseTo(expected);
+  expect(s.radius).toBeCloseTo(2);
+});
+
+test("makeSafe leaves theta unchanged when already in range", () => {
+  const phi = glMatrix.toRadian(30);
+  const theta = glMatrix.toRadian(30);
+  const s = new Spherical(2, phi, theta);
+
+  s.makeSafe();
+
+  expect(s.phi).toBe(glMatrix.toRadian(30));
+  expect(s.theta).toBe(glMatrix.toRadian(30));
+  expect(s.radius).toBe(2);
+});
+
+test("toVec3 basic", () => {
+  const phi = PI_OVER_4;
+  const theta = PI_OVER_4;
+  const s = new Spherical(1, phi, theta);
+  const v = s.toVec3();
+
+  const expect_x = Math.sin(phi) * Math.cos(theta);
+  const expect_y = -Math.sin(theta);
+  const expect_z = Math.cos(phi) * Math.cos(theta);
+
+  expectVec3Close(v, [expect_x, expect_y, expect_z]);
+});
+
+test("toVec3 south pole, θ = +π/2 ignores phi", () => {
+  const phi = PI_OVER_4;
+  const theta = PI_OVER_2;
+  const s = new Spherical(3, phi, theta);
+  const v = s.toVec3();
+
+  expectVec3Close(v, [0, -3, 0]);
+});
+
+test("toVec3 equator, phi = π/2 → +X", () => {
+  const phi = PI_OVER_2;
+  const theta = 0;
+  const s = new Spherical(3, phi, theta);
+  const v = s.toVec3();
+
+  expectVec3Close(v, [3, 0, 0]);
+});
+
+test("toVec3 equator, phi = 0 → +Z", () => {
+  const phi = 0;
+  const theta = 0;
+  const s = new Spherical(3, phi, theta);
+  const v = s.toVec3();
+
+  expectVec3Close(v, [0, 0, 3]);
+});


### PR DESCRIPTION
### Summary

This PR adds orbit controls for perspective cameras, using spherical coordinates
and common mappings: right mouse button to orbit, middle (or shift + left) mouse
to pan, and scroll to zoom. This feature was prioritized to accelerate 3D volume
rendering development.

### Notes

- Test this feature on the temporary `shlomnissan/feature/volume-layer-2d1f` branch. Open the "Volume Rendering" example from the list to verify the controls.
- Input event updates aren’t particularly stable, they fire inconsistently and can make the controls feel jittery. We can achieve smoother motion by updating the camera each frame in the main loop and scaling movements by the frame’s delta time. I’ll likely post a follow-up once this is merged.
- This local implementation also reflects what I had in mind for 2D controls. I’m not a fan of having zoom and pan methods baked into the camera base class. These actions belong in the control layer, not the camera itself.
- The Spherical implementation follows a common convention used in game development, where phi controls horizontal rotation around the Y-axis and theta controls vertical rotation relative to the equator. These axis directions and angle orientations are ultimately arbitrary.

### Tests & Checks

- All checks have passed.
- Visual verification (see video below).
- Added basic unit tests for the spherical coordinates class.

https://github.com/user-attachments/assets/f31a1ff4-0e73-43df-bf68-4a414a97d69d


