### PR TITLE
Remove row stride from chunk and texture

### DIFF
--- a/packages/core/src/core/chunk_manager_source.ts
+++ b/packages/core/src/core/chunk_manager_source.ts
@@ -83,7 +83,6 @@ export class ChunkManagerSource {
 
         for (let x = 0; x < chunksX; ++x) {
           const xOffset = xLod.translation + x * xLod.chunkSize * xLod.scale;
-          const rowStride = Math.min(chunkWidth, xLod.size - x * chunkWidth);
           for (let y = 0; y < chunksY; ++y) {
             const yOffset = yLod.translation + y * yLod.chunkSize * yLod.scale;
             for (let z = 0; z < chunksZ; ++z) {
@@ -105,7 +104,6 @@ export class ChunkManagerSource {
                     z: Math.min(chunkDepth, (zLod?.size ?? 1) - z * chunkDepth),
                     c: 1,
                   },
-                  rowStride,
                   rowAlignmentBytes: 1,
                   chunkIndex: { x, y, z, c, t },
                   scale: {

--- a/packages/core/src/data/chunk.ts
+++ b/packages/core/src/data/chunk.ts
@@ -41,7 +41,6 @@ export type Chunk = {
     z: number;
     c: number;
   };
-  rowStride: number;
   rowAlignmentBytes: TextureUnpackRowAlignment;
   chunkIndex: {
     x: number;

--- a/packages/core/src/data/ome_zarr/image_loader.ts
+++ b/packages/core/src/data/ome_zarr/image_loader.ts
@@ -92,7 +92,7 @@ export class OmeZarrImageLoader {
       );
     }
 
-    validateCompactChunk(receivedChunk);
+    validateTightlyPackedChunk(receivedChunk);
 
     const receivedShape = {
       x: receivedChunk.shape[this.dimensions_.x.index],
@@ -195,7 +195,7 @@ export class OmeZarrImageLoader {
       );
     }
 
-    validateCompactChunk(subarray);
+    validateTightlyPackedChunk(subarray);
 
     if (subarray.shape.length !== 2 && subarray.shape.length !== 3) {
       throw new Error(
@@ -376,12 +376,12 @@ function findDimensionIndexSafe(dimensions: string[], target: string): number {
   return dimensions.findIndex((d) => compareDimensions(d, target));
 }
 
-function validateCompactChunk(chunk: zarr.Chunk<zarr.DataType>): void {
+function validateTightlyPackedChunk(chunk: zarr.Chunk<zarr.DataType>): void {
   let stride = 1;
   for (let i = chunk.shape.length - 1; i >= 0; i--) {
     if (chunk.stride[i] !== stride) {
       throw new Error(
-        `Chunk is not compact, stride=${JSON.stringify(chunk.stride)}, shape=${JSON.stringify(chunk.shape)}`
+        `Chunk data is not tightly packed, stride=${JSON.stringify(chunk.stride)}, shape=${JSON.stringify(chunk.shape)}`
       );
     }
     stride *= chunk.shape[i];

--- a/packages/core/src/data/ome_zarr/image_loader.ts
+++ b/packages/core/src/data/ome_zarr/image_loader.ts
@@ -92,6 +92,8 @@ export class OmeZarrImageLoader {
       );
     }
 
+    validateCompactChunk(receivedChunk);
+
     const receivedShape = {
       x: receivedChunk.shape[this.dimensions_.x.index],
       y: receivedChunk.shape[this.dimensions_.y.index],
@@ -125,7 +127,6 @@ export class OmeZarrImageLoader {
       );
     } else {
       chunk.data = receivedChunk.data;
-      chunk.rowStride = receivedChunk.stride[this.dimensions_.y.index];
     }
 
     const rowAlignment = chunk.data.BYTES_PER_ELEMENT;
@@ -194,6 +195,8 @@ export class OmeZarrImageLoader {
       );
     }
 
+    validateCompactChunk(subarray);
+
     if (subarray.shape.length !== 2 && subarray.shape.length !== 3) {
       throw new Error(
         `Expected to receive a 2D or 3D subarray. Instead chunk has shape ${subarray.shape}`
@@ -235,7 +238,6 @@ export class OmeZarrImageLoader {
         c: subarray.shape.length === 3 ? subarray.shape[0] : 1,
       },
       chunkIndex: { x: 0, y: 0, z: 0, c: 0, t: 0 },
-      rowStride: subarray.stride[subarray.stride.length - 2],
       rowAlignmentBytes: rowAlignment,
       scale: {
         x: scale[indices.length - 1],
@@ -372,4 +374,18 @@ function findDimensionIndex(dimensions: string[], target: string): number {
 
 function findDimensionIndexSafe(dimensions: string[], target: string): number {
   return dimensions.findIndex((d) => compareDimensions(d, target));
+}
+
+function validateCompactChunk(chunk: zarr.Chunk<zarr.DataType>): void {
+  let stride = 1;
+  for (let i = chunk.shape.length - 1; i >= 0; i--) {
+    if (chunk.stride[i] !== stride) {
+      throw new Error(
+        `Chunk is not compact, stride=${JSON.stringify(
+          chunk.stride
+        )}, shape=${JSON.stringify(chunk.shape)}`
+      );
+    }
+    stride *= chunk.shape[i];
+  }
 }

--- a/packages/core/src/data/ome_zarr/image_loader.ts
+++ b/packages/core/src/data/ome_zarr/image_loader.ts
@@ -381,9 +381,7 @@ function validateCompactChunk(chunk: zarr.Chunk<zarr.DataType>): void {
   for (let i = chunk.shape.length - 1; i >= 0; i--) {
     if (chunk.stride[i] !== stride) {
       throw new Error(
-        `Chunk is not compact, stride=${JSON.stringify(
-          chunk.stride
-        )}, shape=${JSON.stringify(chunk.shape)}`
+        `Chunk is not compact, stride=${JSON.stringify(chunk.stride)}, shape=${JSON.stringify(chunk.shape)}`
       );
     }
     stride *= chunk.shape[i];

--- a/packages/core/src/layers/chunked_image_layer.ts
+++ b/packages/core/src/layers/chunked_image_layer.ts
@@ -302,7 +302,7 @@ export class ChunkedImageLayer extends Layer implements ChannelsEnabled {
         this.sliceCoords_.z !== undefined
           ? this.slicePlane(chunk, this.sliceCoords_.z)!
           : chunk.data;
-      const pixelIndex = y * chunk.rowStride + x;
+      const pixelIndex = y * chunk.shape.x + x;
 
       // For multi-channel images, take the first channel value
       return data[pixelIndex];
@@ -373,7 +373,6 @@ export function poolKeyForImageRenderable(chunk: Chunk) {
   return [
     `lod${chunk.lod}`,
     `shape${chunk.shape.x}x${chunk.shape.y}`,
-    `stride${chunk.rowStride}`,
     `align${chunk.rowAlignmentBytes}`,
   ].join(":");
 }

--- a/packages/core/src/layers/image_layer.ts
+++ b/packages/core/src/layers/image_layer.ts
@@ -163,7 +163,7 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
       y >= 0 &&
       y < this.chunk_.shape.y
     ) {
-      const pixelIndex = y * this.chunk_.rowStride + x;
+      const pixelIndex = y * this.chunk_.shape.x + x;
       // For multi-channel images, take the first channel value
       return this.chunk_.data[pixelIndex];
     }

--- a/packages/core/src/layers/label_image_layer.ts
+++ b/packages/core/src/layers/label_image_layer.ts
@@ -153,7 +153,7 @@ export class LabelImageLayer extends Layer {
       return null;
     }
 
-    const pixelIndex = y * this.imageChunk_.rowStride + x;
+    const pixelIndex = y * this.imageChunk_.shape.x + x;
     const data = this.imageChunk_.data;
     return data[pixelIndex];
   }

--- a/packages/core/src/objects/textures/texture.ts
+++ b/packages/core/src/objects/textures/texture.ts
@@ -82,7 +82,6 @@ export abstract class Texture extends Node {
   public minFilter: TextureFilter = "nearest";
   public mipmapLevels = 1;
   public unpackAlignment: TextureUnpackRowAlignment = 4;
-  public unpackRowLength = 0;
   public wrapR: TextureWrapMode = "clamp_to_edge";
   public wrapS: TextureWrapMode = "clamp_to_edge";
   public wrapT: TextureWrapMode = "clamp_to_edge";

--- a/packages/core/src/objects/textures/texture_2d.ts
+++ b/packages/core/src/objects/textures/texture_2d.ts
@@ -71,7 +71,6 @@ export class Texture2D extends Texture {
     }
 
     const texture = new Texture2D(source, chunk.shape.x, chunk.shape.y);
-    texture.unpackRowLength = chunk.rowStride;
     texture.unpackAlignment = chunk.rowAlignmentBytes;
     return texture;
   }

--- a/packages/core/src/objects/textures/texture_2d_array.ts
+++ b/packages/core/src/objects/textures/texture_2d_array.ts
@@ -81,7 +81,6 @@ export class Texture2DArray extends Texture {
       );
     }
     const texture = new Texture2DArray(source, chunk.shape.x, chunk.shape.y);
-    texture.unpackRowLength = chunk.rowStride;
     texture.unpackAlignment = chunk.rowAlignmentBytes;
     return texture;
   }

--- a/packages/core/src/renderers/webgl_textures.ts
+++ b/packages/core/src/renderers/webgl_textures.ts
@@ -139,7 +139,6 @@ export class WebGLTextures {
     const maxFilter = this.getFilter(texture.maxFilter, texture);
 
     gl.pixelStorei(gl.UNPACK_ALIGNMENT, texture.unpackAlignment);
-    gl.pixelStorei(gl.UNPACK_ROW_LENGTH, texture.unpackRowLength);
     gl.texParameteri(type, gl.TEXTURE_MIN_FILTER, minFilter);
     gl.texParameteri(type, gl.TEXTURE_MAG_FILTER, maxFilter);
     gl.texParameteri(type, gl.TEXTURE_WRAP_S, this.getWrapMode(texture.wrapS));

--- a/packages/core/test/helpers.ts
+++ b/packages/core/test/helpers.ts
@@ -20,7 +20,6 @@ export function makeChunk(overrides: ChunkOverrides = {}): Chunk {
     priority: null,
     orderKey: null,
     shape: { x: 256, y: 256, z: 256, c: 1 },
-    rowStride: 256,
     rowAlignmentBytes: 1,
     chunkIndex: { x: 0, y: 0, z: 0, c: 0, t: 0 },
     scale: { x: 1, y: 1, z: 1 },
@@ -36,7 +35,6 @@ export function makeChunk(overrides: ChunkOverrides = {}): Chunk {
     chunkIndex: { ...defaultChunk.chunkIndex, ...(chunkIndex ?? {}) },
     scale: { ...defaultChunk.scale, ...(scale ?? {}) },
     offset: { ...defaultChunk.offset, ...(offset ?? {}) },
-    rowStride: mergedShape.x,
   };
 }
 

--- a/packages/core/test/renderable_pool.test.ts
+++ b/packages/core/test/renderable_pool.test.ts
@@ -76,6 +76,6 @@ describe("poolKeyForImageRenderable", () => {
       })
     );
 
-    expect(key).toBe("lod2:shape256x128:stride256:align4");
+    expect(key).toBe("lod2:shape256x128:align4");
   });
 });


### PR DESCRIPTION
### Summary
This change removes the `Chunk.rowStride` and the `Texture.unpackRowLength` properties. Instead, it validates that each zarr chunk is compact (i.e. the shape exactly specifies the stride) after loading.

### Related Issue
Closes #517

### Tests & Checks
I manually tested all the examples.
