### PR TITLE
Export ImageSourcePolicy type

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -28,6 +28,7 @@ export { OmeZarrImageSource } from "./data/ome_zarr/image_source";
 
 export type {
   PriorityCategory,
+  ImageSourcePolicy,
   ImageSourcePolicyConfig,
 } from "./core/image_source_policy";
 


### PR DESCRIPTION
### Summary
This change exports `ImageSourcePolicy` as a type, which allows dependents to directly import and use that as a type instead of relying on things like `ReturnType<typeof createImageSourcePolicy>`.

### Related Issue
Closes #510

### Tests & Checks
This only exports an additional type. No manual testing needed.
