### PR TITLE
fix: Pass ChannelCount uniform to improve multi-channel image fragment shader

### DIFF
--- a/packages/core/src/objects/renderable/image_renderable.ts
+++ b/packages/core/src/objects/renderable/image_renderable.ts
@@ -20,6 +20,7 @@ type SingleUniformValues = {
 
 type ArrayUniformValues = {
   ImageSampler: number;
+  ChannelCount: number;
   "Visible[0]": boolean[];
   "Color[0]": number[];
   "ValueOffset[0]": number[];

--- a/packages/core/src/objects/renderable/image_renderable.ts
+++ b/packages/core/src/objects/renderable/image_renderable.ts
@@ -15,6 +15,7 @@ type SingleUniformValues = {
   Color: vec3;
   ValueOffset: number;
   ValueScale: number;
+  ChannelCount: number;
 };
 
 type ArrayUniformValues = {
@@ -76,6 +77,7 @@ export class ImageRenderable extends RenderableObject {
         Color: color.rgb,
         ValueOffset: -contrastLimits[0],
         ValueScale: 1 / (contrastLimits[1] - contrastLimits[0]),
+        ChannelCount: 1,
       };
     } else {
       // Texture2DArray case
@@ -100,6 +102,7 @@ export class ImageRenderable extends RenderableObject {
         "Color[0]": color,
         "ValueOffset[0]": valueOffset,
         "ValueScale[0]": valueScale,
+        ChannelCount: this.channels_.length,
       };
     }
   }

--- a/packages/core/src/renderers/shaders/scalar_image_array_frag.glsl
+++ b/packages/core/src/renderers/shaders/scalar_image_array_frag.glsl
@@ -19,12 +19,13 @@ uniform vec3 Color[MAX_CHANNELS];
 uniform float ValueOffset[MAX_CHANNELS];
 uniform float ValueScale[MAX_CHANNELS];
 uniform float u_opacity;
+uniform int ChannelCount;
 
 in vec2 TexCoords;
 
 void main() {
     vec3 rgbColor = vec3(0, 0, 0);
-    for (int i = 0; i < MAX_CHANNELS; i++) {
+    for (int i = 0; i < ChannelCount; i++) {
         if (!Visible[i]) continue;
         float texel = float(texture(ImageSampler, vec3(TexCoords, i)).r);
         float value = (texel + ValueOffset[i]) * ValueScale[i];

--- a/packages/core/src/renderers/shaders/scalar_image_array_frag.glsl
+++ b/packages/core/src/renderers/shaders/scalar_image_array_frag.glsl
@@ -14,18 +14,18 @@ uniform mediump sampler2DArray ImageSampler;
 #endif
 // Define a maximum number of channels
 #define MAX_CHANNELS 32
+uniform uint ChannelCount;
 uniform bool Visible[MAX_CHANNELS];
 uniform vec3 Color[MAX_CHANNELS];
 uniform float ValueOffset[MAX_CHANNELS];
 uniform float ValueScale[MAX_CHANNELS];
 uniform float u_opacity;
-uniform int ChannelCount;
 
 in vec2 TexCoords;
 
 void main() {
     vec3 rgbColor = vec3(0, 0, 0);
-    for (int i = 0; i < ChannelCount; i++) {
+    for (uint i = 0u; i < ChannelCount; i++) {
         if (!Visible[i]) continue;
         float texel = float(texture(ImageSampler, vec3(TexCoords, i)).r);
         float value = (texel + ValueOffset[i]) * ValueScale[i];

--- a/packages/core/src/renderers/webgl_shader_program.ts
+++ b/packages/core/src/renderers/webgl_shader_program.ts
@@ -63,6 +63,9 @@ export class WebGLShaderProgram {
       case this.gl_.FLOAT_MAT4:
         this.gl_.uniformMatrix4fv(location, false, value as mat4);
         break;
+      case this.gl_.INT:
+        this.gl_.uniform1i(location, value as number);
+        break;
       // For samplers, the value is the texture index.
       case this.gl_.SAMPLER_2D:
       case this.gl_.SAMPLER_CUBE:
@@ -165,6 +168,7 @@ const SUPPORTED_UNIFORM_TYPES_ =
         WebGL2RenderingContext.FLOAT_VEC2,
         WebGL2RenderingContext.FLOAT_VEC3,
         WebGL2RenderingContext.FLOAT_MAT4,
+        WebGL2RenderingContext.INT,
         WebGL2RenderingContext.SAMPLER_2D,
         WebGL2RenderingContext.SAMPLER_CUBE,
         WebGL2RenderingContext.SAMPLER_3D,

--- a/packages/core/src/renderers/webgl_shader_program.ts
+++ b/packages/core/src/renderers/webgl_shader_program.ts
@@ -66,6 +66,9 @@ export class WebGLShaderProgram {
       case this.gl_.INT:
         this.gl_.uniform1i(location, value as number);
         break;
+      case this.gl_.UNSIGNED_INT:
+        this.gl_.uniform1ui(location, value as number);
+        break;
       // For samplers, the value is the texture index.
       case this.gl_.SAMPLER_2D:
       case this.gl_.SAMPLER_CUBE:
@@ -168,7 +171,6 @@ const SUPPORTED_UNIFORM_TYPES_ =
         WebGL2RenderingContext.FLOAT_VEC2,
         WebGL2RenderingContext.FLOAT_VEC3,
         WebGL2RenderingContext.FLOAT_MAT4,
-        WebGL2RenderingContext.INT,
         WebGL2RenderingContext.SAMPLER_2D,
         WebGL2RenderingContext.SAMPLER_CUBE,
         WebGL2RenderingContext.SAMPLER_3D,
@@ -176,10 +178,12 @@ const SUPPORTED_UNIFORM_TYPES_ =
         WebGL2RenderingContext.SAMPLER_2D_SHADOW,
         WebGL2RenderingContext.SAMPLER_CUBE_SHADOW,
         WebGL2RenderingContext.SAMPLER_2D_ARRAY_SHADOW,
+        WebGL2RenderingContext.INT,
         WebGL2RenderingContext.INT_SAMPLER_2D,
         WebGL2RenderingContext.INT_SAMPLER_3D,
         WebGL2RenderingContext.INT_SAMPLER_CUBE,
         WebGL2RenderingContext.INT_SAMPLER_2D_ARRAY,
+        WebGL2RenderingContext.UNSIGNED_INT,
         WebGL2RenderingContext.UNSIGNED_INT_SAMPLER_2D,
         WebGL2RenderingContext.UNSIGNED_INT_SAMPLER_3D,
         WebGL2RenderingContext.UNSIGNED_INT_SAMPLER_CUBE,


### PR DESCRIPTION
### Summary
I was seeing rather large FPS drops/changes with window size.

Initially I just wrote this off as the number of tiles being rendered or something and didn't really think about it, but then @shlomnissan said:
> Why would rendering FPS change based on window size and LOD?

Great question! This prompt gave me pause. Even at LOD0 and full screen it's something like 24 tiles which should be no problem. I hadn't done the profiling to see what the limitation was but I saw the same behavior in the chunk streaming example on main. I think vsync can make it seem more drastic because FPS seems to hover around integer fractions of the refresh rate (20, 30, 40, 60 FPS, etc,).

So I set out to do that profiling. `gl.finish()` did not seem to be enough to actually block until the draw was done, but I found this code which does (h/t Claude):
```
gl.flush(); // Submit commands
gl.finish(); // Wait for completion
// Read a pixel to force full pipeline flush
const dummy = new Uint8Array(4);
gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, dummy);
```
This showed rendering at full screen on my external monitor takes ~**10 ms**. Full screen on my laptop monitor is about 2x the pixels and takes close to **20 ms**. Double the pixels double the time felt like a fragment shader issue.

So....I looked again at our fragment shader. It's very simple, but there is a loop over `MAX_CHANNELS`. Hard-coding the loop to 1 channel fixes the problem completely. I think this is a case of the GPU/shader compiler having poor branch prediction and optimization. So even though we `continue` the loop it is slow! Passing a uniform for `ChannelCount` also fixes the problem and I get a very solid 120 FPS (except examples that include volume rendering, but this is not necessarily unexpected at this time).

### Related Issue
[Slack thread](https://czi-sci.slack.com/archives/C07GHGSJSQP/p1763069155880939?thread_ts=1763059524.732459&cid=C07GHGSJSQP)

### Tests & Checks
Tested FPS from stats.js and with logging timing
GPU time is now comfortably <10ms/frame for the chunk_streaming examples.
