### PR TITLE
feat: add Texture3D class and use in webgl renderer

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -64,4 +64,4 @@ export type { ChannelProps, ChannelsEnabled } from "./objects/textures/channel";
 
 export { Points } from "./objects/renderable/points";
 export { Texture2DArray } from "./objects/textures/texture_2d_array";
-export { Texture3D } from ".objects/textures/texture_3d";
+export { Texture3D } from "./objects/textures/texture_3d";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -62,3 +62,4 @@ export type { ChannelProps, ChannelsEnabled } from "./objects/textures/channel";
 
 export { Points } from "./objects/renderable/points";
 export { Texture2DArray } from "./objects/textures/texture_2d_array";
+export { Texture3D } from ".objects/textures/texture_3d";

--- a/packages/core/src/objects/textures/texture_3d.ts
+++ b/packages/core/src/objects/textures/texture_3d.ts
@@ -1,0 +1,95 @@
+import {
+  DataTextureTypedArray,
+  Texture,
+  bufferToDataType,
+} from "./texture";
+import { Chunk, ChunkData } from "../../data/chunk";
+
+export class Texture3D extends Texture {
+  private data_: DataTextureTypedArray;
+  private readonly width_: number;
+  private readonly height_: number;
+  private readonly depth_: number;
+
+  constructor(
+    data: DataTextureTypedArray,
+    width: number,
+    height: number,
+    depth: number
+  ) {
+    super();
+    this.dataFormat = "scalar";
+    this.dataType = bufferToDataType(data);
+
+    this.data_ = data;
+    this.width_ = width;
+    this.height_ = height;
+    this.depth_ = depth;
+  }
+
+  public set data(data: DataTextureTypedArray) {
+    this.data_ = data;
+    this.needsUpdate = true;
+  }
+
+  public get type() {
+    return "Texture3D";
+  }
+
+  public get data() {
+    return this.data_;
+  }
+
+  public get width() {
+    return this.width_;
+  }
+
+  public get height() {
+    return this.height_;
+  }
+
+  public get depth() {
+    return this.depth_;
+  }
+
+  public updateWithChunk(chunk: Chunk, data?: ChunkData) {
+    const source = data ?? chunk.data;
+    if (!source) {
+      throw new Error(
+        "Unable to update texture, chunk data is not initialized."
+      );
+    }
+
+    if (this.data === source) return;
+
+    if (
+      this.width != chunk.shape.x ||
+      this.height != chunk.shape.y ||
+      this.depth != chunk.shape.z ||
+      this.dataType != bufferToDataType(source)
+    ) {
+      throw new Error("Unable to update texture, texture buffer mismatch.");
+    }
+
+    this.data = source;
+  }
+
+  public static createWithChunk(chunk: Chunk, data?: ChunkData) {
+    const source = data ?? chunk.data;
+    if (!source) {
+      throw new Error(
+        "Unable to create texture, chunk data is not initialized."
+      );
+    }
+
+    const texture = new Texture3D(
+      source,
+      chunk.shape.x,
+      chunk.shape.y,
+      chunk.shape.z
+    );
+    texture.unpackRowLength = chunk.rowStride;
+    texture.unpackAlignment = chunk.rowAlignmentBytes;
+    return texture;
+  }
+}

--- a/packages/core/src/objects/textures/texture_3d.ts
+++ b/packages/core/src/objects/textures/texture_3d.ts
@@ -48,8 +48,8 @@ export class Texture3D extends Texture {
     return this.depth_;
   }
 
