### PR TITLE
Add bounding boxes to renderable objects

### DIFF
--- a/packages/core/src/core/geometry.ts
+++ b/packages/core/src/core/geometry.ts
@@ -1,4 +1,6 @@
 import { Node } from "./node";
+import { Box3 } from "../math/box3";
+import { vec3 } from "gl-matrix";
 
 export type Primitive = "triangles" | "points" | "lines";
 
@@ -34,6 +36,7 @@ type GeometryAttribute = {
 };
 
 export class Geometry extends Node {
+  private boundingBox_: Box3 | null = null;
   protected primitive_: Primitive;
   protected attributes_: GeometryAttribute[];
   protected vertexData_: Float32Array;
@@ -53,18 +56,25 @@ export class Geometry extends Node {
 
   public addAttribute(attr: GeometryAttribute) {
     this.attributes_.push(attr);
+    this.boundingBox_ = null;
+  }
+
+  public getAttribute(type: GeometryAttributeType) {
+    return this.attributes_.find((a) => a.type === type);
   }
 
   public get vertexCount() {
-    return this.vertexData_.byteLength / this.stride;
+    return this.vertexData_.byteLength / this.strideBytes;
   }
 
   public get stride() {
-    return (
-      this.attributes_.reduce((acc, curr) => {
-        return acc + curr.itemSize;
-      }, 0) * Float32Array.BYTES_PER_ELEMENT
-    );
+    return this.attributes_.reduce((acc, curr) => {
+      return acc + curr.itemSize;
+    }, 0);
+  }
+
+  public get strideBytes() {
+    return this.stride * Float32Array.BYTES_PER_ELEMENT;
   }
 
   public get primitive() {
@@ -81,6 +91,28 @@ export class Geometry extends Node {
 
   public get attributes() {
     return this.attributes_;
+  }
+
+  public get boundingBox() {
+    if (this.boundingBox_ === null) {
+      const attr = this.getAttribute("position");
+      if (!attr || this.vertexCount === 0) {
+        throw new Error("Failed to generate bounding box");
+      }
+
+      const offset = (attr.offset ?? 0) / Float32Array.BYTES_PER_ELEMENT;
+      const box = new Box3();
+      const point = vec3.create();
+      for (let i = 0; i < this.vertexData_.length; i += this.stride) {
+        point[0] = this.vertexData_[i + offset + 0];
+        point[1] = this.vertexData_[i + offset + 1];
+        point[2] = this.vertexData_[i + offset + 2];
+        box.expandWithPoint(point);
+      }
+
+      this.boundingBox_ = box;
+    }
+    return this.boundingBox_;
   }
 
   public get type() {

--- a/packages/core/src/core/renderable_object.ts
+++ b/packages/core/src/core/renderable_object.ts
@@ -59,6 +59,12 @@ export abstract class RenderableObject extends Node {
     return this.programName_;
   }
 
+  public get boundingBox() {
+    const box = this.geometry_.boundingBox.clone();
+    box.applyTransform(this.transform_.matrix);
+    return box;
+  }
+
   protected set programName(programName: Shader) {
     this.programName_ = programName;
   }

--- a/packages/core/src/math/box3.ts
+++ b/packages/core/src/math/box3.ts
@@ -1,4 +1,4 @@
-import { vec3 } from "gl-matrix";
+import { mat4, vec3 } from "gl-matrix";
 
 export class Box3 {
   public min: vec3;
@@ -37,5 +37,38 @@ export class Box3 {
     if (a.max[1] <= b.min[1] || a.min[1] >= b.max[1]) return false;
     if (a.max[2] <= b.min[2] || a.min[2] >= b.max[2]) return false;
     return true;
+  }
+
+  public expandWithPoint(p: vec3) {
+    if (p[0] < this.min[0]) this.min[0] = p[0];
+    if (p[1] < this.min[1]) this.min[1] = p[1];
+    if (p[2] < this.min[2]) this.min[2] = p[2];
+    if (p[0] > this.max[0]) this.max[0] = p[0];
+    if (p[1] > this.max[1]) this.max[1] = p[1];
+    if (p[2] > this.max[2]) this.max[2] = p[2];
+  }
+
+  public applyTransform(matrix: mat4) {
+    const { min, max } = this;
+    const corners: vec3[] = [
+      vec3.fromValues(min[0], min[1], min[2]),
+      vec3.fromValues(min[0], min[1], max[2]),
+      vec3.fromValues(min[0], max[1], min[2]),
+      vec3.fromValues(min[0], max[1], max[2]),
+      vec3.fromValues(max[0], min[1], min[2]),
+      vec3.fromValues(max[0], min[1], max[2]),
+      vec3.fromValues(max[0], max[1], min[2]),
+      vec3.fromValues(max[0], max[1], max[2]),
+    ];
+
+    // "Empty" box before expanding
+    this.min = vec3.fromValues(+Infinity, +Infinity, +Infinity);
+    this.max = vec3.fromValues(-Infinity, -Infinity, -Infinity);
+
+    const tmp = vec3.create();
+    for (const c of corners) {
+      vec3.transformMat4(tmp, c, matrix);
+      this.expandWithPoint(tmp);
+    }
   }
 }

--- a/packages/core/src/objects/renderable/points.ts
+++ b/packages/core/src/objects/renderable/points.ts
@@ -51,17 +51,17 @@ export class Points extends RenderableObject {
     geometry.addAttribute({
       type: "color",
       itemSize: 4,
-      offset: geometry.stride,
+      offset: geometry.strideBytes,
     });
     geometry.addAttribute({
       type: "size",
       itemSize: 1,
-      offset: geometry.stride,
+      offset: geometry.strideBytes,
     });
     geometry.addAttribute({
       type: "marker",
       itemSize: 1,
-      offset: geometry.stride,
+      offset: geometry.strideBytes,
     });
 
     this.geometry = geometry;

--- a/packages/core/src/renderers/webgl_buffers.ts
+++ b/packages/core/src/renderers/webgl_buffers.ts
@@ -72,7 +72,7 @@ export class WebGLBuffers {
     this.gl_.bindBuffer(vboType, vbo);
     this.gl_.bufferData(vboType, vertexData, this.gl_.STATIC_DRAW);
 
-    const { attributes, stride } = geometry;
+    const { attributes, strideBytes } = geometry;
     attributes.forEach((attr) => {
       const idx = GeometryAttributeIndex[attr.type];
       this.gl_.vertexAttribPointer(
@@ -80,7 +80,7 @@ export class WebGLBuffers {
         attr.itemSize,
         this.gl_.FLOAT,
         false,
-        stride,
+        strideBytes,
         attr.offset
       );
       this.gl_.enableVertexAttribArray(idx);

--- a/packages/core/test/box3.test.ts
+++ b/packages/core/test/box3.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "vitest";
-import { vec3 } from "gl-matrix";
+import { mat4, vec3 } from "gl-matrix";
 
 import { Box3 } from "@";
 
@@ -52,6 +52,66 @@ test("intersects: empty and non-empty box do not intersect", () => {
   expect(a.isEmpty()).toBe(true);
   expect(b.isEmpty()).toBe(false);
   expect(Box3.intersects(a, b)).toBe(false);
+});
+
+test("expand with points", () => {
+  const b = new Box3(vec3.fromValues(0, 0, 0), vec3.fromValues(1, 1, 1));
+
+  b.expandWithPoint(vec3.fromValues(1, 2, -2));
+  b.expandWithPoint(vec3.fromValues(3, -4, 1));
+  b.expandWithPoint(vec3.fromValues(-2, 5, 0));
+  b.expandWithPoint(vec3.fromValues(0.5, 0.5, 0.5));
+  b.expandWithPoint(vec3.fromValues(3, 2, 1));
+  b.expandWithPoint(vec3.fromValues(-2, -4, -3));
+
+  expect(b.min).toEqual(vec3.fromValues(-2, -4, -3));
+  expect(b.max).toEqual(vec3.fromValues(3, 5, 1));
+});
+
+test("expand with points no-op when point lies inside (including boundary)", () => {
+  const b = new Box3(vec3.fromValues(-1, -1, -1), vec3.fromValues(1, 1, 1));
+  const beforeMin = vec3.clone(b.min);
+  const beforeMax = vec3.clone(b.max);
+
+  b.expandWithPoint(vec3.fromValues(0.25, -0.5, 0.9));
+  b.expandWithPoint(vec3.fromValues(1, 0, 0));
+  b.expandWithPoint(vec3.fromValues(-1, -1, -1));
+  b.expandWithPoint(vec3.fromValues(1, 1, 1));
+
+  expect(b.min).toEqual(beforeMin);
+  expect(b.max).toEqual(beforeMax);
+});
+
+test("apply transform identity leaves box unchanged", () => {
+  const b = new Box3(vec3.fromValues(0, 0, 0), vec3.fromValues(1, 1, 1));
+  const m = mat4.create();
+  b.applyTransform(m);
+
+  expect(b.min).toEqual(vec3.fromValues(0, 0, 0));
+  expect(b.max).toEqual(vec3.fromValues(1, 1, 1));
+});
+
+test("apply transform with translation shifts box by offset", () => {
+  const b = new Box3(vec3.fromValues(-1, 2, 3), vec3.fromValues(4, 5, 6));
+  const m = mat4.fromTranslation(mat4.create(), vec3.fromValues(10, -2, 7));
+  b.applyTransform(m);
+
+  expect(b.min).toEqual(vec3.fromValues(9, 0, 10));
+  expect(b.max).toEqual(vec3.fromValues(14, 3, 13));
+});
+
+test("apply transform rotation 90° around Z", () => {
+  const b = new Box3(vec3.fromValues(0, 0, 0), vec3.fromValues(1, 1, 1));
+  const m = mat4.fromZRotation(mat4.create(), Math.PI / 2);
+  b.applyTransform(m);
+
+  const expectedMin = vec3.fromValues(-1, 0, 0);
+  const expectedMax = vec3.fromValues(0, 1, 1);
+
+  for (let i = 0; i < 3; i++) {
+    expect(b.min[i]).toBeCloseTo(expectedMin[i]);
+    expect(b.max[i]).toBeCloseTo(expectedMax[i]);
+  }
 });
 
 test("clone creates a deep copy", () => {


### PR DESCRIPTION
### Summary

This PR adds bounding boxes to renderable objects. These will be used for
frustum-culling debugging or any renderer-level culling we may need, though the main
path is more likely to generate boxes directly from chunks. The computation is lazy,
so it introduces no extra perf cost, but we can roll some of this work back if it's no
longer useful beyond debugging.

### Tests & Checks
- All checks have passed
- Added basic tests for new `Box3` functionality
