### PR TITLE
Add volume layer placeholders

### DIFF
--- a/packages/core/examples/volume_rendering/index.html
+++ b/packages/core/examples/volume_rendering/index.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Volume Rendering</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        display: flex;
+        width: 100%;
+        height: 100%;
+      }
+      #main {
+        display: flex;
+        flex-direction: column;
+        width: 100%;
+        height: 100%;
+      }
+      #canvas {
+        width: 100%;
+        height: 100%;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="main">
+      <canvas id="canvas"></canvas>
+    </div>
+    <script type="module" src="./main.ts"></script>
+  </body>
+</html>

--- a/packages/core/examples/volume_rendering/main.ts
+++ b/packages/core/examples/volume_rendering/main.ts
@@ -1,0 +1,13 @@
+import { Idetik, VolumeLayer, PerspectiveCamera } from "@";
+import { OrbitControls } from "@/objects/cameras/orbit_controls";
+
+const camera = new PerspectiveCamera();
+
+new Idetik({
+  canvas: document.querySelector<HTMLCanvasElement>("#canvas")!,
+  camera,
+  cameraControls: new OrbitControls(camera, { radius: 3 }),
+  layers: [new VolumeLayer()],
+  overlays: [],
+  showStats: true,
+}).start();

--- a/packages/core/examples/volume_rendering/main.ts
+++ b/packages/core/examples/volume_rendering/main.ts
@@ -8,6 +8,5 @@ new Idetik({
   camera,
   cameraControls: new OrbitControls(camera, { radius: 3 }),
   layers: [new VolumeLayer()],
-  overlays: [],
   showStats: true,
 }).start();

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -18,6 +18,7 @@ export { AxesLayer } from "./layers/axes_layer";
 export { ProjectedLineLayer } from "./layers/projected_line_layer";
 export { TracksLayer } from "./layers/tracks_layer";
 export { ChunkedImageLayer } from "./layers/chunked_image_layer";
+export { VolumeLayer } from "./layers/volume_layer";
 export { ImageLayer } from "./layers/image_layer";
 export type { Chunk, ChunkLoader, SliceCoordinates } from "./data/chunk";
 export { LabelImageLayer } from "./layers/label_image_layer";

--- a/packages/core/src/layers/volume_layer.ts
+++ b/packages/core/src/layers/volume_layer.ts
@@ -1,0 +1,20 @@
+import { Layer } from "../core/layer";
+import { VolumeRenderable } from "../objects/renderable/volume_renderable";
+
+export class VolumeLayer extends Layer {
+  public readonly type = "VolumeLayer";
+
+  constructor() {
+    super();
+
+    const renderable = new VolumeRenderable();
+    renderable.wireframeEnabled = true;
+
+    this.addObject(renderable);
+    this.setState("ready");
+  }
+
+  public update() {
+    // TODO: implement
+  }
+}

--- a/packages/core/src/objects/cameras/orbit_controls.ts
+++ b/packages/core/src/objects/cameras/orbit_controls.ts
@@ -14,6 +14,12 @@ const ORBIT_SPEED = 0.009;
 const PAN_SPEED = 0.001;
 const ZOOM_SPEED = 0.0009;
 
