### PR TITLE
feat: allow simple LOD and time coordinate selection in volume layer

### DIFF
--- a/packages/core/examples/multi_viewport/main.ts
+++ b/packages/core/examples/multi_viewport/main.ts
@@ -35,6 +35,11 @@ const imageLayer = new ChunkedImageLayer({
   policy: createExplorationPolicy(),
   channelProps: [{ contrastLimits: [0, 200] }],
 });
+const volumeLayer = new VolumeLayer({
+  source,
+  sliceCoords,
+  policy: createExplorationPolicy(),
+});
 
 // TODO: the reason this example works is that the volume viewport uses a perspective camera
 // otherwise the ChunkManager update causes interference between the two viewports
@@ -50,7 +55,7 @@ new Idetik({
       element: document.querySelector<HTMLDivElement>("#viewport-left")!,
       camera: camera3D,
       cameraControls: new OrbitControls(camera3D, { radius: 3 }),
-      layers: [new VolumeLayer()],
+      layers: [volumeLayer],
     },
     {
       id: "slice",

--- a/packages/core/examples/volume_rendering/index.html
+++ b/packages/core/examples/volume_rendering/index.html
@@ -12,6 +12,8 @@
         display: flex;
         width: 100%;
         height: 100%;
+        font-family: monospace;
+        font-size: 12px;
       }
       #main {
         display: flex;
@@ -23,12 +25,23 @@
         width: 100%;
         height: 100%;
       }
+
+      #time-point {
+        position: absolute;
+        bottom: 0.5em;
+        left: 0.3em;
+        margin: 1em;
+        padding: 1em;
+        color: white;
+        background-color: rgba(0, 0, 0, 0.5);
+      }
     </style>
   </head>
   <body>
     <div id="main">
       <canvas id="canvas"></canvas>
     </div>
+    <div id="time-point"></div>
     <script type="module" src="./main.ts"></script>
   </body>
 </html>

--- a/packages/core/examples/volume_rendering/main.ts
+++ b/packages/core/examples/volume_rendering/main.ts
@@ -56,6 +56,7 @@ idetik.start();
 const controls = {
   showWireframes: volumeLayer.debugMode,
   showTimePointOverlay: true,
+  lod: 2,
 };
 
 const gui = new GUI({ width: 500 });
@@ -90,4 +91,14 @@ overlaysFolder
   .onChange((show: boolean) => {
     volumeLayer.debugMode = show;
     controls.showWireframes = show;
+  });
+
+const volumeFolder = gui.addFolder("Volume Rendering");
+
+volumeFolder
+  .add(controls, "lod", 0, 2, 1)
+  .name("Level of Detail (LOD)")
+  .onChange((lod: number) => {
+    volumeLayer.lod = lod;
+    controls.lod = lod;
   });

--- a/packages/core/examples/volume_rendering/main.ts
+++ b/packages/core/examples/volume_rendering/main.ts
@@ -1,6 +1,11 @@
 import { Idetik, VolumeLayer, PerspectiveCamera, OmeZarrImageSource } from "@";
 import { OrbitControls } from "@/objects/cameras/orbit_controls";
-import { createExplorationPolicy } from "@/core/image_source_policy";
+import {
+  createExplorationPolicy,
+  createPlaybackPolicy,
+} from "@/core/image_source_policy";
+import { addDimensionSlider } from "../lil_gui_utils";
+import GUI from "lil-gui";
 
 const url =
   "https://public.czbiohub.org/royerlab/zebrahub/imaging/single-objective/ZSNS001.ome.zarr/";
@@ -20,7 +25,20 @@ const volumeLayer = new VolumeLayer({
 });
 volumeLayer.debugMode = true;
 