-  public updateWithChunk(chunk: Chunk, data?: ChunkData) {
-    const source = data ?? chunk.data;
+  public updateWithChunk(chunk: Chunk) {
+    const source = chunk.data;
     if (!source) {
       throw new Error(
         "Unable to update texture, chunk data is not initialized."

--- a/packages/core/src/objects/textures/texture_3d.ts
+++ b/packages/core/src/objects/textures/texture_3d.ts
@@ -70,8 +70,8 @@ export class Texture3D extends Texture {
     this.data = source;
   }
 
-  public static createWithChunk(chunk: Chunk, data?: ChunkData) {
-    const source = data ?? chunk.data;
+  public static createWithChunk(chunk: Chunk) {
+    const source = chunk.data;
     if (!source) {
       throw new Error(
         "Unable to create texture, chunk data is not initialized."

--- a/packages/core/src/objects/textures/texture_3d.ts
+++ b/packages/core/src/objects/textures/texture_3d.ts
@@ -1,8 +1,4 @@
-import {
-  DataTextureTypedArray,
-  Texture,
-  bufferToDataType,
-} from "./texture";
+import { DataTextureTypedArray, Texture, bufferToDataType } from "./texture";
 import { Chunk, ChunkData } from "../../data/chunk";
 
 export class Texture3D extends Texture {

--- a/packages/core/src/objects/textures/texture_3d.ts
+++ b/packages/core/src/objects/textures/texture_3d.ts
@@ -84,7 +84,6 @@ export class Texture3D extends Texture {
       chunk.shape.y,
       chunk.shape.z
     );
-    texture.unpackRowLength = chunk.rowStride;
     texture.unpackAlignment = chunk.rowAlignmentBytes;
     return texture;
   }

--- a/packages/core/src/objects/textures/texture_3d.ts
+++ b/packages/core/src/objects/textures/texture_3d.ts
@@ -1,5 +1,5 @@
 import { DataTextureTypedArray, Texture, bufferToDataType } from "./texture";
-import { Chunk, ChunkData } from "../../data/chunk";
+import { Chunk } from "../../data/chunk";
 
 export class Texture3D extends Texture {
   private data_: DataTextureTypedArray;

--- a/packages/core/src/renderers/webgl_textures.ts
+++ b/packages/core/src/renderers/webgl_textures.ts
@@ -115,7 +115,7 @@ export class WebGLTextures {
         texture.width,
         texture.height
       );
-    } else if (this.isTexture2DArray(texture) || this.isTexture3D(texture)) {
+    } else if (this.isTextureStorage3D(texture)) {
       this.gl_.texStorage3D(
         type,
         texture.mipmapLevels,
@@ -174,7 +174,7 @@ export class WebGLTextures {
         // https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/texSubImage2D#syntax
         texture.data as ArrayBufferView
       );
-    } else if (this.isTexture2DArray(texture) || this.isTexture3D(texture)) {
+    } else if (this.isTextureStorage3D(texture)) {
       this.gl_.texSubImage3D(
         type,
         mipmapLevel,
@@ -307,7 +307,7 @@ export class WebGLTextures {
   ): number {
     const bytes = this.bytesPerTexel(info);
     const levels = Math.max(1, texture.mipmapLevels);
-    const depth = this.isTexture2DArray(texture)
+    const depth = this.isTextureStorage3D(texture)
       ? Math.max(1, texture.depth)
       : 1;
 
@@ -343,6 +343,12 @@ export class WebGLTextures {
     if (info.format === gl.RED && info.type === gl.FLOAT) return 4;
 
     throw new Error("bytesPerTexel: unsupported format/type");
+  }
+
+  private isTextureStorage3D(
+    texture: Texture
+  ): texture is Texture2DArray | Texture3D {
+    return this.isTexture2DArray(texture) || this.isTexture3D(texture);
   }
 
   private isTexture2D(texture: Texture): texture is Texture2D {

--- a/packages/core/src/renderers/webgl_textures.ts
+++ b/packages/core/src/renderers/webgl_textures.ts
@@ -9,6 +9,7 @@ import {
 
 import { Texture2D } from "../objects/textures/texture_2d";
 import { Texture2DArray } from "../objects/textures/texture_2d_array";
+import { Texture3D } from "../objects/textures/texture_3d";
 
 type TextureFormatInfo = {
   internalFormat: number;
@@ -114,7 +115,7 @@ export class WebGLTextures {
         texture.width,
         texture.height
       );
-    } else if (this.isTexture2DArray(texture)) {
+    } else if (this.isTexture2DArray(texture) || this.isTexture3D(texture)) {
       this.gl_.texStorage3D(
         type,
         texture.mipmapLevels,
@@ -174,7 +175,7 @@ export class WebGLTextures {
         // https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/texSubImage2D#syntax
         texture.data as ArrayBufferView
       );
-    } else if (this.isTexture2DArray(texture)) {
+    } else if (this.isTexture2DArray(texture) || this.isTexture3D(texture)) {
       this.gl_.texSubImage3D(
         type,
         mipmapLevel,
@@ -219,6 +220,7 @@ export class WebGLTextures {
   private getTextureType(texture: Texture) {
     if (this.isTexture2D(texture)) return this.gl_.TEXTURE_2D;
     if (this.isTexture2DArray(texture)) return this.gl_.TEXTURE_2D_ARRAY;
+    if (this.isTexture3D(texture)) return this.gl_.TEXTURE_3D;
     throw new Error(`Unknown texture type ${texture.type}`);
   }
 
@@ -350,5 +352,9 @@ export class WebGLTextures {
 
   private isTexture2DArray(texture: Texture): texture is Texture2DArray {
     return texture.type === "Texture2DArray";
+  }
+
+  private isTexture3D(texture: Texture): texture is Texture3D {
+    return texture.type === "Texture3D";
   }
 }


### PR DESCRIPTION
### Summary
<!---
  Please try to cover the following questions in your summary:
  1. Describe the product (or technical) problem you are solving.
  2. Explain the engineering solution you have chosen.
  3. Discuss the implementation choices/tradeoffs you have made.
-->

These changes allow the creation of a 3D texture object as a subclass of `Texture`, and implements checks in the webgl renderer to use the 3D texture. The 3D texture handling currently shares the same path in the code as the texture 2d array in the renderer (except for getting the texture type).

### Tests & Checks
<!---
  How did you validate that your changes were implemented correctly?
  
  Please think about the following prompts:
  1. I wrote automated tests.
  2. I manually tested my changes, and here's what I did:
-->

Manually tested changes from an example in the [draft volume rendering branch](https://github.com/chanzuckerberg/idetik/pull/515/files#diff-066e85ab63c16922810b3437fea8bddff3b60147dda5b1443d6811b983e5e394)

This is using the example dataset for the chunk streaming
<img width="984" height="847" alt="rendering3d" src="https://github.com/user-attachments/assets/f50faf15-7aea-4d0b-b780-a88872d258a5" />

