### PR TITLE
Fix some prefetched chunks from being disposed

### DIFF
--- a/packages/core/src/core/chunk_manager_source.ts
+++ b/packages/core/src/core/chunk_manager_source.ts
@@ -357,7 +357,7 @@ export class ChunkManagerSource {
           isFallbackLOD,
           isCurrentLOD,
           isVisible,
-          chunk.prefetch,
+          eligibleForPrefetch,
           isChannelInSlice
         )
       ) {

--- a/packages/core/src/core/chunk_manager_source.ts
+++ b/packages/core/src/core/chunk_manager_source.ts
@@ -412,14 +412,14 @@ export class ChunkManagerSource {
     isFallbackLOD: boolean,
     isCurrentLOD: boolean,
     isVisible: boolean,
-    isPrefetch: boolean,
+    eligibleForPrefetch: boolean,
     isChannelInSlice: boolean
   ) {
     if (!isLoaded) return false;
     if (!isChannelInSlice) return true;
     if (isFallbackLOD) return false;
     if (!isCurrentLOD) return true;
-    return !isVisible && !isPrefetch;
+    return !isVisible && !eligibleForPrefetch;
   }
 
   private disposeChunk(chunk: Chunk) {


### PR DESCRIPTION
### Summary
This fixes a bug that was introduced in #493 because `chunk.prefetch` is not equivalent to `eligibleForPrefetch` in the `shouldDispose` method.

That bug can be reproduced on `main` by loading the default chunk streaming example, panning the camera, and observing the chunk stats changing in a way that they shouldn't (i.e. some prefetched chunks get reloaded).

### Tests & Checks
I tested the chunk streaming example.
