### PR TITLE
Remove rowStride property from test chunk omissions

### DIFF
--- a/packages/core/test/helpers.ts
+++ b/packages/core/test/helpers.ts
@@ -1,7 +1,7 @@
 import type { Chunk } from "../src/data/chunk";
 
 type ChunkOverrides = Partial<
-  Omit<Chunk, "shape" | "chunkIndex" | "scale" | "offset" | "rowStride">
+  Omit<Chunk, "shape" | "chunkIndex" | "scale" | "offset">
 > & {
   shape?: Partial<Chunk["shape"]>;
   chunkIndex?: Partial<Chunk["chunkIndex"]>;


### PR DESCRIPTION
### Summary
This is a very tiny miss from PR #518. Since this change removes a property that is omitted in a type, it is not strictly needed, but helps to keep things as clean and concise as possible.

### Tests & Checks
This is test only code, so automated checks are sufficient.
