### PR TITLE
feat: rename npm package from pre-release to core

### DIFF
--- a/.github/workflows/deploy-examples.yml
+++ b/.github/workflows/deploy-examples.yml
@@ -33,10 +33,10 @@ jobs:
         run: npm ci
 
       - name: Build core library
-        run: npm run build --workspace=@idetik/core-prerelease
+        run: npm run build --workspace=@idetik/core
 
       - name: Build examples for production
-        run: npm run build:examples --workspace=@idetik/core-prerelease
+        run: npm run build:examples --workspace=@idetik/core
 
       - name: Setup Pages
         uses: actions/configure-pages@v4

--- a/.github/workflows/lint-test-build.yml
+++ b/.github/workflows/lint-test-build.yml
@@ -30,17 +30,17 @@ jobs:
 
       - name: Compile TypeScript
         run: |
-          npm run compile --workspace=@idetik/core-prerelease
-          npm run build --workspace=@idetik/core-prerelease
+          npm run compile --workspace=@idetik/core
+          npm run build --workspace=@idetik/core
 
       - name: Lint
         run: |
-          npm run lint --workspace=@idetik/core-prerelease
-          npm run format-check --workspace=@idetik/core-prerelease
+          npm run lint --workspace=@idetik/core
+          npm run format-check --workspace=@idetik/core
 
       - name: Run tests with coverage
         run: |
-          npm run test-with-coverage --workspace=@idetik/core-prerelease
+          npm run test-with-coverage --workspace=@idetik/core
 
   build:
     needs: lint-and-test

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ A layer-based library for interactive visualization of large datasets.
 
 ## Release
 
-Currently, we maintain the [@idetik/core-prerelease](https://www.npmjs.com/package/@idetik/core-prerelease?activeTab=readme) package on npm.
+We maintain the [@idetik/core](https://www.npmjs.com/package/@idetik/core?activeTab=readme) package on npm.
 
 ### Automatic Release Process (Recommended)
 
@@ -55,7 +55,7 @@ We use [semantic-release](https://github.com/semantic-release/semantic-release) 
    - Determines the version bump
    - Updates the version in `packages/core/package.json`
    - Generates/updates `CHANGELOG.md`
-   - Publishes to npm as `@idetik/core-prerelease`
+   - Publishes to npm as `@idetik/core`
    - Creates a GitHub release with release notes
    - Tags the release (e.g., `v7.1.0`)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1198,7 +1198,7 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
-    "node_modules/@idetik/core-prerelease": {
+    "node_modules/@idetik/core": {
       "resolved": "packages/core",
       "link": true
     },
@@ -12473,8 +12473,8 @@
       }
     },
     "packages/core": {
-      "name": "@idetik/core-prerelease",
-      "version": "7.0.0",
+      "name": "@idetik/core",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "gl-matrix": "^3.4.3",

--- a/package.json
+++ b/package.json
@@ -8,14 +8,14 @@
     "npm": ">=11.3.0"
   },
   "scripts": {
-    "build": "npm run build --workspace=@idetik/core-prerelease",
-    "build:examples": "npm run build:examples --workspace=@idetik/core-prerelease",
-    "examples": "npm run dev --workspace=@idetik/core-prerelease",
-    "compile": "npm run compile --workspace=@idetik/core-prerelease",
-    "lint": "npm run lint --workspace=@idetik/core-prerelease",
-    "format": "npm run format --workspace=@idetik/core-prerelease",
-    "format-check": "npm run format-check --workspace=@idetik/core-prerelease",
-    "test-with-coverage": "npm run test-with-coverage --workspace=@idetik/core-prerelease"
+    "build": "npm run build --workspace=@idetik/core",
+    "build:examples": "npm run build:examples --workspace=@idetik/core",
+    "examples": "npm run dev --workspace=@idetik/core",
+    "compile": "npm run compile --workspace=@idetik/core",
+    "lint": "npm run lint --workspace=@idetik/core",
+    "format": "npm run format --workspace=@idetik/core",
+    "format-check": "npm run format-check --workspace=@idetik/core",
+    "test-with-coverage": "npm run test-with-coverage --workspace=@idetik/core"
   },
   "devDependencies": {
     "@rollup/plugin-typescript": "^12.1.2",

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,13 +1,11 @@
-# @idetik/core-prerelease
-
-🚨 **This package is under active development.** Use at your own risk in production environments.
+# @idetik/core
 
 A layer-based visualization abstraction for interactive rendering of large datasets, with particular focus on scientific imaging and bioinformatics data formats.
 
 ## Installation
 
 ```bash
-npm install @idetik/core-prerelease
+npm install @idetik/core
 ```
 
 ## Releasing

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@idetik/core-prerelease",
-  "version": "7.0.0",
+  "name": "@idetik/core",
+  "version": "0.1.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
  ## Summary
  Renames the package from `@idetik/core-prerelease` to `@idetik/core` and resets versioning to `0.1.0`.

  ## Changes
  - Updated package name in `packages/core/package.json`
  - Reset version to `0.1.0`
  - Updated all workspace references in root `package.json`
  - Updated package references in READMEs and documentation
  - Updated GitHub workflows to use new package name

  ## Migration Notes
  The old `@idetik/core-prerelease` package will be deprecated on npm with a notice directing users to `@idetik/core`.

  Users should update their dependencies:
  ```bash
  npm uninstall @idetik/core-prerelease
  npm install @idetik/core
```

Pre-Merge Steps
  - delete existing tags

  Post-Merge Steps

  - Publish @idetik/core@0.1.0 to npm
  - Deprecate @idetik/core-prerelease on npm