+type OrbitParams = {
+  radius?: number;
+  yaw?: number;
+  pitch?: number;
+};
+
 export class OrbitControls implements CameraControls {
   private readonly camera_: PerspectiveCamera;
   private readonly sphericalPos_: Spherical;
@@ -21,9 +27,13 @@ export class OrbitControls implements CameraControls {
 
   private currMouseButton_ = MOUSE_BUTTON_NONE;
 
-  constructor(camera: PerspectiveCamera, radius = 1, yaw = 0, pitch = 0) {
+  constructor(camera: PerspectiveCamera, params?: OrbitParams) {
     this.camera_ = camera;
-    this.sphericalPos_ = new Spherical(radius, yaw, pitch);
+    this.sphericalPos_ = new Spherical(
+      params?.radius ?? 1,
+      params?.yaw ?? 0,
+      params?.pitch ?? 0
+    );
     this.update();
   }
 

--- a/packages/core/src/objects/renderable/volume_renderable.ts
+++ b/packages/core/src/objects/renderable/volume_renderable.ts
@@ -1,0 +1,14 @@
+import { RenderableObject } from "../../core/renderable_object";
+import { BoxGeometry } from "../geometry/box_geometry";
+
+export class VolumeRenderable extends RenderableObject {
+  constructor() {
+    super();
+    this.geometry = new BoxGeometry(1, 1, 1, 1, 1, 1);
+    this.programName = "volume";
+  }
+
+  public get type() {
+    return "VolumeRenderable";
+  }
+}

--- a/packages/core/src/renderers/shaders/index.ts
+++ b/packages/core/src/renderers/shaders/index.ts
@@ -7,19 +7,22 @@ import pointsVertexShader from "./points_vert.glsl";
 import pointsFragmentShader from "./points_frag.glsl";
 import wireframeVertexShader from "./wireframe_vert.glsl";
 import wireframeFragmentShader from "./wireframe_frag.glsl";
+import volumeVertexShader from "./volume_vert.glsl";
+import volumeFragmentShader from "./volume_frag.glsl";
 import labelImage from "./label_image_frag.glsl";
 
 export type Shader =
-  | "projectedLine"
-  | "points"
-  | "wireframe"
   | "floatScalarImage"
   | "floatScalarImageArray"
   | "intScalarImage"
   | "intScalarImageArray"
+  | "labelImage"
+  | "points"
+  | "projectedLine"
   | "uintScalarImage"
   | "uintScalarImageArray"
-  | "labelImage";
+  | "volume"
+  | "wireframe";
 
 type ShaderCode = {
   vertex: string;
@@ -72,5 +75,9 @@ export const shaderCode: Record<Shader, ShaderCode> = {
   labelImage: {
     vertex: meshVertexShader,
     fragment: labelImage,
+  },
+  volume: {
+    vertex: volumeVertexShader,
+    fragment: volumeFragmentShader,
   },
 };

--- a/packages/core/src/renderers/shaders/volume_frag.glsl
+++ b/packages/core/src/renderers/shaders/volume_frag.glsl
@@ -1,0 +1,9 @@
+#version 300 es
+
+precision mediump float;
+
+layout (location = 0) out vec4 fragColor;
+
+void main() {
+    fragColor = vec4(0.6, 0.6, 0.6, 1.0);
+}

--- a/packages/core/src/renderers/shaders/volume_vert.glsl
+++ b/packages/core/src/renderers/shaders/volume_vert.glsl
@@ -1,0 +1,10 @@
+#version 300 es
+
+layout (location = 0) in vec3 inPosition;
+
+uniform mat4 Projection;
+uniform mat4 ModelView;
+
+void main() {
+    gl_Position = Projection * ModelView * vec4(inPosition, 1.0);
+}

--- a/packages/core/src/utilities/logger.ts
+++ b/packages/core/src/utilities/logger.ts
@@ -29,13 +29,14 @@ type Module =
   | "LabelImageLayer"
   | "Layer"
   | "PixelSizeObserver"
-  | "ZarrWorker"
   | "RenderablePool"
   | "Viewport"
+  | "VolumeLayer"
   | "WebGLRenderer"
   | "WebGLShaderProgram"
   | "WebGLTexture"
-  | "WireframeGeometry";
+  | "WireframeGeometry"
+  | "ZarrWorker";
 
 export function getMode(): "production" | "development" | "test" {
   const nodeEnv =


### PR DESCRIPTION
### Summary

This PR adds basic volume rendering placeholders: layer, renderable, shaders, and example.
It doesn't do much beyond adding structure.

### Tests & Checks

- All checks have passed.
