### PR TITLE
feat: add volume shaders for different texture data types

### DIFF
--- a/packages/core/src/layers/volume_layer.ts
+++ b/packages/core/src/layers/volume_layer.ts
@@ -1,4 +1,5 @@
 import { Layer } from "../core/layer";
+import { Texture3D } from "../objects/textures/texture_3d";
 import { VolumeRenderable } from "../objects/renderable/volume_renderable";
 
 export class VolumeLayer extends Layer {
@@ -7,7 +8,10 @@ export class VolumeLayer extends Layer {
   constructor() {
     super();
 
-    const renderable = new VolumeRenderable();
+    const data = new Uint8Array([127, 0, 0, 127, 127, 0, 0, 127]);
+    const texture = new Texture3D(data, 2, 2, 2);
+    texture.unpackAlignment = 1;
+    const renderable = new VolumeRenderable(1, 1, 1, texture);
     renderable.wireframeEnabled = true;
 
     this.addObject(renderable);

--- a/packages/core/src/layers/volume_layer.ts
+++ b/packages/core/src/layers/volume_layer.ts
@@ -8,7 +8,7 @@ export class VolumeLayer extends Layer {
   constructor() {
     super();
 
-    const data = new Uint8Array([127, 0, 0, 127, 127, 0, 0, 127]);
+    const data = new Int8Array([127, 0, 0, 127, 127, 0, 0, 127]);
     const texture = new Texture3D(data, 2, 2, 2);
     texture.unpackAlignment = 1;
     const renderable = new VolumeRenderable(1, 1, 1, texture);

--- a/packages/core/src/objects/renderable/volume_renderable.ts
+++ b/packages/core/src/objects/renderable/volume_renderable.ts
@@ -27,12 +27,12 @@ function dataTypeToVolumeShader(dataType: TextureDataType): Shader {
     case "byte":
     case "int":
     case "short":
-      return "intVolumeImage";
+      return "intVolume";
     case "unsigned_short":
     case "unsigned_byte":
     case "unsigned_int":
-      return "uintVolumeImage";
+      return "uintVolume";
     case "float":
-      return "floatVolumeImage";
+      return "floatVolume";
   }
 }

--- a/packages/core/src/objects/renderable/volume_renderable.ts
+++ b/packages/core/src/objects/renderable/volume_renderable.ts
@@ -1,14 +1,38 @@
+import { Shader } from "../../renderers/shaders";
 import { RenderableObject } from "../../core/renderable_object";
 import { BoxGeometry } from "../geometry/box_geometry";
+import { TextureDataType } from "../textures/texture";
+import { Texture3D } from "../textures/texture_3d";
 
 export class VolumeRenderable extends RenderableObject {
-  constructor() {
+  constructor(
+    width: number,
+    height: number,
+    depth: number,
+    texture: Texture3D
+  ) {
     super();
-    this.geometry = new BoxGeometry(1, 1, 1, 1, 1, 1);
-    this.programName = "volume";
+    this.geometry = new BoxGeometry(width, height, depth, 1, 1, 1);
+    this.setTexture(0, texture);
+    this.programName = dataTypeToImageShader(texture.dataType);
   }
 
   public get type() {
     return "VolumeRenderable";
+  }
+}
+
+function dataTypeToImageShader(dataType: TextureDataType): Shader {
+  switch (dataType) {
+    case "byte":
+    case "int":
+    case "short":
+      return "intVolumeImage";
+    case "unsigned_short":
+    case "unsigned_byte":
+    case "unsigned_int":
+      return "uintVolumeImage";
+    case "float":
+      return "floatVolumeImage";
   }
 }

--- a/packages/core/src/objects/renderable/volume_renderable.ts
+++ b/packages/core/src/objects/renderable/volume_renderable.ts
@@ -14,7 +14,7 @@ export class VolumeRenderable extends RenderableObject {
     super();
     this.geometry = new BoxGeometry(width, height, depth, 1, 1, 1);
     this.setTexture(0, texture);
-    this.programName = dataTypeToImageShader(texture.dataType);
+    this.programName = dataTypeToVolumeShader(texture.dataType);
   }
 
   public get type() {
@@ -22,7 +22,7 @@ export class VolumeRenderable extends RenderableObject {
   }
 }
 
-function dataTypeToImageShader(dataType: TextureDataType): Shader {
+function dataTypeToVolumeShader(dataType: TextureDataType): Shader {
   switch (dataType) {
     case "byte":
     case "int":

--- a/packages/core/src/renderers/shaders/index.ts
+++ b/packages/core/src/renderers/shaders/index.ts
@@ -14,14 +14,16 @@ import labelImage from "./label_image_frag.glsl";
 export type Shader =
   | "floatScalarImage"
   | "floatScalarImageArray"
+  | "floatVolumeImage"
   | "intScalarImage"
   | "intScalarImageArray"
+  | "intVolumeImage"
   | "labelImage"
   | "points"
   | "projectedLine"
   | "uintScalarImage"
   | "uintScalarImageArray"
-  | "volume"
+  | "uintVolumeImage"
   | "wireframe";
 
 type ShaderCode = {
@@ -76,8 +78,18 @@ export const shaderCode: Record<Shader, ShaderCode> = {
     vertex: meshVertexShader,
     fragment: labelImage,
   },
-  volume: {
+  floatVolumeImage: {
     vertex: volumeVertexShader,
     fragment: volumeFragmentShader,
+  },
+  intVolumeImage: {
+    vertex: volumeVertexShader,
+    fragment: volumeFragmentShader,
+    fragmentDefines: new Map([["TEXTURE_DATA_TYPE_INT", "1"]]),
+  },
+  uintVolumeImage: {
+    vertex: volumeVertexShader,
+    fragment: volumeFragmentShader,
+    fragmentDefines: new Map([["TEXTURE_DATA_TYPE_UINT", "1"]]),
   },
 };

--- a/packages/core/src/renderers/shaders/index.ts
+++ b/packages/core/src/renderers/shaders/index.ts
@@ -14,16 +14,16 @@ import labelImage from "./label_image_frag.glsl";
 export type Shader =
   | "floatScalarImage"
   | "floatScalarImageArray"
-  | "floatVolumeImage"
+  | "floatVolume"
   | "intScalarImage"
   | "intScalarImageArray"
-  | "intVolumeImage"
+  | "intVolume"
   | "labelImage"
   | "points"
   | "projectedLine"
   | "uintScalarImage"
   | "uintScalarImageArray"
-  | "uintVolumeImage"
+  | "uintVolume"
   | "wireframe";
 
 type ShaderCode = {
@@ -78,16 +78,16 @@ export const shaderCode: Record<Shader, ShaderCode> = {
     vertex: meshVertexShader,
     fragment: labelImage,
   },
-  floatVolumeImage: {
+  floatVolume: {
     vertex: volumeVertexShader,
     fragment: volumeFragmentShader,
   },
-  intVolumeImage: {
+  intVolume: {
     vertex: volumeVertexShader,
     fragment: volumeFragmentShader,
     fragmentDefines: new Map([["TEXTURE_DATA_TYPE_INT", "1"]]),
   },
-  uintVolumeImage: {
+  uintVolume: {
     vertex: volumeVertexShader,
     fragment: volumeFragmentShader,
     fragmentDefines: new Map([["TEXTURE_DATA_TYPE_UINT", "1"]]),

--- a/packages/core/src/renderers/shaders/volume_frag.glsl
+++ b/packages/core/src/renderers/shaders/volume_frag.glsl
@@ -1,9 +1,29 @@
 #version 300 es
+#pragma inject_defines
 
 precision mediump float;
 
 layout (location = 0) out vec4 fragColor;
 
+#if defined TEXTURE_DATA_TYPE_INT
+uniform mediump isampler3D ImageSampler;
+#elif defined TEXTURE_DATA_TYPE_UINT
+uniform mediump usampler3D ImageSampler;
+#else
+uniform mediump sampler3D ImageSampler;
+#endif
+
+in vec2 TexCoords;
+
 void main() {
-    fragColor = vec4(0.6, 0.6, 0.6, 1.0);
+    float alpha = 0.0;
+    /* Will replace fixed steps and normalization with uniforms later */
+    for (int i = 0; i < 256; i++) {
+        float z = float(i) / 255.0;
+        float texel = float(texture(ImageSampler, vec3(TexCoords, z)).r);
+        float newAlpha = clamp(texel / 1000.0, 0.0, 1.0);
+        alpha = (1.0 - alpha) * newAlpha + alpha;
+    }
+    float displayValue = alpha;
+    fragColor = vec4(displayValue, displayValue, displayValue, 1.0);
 }

--- a/packages/core/src/renderers/shaders/volume_vert.glsl
+++ b/packages/core/src/renderers/shaders/volume_vert.glsl
@@ -1,10 +1,14 @@
 #version 300 es
 
 layout (location = 0) in vec3 inPosition;
+layout (location = 2) in vec2 inUV;
 
 uniform mat4 Projection;
 uniform mat4 ModelView;
 
+out vec2 TexCoords;
+
 void main() {
+    TexCoords = inUV;
     gl_Position = Projection * ModelView * vec4(inPosition, 1.0);
 }


### PR DESCRIPTION
### Summary
<!---
  Please try to cover the following questions in your summary:
  1. Describe the product (or technical) problem you are solving.
  2. Explain the engineering solution you have chosen.
  3. Discuss the implementation choices/tradeoffs you have made.
-->

Primary goal here is to add support for different texture data types in volume rendering.

This adds support for passing width, height, depth, and a Texture3D to the volume renderable object. The dataType in the Texture3D is used to determine the correct shader program name to use for the volume renderable based on the type of data stored in the texture. This is using a similar pattern to how the image renderable uses the texture to determine the program name.

Three new shader programs are added, a `floatVolume`, `intVolume` and `uintVolume`. Also added is an example volume rendering fragment shader, and passing UVs from the vertex shader for volume rendering to the fragment shader for volume rendering. This volume rendering is still straight down Z of the volume, will be updated later to respect camera parameters and allow inputs to modify normalization of values.

For the example of trying these, a simple checker board style small texture has been defined in the volume layer.  https://github.com/chanzuckerberg/idetik/pull/515/files has more progress on using actual data here, but this PR is separated into two to hopefully be easier to review. 

<img width="889" height="721" alt="image" src="https://github.com/user-attachments/assets/a4bc97b6-316a-4623-88fe-d295887086f0" />


### Tests & Checks
<!---
  How did you validate that your changes were implemented correctly?
  
  Please think about the following prompts:
  1. I wrote automated tests.
  2. I manually tested my changes, and here's what I did:
-->

Manually tested changes by changing the data type of the texture used in the volume layer example. Also checked other pre-existing examples just in case. This changes the multiple-viewports example to look as:
<img width="1658" height="880" alt="image" src="https://github.com/user-attachments/assets/de62ac3d-f097-47ac-83fa-8a2a2e3c435c" />

