### PR TITLE
Add frustum culling to the renderer

### DIFF
--- a/packages/core/examples/chunk_streaming/chunk_info_overlay.ts
+++ b/packages/core/examples/chunk_streaming/chunk_info_overlay.ts
@@ -89,6 +89,7 @@ export class ChunkInfoOverlay {
       "",
       `Number of textures ${numTextures}`,
       `GPU Texture Memory in use ${totalTextureSizeMB}MB`,
+      `Rendered objects: ${idetik.renderedObjects}`,
     ].join("<br>");
   }
 }

--- a/packages/core/src/core/geometry.ts
+++ b/packages/core/src/core/geometry.ts
@@ -59,10 +59,6 @@ export class Geometry extends Node {
     this.boundingBox_ = null;
   }
 
-  public getAttribute(type: GeometryAttributeType) {
-    return this.attributes_.find((a) => a.type === type);
-  }
-
   public get vertexCount() {
     return this.vertexData_.byteLength / this.strideBytes;
   }
@@ -117,5 +113,9 @@ export class Geometry extends Node {
 
   public get type() {
     return "Geometry";
+  }
+
+  private getAttribute(type: GeometryAttributeType) {
+    return this.attributes_.find((a) => a.type === type);
   }
 }

--- a/packages/core/src/core/renderer.ts
+++ b/packages/core/src/core/renderer.ts
@@ -9,6 +9,7 @@ export abstract class Renderer {
   private height_ = 0;
   private backgroundColor_: Color = new Color(0, 0, 0, 0);
 
+  protected renderedObjects_ = 0;
   protected abstract resize(width: number, height: number): void;
   protected abstract renderObject(
     layer: Layer,
@@ -51,6 +52,10 @@ export abstract class Renderer {
 
   public get backgroundColor(): Color {
     return this.backgroundColor_;
+  }
+
+  public get renderedObjects() {
+    return this.renderedObjects_;
   }
 
   public set backgroundColor(color: ColorLike) {

--- a/packages/core/src/idetik.ts
+++ b/packages/core/src/idetik.ts
@@ -116,6 +116,10 @@ export class Idetik {
     this.sizeObserver_ = new PixelSizeObserver(sizeDependents);
   }
 
+  public get renderedObjects() {
+    return this.renderer_.renderedObjects;
+  }
+
   public get width() {
     return this.renderer_.width;
   }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -41,6 +41,8 @@ export {
 
 export { Box2 } from "./math/box2";
 export { Box3 } from "./math/box3";
+export { Frustum } from "./math/frustum";
+export { Plane } from "./math/plane";
 export { Spherical } from "./math/spherical";
 
 export type { Region } from "./data/region";

--- a/packages/core/src/math/frustum.ts
+++ b/packages/core/src/math/frustum.ts
@@ -1,0 +1,75 @@
+import { Plane } from "./plane";
+import { Box3 } from "./box3";
+import { mat4, vec3 } from "gl-matrix";
+
+export class Frustum {
+  private readonly planes_: [Plane, Plane, Plane, Plane, Plane, Plane];
+
+  constructor(m: mat4) {
+    this.planes_ = [
+      new Plane(vec3.create(), 0),
+      new Plane(vec3.create(), 0),
+      new Plane(vec3.create(), 0),
+      new Plane(vec3.create(), 0),
+      new Plane(vec3.create(), 0),
+      new Plane(vec3.create(), 0),
+    ];
+    this.setWithViewProjection(m);
+  }
+
+  // Uses the fast plane-extraction algorithm described in
+  // Gribb & Hartmann (1997): https://tinyurl.com/5x5htcwm
+  public setWithViewProjection(m: mat4) {
+    const n = vec3.create();
+
+    // Left: row3 + row0
+    this.planes_[0].set(
+      vec3.set(n, m[3] + m[0], m[7] + m[4], m[11] + m[8]),
+      m[15] + m[12]
+    );
+
+    // Right: row3 - row0
+    this.planes_[1].set(
+      vec3.set(n, m[3] - m[0], m[7] - m[4], m[11] - m[8]),
+      m[15] - m[12]
+    );
+
+    // Top: row3 - row1
+    this.planes_[2].set(
+      vec3.set(n, m[3] - m[1], m[7] - m[5], m[11] - m[9]),
+      m[15] - m[13]
+    );
+
+    // Bottom: row3 + row1
+    this.planes_[3].set(
+      vec3.set(n, m[3] + m[1], m[7] + m[5], m[11] + m[9]),
+      m[15] + m[13]
+    );
+
+    // Near: row3 + row2
+    this.planes_[4].set(
+      vec3.set(n, m[3] + m[2], m[7] + m[6], m[11] + m[10]),
+      m[15] + m[14]
+    );
+
+    // Far: row3 - row2
+    this.planes_[5].set(
+      vec3.set(n, m[3] - m[2], m[7] - m[6], m[11] - m[10]),
+      m[15] - m[14]
+    );
+
+    for (const p of this.planes_) p.normalize();
+  }
+
+  public intersectsWithBox3(box: Box3) {
+    const v = vec3.create();
+    for (const plane of this.planes_) {
+      const n = plane.normal;
+      v[0] = n[0] > 0 ? box.max[0] : box.min[0];
+      v[1] = n[1] > 0 ? box.max[1] : box.min[1];
+      v[2] = n[2] > 0 ? box.max[2] : box.min[2];
+      if (plane.signedDistanceToPoint(v) < 0) return false;
+    }
+    return true;
+  }
+}

--- a/packages/core/src/math/plane.ts
+++ b/packages/core/src/math/plane.ts
@@ -1,0 +1,31 @@
+import { vec3 } from "gl-matrix";
+
+export class Plane {
+  public normal: vec3;
+  public signedDistance: number;
+
+  constructor(normal: vec3 = vec3.fromValues(0, 1, 0), distance = 0) {
+    this.normal = vec3.clone(normal);
+    this.signedDistance = distance;
+  }
+
+  public set(normal: vec3, distance: number) {
+    this.normal = vec3.clone(normal);
+    this.signedDistance = distance;
+  }
+
+  public signedDistanceToPoint(point: vec3) {
+    // Algebraic convention ax + by + cz + d = 0
+    // Negative values mean the point lies opposite the plane's normal
+    return vec3.dot(this.normal, point) + this.signedDistance;
+  }
+
+  public normalize() {
+    const len = vec3.length(this.normal);
+    if (len > 0) {
+      const inv = 1 / len;
+      vec3.scale(this.normal, this.normal, inv);
+      this.signedDistance *= inv;
+    }
+  }
+}

--- a/packages/core/src/objects/cameras/camera.ts
+++ b/packages/core/src/objects/cameras/camera.ts
@@ -1,4 +1,5 @@
 import { RenderableObject } from "../../core/renderable_object";
+import { Frustum } from "../../math/frustum";
 import { mat4, vec3, vec4 } from "gl-matrix";
 
 export type CameraType = "OrthographicCamera" | "PerspectiveCamera";
@@ -32,6 +33,12 @@ export abstract class Camera extends RenderableObject {
   get up() {
     const m = this.transform.matrix;
     return vec3.fromValues(m[4], m[5], m[6]);
+  }
+
+  get frustum() {
+    return new Frustum(
+      mat4.multiply(mat4.create(), this.projectionMatrix, this.viewMatrix)
+    );
   }
 
   public abstract setAspectRatio(aspectRatio: number): void;

--- a/packages/core/src/renderers/webgl_renderer.ts
+++ b/packages/core/src/renderers/webgl_renderer.ts
@@ -15,6 +15,7 @@ import { Viewport } from "../core/viewport";
 import { Camera } from "../objects/cameras/camera";
 
 import { mat4, vec2 } from "gl-matrix";
+import { Frustum } from "../math/frustum";
 
 // The library's coordinate system is left-handed.
 // With the default camera, the standard basis vectors should
@@ -34,6 +35,7 @@ export class WebGLRenderer extends Renderer {
   private readonly bindings_: WebGLBuffers;
   private readonly textures_: WebGLTextures;
   private readonly state_: WebGLState;
+  private renderedObjectsPerFrame_ = 0;
 
   constructor(canvas: HTMLCanvasElement) {
     super(canvas);
@@ -76,16 +78,19 @@ export class WebGLRenderer extends Renderer {
       return;
     }
     this.state_.setViewport(viewportBox);
-
+    this.renderedObjectsPerFrame_ = 0;
     this.clear();
 
     const { opaque, transparent } = viewport.layerManager.partitionLayers();
 
     this.state_.setDepthMask(true);
+
+    const frustum = viewport.camera.frustum;
+
     for (const layer of opaque) {
       layer.update();
       if (layer.state === "ready") {
-        this.renderLayer(layer, viewport.camera);
+        this.renderLayer(layer, viewport.camera, frustum);
       }
     }
 
@@ -93,18 +98,26 @@ export class WebGLRenderer extends Renderer {
     for (const layer of transparent) {
       layer.update();
       if (layer.state !== "ready") continue;
-      this.renderLayer(layer, viewport.camera);
+      this.renderLayer(layer, viewport.camera, frustum);
     }
     this.state_.setDepthMask(true);
+
+    this.renderedObjects_ = this.renderedObjectsPerFrame_;
   }
 
   public get textureInfo() {
     return this.textures_.textureInfo;
   }
 
-  private renderLayer(layer: Layer, camera: Camera) {
+  private renderLayer(layer: Layer, camera: Camera, frustum: Frustum) {
     this.state_.setBlendingMode(layer.transparent ? layer.blendMode : "none");
-    layer.objects.forEach((_, i) => this.renderObject(layer, i, camera));
+
+    layer.objects.forEach((object, i) => {
+      if (frustum.intersectsWithBox3(object.boundingBox)) {
+        this.renderObject(layer, i, camera);
+        this.renderedObjectsPerFrame_ += 1;
+      }
+    });
   }
 
   protected renderObject(layer: Layer, objectIndex: number, camera: Camera) {

--- a/packages/core/test/frustum.test.ts
+++ b/packages/core/test/frustum.test.ts
@@ -3,8 +3,34 @@ import { mat4, vec3 } from "gl-matrix";
 
 import { Box3, Frustum } from "@";
 
+function identity(): mat4 {
+  return mat4.create();
+}
+
+function ortho(p: {
+  left: number;
+  right: number;
+  bottom: number;
+  top: number;
+  near: number;
+  far: number;
+}): mat4 {
+  const { left, right, bottom, top, near, far } = p;
+  return mat4.ortho(mat4.create(), left, right, bottom, top, near, far);
+}
+
+function perspective(p: {
+  fov: number; // radians
+  aspect: number;
+  near: number;
+  far: number;
+}): mat4 {
+  const { fov, aspect, near, far } = p;
+  return mat4.perspective(mat4.create(), fov, aspect, near, far);
+}
+
 test("identity frustum with box fully inside", () => {
-  const vp = mat4.create();
+  const vp = identity();
   const frustum = new Frustum(vp);
 
   const b = new Box3(
@@ -15,7 +41,7 @@ test("identity frustum with box fully inside", () => {
 });
 
 test("identity frustum with box fully outside on +X", () => {
-  const vp = mat4.create();
+  const vp = identity();
   const frustum = new Frustum(vp);
 
   const b = new Box3(
@@ -26,7 +52,7 @@ test("identity frustum with box fully outside on +X", () => {
 });
 
 test("identity frustum with box touching +X plane counts as intersecting", () => {
-  const vp = mat4.create();
+  const vp = identity();
   const frustum = new Frustum(vp);
 
   const b = new Box3(
@@ -37,7 +63,14 @@ test("identity frustum with box touching +X plane counts as intersecting", () =>
 });
 
 test("orthographic frustum with inside box", () => {
-  const vp = mat4.ortho(mat4.create(), -1, 1, -1, 1, 1, 10);
+  const vp = ortho({
+    left: -1,
+    right: 1,
+    bottom: -1,
+    top: 1,
+    near: 1,
+    far: 10,
+  });
   const frustum = new Frustum(vp);
 
   const b = new Box3(
@@ -48,7 +81,14 @@ test("orthographic frustum with inside box", () => {
 });
 
 test("orthographic frustum rejects box fully outside on -X", () => {
-  const vp = mat4.ortho(mat4.create(), -1, 1, -1, 1, 1, 10);
+  const vp = ortho({
+    left: -1,
+    right: 1,
+    bottom: -1,
+    top: 1,
+    near: 1,
+    far: 10,
+  });
   const frustum = new Frustum(vp);
 
   const b = new Box3(
@@ -59,7 +99,14 @@ test("orthographic frustum rejects box fully outside on -X", () => {
 });
 
 test("orthographic frustum rejects box in front of near plane", () => {
-  const vp = mat4.ortho(mat4.create(), -1, 1, -1, 1, 1, 10);
+  const vp = ortho({
+    left: -1,
+    right: 1,
+    bottom: -1,
+    top: 1,
+    near: 1,
+    far: 10,
+  });
   const frustum = new Frustum(vp);
 
   const b = new Box3(
@@ -70,7 +117,14 @@ test("orthographic frustum rejects box in front of near plane", () => {
 });
 
 test("orthographic frustum rejects box beyond far plane", () => {
-  const vp = mat4.ortho(mat4.create(), -1, 1, -1, 1, 1, 10);
+  const vp = ortho({
+    left: -1,
+    right: 1,
+    bottom: -1,
+    top: 1,
+    near: 1,
+    far: 10,
+  });
   const frustum = new Frustum(vp);
 
   const b = new Box3(
@@ -81,8 +135,8 @@ test("orthographic frustum rejects box beyond far plane", () => {
 });
 
 test("perspective frustum with small box at z = -3 inside", () => {
-  const proj = mat4.perspective(mat4.create(), Math.PI / 2, 1, 1, 10);
-  const frustum = new Frustum(proj);
+  const vp = perspective({ fov: Math.PI / 2, aspect: 1, near: 1, far: 10 });
+  const frustum = new Frustum(vp);
 
   const b = new Box3(
     vec3.fromValues(-0.2, -0.2, -3.2),
@@ -92,8 +146,8 @@ test("perspective frustum with small box at z = -3 inside", () => {
 });
 
 test("perspective frustum rejects far left box at z = -3", () => {
-  const proj = mat4.perspective(mat4.create(), Math.PI / 2, 1, 1, 10);
-  const frustum = new Frustum(proj);
+  const vp = perspective({ fov: Math.PI / 2, aspect: 1, near: 1, far: 10 });
+  const frustum = new Frustum(vp);
 
   const b = new Box3(
     vec3.fromValues(-4.25, -0.25, -3.25),
@@ -103,8 +157,8 @@ test("perspective frustum rejects far left box at z = -3", () => {
 });
 
 test("perspective frustum rejects boxes in front of near and beyond far", () => {
-  const proj = mat4.perspective(mat4.create(), Math.PI / 2, 1, 1, 10);
-  const frustum = new Frustum(proj);
+  const vp = perspective({ fov: Math.PI / 2, aspect: 1, near: 1, far: 10 });
+  const frustum = new Frustum(vp);
 
   const tooNear = new Box3(
     vec3.fromValues(-0.1, -0.1, -0.6),
@@ -120,8 +174,8 @@ test("perspective frustum rejects boxes in front of near and beyond far", () => 
 });
 
 test("perspective frustum with box touching side plane counts as intersecting", () => {
-  const proj = mat4.perspective(mat4.create(), Math.PI / 2, 1, 1, 10);
-  const frustum = new Frustum(proj);
+  const vp = perspective({ fov: Math.PI / 2, aspect: 1, near: 1, far: 10 });
+  const frustum = new Frustum(vp);
 
   const b = new Box3(
     vec3.fromValues(1.5, -0.2, -2.2),

--- a/packages/core/test/frustum.test.ts
+++ b/packages/core/test/frustum.test.ts
@@ -1,0 +1,131 @@
+import { expect, test } from "vitest";
+import { mat4, vec3 } from "gl-matrix";
+
+import { Box3, Frustum } from "@";
+
+test("identity frustum with box fully inside", () => {
+  const vp = mat4.create();
+  const frustum = new Frustum(vp);
+
+  const b = new Box3(
+    vec3.fromValues(-0.25, -0.25, -0.25),
+    vec3.fromValues(0.25, 0.25, 0.25)
+  );
+  expect(frustum.intersectsWithBox3(b)).toBe(true);
+});
+
+test("identity frustum with box fully outside on +X", () => {
+  const vp = mat4.create();
+  const frustum = new Frustum(vp);
+
+  const b = new Box3(
+    vec3.fromValues(1.25, -0.25, -0.25),
+    vec3.fromValues(1.75, 0.25, 0.25)
+  );
+  expect(frustum.intersectsWithBox3(b)).toBe(false);
+});
+
+test("identity frustum with box touching +X plane counts as intersecting", () => {
+  const vp = mat4.create();
+  const frustum = new Frustum(vp);
+
+  const b = new Box3(
+    vec3.fromValues(0.5, -0.2, -0.2),
+    vec3.fromValues(1.0, 0.2, 0.2)
+  );
+  expect(frustum.intersectsWithBox3(b)).toBe(true);
+});
+
+test("orthographic frustum with inside box", () => {
+  const vp = mat4.ortho(mat4.create(), -1, 1, -1, 1, 1, 10);
+  const frustum = new Frustum(vp);
+
+  const b = new Box3(
+    vec3.fromValues(-0.25, -0.25, -3.25),
+    vec3.fromValues(0.25, 0.25, -2.75)
+  );
+  expect(frustum.intersectsWithBox3(b)).toBe(true);
+});
+
+test("orthographic frustum rejects box fully outside on -X", () => {
+  const vp = mat4.ortho(mat4.create(), -1, 1, -1, 1, 1, 10);
+  const frustum = new Frustum(vp);
+
+  const b = new Box3(
+    vec3.fromValues(-2.25, -0.25, -3.25),
+    vec3.fromValues(-1.75, 0.25, -2.75)
+  );
+  expect(frustum.intersectsWithBox3(b)).toBe(false);
+});
+
+test("orthographic frustum rejects box in front of near plane", () => {
+  const vp = mat4.ortho(mat4.create(), -1, 1, -1, 1, 1, 10);
+  const frustum = new Frustum(vp);
+
+  const b = new Box3(
+    vec3.fromValues(-0.1, -0.1, -0.6),
+    vec3.fromValues(0.1, 0.1, -0.4)
+  );
+  expect(frustum.intersectsWithBox3(b)).toBe(false);
+});
+
+test("orthographic frustum rejects box beyond far plane", () => {
+  const vp = mat4.ortho(mat4.create(), -1, 1, -1, 1, 1, 10);
+  const frustum = new Frustum(vp);
+
+  const b = new Box3(
+    vec3.fromValues(-0.25, -0.25, -11.25),
+    vec3.fromValues(0.25, 0.25, -10.75)
+  );
+  expect(frustum.intersectsWithBox3(b)).toBe(false);
+});
+
+test("perspective frustum with small box at z = -3 inside", () => {
+  const proj = mat4.perspective(mat4.create(), Math.PI / 2, 1, 1, 10);
+  const frustum = new Frustum(proj);
+
+  const b = new Box3(
+    vec3.fromValues(-0.2, -0.2, -3.2),
+    vec3.fromValues(0.2, 0.2, -2.8)
+  );
+  expect(frustum.intersectsWithBox3(b)).toBe(true);
+});
+
+test("perspective frustum rejects far left box at z = -3", () => {
+  const proj = mat4.perspective(mat4.create(), Math.PI / 2, 1, 1, 10);
+  const frustum = new Frustum(proj);
+
+  const b = new Box3(
+    vec3.fromValues(-4.25, -0.25, -3.25),
+    vec3.fromValues(-3.75, 0.25, -2.75)
+  );
+  expect(frustum.intersectsWithBox3(b)).toBe(false);
+});
+
+test("perspective frustum rejects boxes in front of near and beyond far", () => {
+  const proj = mat4.perspective(mat4.create(), Math.PI / 2, 1, 1, 10);
+  const frustum = new Frustum(proj);
+
+  const tooNear = new Box3(
+    vec3.fromValues(-0.1, -0.1, -0.6),
+    vec3.fromValues(0.1, 0.1, -0.4)
+  );
+  const tooFar = new Box3(
+    vec3.fromValues(-0.5, -0.5, -11.5),
+    vec3.fromValues(0.5, 0.5, -10.5)
+  );
+
+  expect(frustum.intersectsWithBox3(tooNear)).toBe(false);
+  expect(frustum.intersectsWithBox3(tooFar)).toBe(false);
+});
+
+test("perspective frustum with box touching side plane counts as intersecting", () => {
+  const proj = mat4.perspective(mat4.create(), Math.PI / 2, 1, 1, 10);
+  const frustum = new Frustum(proj);
+
+  const b = new Box3(
+    vec3.fromValues(1.5, -0.2, -2.2),
+    vec3.fromValues(2.0, 0.2, -1.8)
+  );
+  expect(frustum.intersectsWithBox3(b)).toBe(true);
+});

--- a/packages/core/test/plane.test.ts
+++ b/packages/core/test/plane.test.ts
@@ -1,0 +1,56 @@
+import { expect, test } from "vitest";
+import { vec3 } from "gl-matrix";
+
+import { Plane } from "@";
+
+test("constructed with default values", () => {
+  const plane = new Plane();
+
+  expect(plane.normal).toEqual(vec3.fromValues(0, 1, 0));
+  expect(plane.signedDistance).toEqual(0);
+});
+
+test("distance to point returns correct sign relative to plane", () => {
+  const plane = new Plane(vec3.fromValues(0, 1, 0), 1);
+
+  expect(plane.signedDistanceToPoint(vec3.fromValues(0, -1, 0))).toBe(0);
+  expect(plane.signedDistanceToPoint(vec3.fromValues(0, -2, 0))).toBeLessThan(
+    0
+  );
+  expect(plane.signedDistanceToPoint(vec3.fromValues(0, 0, 0))).toBeGreaterThan(
+    0
+  );
+});
+
+test("arbitrary normal and distance yields correct distance magnitude", () => {
+  const plane = new Plane(vec3.fromValues(1, 1, 1), 3);
+
+  expect(plane.signedDistanceToPoint(vec3.fromValues(-1, -1, -1))).toBe(0);
+  expect(plane.signedDistanceToPoint(vec3.fromValues(0, 0, 0))).toBe(3);
+  expect(plane.signedDistanceToPoint(vec3.fromValues(-2, -2, -2))).toBe(-3);
+});
+
+test("normalize scales normal to unit length and adjusts distance", () => {
+  const plane = new Plane(vec3.fromValues(0, 2, 0), 2);
+  plane.normalize();
+
+  expect(vec3.length(plane.normal)).toBeCloseTo(1);
+  expect(plane.signedDistance).toBeCloseTo(1);
+});
+
+test("normalize handles zero-length normal safely", () => {
+  const plane = new Plane(vec3.fromValues(0, 0, 0), 5);
+  plane.normalize();
+
+  expect(plane.normal).toEqual(vec3.fromValues(0, 0, 0));
+  expect(plane.signedDistance).toBe(5);
+});
+
+test("plane with inverted normal flips distance sign", () => {
+  const planePositiveY = new Plane(vec3.fromValues(0, 1, 0), 1);
+  const planeNegativeY = new Plane(vec3.fromValues(0, -1, 0), -1);
+  const point = vec3.fromValues(0, 2, 0);
+
+  expect(planePositiveY.signedDistanceToPoint(point)).toBe(3);
+  expect(planeNegativeY.signedDistanceToPoint(point)).toBe(-3);
+});


### PR DESCRIPTION
### Summary

This PR introduces a `Frustum` type that can be constructed from a projection
matrix and integrates frustum culling into the rendering pipeline. The
integration was primarily done to verify correctness, but I think it makes
sense to keep it as part of the pipeline.

### Note

In the next PR, I plan to integrate the `Frustum` into the `ChunkManagerSource`, replacing the current 2D view-bounds intersection logic. This will move us closer to a unified 2D/3D system that supports chunked images, orthoslices, and volume rendering.

### Tests & Checks

- All the checks have passed
- Added unit tests for `Plane` and `Frustum`
- Visual verification
  - I added a "Rendered Objects" count to the chunk info overlay
  - I manually verified the perspective camera case in 3D (see video below)

https://github.com/user-attachments/assets/02c859c1-30fd-4209-b6b6-b14ffa2959b3
