### PR TITLE
chore: configure dependabot to add a conventional commit prefix

### DIFF
--- a/.github/depentabot.yml
+++ b/.github/depentabot.yml
@@ -5,9 +5,8 @@ updates:
     schedule:
       interval: "weekly"
     commit-message:
-      # fix will trigger a patch release
+      # see .releaserc.json in the repo root for how these prefixes map to version bumps
       prefix: "fix"
-      # chore will *also* trigger a patch release
       prefix-development: "chore"
       # includes the scope in the prefix, like this:
       # fix(deps):

--- a/.github/depentabot.yml
+++ b/.github/depentabot.yml
@@ -7,7 +7,7 @@ updates:
     commit-message:
       # fix will trigger a patch release
       prefix: "fix"
-      # chore does not trigger a release
+      # chore will *also* trigger a patch release
       prefix-development: "chore"
       # includes the scope in the prefix, like this:
       # fix(deps):

--- a/.github/depentabot.yml
+++ b/.github/depentabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      # fix will trigger a patch release
+      prefix: "fix"
+      # chore does not trigger a release
+      prefix-development: "chore"
+      # includes the scope in the prefix, like this:
+      # fix(deps):
+      # chore(deps-dev):
+      include: "scope"

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -10,10 +10,12 @@ on:
       - edited
       - synchronize
       - reopened
+      - ready_for_review
 
 jobs:
   check-pr-title:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
     steps:
       - name: Check PR title
         uses: amannn/action-semantic-pull-request@v5


### PR DESCRIPTION
### Summary
Every time dependabot makes a PR it fails the PR title test. I'm hoping this will fix it.

I'm not sure it will take effect for the existing PRs, so we might need to wait for the next to confirm it's working.

I also added configs to skip the title check for draft PRs just to show a bit less red in the PR list.