-new Idetik({
+// Largely copied from chunk streaming example
+const t = { translate: 0.0, scale: 1.0, shape: 791 };
+const tMin = t.translate;
+const tMax = t.translate + t.scale * t.shape - t.scale;
+const tRange = { min: tMin, max: tMax };
+const timePointDiv = document.querySelector<HTMLDivElement>("#time-point")!;
+const timePointOverlay = {
+  update(_idetik: Idetik, _timestamp?: DOMHighResTimeStamp) {
+    const time = sliceCoords.t;
+    timePointDiv.textContent = `t = ${time}`;
+  },
+};
+
+const idetik = new Idetik({
   canvas: document.querySelector<HTMLCanvasElement>("#canvas")!,
   viewports: [
     {
@@ -29,5 +47,47 @@ new Idetik({
       layers: [volumeLayer],
     },
   ],
+  overlays: [timePointOverlay],
   showStats: true,
-}).start();
+});
+
+idetik.start();
+
+const controls = {
+  showWireframes: volumeLayer.debugMode,
+  showTimePointOverlay: true,
+};
+
+const gui = new GUI({ width: 500 });
+
+addDimensionSlider({
+  gui,
+  sliceCoords,
+  dimensionName: "t",
+  minValue: tRange.min,
+  maxValue: tRange.max,
+  stepValue: t.scale,
+  playback: {
+    onRateChange: (rateHz: number) => {
+      volumeLayer.sourcePolicy =
+        rateHz > 0 ? createPlaybackPolicy() : createExplorationPolicy();
+    },
+  },
+});
+
+const overlaysFolder = gui.addFolder("Overlays");
+
+overlaysFolder
+  .add(controls, "showTimePointOverlay")
+  .name("Show time point overlay")
+  .onChange((show: boolean) => {
+    timePointDiv.style.display = show ? "block" : "none";
+  });
+
+overlaysFolder
+  .add(controls, "showWireframes")
+  .name("Show tile wireframes")
+  .onChange((show: boolean) => {
+    volumeLayer.debugMode = show;
+    controls.showWireframes = show;
+  });

--- a/packages/core/examples/volume_rendering/main.ts
+++ b/packages/core/examples/volume_rendering/main.ts
@@ -1,15 +1,32 @@
-import { Idetik, VolumeLayer, PerspectiveCamera } from "@";
+import { Idetik, VolumeLayer, PerspectiveCamera, OmeZarrImageSource } from "@";
 import { OrbitControls } from "@/objects/cameras/orbit_controls";
+import { createExplorationPolicy } from "@/core/image_source_policy";
+
+const url =
+  "https://public.czbiohub.org/royerlab/zebrahub/imaging/single-objective/ZSNS001.ome.zarr/";
+const source = new OmeZarrImageSource(url);
+
+const sliceCoords = {
+  t: 400,
+  z: undefined,
+  c: 0,
+};
 
 const camera = new PerspectiveCamera();
+const volumeLayer = new VolumeLayer({
+  source,
+  sliceCoords,
+  policy: createExplorationPolicy(),
+});
+volumeLayer.debugMode = true;
 
 new Idetik({
   canvas: document.querySelector<HTMLCanvasElement>("#canvas")!,
   viewports: [
     {
       camera,
-      cameraControls: new OrbitControls(camera, { radius: 3 }),
-      layers: [new VolumeLayer()],
+      cameraControls: new OrbitControls(camera, { radius: 2000 }),
+      layers: [volumeLayer],
     },
   ],
   showStats: true,

--- a/packages/core/src/core/chunk_manager_source.ts
+++ b/packages/core/src/core/chunk_manager_source.ts
@@ -165,6 +165,10 @@ export class ChunkManagerSource {
       .every((c) => c.state === "loaded");
   }
 
+  public getAllChunksAtLod(lod: number): Chunk[] {
+    return this.getChunksAtCurrentTime().filter((c) => c.lod === lod);
+  }
+
   public updateAndCollectChunkChanges(lodFactor: number, viewBounds2D: Box2) {
     this.setLOD(lodFactor);
 

--- a/packages/core/src/layers/volume_layer.ts
+++ b/packages/core/src/layers/volume_layer.ts
@@ -139,6 +139,8 @@ export class VolumeLayer extends Layer {
       this.lastLoadedTime_ === this.sliceCoords_.t
     )
       return chunks;
+    this.clearObjects();
+    this.releaseAndRemoveChunks(this.visibleChunks_.keys());
     Logger.debug("VolumeLayer", `Loading chunks for LOD ${this.lod_}`);
     for (const chunk of chunks) {
       this.chunkManagerSource_.loadChunkData(

--- a/packages/core/src/layers/volume_layer.ts
+++ b/packages/core/src/layers/volume_layer.ts
@@ -2,7 +2,10 @@ import { Chunk, ChunkSource, SliceCoordinates } from "../data/chunk";
 import { Layer, LayerOptions } from "../core/layer";
 import { VolumeRenderable } from "../objects/renderable/volume_renderable";
 import { IdetikContext } from "../idetik";
-import { ChunkManagerSource } from "../core/chunk_manager_source";
+import {
+  ChunkManagerSource,
+  INTERNAL_POLICY_KEY,
+} from "../core/chunk_manager_source";
 import { ImageSourcePolicy } from "../core/image_source_policy";
 import { Texture3D } from "../objects/textures/texture_3d";
 import { Logger } from "../utilities/logger";
@@ -20,12 +23,13 @@ export class VolumeLayer extends Layer {
   private readonly sliceCoords_: SliceCoordinates;
   private readonly visibleChunks_: Map<Chunk, VolumeRenderable> = new Map();
 
-  private policy_: ImageSourcePolicy;
+  private sourcePolicy_: ImageSourcePolicy;
   private chunkManagerSource_?: ChunkManagerSource;
   private lod_ = -1;
   private debugMode_ = false;
 
   private lastLoadedLod_ = -1;
+  private lastLoadedTime_ = -1;
 
   public get lod() {
     return this.lod_;
@@ -43,6 +47,22 @@ export class VolumeLayer extends Layer {
 
   public set debugMode(debug: boolean) {
     this.debugMode_ = debug;
+  }
+
+  public get sourcePolicy(): Readonly<ImageSourcePolicy> {
+    return this.sourcePolicy_;
+  }
+
+  public set sourcePolicy(newPolicy: ImageSourcePolicy) {
+    if (this.sourcePolicy_ !== newPolicy) {
+      this.sourcePolicy_ = newPolicy;
+      if (this.chunkManagerSource_) {
+        this.chunkManagerSource_.setImageSourcePolicy(
+          newPolicy,
+          INTERNAL_POLICY_KEY
+        );
+      }
+    }
   }
 
   private createVolume(chunk: Chunk) {
@@ -75,7 +95,7 @@ export class VolumeLayer extends Layer {
     super(layerOptions);
     this.source_ = source;
     this.sliceCoords_ = sliceCoords;
-    this.policy_ = policy;
+    this.sourcePolicy_ = policy;
 
     this.setState("initialized");
   }
@@ -97,7 +117,7 @@ export class VolumeLayer extends Layer {
     this.chunkManagerSource_ = await context.chunkManager.addSource(
       this.source_,
       this.sliceCoords_,
-      this.policy_
+      this.sourcePolicy_
     );
   }
 
@@ -114,7 +134,11 @@ export class VolumeLayer extends Layer {
       this.lod_ = this.chunkManagerSource_.lodCount - 1;
     }
     const chunks = this.chunkManagerSource_.getAllChunksAtLod(this.lod_);
-    if (this.lastLoadedLod_ === this.lod_) return chunks;
+    if (
+      this.lastLoadedLod_ === this.lod_ &&
+      this.lastLoadedTime_ === this.sliceCoords_.t
+    )
+      return chunks;
     Logger.debug("VolumeLayer", `Loading chunks for LOD ${this.lod_}`);
     for (const chunk of chunks) {
       this.chunkManagerSource_.loadChunkData(
@@ -123,6 +147,7 @@ export class VolumeLayer extends Layer {
       );
     }
     this.lastLoadedLod_ = this.lod_;
+    this.lastLoadedTime_ = this.sliceCoords_.t ?? -1;
     return chunks;
   }
 

--- a/packages/core/src/layers/volume_layer.ts
+++ b/packages/core/src/layers/volume_layer.ts
@@ -1,24 +1,156 @@
-import { Layer } from "../core/layer";
-import { Texture3D } from "../objects/textures/texture_3d";
+import { Chunk, ChunkSource, SliceCoordinates } from "../data/chunk";
+import { Layer, LayerOptions } from "../core/layer";
 import { VolumeRenderable } from "../objects/renderable/volume_renderable";
+import { IdetikContext } from "../idetik";
+import { ChunkManagerSource } from "../core/chunk_manager_source";
+import { ImageSourcePolicy } from "../core/image_source_policy";
+import { Texture3D } from "../objects/textures/texture_3d";
+import { Logger } from "../utilities/logger";
+
+export type VolumeLayerProps = LayerOptions & {
+  source: ChunkSource;
+  sliceCoords: SliceCoordinates;
+  policy: ImageSourcePolicy;
+};
 
 export class VolumeLayer extends Layer {
   public readonly type = "VolumeLayer";
 
-  constructor() {
-    super();
+  private readonly source_: ChunkSource;
+  private readonly sliceCoords_: SliceCoordinates;
+  private readonly visibleChunks_: Map<Chunk, VolumeRenderable> = new Map();
 
-    const data = new Int8Array([127, 0, 0, 127, 127, 0, 0, 127]);
-    const texture = new Texture3D(data, 2, 2, 2);
-    texture.unpackAlignment = 1;
-    const renderable = new VolumeRenderable(1, 1, 1, texture);
-    renderable.wireframeEnabled = true;
+  private policy_: ImageSourcePolicy;
+  private chunkManagerSource_?: ChunkManagerSource;
+  private lod_ = -1;
+  private debugMode_ = false;
 
-    this.addObject(renderable);
-    this.setState("ready");
+  private lastLoadedLod_ = -1;
+
+  public get lod() {
+    return this.lod_;
+  }
+
+  public set lod(value: number) {
+    this.lod_ = value;
+    this.clearObjects();
+    this.updateChunks();
+  }
+
+  public get debugMode(): boolean {
+    return this.debugMode_;
+  }
+
+  public set debugMode(debug: boolean) {
+    this.debugMode_ = debug;
+  }
+
+  private createVolume(chunk: Chunk) {
+    const volume = new VolumeRenderable(
+      chunk.shape.x,
+      chunk.shape.y,
+      chunk.shape.z,
+      Texture3D.createWithChunk(chunk)
+    );
+    volume.transform.setScale([chunk.scale.x, chunk.scale.y, chunk.scale.z]);
+    const originOffset = {
+      x: (chunk.shape.x * chunk.scale.x) / 2,
+      y: (chunk.shape.y * chunk.scale.y) / 2,
+      z: (chunk.shape.z * chunk.scale.z) / 2,
+    };
+    volume.transform.setTranslation([
+      chunk.offset.x + originOffset.x,
+      chunk.offset.y + originOffset.y,
+      chunk.offset.z + originOffset.z,
+    ]);
+    return volume;
+  }
+
+  constructor({
+    source,
+    sliceCoords,
+    policy,
+    ...layerOptions
+  }: VolumeLayerProps) {
+    super(layerOptions);
+    this.source_ = source;
+    this.sliceCoords_ = sliceCoords;
+    this.policy_ = policy;
+
+    this.setState("initialized");
+  }
+
+  private getVolumeRenderableForChunk(chunk: Chunk): VolumeRenderable {
+    const existing = this.visibleChunks_.get(chunk);
+    if (existing) return existing;
+
+    return this.createVolume(chunk);
+  }
+
+  public async onAttached(context: IdetikContext) {
+    if (this.chunkManagerSource_) {
+      throw new Error(
+        "ChunkedImageLayer is already attached. " +
+          "A layer cannot be attached to multiple LayerManagers simultaneously."
+      );
+    }
+    this.chunkManagerSource_ = await context.chunkManager.addSource(
+      this.source_,
+      this.sliceCoords_,
+      this.policy_
+    );
+  }
+
+  public onDetached(): void {
+    this.chunkManagerSource_ = undefined;
+    this.releaseAndRemoveChunks(this.visibleChunks_.keys());
+    this.clearObjects();
+  }
+
+  // Should ideally use chunk manager for this
+  private loadChunks() {
+    if (!this.chunkManagerSource_) return;
+    if (this.lod_ === -1) {
+      this.lod_ = this.chunkManagerSource_.lodCount - 1;
+    }
+    const chunks = this.chunkManagerSource_.getAllChunksAtLod(this.lod_);
+    if (this.lastLoadedLod_ === this.lod_) return chunks;
+    Logger.debug("VolumeLayer", `Loading chunks for LOD ${this.lod_}`);
+    for (const chunk of chunks) {
+      this.chunkManagerSource_.loadChunkData(
+        chunk,
+        new AbortController().signal
+      );
+    }
+    this.lastLoadedLod_ = this.lod_;
+    return chunks;
+  }
+
+  private updateChunks() {
+    const chunks = this.loadChunks();
+    if (!chunks) return;
+    for (const chunk of chunks) {
+      // TODO should be able to use loaded state later
+      if (!chunk.data) continue;
+      if (this.visibleChunks_.has(chunk)) continue;
+      const volume = this.getVolumeRenderableForChunk(chunk);
+      volume.wireframeEnabled = this.debugMode;
+      this.visibleChunks_.set(chunk, volume);
+      this.addObject(volume);
+    }
+    if (this.state !== "ready") this.setState("ready");
+  }
+
+  private releaseAndRemoveChunks(chunks: Iterable<Chunk>) {
+    for (const chunk of chunks) {
+      const volume = this.visibleChunks_.get(chunk);
+      if (volume) {
+        this.visibleChunks_.delete(chunk);
+      }
+    }
   }
 
   public update() {
-    // TODO: implement
+    this.updateChunks();
   }
 }

--- a/packages/core/src/objects/renderable/volume_renderable.ts
+++ b/packages/core/src/objects/renderable/volume_renderable.ts
@@ -13,7 +13,8 @@ export class VolumeRenderable extends RenderableObject {
   ) {
     super();
     this.geometry = new BoxGeometry(width, height, depth, 1, 1, 1);
-    this.cullFaceMode = "back";
+    // TODO temp change, works with SimpleGeometry not box geometry
+    this.cullFaceMode = "none";
     this.setTexture(0, texture);
     this.programName = dataTypeToVolumeShader(texture.dataType);
   }


### PR DESCRIPTION
### Summary

This is designed to help us in discussing and getting feedback on how we should integrate the volume layer with the chunk manager. This first pass shown here is really designed to allow quickly setting up volume rendering itself, with the focus being on picking a time + lod combo, loading all chunks corresponding to that, and doing the rendering.

This was to allow making quick progress on rendering without getting too bogged down on data loading.

I'm very sorry this description is a bit brief! I'd be happy to point to specific details or chat through this together as to how to integrate this later.

Please see https://github.com/chanzuckerberg/idetik/tree/seankmartin-aranega/develop-demo-marching for the example shown in the image, that branch builds on top of this simple data loading to actually do blending, turn off depth testing, and do ray marching based on the camera position:

<img width="1835" height="877" alt="image" src="https://github.com/user-attachments/assets/c379c81b-0c23-4149-88de-23ccf9c660a4" />

<img width="1835" height="877" alt="image" src="https://github.com/user-attachments/assets/bcc8762f-790a-4535-880e-14d64f3be8fe" />
