### PR TITLE
Introduce multiple-viewport API (breaking changes)

### DIFF
--- a/packages/core/examples/ca_wave_dynamics/main.ts
+++ b/packages/core/examples/ca_wave_dynamics/main.ts
@@ -63,9 +63,13 @@ const timePointOverlay = {
 
 new Idetik({
   canvas: document.querySelector<HTMLCanvasElement>("#canvas")!,
-  camera,
-  cameraControls: new PanZoomControls(camera),
-  layers: [imageLayer],
+  viewports: [
+    {
+      camera,
+      cameraControls: new PanZoomControls(camera),
+      layers: [imageLayer],
+    },
+  ],
   overlays: [timePointOverlay],
   showStats: true,
 }).start();

--- a/packages/core/examples/chunk_streaming/main.ts
+++ b/packages/core/examples/chunk_streaming/main.ts
@@ -77,9 +77,13 @@ const timePointOverlay = {
 
 new Idetik({
   canvas: document.querySelector<HTMLCanvasElement>("#canvas")!,
-  camera,
-  cameraControls: new PanZoomControls(camera),
-  layers: [imageLayer],
+  viewports: [
+    {
+      camera,
+      cameraControls: new PanZoomControls(camera),
+      layers: [imageLayer],
+    },
+  ],
   overlays: [chunkInfoOverlay, timePointOverlay],
   showStats: true,
 }).start();

--- a/packages/core/examples/image2d_from_omezarr4d_hcs/main.ts
+++ b/packages/core/examples/image2d_from_omezarr4d_hcs/main.ts
@@ -34,13 +34,12 @@ wellPaths.forEach((path) => {
 });
 
 const camera = new OrthographicCamera(0, 840, 0, 360);
-const controls = new PanZoomControls(camera);
 const app = new Idetik({
   canvas: document.querySelector<HTMLCanvasElement>("canvas")!,
   viewports: [
     {
       camera,
-      cameraControls: controls,
+      cameraControls: new PanZoomControls(camera),
     },
   ],
 }).start();

--- a/packages/core/examples/image2d_from_omezarr4d_hcs/main.ts
+++ b/packages/core/examples/image2d_from_omezarr4d_hcs/main.ts
@@ -37,9 +37,15 @@ const camera = new OrthographicCamera(0, 840, 0, 360);
 const controls = new PanZoomControls(camera);
 const app = new Idetik({
   canvas: document.querySelector<HTMLCanvasElement>("canvas")!,
-  camera,
-  cameraControls: controls,
+  viewports: [
+    {
+      camera,
+      cameraControls: controls,
+    },
+  ],
 }).start();
+
+const viewport = app.viewports[0];
 
 const region: Region = [
   { dimension: "T", index: { type: "point", value: 0 } },
@@ -53,7 +59,7 @@ const imageSelector = document.querySelector("#image") as HTMLSelectElement;
 
 const onImageChange = async () => {
   console.debug("onImageChange: ", imageSelector.value);
-  app.layerManager.removeAll();
+  viewport.layerManager.removeAll();
   const imageUrl =
     plateUrl + "/" + wellSelector.value + "/" + imageSelector.value;
   const source = new OmeZarrImageSource(imageUrl);
@@ -80,7 +86,7 @@ const onImageChange = async () => {
     ],
     lod: 0,
   });
-  app.layerManager.add(newLayer);
+  viewport.layerManager.add(newLayer);
   newLayer.addStateChangeCallback((state) => {
     if (state === "ready" && newLayer.extent) {
       camera.setFrame(0, newLayer.extent.x, 0, newLayer.extent.y);
@@ -91,7 +97,7 @@ const onImageChange = async () => {
 
 const onWellChange = async () => {
   console.debug("onWellChange: ", wellSelector.value);
-  app.layerManager.removeAll();
+  viewport.layerManager.removeAll();
   const path = wellSelector.value;
   const well = await loadOmeZarrWell(plateUrl, path);
   console.debug("well", well);

--- a/packages/core/examples/image2d_from_omezarr5d_u16/main.ts
+++ b/packages/core/examples/image2d_from_omezarr5d_u16/main.ts
@@ -38,8 +38,12 @@ const scaleBar = new ScaleBar({
 
 new Idetik({
   canvas: document.querySelector<HTMLCanvasElement>("canvas")!,
-  camera,
-  cameraControls: new PanZoomControls(camera),
-  layers: [layer, axes],
+  viewports: [
+    {
+      camera,
+      cameraControls: new PanZoomControls(camera),
+      layers: [layer, axes],
+    },
+  ],
   overlays: [scaleBar],
 }).start();

--- a/packages/core/examples/image2d_from_omezarr5d_u16/scale_bar.ts
+++ b/packages/core/examples/image2d_from_omezarr5d_u16/scale_bar.ts
@@ -18,7 +18,8 @@ export class ScaleBar {
   }
 
   public update(idetik: Idetik, _timestamp?: DOMHighResTimeStamp): void {
-    const camera = idetik.camera;
+    const viewport = idetik.viewports[0];
+    const camera = viewport.camera;
     if (camera.type !== "OrthographicCamera") {
       console.error("ScaleBar can only be used with OrthographicCamera");
       return;

--- a/packages/core/examples/image_labels_overlay_with_value_picking/main.ts
+++ b/packages/core/examples/image_labels_overlay_with_value_picking/main.ts
@@ -126,10 +126,16 @@ let labelsLayer = createLabelsLayer();
 // Create Idetik instance
 const idetik = new Idetik({
   canvas,
-  camera,
-  layers: [imageLayer, labelsLayer],
-  cameraControls: new PanZoomControls(camera),
+  viewports: [
+    {
+      camera,
+      cameraControls: new PanZoomControls(camera),
+      layers: [imageLayer, labelsLayer],
+    },
+  ],
 });
+
+const viewport = idetik.viewports[0];
 
 // Add toggle functionality
 const modeText = document.querySelector<HTMLSpanElement>("#mode-text")!;
@@ -138,9 +144,9 @@ toggleDiv.addEventListener("click", () => {
   modeText.textContent = outlineMode ? "Outline" : "Fill";
 
   // Remove old layer and create new one with updated mode
-  idetik.layerManager.remove(labelsLayer);
+  viewport.layerManager.remove(labelsLayer);
   labelsLayer = createLabelsLayer();
-  idetik.layerManager.add(labelsLayer);
+  viewport.layerManager.add(labelsLayer);
 });
 
 idetik.start();

--- a/packages/core/examples/image_mask_overlay/main.ts
+++ b/packages/core/examples/image_mask_overlay/main.ts
@@ -95,15 +95,21 @@ zSlider.addEventListener("input", (event) => {
 const camera = new OrthographicCamera(0, 128, 0, 128);
 const app = new Idetik({
   canvas: document.querySelector<HTMLCanvasElement>("canvas")!,
-  camera,
-  layers: [imageLayer, maskLayer],
+  viewports: [
+    {
+      camera,
+      layers: [imageLayer, maskLayer],
+    },
+  ],
 }).start();
+
+const viewport = app.viewports[0];
 
 imageLayer.setIndex(zSlider.valueAsNumber);
 const setCameraFrame = (newState: LayerState) => {
   if (newState === "ready" && imageLayer.extent !== undefined) {
     camera.setFrame(0, imageLayer.extent.x, 0, imageLayer.extent.y);
-    app.cameraControls = new PanZoomControls(camera);
+    viewport.cameraControls = new PanZoomControls(camera);
     camera.update();
     // remove the callback to only set the camera frame once
     imageLayer.removeStateChangeCallback(setCameraFrame);

--- a/packages/core/examples/image_series_from_omezarr5d_u8/main.ts
+++ b/packages/core/examples/image_series_from_omezarr5d_u8/main.ts
@@ -63,6 +63,10 @@ layer.preloadSeries();
 
 new Idetik({
   canvas: document.querySelector<HTMLCanvasElement>("canvas")!,
-  camera: new OrthographicCamera(0, 1920, 0, 1440),
-  layers: [layer],
+  viewports: [
+    {
+      camera: new OrthographicCamera(0, 1920, 0, 1440),
+      layers: [layer],
+    },
+  ],
 }).start();

--- a/packages/core/examples/image_series_labels_overlay/main.ts
+++ b/packages/core/examples/image_series_labels_overlay/main.ts
@@ -116,15 +116,21 @@ tSlider.addEventListener("input", (event) => {
 const camera = new OrthographicCamera(0, 128, 0, 128);
 const app = new Idetik({
   canvas: document.querySelector<HTMLCanvasElement>("canvas")!,
-  camera,
-  layers: [imageLayer, labelsLayer],
+  viewports: [
+    {
+      camera,
+      layers: [imageLayer, labelsLayer],
+    },
+  ],
 }).start();
+
+const viewport = app.viewports[0];
 
 imageLayer.setIndex(tSlider.valueAsNumber);
 const setCameraFrame = (newState: LayerState) => {
   if (newState === "ready" && imageLayer.extent !== undefined) {
     camera.setFrame(0, imageLayer.extent.x, 0, imageLayer.extent.y);
-    app.cameraControls = new PanZoomControls(camera);
+    viewport.cameraControls = new PanZoomControls(camera);
     camera.update();
     // remove the callback to only set the camera frame once
     imageLayer.removeStateChangeCallback(setCameraFrame);

--- a/packages/core/examples/layer_blending/main.ts
+++ b/packages/core/examples/layer_blending/main.ts
@@ -115,6 +115,10 @@ overlayLayer.preloadSeries();
 const camera = new OrthographicCamera(0, 1920, 0, 1440);
 new Idetik({
   canvas: document.querySelector<HTMLCanvasElement>("canvas")!,
-  camera,
-  layers: [layer, overlayLayer],
+  viewports: [
+    {
+      camera,
+      layers: [layer, overlayLayer],
+    },
+  ],
 }).start();

--- a/packages/core/examples/multi_viewport/index.html
+++ b/packages/core/examples/multi_viewport/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Multi-Viewport Example</title>
+    <title>Multiple Viewports</title>
     <style>
       body {
         margin: 0;

--- a/packages/core/examples/multi_viewport/index.html
+++ b/packages/core/examples/multi_viewport/index.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Multi-Viewport Example</title>
+    <style>
+      body {
+        margin: 0;
+        padding: 0;
+        overflow: hidden;
+        font-family: sans-serif;
+      }
+
+      #container {
+        display: flex;
+        width: 100vw;
+        height: 100vh;
+      }
+
+      .viewport {
+        flex: 1;
+        border: 3px solid black;
+      }
+      .viewport:hover {
+        border: 3px solid #aaaa00;
+      }
+
+      canvas {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        z-index: -1;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="container">
+      <div class="viewport" id="viewport-left"></div>
+      <div class="viewport" id="viewport-right"></div>
+    </div>
+    <canvas id="canvas"></canvas>
+    <script type="module" src="./main.ts"></script>
+  </body>
+</html>

--- a/packages/core/examples/multi_viewport/main.ts
+++ b/packages/core/examples/multi_viewport/main.ts
@@ -1,0 +1,74 @@
+import {
+  Idetik,
+  ChunkedImageLayer,
+  OmeZarrImageSource,
+  OrthographicCamera,
+  PerspectiveCamera,
+  VolumeLayer,
+} from "@";
+import { PanZoomControls } from "@/objects/cameras/controls";
+import { OrbitControls } from "@/objects/cameras/orbit_controls";
+import { addDimensionSlider } from "../lil_gui_utils";
+import { createExplorationPolicy } from "@/core/image_source_policy";
+
+import GUI from "lil-gui";
+
+const url =
+  "https://public.czbiohub.org/royerlab/zebrahub/imaging/single-objective/ZSNS001.ome.zarr/";
+const left = 150;
+const right = 950;
+const top = 100;
+const bottom = 900;
+
+// values copied from source
+const z = { translate: 0.0, scale: 1.24, shape: 448 };
+const zMin = z.translate;
+const zMax = z.translate + z.scale * z.shape - z.scale;
+const zRange = { min: zMin, max: zMax };
+
+const source = new OmeZarrImageSource(url);
+const sliceCoords = { t: 400, z: 200, c: 0 };
+const camera2D = new OrthographicCamera(left, right, top, bottom);
+const imageLayer = new ChunkedImageLayer({
+  source,
+  sliceCoords,
+  policy: createExplorationPolicy(),
+  channelProps: [{ contrastLimits: [0, 200] }],
+});
+
+// TODO: the reason this example works is that the volume viewport uses a perspective camera
+// otherwise the ChunkManager update causes interference between the two viewports
+// this example can be updated to include multiple views of the same volume once we have
+// better handling of multiple viewports using the same source
+const camera3D = new PerspectiveCamera();
+
+new Idetik({
+  canvas: document.querySelector<HTMLCanvasElement>("#canvas")!,
+  viewports: [
+    {
+      id: "volume",
+      element: document.querySelector<HTMLDivElement>("#viewport-left")!,
+      camera: camera3D,
+      cameraControls: new OrbitControls(camera3D, { radius: 3 }),
+      layers: [new VolumeLayer()],
+    },
+    {
+      id: "slice",
+      element: document.querySelector<HTMLDivElement>("#viewport-right")!,
+      camera: camera2D,
+      cameraControls: new PanZoomControls(camera2D),
+      layers: [imageLayer],
+    },
+  ],
+  showStats: true,
+}).start();
+
+const gui = new GUI({ width: 300 });
+addDimensionSlider({
+  gui,
+  sliceCoords,
+  dimensionName: "z",
+  minValue: zRange.min,
+  maxValue: zRange.max,
+  stepValue: z.scale,
+});

--- a/packages/core/examples/ome_zarr_v05/main.ts
+++ b/packages/core/examples/ome_zarr_v05/main.ts
@@ -70,14 +70,20 @@ const cameraControls = new PanZoomControls(camera);
 
 const idetik = new Idetik({
   canvas: document.querySelector<HTMLCanvasElement>("canvas")!,
-  camera,
-  cameraControls,
-  layers: [layer],
+  viewports: [
+    {
+      camera,
+      cameraControls,
+      layers: [layer],
+    },
+  ],
 }).start();
+
+const viewport = idetik.viewports[0];
 
 const controls = {
   showWireframes: layer.debugMode,
-  showAxes: idetik.layerManager.layers.includes(axes),
+  showAxes: viewport.layerManager.layers.includes(axes),
 };
 
 const gui = new GUI({ width: 500 });
@@ -101,9 +107,9 @@ gui
   .add(controls, "showAxes")
   .name("Show axes")
   .onChange((show: boolean) => {
-    if (show && !idetik.layerManager.layers.includes(axes)) {
-      idetik.layerManager.add(axes);
-    } else if (!show && idetik.layerManager.layers.includes(axes)) {
-      idetik.layerManager.remove(axes);
+    if (show && !viewport.layerManager.layers.includes(axes)) {
+      viewport.layerManager.add(axes);
+    } else if (!show && viewport.layerManager.layers.includes(axes)) {
+      viewport.layerManager.remove(axes);
     }
   });

--- a/packages/core/examples/points/main.ts
+++ b/packages/core/examples/points/main.ts
@@ -217,19 +217,25 @@ const imageLayer = new ImageSeriesLayer({
 const camera = new OrthographicCamera(0, 1024, 0, 1024, -10000, 10000);
 const app = new Idetik({
   canvas: document.querySelector<HTMLCanvasElement>("canvas")!,
-  camera,
-  layers: [imageLayer],
+  viewports: [
+    {
+      camera,
+      layers: [imageLayer],
+    },
+  ],
 }).start();
+
+const viewport = app.viewports[0];
 
 const onFirstImageLoad = (newState: LayerState) => {
   if (newState === "ready" && imageLayer.extent !== undefined) {
     camera.setFrame(0, imageLayer.extent.x, 0, imageLayer.extent.y);
-    app.cameraControls = new PanZoomControls(camera);
+    viewport.cameraControls = new PanZoomControls(camera);
     camera.update();
 
-    app.layerManager.add(ribosomes);
-    app.layerManager.add(ferritin);
-    app.layerManager.add(virusLike);
+    viewport.layerManager.add(ribosomes);
+    viewport.layerManager.add(ferritin);
+    viewport.layerManager.add(virusLike);
 
     // remove the callback to only set the camera frame once
     imageLayer.removeStateChangeCallback(onFirstImageLoad);

--- a/packages/core/examples/projected_lines/main.ts
+++ b/packages/core/examples/projected_lines/main.ts
@@ -21,8 +21,12 @@ const layer = new ProjectedLineLayer([
 
 new Idetik({
   canvas: document.querySelector<HTMLCanvasElement>("canvas")!,
-  camera: new PerspectiveCamera({ fov: 60 }),
-  layers: [layer],
+  viewports: [
+    {
+      camera: new PerspectiveCamera({ fov: 60 }),
+      layers: [layer],
+    },
+  ],
 }).start();
 
 function generateHelix(params: {

--- a/packages/core/examples/tracks/main.ts
+++ b/packages/core/examples/tracks/main.ts
@@ -118,7 +118,11 @@ camera.zoom(0.5);
 
 new Idetik({
   canvas: document.querySelector<HTMLCanvasElement>("canvas")!,
-  camera,
-  cameraControls: new PanZoomControls(camera),
-  layers: [imageSeriesLayer, lineLayer],
+  viewports: [
+    {
+      camera,
+      cameraControls: new PanZoomControls(camera),
+      layers: [imageSeriesLayer, lineLayer],
+    },
+  ],
 }).start();

--- a/packages/core/examples/volume_rendering/main.ts
+++ b/packages/core/examples/volume_rendering/main.ts
@@ -5,8 +5,12 @@ const camera = new PerspectiveCamera();
 
 new Idetik({
   canvas: document.querySelector<HTMLCanvasElement>("#canvas")!,
-  camera,
-  cameraControls: new OrbitControls(camera, { radius: 3 }),
-  layers: [new VolumeLayer()],
+  viewports: [
+    {
+      camera,
+      cameraControls: new OrbitControls(camera, { radius: 3 }),
+      layers: [new VolumeLayer()],
+    },
+  ],
   showStats: true,
 }).start();

--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -3,6 +3,7 @@ import { OrthographicCamera } from "../objects/cameras/orthographic_camera";
 import { ChunkQueue } from "../data/chunk_queue";
 import { ChunkManagerSource } from "./chunk_manager_source";
 import { ImageSourcePolicy } from "./image_source_policy";
+import { Logger } from "../utilities/logger";
 
 export class ChunkManager {
   private readonly sources_ = new Map<ChunkSource, ChunkManagerSource>();
@@ -20,14 +21,11 @@ export class ChunkManager {
     const existingOrPending =
       this.sources_.get(source) ?? this.pendingSources_.get(source);
     if (existingOrPending) {
-      // TODO: this is a temporary limitation because currently ChunkManagerSource is not designed
-      // to be shared across multiple layers or viewports. We need to refactor ChunkManagerSource
-      // to support reuse with a shared collection of chunks.
-      throw new Error(
-        "ChunkSource cannot be reused across multiple layers or viewports. " +
-          "Each ChunkedImageLayer must have a unique ChunkSource instance. " +
-          "This limitation will be removed in a future update."
+      Logger.warn(
+        "ChunkManager",
+        "ChunkSource is being reused across multiple layers. This may cause unexpected behavior."
       );
+      return existingOrPending;
     }
 
     const initializeSource = async () => {

--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -20,7 +20,14 @@ export class ChunkManager {
     const existingOrPending =
       this.sources_.get(source) ?? this.pendingSources_.get(source);
     if (existingOrPending) {
-      return existingOrPending;
+      // TODO: this is a temporary limitation because currently ChunkManagerSource is not designed
+      // to be shared across multiple layers or viewports. We need to refactor ChunkManagerSource
+      // to support reuse with a shared collection of chunks.
+      throw new Error(
+        "ChunkSource cannot be reused across multiple layers or viewports. " +
+          "Each ChunkedImageLayer must have a unique ChunkSource instance. " +
+          "This limitation will be removed in a future update."
+      );
     }
 
     const initializeSource = async () => {

--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -3,7 +3,6 @@ import { OrthographicCamera } from "../objects/cameras/orthographic_camera";
 import { ChunkQueue } from "../data/chunk_queue";
 import { ChunkManagerSource } from "./chunk_manager_source";
 import { ImageSourcePolicy } from "./image_source_policy";
-import { Logger } from "../utilities/logger";
 
 export class ChunkManager {
   private readonly sources_ = new Map<ChunkSource, ChunkManagerSource>();
@@ -21,10 +20,6 @@ export class ChunkManager {
     const existingOrPending =
       this.sources_.get(source) ?? this.pendingSources_.get(source);
     if (existingOrPending) {
-      Logger.warn(
-        "ChunkManager",
-        "ChunkSource is being reused across multiple layers. This may cause unexpected behavior."
-      );
       return existingOrPending;
     }
 

--- a/packages/core/src/core/viewport.ts
+++ b/packages/core/src/core/viewport.ts
@@ -11,7 +11,7 @@ import { IdetikContext } from "../idetik";
 
 export interface ViewportConfig {
   id?: string;
-  element?: HTMLElement;  // defaults to canvas for single-viewport setups
+  element?: HTMLElement;
   camera: Camera;
   layers?: Layer[];
   cameraControls?: CameraControls;
@@ -133,9 +133,7 @@ export class Viewport {
 }
 
 function validateViewportConfigs(
-  viewportConfigs: Array<
-    Required<Pick<ViewportConfig, "element" | "camera">> & ViewportConfig
-  >
+  viewportConfigs: Array<ViewportConfig & { element: HTMLElement }>
 ): void {
   const elementToViewportId = new Map<HTMLElement, string>();
   const seenViewportIds = new Set<string>();
@@ -177,18 +175,10 @@ export function parseViewportConfigs(
   context: IdetikContext
 ): Viewport[] {
   const configsWithElements: Array<ViewportConfig & { element: HTMLElement }> =
-    viewportConfigs.map((config) => {
-      if (viewportConfigs.length === 1 && !config.element) {
-        // single-viewport setup with no explicit element uses the whole canvas
-        return { ...config, element: canvas };
-      } else if (!config.element) {
-        throw new Error(
-          "Multi-viewport configurations require an explicit element for each viewport. " +
-            "Use element: canvas to render a viewport on the full canvas."
-        );
-      }
-      return { ...config, element: config.element };
-    });
+    viewportConfigs.map((config) => ({
+      ...config,
+      element: config.element ?? canvas,
+    }));
 
   validateViewportConfigs(configsWithElements);
 

--- a/packages/core/src/core/viewport.ts
+++ b/packages/core/src/core/viewport.ts
@@ -17,6 +17,12 @@ export interface ViewportConfig {
   cameraControls?: CameraControls;
 }
 
+interface ViewportProps extends ViewportConfig {
+  id: string;
+  element: HTMLElement;
+  layerManager: LayerManager;
+}
+
 export class Viewport {
   public readonly id: string;
   public readonly element: HTMLElement;
@@ -25,15 +31,12 @@ export class Viewport {
   public readonly events: EventDispatcher;
   public cameraControls?: CameraControls;
 
-  constructor(
-    config: ViewportConfig & { element: HTMLElement },
-    layerManager: LayerManager
-  ) {
-    this.id = config.id || config.element.id || generateUUID();
-    this.element = config.element;
-    this.camera = config.camera;
-    this.layerManager = layerManager;
-    this.cameraControls = config.cameraControls;
+  constructor(props: ViewportProps) {
+    this.id = props.id;
+    this.element = props.element;
+    this.camera = props.camera;
+    this.layerManager = props.layerManager;
+    this.cameraControls = props.cameraControls;
     this.updateAspectRatio();
     this.events = new EventDispatcher(this.element);
     this.events.addEventListener((event: EventContext) => {
@@ -53,7 +56,7 @@ export class Viewport {
       this.cameraControls?.onEvent(event);
     });
 
-    for (const layer of config.layers ?? []) {
+    for (const layer of props.layers ?? []) {
       this.layerManager.add(layer);
     }
   }
@@ -132,40 +135,29 @@ export class Viewport {
   }
 }
 
-function validateViewportConfigs(
-  viewportConfigs: Array<ViewportConfig & { element: HTMLElement }>
-): void {
+function validateViewportProps(viewportProps: ViewportProps[]): void {
   const elementToViewportId = new Map<HTMLElement, string>();
   const seenViewportIds = new Set<string>();
 
-  for (const config of viewportConfigs) {
-    const viewportId = config.id || config.element.id;
-
-    // check for duplicate viewport IDs if we have an explicit ID
-    // (viewports without IDs will get unique generated IDs)
-    if (viewportId && seenViewportIds.has(viewportId)) {
+  for (const props of viewportProps) {
+    if (seenViewportIds.has(props.id)) {
       throw new Error(
-        `Duplicate viewport ID "${viewportId}". Each viewport must have a unique ID.`
+        `Duplicate viewport ID "${props.id}". Each viewport must have a unique ID.`
       );
     }
-    if (viewportId) {
-      seenViewportIds.add(viewportId);
-    }
+    seenViewportIds.add(props.id);
 
-    const newViewportId = viewportId || "unnamed-viewport";
-
-    // check for multiple viewports specified with the same element
-    if (elementToViewportId.has(config.element)) {
-      const existingViewportId = elementToViewportId.get(config.element)!;
+    if (elementToViewportId.has(props.element)) {
+      const existingViewportId = elementToViewportId.get(props.element)!;
       const elementDescription =
-        config.element.tagName.toLowerCase() +
-        (config.element.id ? `#${config.element.id}` : "[element has no id]");
+        props.element.tagName.toLowerCase() +
+        (props.element.id ? `#${props.element.id}` : "[element has no id]");
       throw new Error(
         "Multiple viewports cannot share the same HTML element: " +
-          `viewports "${existingViewportId}" and "${newViewportId}" both use ${elementDescription}`
+          `viewports "${existingViewportId}" and "${props.id}" both use ${elementDescription}`
       );
     }
-    elementToViewportId.set(config.element, newViewportId);
+    elementToViewportId.set(props.element, props.id);
   }
 }
 
@@ -174,16 +166,15 @@ export function parseViewportConfigs(
   canvas: HTMLCanvasElement,
   context: IdetikContext
 ): Viewport[] {
-  const configsWithElements: Array<ViewportConfig & { element: HTMLElement }> =
-    viewportConfigs.map((config) => ({
+  const viewportProps: ViewportProps[] = viewportConfigs.map((config) => {
+    const element = config.element ?? canvas;
+    return {
       ...config,
-      element: config.element ?? canvas,
-    }));
-
-  validateViewportConfigs(configsWithElements);
-
-  return configsWithElements.map((config) => {
-    const layerManager = new LayerManager(context);
-    return new Viewport(config, layerManager);
+      element,
+      id: config.id ?? element.id ?? generateUUID(),
+      layerManager: new LayerManager(context),
+    };
   });
+  validateViewportProps(viewportProps);
+  return viewportProps.map((props) => new Viewport(props));
 }

--- a/packages/core/src/core/viewport.ts
+++ b/packages/core/src/core/viewport.ts
@@ -7,10 +7,11 @@ import { vec2, vec3 } from "gl-matrix";
 import { generateUUID } from "../utilities/uuid_generator";
 import { Logger } from "../utilities/logger";
 import { EventContext, EventDispatcher } from "./event_dispatcher";
+import { IdetikContext } from "../idetik";
 
 export interface ViewportConfig {
   id?: string;
-  element: HTMLElement;
+  element?: HTMLElement;  // defaults to canvas for single-viewport setups
   camera: Camera;
   layers?: Layer[];
   cameraControls?: CameraControls;
@@ -24,7 +25,10 @@ export class Viewport {
   public readonly events: EventDispatcher;
   public cameraControls?: CameraControls;
 
-  constructor(config: ViewportConfig, layerManager: LayerManager) {
+  constructor(
+    config: ViewportConfig & { element: HTMLElement },
+    layerManager: LayerManager
+  ) {
     this.id = config.id || config.element.id || generateUUID();
     this.element = config.element;
     this.camera = config.camera;
@@ -128,7 +132,11 @@ export class Viewport {
   }
 }
 
-function validateViewportConfigs(viewportConfigs: ViewportConfig[]): void {
+function validateViewportConfigs(
+  viewportConfigs: Array<
+    Required<Pick<ViewportConfig, "element" | "camera">> & ViewportConfig
+  >
+): void {
   const elementToViewportId = new Map<HTMLElement, string>();
   const seenViewportIds = new Set<string>();
 
@@ -155,7 +163,7 @@ function validateViewportConfigs(viewportConfigs: ViewportConfig[]): void {
         config.element.tagName.toLowerCase() +
         (config.element.id ? `#${config.element.id}` : "[element has no id]");
       throw new Error(
-        `Multiple viewports cannot share the same HTML element: ` +
+        "Multiple viewports cannot share the same HTML element: " +
           `viewports "${existingViewportId}" and "${newViewportId}" both use ${elementDescription}`
       );
     }
@@ -165,12 +173,27 @@ function validateViewportConfigs(viewportConfigs: ViewportConfig[]): void {
 
 export function parseViewportConfigs(
   viewportConfigs: ViewportConfig[],
-  createLayerManager: () => LayerManager
+  canvas: HTMLCanvasElement,
+  context: IdetikContext
 ): Viewport[] {
-  validateViewportConfigs(viewportConfigs);
+  const configsWithElements: Array<ViewportConfig & { element: HTMLElement }> =
+    viewportConfigs.map((config) => {
+      if (viewportConfigs.length === 1 && !config.element) {
+        // single-viewport setup with no explicit element uses the whole canvas
+        return { ...config, element: canvas };
+      } else if (!config.element) {
+        throw new Error(
+          "Multi-viewport configurations require an explicit element for each viewport. " +
+            "Use element: canvas to render a viewport on the full canvas."
+        );
+      }
+      return { ...config, element: config.element };
+    });
 
-  return viewportConfigs.map((config) => {
-    const layerManager = createLayerManager();
+  validateViewportConfigs(configsWithElements);
+
+  return configsWithElements.map((config) => {
+    const layerManager = new LayerManager(context);
     return new Viewport(config, layerManager);
   });
 }

--- a/packages/core/src/idetik.ts
+++ b/packages/core/src/idetik.ts
@@ -51,7 +51,7 @@ export class Idetik {
    *
    * @example
    * // Single viewport (element defaults to canvas)
-   *  const camera = new OrthographicCamera(0, 1024, 0, 1024);
+   * const camera = new OrthographicCamera(0, 1024, 0, 1024);
    * const idetik = new Idetik({
    *   canvas: document.querySelector('canvas')!,
    *   viewports: [{

--- a/packages/core/src/idetik.ts
+++ b/packages/core/src/idetik.ts
@@ -16,7 +16,7 @@ type Overlay = {
 
 type IdetikParams = {
   canvas: HTMLCanvasElement;
-  viewports: [ViewportConfig, ...ViewportConfig[]];  // at least one viewport required
+  viewports: [ViewportConfig, ...ViewportConfig[]]; // at least one viewport required
   overlays?: Overlay[];
   showStats?: boolean;
 };
@@ -41,15 +41,15 @@ export class Idetik {
    *
    * @param params - Configuration parameters for the Idetik instance
    * @param params.canvas - HTMLCanvasElement to render to
-   * @param params.viewports - Array of viewport configurations. Each viewport renders to a specific area with its own camera, layers, and controls.
-   *   - For single-viewport applications, pass an array with one element
-   *   - For multi-viewport applications, each viewport must specify an `element` property
-   *   - Single-viewport configs can omit `element` (defaults to the canvas)
+   * @param params.viewports - Array of viewport configurations. Each viewport renders with its own camera, layers, and controls.
+   *   The `element` property is optional and defaults to the canvas if not provided.
+   *   Elements must be unique across viewports.
+   *   The `id` property is optional but useful for referencing specific viewports later.
    * @param params.overlays - Optional array of overlay objects that update each frame (e.g., for HUD elements)
    * @param params.showStats - Optional flag to display performance statistics
    *
    * @example
-   * // Single viewport (element optional, defaults to canvas)
+   * // Single viewport (element defaults to canvas)
    * const idetik = new Idetik({
    *   canvas: document.querySelector('canvas')!,
    *   viewports: [{
@@ -60,28 +60,27 @@ export class Idetik {
    * });
    *
    * @example
-   * // Multiple viewports (element required for each, one can be the canvas)
-   * const canvas = document.querySelector('canvas')!,
+   * // Multiple viewports - one defaults to canvas, others use separate elements
    * const idetik = new Idetik({
-   *   canvas,
+   *   canvas: document.querySelector('canvas')!,
    *   viewports: [
    *     {
    *       id: 'main',
-   *       element: canvas,
+   *       // element omitted - defaults to canvas
    *       camera: camera1,
    *       layers: [layer1]
    *     },
    *     {
    *       id: 'minimap',
-   *       element: document.querySelector('#viewport2')!,
+   *       element: document.querySelector('#minimap')!,
    *       camera: camera2,
    *       layers: [layer2]
    *     }
    *   ]
    * });
    *
-   * @throws {Error} If viewports array is empty
-   * @throws {Error} If viewports fail validation (e.g. missing elements, duplicate IDs or elements)
+   * @throws {Error} If viewports array is empty or not provided
+   * @throws {Error} If viewports have duplicate IDs or shared elements
    */
   constructor(params: IdetikParams) {
     this.canvas = params.canvas;

--- a/packages/core/src/idetik.ts
+++ b/packages/core/src/idetik.ts
@@ -1,11 +1,6 @@
-import { Camera } from "./objects/cameras/camera";
-import { Layer } from "./core/layer";
-import { LayerManager } from "./core/layer_manager";
 import { WebGLRenderer } from "./renderers/webgl_renderer";
-import { CameraControls } from "./objects/cameras/controls";
 import { Logger } from "./utilities/logger";
 import { ChunkManager } from "./core/chunk_manager";
-import { vec2, vec3 } from "gl-matrix";
 import { OrthographicCamera } from "./objects/cameras/orthographic_camera";
 import { createStats, type Stats } from "./utilities/stats";
 import {
@@ -20,11 +15,8 @@ type Overlay = {
 };
 
 type IdetikParams = {
-  canvas?: HTMLCanvasElement;
-  canvasSelector?: string;
-  camera: Camera;
-  cameraControls?: CameraControls;
-  layers?: Layer[];
+  canvas: HTMLCanvasElement;
+  viewports: [ViewportConfig, ...ViewportConfig[]];  // at least one viewport required
   overlays?: Overlay[];
   showStats?: boolean;
 };
@@ -44,42 +36,71 @@ export class Idetik {
   private readonly stats_?: Stats;
   private readonly sizeObserver_: PixelSizeObserver;
 
+  /**
+   * Creates a new Idetik visualization runtime instance.
+   *
+   * @param params - Configuration parameters for the Idetik instance
+   * @param params.canvas - HTMLCanvasElement to render to
+   * @param params.viewports - Array of viewport configurations. Each viewport renders to a specific area with its own camera, layers, and controls.
+   *   - For single-viewport applications, pass an array with one element
+   *   - For multi-viewport applications, each viewport must specify an `element` property
+   *   - Single-viewport configs can omit `element` (defaults to the canvas)
+   * @param params.overlays - Optional array of overlay objects that update each frame (e.g., for HUD elements)
+   * @param params.showStats - Optional flag to display performance statistics
+   *
+   * @example
+   * // Single viewport (element optional, defaults to canvas)
+   * const idetik = new Idetik({
+   *   canvas: document.querySelector('canvas')!,
+   *   viewports: [{
+   *     camera: new OrthographicCamera(0, 1024, 0, 1024),
+   *     layers: [imageLayer],
+   *     cameraControls: new PanZoomControls(camera)
+   *   }]
+   * });
+   *
+   * @example
+   * // Multiple viewports (element required for each, one can be the canvas)
+   * const canvas = document.querySelector('canvas')!,
+   * const idetik = new Idetik({
+   *   canvas,
+   *   viewports: [
+   *     {
+   *       id: 'main',
+   *       element: canvas,
+   *       camera: camera1,
+   *       layers: [layer1]
+   *     },
+   *     {
+   *       id: 'minimap',
+   *       element: document.querySelector('#viewport2')!,
+   *       camera: camera2,
+   *       layers: [layer2]
+   *     }
+   *   ]
+   * });
+   *
+   * @throws {Error} If viewports array is empty
+   * @throws {Error} If viewports fail validation (e.g. missing elements, duplicate IDs or elements)
+   */
   constructor(params: IdetikParams) {
-    if (!params.canvas && !params.canvasSelector) {
-      throw new Error("Either canvas or canvasSelector must be provided");
-    }
-    if (params.canvas && params.canvasSelector) {
-      throw new Error("Cannot provide both canvas and canvasSelector");
+    this.canvas = params.canvas;
+
+    if (params.viewports.length === 0) {
+      throw new Error("At least one viewport config must be specified.");
     }
 
-    const canvas =
-      params.canvas ??
-      document.querySelector<HTMLCanvasElement>(params.canvasSelector!);
-    if (!canvas) {
-      throw new Error(`Canvas not found: ${params.canvasSelector}`);
-    }
-    this.canvas = canvas;
-
-    this.renderer_ = new WebGLRenderer(canvas);
+    this.renderer_ = new WebGLRenderer(this.canvas);
     this.chunkManager_ = new ChunkManager();
     this.context_ = {
       chunkManager: this.chunkManager_,
     };
 
-    // TEMP: creating a single viewport for now to maintain the existing API
-    const viewportConfigs: ViewportConfig[] = [
-      {
-        id: "main",
-        element: canvas,
-        camera: params.camera,
-        layers: params.layers,
-        cameraControls: params.cameraControls,
-      },
-    ];
-    // TEMP: pass closure to reuse the main LayerManager instead of creating new ones
-    // This avoids circular import issues while maintaining shared context
-    const createLayerManager = () => new LayerManager(this.context_);
-    this.viewports_ = parseViewportConfigs(viewportConfigs, createLayerManager);
+    this.viewports_ = parseViewportConfigs(
+      params.viewports,
+      this.canvas,
+      this.context_
+    );
 
     this.overlays = params.overlays ?? [];
 
@@ -106,26 +127,12 @@ export class Idetik {
     return this.renderer_.textureInfo;
   }
 
-  // TEMP: backward-compatible getters/setter for events, camera, layerManager, and cameraControls
-  // to be removed on completion of multi-viewport implementation
-  public get events() {
-    return this.viewports_[0].events;
+  public get viewports(): readonly Viewport[] {
+    return this.viewports_;
   }
 
-  public get camera() {
-    return this.viewports_[0].camera;
-  }
-
-  public get layerManager() {
-    return this.viewports_[0].layerManager;
-  }
-
-  public set cameraControls(controls: CameraControls | undefined) {
-    this.viewports_[0].cameraControls = controls;
-  }
-
-  public clientToClip(position: vec2, depth: number = 0): vec3 {
-    return this.viewports_[0].clientToClip(position, depth);
+  public getViewport(id: string): Viewport | undefined {
+    return this.viewports_.find((v) => v.id === id);
   }
 
   public start() {

--- a/packages/core/src/idetik.ts
+++ b/packages/core/src/idetik.ts
@@ -41,7 +41,8 @@ export class Idetik {
    *
    * @param params - Configuration parameters for the Idetik instance
    * @param params.canvas - HTMLCanvasElement to render to
-   * @param params.viewports - Array of viewport configurations. Each viewport renders with its own camera, layers, and controls.
+   * @param params.viewports - Array of viewport configurations. (At least one required.)
+   *   Each viewport renders with its own camera, layers, and controls.
    *   The `element` property is optional and defaults to the canvas if not provided.
    *   Elements must be unique across viewports.
    *   The `id` property is optional but useful for referencing specific viewports later.
@@ -50,10 +51,11 @@ export class Idetik {
    *
    * @example
    * // Single viewport (element defaults to canvas)
+   *  const camera = new OrthographicCamera(0, 1024, 0, 1024);
    * const idetik = new Idetik({
    *   canvas: document.querySelector('canvas')!,
    *   viewports: [{
-   *     camera: new OrthographicCamera(0, 1024, 0, 1024),
+   *     camera: camera,
    *     layers: [imageLayer],
    *     cameraControls: new PanZoomControls(camera)
    *   }]

--- a/packages/core/test/idetik.test.ts
+++ b/packages/core/test/idetik.test.ts
@@ -2,72 +2,22 @@ import { expect, test, vi } from "vitest";
 import { Idetik } from "@/idetik";
 import { OrthographicCamera } from "@/objects/cameras/orthographic_camera";
 
-test("Runtime constructor throws error when neither canvas nor canvasSelector provided", () => {
-  const camera = new OrthographicCamera(0, 128, 0, 128);
-
-  expect(() => {
-    new Idetik({ camera });
-  }).toThrow("Either canvas or canvasSelector must be provided");
-});
-
-test("Runtime constructor throws error when both canvas and canvasSelector provided", () => {
-  const canvas = document.createElement("canvas");
-  const camera = new OrthographicCamera(0, 128, 0, 128);
-
-  expect(() => {
-    new Idetik({
-      canvas,
-      canvasSelector: "#canvas",
-      camera,
-    });
-  }).toThrow("Cannot provide both canvas and canvasSelector");
-});
-
-test("Runtime constructor throws error when canvas not found with selector", () => {
-  const camera = new OrthographicCamera(0, 128, 0, 128);
-
-  expect(() => {
-    new Idetik({
-      canvasSelector: "#non-existent-canvas",
-      camera,
-    });
-  }).toThrow("Canvas not found: #non-existent-canvas");
-});
-
 test("Runtime initializes with canvas element", () => {
   const canvas = document.createElement("canvas");
   const camera = new OrthographicCamera(0, 128, 0, 128);
 
-  const idetik = new Idetik({ canvas, camera });
+  const idetik = new Idetik({ canvas, viewports: [{ camera }] });
 
+  const viewport = idetik.viewports[0];
   expect(idetik.canvas).toBe(canvas);
-  expect(idetik.camera).toBe(camera);
-  expect(idetik.layerManager).toBeDefined();
-});
-
-test("Runtime initializes with canvas selector", () => {
-  const canvas = document.createElement("canvas");
-  canvas.id = "test-canvas";
-  document.body.appendChild(canvas);
-
-  const camera = new OrthographicCamera(0, 128, 0, 128);
-
-  const idetik = new Idetik({
-    canvasSelector: "#test-canvas",
-    camera,
-  });
-
-  expect(idetik.canvas).toBe(canvas);
-  expect(idetik.camera).toBe(camera);
-  expect(idetik.layerManager).toBeDefined();
-
-  document.body.removeChild(canvas);
+  expect(viewport.camera).toBe(camera);
+  expect(viewport.layerManager).toBeDefined();
 });
 
 test("Runtime start/stop controls the animation loop", () => {
   const canvas = document.createElement("canvas");
   const camera = new OrthographicCamera(0, 128, 0, 128);
-  const idetik = new Idetik({ canvas, camera });
+  const idetik = new Idetik({ canvas, viewports: [{ camera }] });
 
   const rafSpy = vi.spyOn(window, "requestAnimationFrame");
   idetik.start();
@@ -82,7 +32,7 @@ test("Width and height properties return (scaled) canvas shape", () => {
   const devicePixelRatio = window.devicePixelRatio;
   const canvas = document.createElement("canvas");
   const camera = new OrthographicCamera(0, 128, 0, 128);
-  const idetik = new Idetik({ canvas, camera });
+  const idetik = new Idetik({ canvas, viewports: [{ camera }] });
 
   expect(idetik.width).toBe(canvas.clientWidth * devicePixelRatio);
   expect(idetik.height).toBe(canvas.clientHeight * devicePixelRatio);

--- a/packages/core/test/viewport.test.ts
+++ b/packages/core/test/viewport.test.ts
@@ -34,13 +34,12 @@ test("Viewport constructor uses provided ID", () => {
   const camera = createTestCamera();
   const layerManager = createTestLayerManager();
 
-  const config = {
+  const viewport = new Viewport({
     id: "custom-viewport",
     element,
     camera,
-  };
-
-  const viewport = new Viewport(config, layerManager);
+    layerManager,
+  });
   expect(viewport.id).toBe("custom-viewport");
 });
 
@@ -49,29 +48,28 @@ test("Viewport constructor falls back to element ID", () => {
   const camera = createTestCamera();
   const layerManager = createTestLayerManager();
 
-  const config = {
+  const viewport = new Viewport({
+    id: "element-id",
     element,
     camera,
-  };
-
-  const viewport = new Viewport(config, layerManager);
+    layerManager,
+  });
   expect(viewport.id).toBe("element-id");
 });
 
-test("Viewport constructor generates a fallback ID when not provided or available", () => {
+test("Viewport constructor requires an ID", () => {
   const element = createTestElement("");
   element.id = ""; // Ensure no ID
   const camera = createTestCamera();
   const layerManager = createTestLayerManager();
 
-  const config = {
+  const viewport = new Viewport({
+    id: "generated-id",
     element,
     camera,
-  };
-
-  const viewport = new Viewport(config, layerManager);
-  expect(viewport.id).toBeDefined();
-  expect(viewport.id.length).toBeGreaterThan(0);
+    layerManager,
+  });
+  expect(viewport.id).toBe("generated-id");
 });
 
 test("parseViewportConfigs creates viewports with validation", () => {

--- a/packages/core/test/viewport.test.ts
+++ b/packages/core/test/viewport.test.ts
@@ -25,8 +25,7 @@ function createTestContext(): IdetikContext {
 }
 
 function createTestLayerManager(): LayerManager {
-  const chunkManager = new ChunkManager();
-  return new LayerManager({ chunkManager });
+  return new LayerManager(createTestContext());
 }
 
 test("Viewport constructor uses provided ID", () => {

--- a/packages/core/test/viewport.test.ts
+++ b/packages/core/test/viewport.test.ts
@@ -7,6 +7,7 @@ import {
   LayerManager,
   OrthographicCamera,
 } from "@";
+import type { IdetikContext } from "@/idetik";
 import { ChunkManager } from "@/core/chunk_manager";
 
 function createTestElement(id: string): HTMLElement {
@@ -19,6 +20,10 @@ function createTestCamera(): OrthographicCamera {
   return new OrthographicCamera(-1, 1, -1, 1);
 }
 
+function createTestContext(): IdetikContext {
+  return { chunkManager: new ChunkManager() };
+}
+
 function createTestLayerManager(): LayerManager {
   const chunkManager = new ChunkManager();
   return new LayerManager({ chunkManager });
@@ -29,7 +34,7 @@ test("Viewport constructor uses provided ID", () => {
   const camera = createTestCamera();
   const layerManager = createTestLayerManager();
 
-  const config: ViewportConfig = {
+  const config = {
     id: "custom-viewport",
     element,
     camera,
@@ -44,7 +49,7 @@ test("Viewport constructor falls back to element ID", () => {
   const camera = createTestCamera();
   const layerManager = createTestLayerManager();
 
-  const config: ViewportConfig = {
+  const config = {
     element,
     camera,
   };
@@ -59,7 +64,7 @@ test("Viewport constructor generates a fallback ID when not provided or availabl
   const camera = createTestCamera();
   const layerManager = createTestLayerManager();
 
-  const config: ViewportConfig = {
+  const config = {
     element,
     camera,
   };
@@ -70,19 +75,19 @@ test("Viewport constructor generates a fallback ID when not provided or availabl
 });
 
 test("parseViewportConfigs creates viewports with validation", () => {
+  const canvas = document.createElement("canvas");
   const element1 = createTestElement("viewport1");
   const element2 = createTestElement("viewport2");
   const camera1 = createTestCamera();
   const camera2 = createTestCamera();
+  const context = createTestContext();
 
   const configs: ViewportConfig[] = [
     { id: "viewport1", element: element1, camera: camera1 },
     { id: "viewport2", element: element2, camera: camera2 },
   ];
 
-  const viewports = parseViewportConfigs(configs, () =>
-    createTestLayerManager()
-  );
+  const viewports = parseViewportConfigs(configs, canvas, context);
 
   expect(viewports).toHaveLength(2);
   expect(viewports[0].id).toBe("viewport1");
@@ -92,50 +97,54 @@ test("parseViewportConfigs creates viewports with validation", () => {
 });
 
 test("parseViewportConfigs throws on duplicate IDs", () => {
+  const canvas = document.createElement("canvas");
   const element1 = createTestElement("viewport1");
   const element2 = createTestElement("viewport2");
   const camera1 = createTestCamera();
   const camera2 = createTestCamera();
+  const context = createTestContext();
 
   const configs: ViewportConfig[] = [
     { id: "duplicate", element: element1, camera: camera1 },
     { id: "duplicate", element: element2, camera: camera2 },
   ];
 
-  expect(() =>
-    parseViewportConfigs(configs, () => createTestLayerManager())
-  ).toThrow('Duplicate viewport ID "duplicate"');
+  expect(() => parseViewportConfigs(configs, canvas, context)).toThrow(
+    'Duplicate viewport ID "duplicate"'
+  );
 });
 
 test("parseViewportConfigs throws on shared elements", () => {
+  const canvas = document.createElement("canvas");
   const sharedElement = createTestElement("shared");
   const camera1 = createTestCamera();
   const camera2 = createTestCamera();
+  const context = createTestContext();
 
   const configs: ViewportConfig[] = [
     { id: "viewport1", element: sharedElement, camera: camera1 },
     { id: "viewport2", element: sharedElement, camera: camera2 },
   ];
 
-  expect(() =>
-    parseViewportConfigs(configs, () => createTestLayerManager())
-  ).toThrow("Multiple viewports cannot share the same HTML element");
+  expect(() => parseViewportConfigs(configs, canvas, context)).toThrow(
+    "Multiple viewports cannot share the same HTML element"
+  );
 });
 
 test("parseViewportConfigs allows viewports without explicit IDs", () => {
+  const canvas = document.createElement("canvas");
   const element1 = createTestElement("element1");
   const element2 = createTestElement("element2");
   const camera1 = createTestCamera();
   const camera2 = createTestCamera();
+  const context = createTestContext();
 
   const configs: ViewportConfig[] = [
     { element: element1, camera: camera1 },
     { element: element2, camera: camera2 },
   ];
 
-  const viewports = parseViewportConfigs(configs, () =>
-    createTestLayerManager()
-  );
+  const viewports = parseViewportConfigs(configs, canvas, context);
 
   expect(viewports).toHaveLength(2);
   expect(viewports[0].id).toBe("element1");


### PR DESCRIPTION
### Summary

This introduces an API for instantiating a multi-viewport runtime. The bulk of the important changes are in `idetik.ts`. The rest of the changes (primarily in the examples) are pretty mechanical, but useful for seeing what the updated API looks like.

In the interest of keeping the configuration explicit, and validation simple, this is a _breaking change_, hence all the updated examples. In summary:
* When instantiating the runtime, you _must_ specify the `viewports` array
* For single-viewport applications, simply specify a single viewport in the array
* Each viewport in the config requires an HTML element that defines its bounds, if you omit this it will default to the base `canvas` element
  * In general this is what you want for a single-viewport app
  * Viewports cannot share elements, so for a multi-viewport case you must specify unique elements for all viewports
  * You may omit the explicit element (again, defaulting to the canvas) for _one_ viewport in a multi-viewport definition
* The following properties/methods of the `Idetik` object ("runtime") have been removed, and must be accessed via the viewport instead:
  * `camera`
  * `cameraControls`
  * `clientToClip`
  * `events`
  * `layerManager`
* You can access a viewport through the runtime object with:
  * `viewports` property, which returns a readonly array of `Viewport` objects
  * `getViewport(id: string): Viewport | undefined` if you have a viewport ID
  * In the common case of a single-viewport app, use `runtime.viewports[0]` to get the viewport
  
I also included a comprehensive JSDoc comment for the `Idetik` constructor to document how it works. Hopefully this is helpful as we look into generating API docs.

Finally, this includes a new example demonstrating multiple viewports in `packages/core/examples/multi_viewport`. Because the `ChunkManager` and associated machinery is not compatible with multiple viewports, I used a `VolumeLayer` and `PerspectiveCamera` in the second viewport as a temporary workaround. This example can serve as a testing rig as we add multi-viewport capability to the chunking infrastructure.
<img width="977" height="838" alt="Screenshot 2025-10-22 at 10 21 33 AM" src="https://github.com/user-attachments/assets/91ed89da-0d38-4f36-94aa-2216a3079112" />

### Related Issue
#486 (does not close)

### Tests & Checks
Tested existing examples and updated automated tests
Included a new example demonstrating multiple viewports, with the limitation that only one can use the `ChunkManager`

N.B. I did not update the React code here in anticipation of #499 merging soon. We will need to update the react library accordingly when this is published. Tests on this branch will probably fail until incorporating the react package removal.