### PR TITLE
refactor: use SourceDimensionMap instead of LoaderAttributes 

### DIFF
--- a/packages/core/examples/image_labels_overlay_with_value_picking/main.ts
+++ b/packages/core/examples/image_labels_overlay_with_value_picking/main.ts
@@ -24,7 +24,7 @@ const labelsSource = new OmeZarrImageSource(labelsUrl);
 
 const lod = 0;
 const loader = await imageSource.open();
-const dimensionMap = loader.getSourceDimensionMap();
+const dimensions = loader.getSourceDimensionMap();
 
 // Phase contrast limits were chosen qualitatively.
 const phaseChannelIndex = 0;
@@ -32,32 +32,12 @@ const phaseContrastLimits: [number, number] = [20, 200];
 
 const tStartPoint = 0;
 
-const dimensionExtent = (dimensionName: string) => {
-  const allDimensions = [
-    dimensionMap.x,
-    dimensionMap.y,
-    dimensionMap.z,
-    dimensionMap.c,
-    dimensionMap.t,
-  ].filter((d) => d !== undefined);
-
-  const dimension = allDimensions.find((d) => d.name === dimensionName);
-  if (!dimension) {
-    throw new Error(`Dimension ${dimensionName} not found`);
-  }
-
-  return {
-    size: dimension.lods[lod].size,
-    scale: dimension.lods[lod].scale,
-  };
-};
-
-const zExtent = dimensionExtent("Z");
-const zMidPoint = 0.5 * zExtent.size * zExtent.scale;
-const xExtent = dimensionExtent("X");
-const xStopPoint = xExtent.size * xExtent.scale;
-const yExtent = dimensionExtent("Y");
-const yStopPoint = yExtent.size * yExtent.scale;
+const zLod = dimensions.z!.lods[0];
+const zMidPoint = 0.5 * zLod.size * zLod.scale;
+const xLod = dimensions.x.lods[0];
+const xStopPoint = xLod.size * xLod.scale;
+const yLod = dimensions.y.lods[0];
+const yStopPoint = yLod.size * yLod.scale;
 
 const sliceCoords = {
   t: tStartPoint,

--- a/packages/core/examples/image_labels_overlay_with_value_picking/main.ts
+++ b/packages/core/examples/image_labels_overlay_with_value_picking/main.ts
@@ -24,8 +24,7 @@ const labelsSource = new OmeZarrImageSource(labelsUrl);
 
 const lod = 0;
 const loader = await imageSource.open();
-const attributes = loader.getAttributes();
-const attributesAtLod = attributes[lod];
+const dimensionMap = loader.getSourceDimensionMap();
 
 // Phase contrast limits were chosen qualitatively.
 const phaseChannelIndex = 0;
@@ -34,12 +33,22 @@ const phaseContrastLimits: [number, number] = [20, 200];
 const tStartPoint = 0;
 
 const dimensionExtent = (dimensionName: string) => {
-  const index = attributesAtLod.dimensionNames.findIndex(
-    (d) => d === dimensionName
-  );
+  const allDimensions = [
+    dimensionMap.x,
+    dimensionMap.y,
+    dimensionMap.z,
+    dimensionMap.c,
+    dimensionMap.t,
+  ].filter((d) => d !== undefined);
+
+  const dimension = allDimensions.find((d) => d.name === dimensionName);
+  if (!dimension) {
+    throw new Error(`Dimension ${dimensionName} not found`);
+  }
+
   return {
-    size: attributesAtLod.shape[index],
-    scale: attributesAtLod.scale[index],
+    size: dimension.lods[lod].size,
+    scale: dimension.lods[lod].scale,
   };
 };
 

--- a/packages/core/examples/image_mask_overlay/main.ts
+++ b/packages/core/examples/image_mask_overlay/main.ts
@@ -18,17 +18,11 @@ const maskUrl = `${baseUrl}/Annotations/100/membrane-1.0_segmentationmask.zarr`;
 // Source is 3D with axes (z, y, x), so we provide an interval in z
 const imageSource = new OmeZarrImageSource(imageUrl);
 const loader = await imageSource.open();
-const dimensionMap = loader.getSourceDimensionMap();
-const lods = dimensionMap.numLods;
-const lastLod = lods - 1;
+const dimensions = loader.getSourceDimensionMap();
 
 const zDimName = "z";
-const zDimension = dimensionMap.z;
-if (!zDimension) {
-  throw new Error(`Dimension ${zDimName} not found`);
-}
 const zMin = 0;
-const zMax = zDimension.lods[lastLod].size;
+const zMax = dimensions.z!.lods[dimensions.numLods - 1].size;
 const region: Region = [
   { dimension: zDimName, index: { type: "full" } },
   { dimension: "x", index: { type: "full" } },

--- a/packages/core/examples/image_mask_overlay/main.ts
+++ b/packages/core/examples/image_mask_overlay/main.ts
@@ -18,16 +18,17 @@ const maskUrl = `${baseUrl}/Annotations/100/membrane-1.0_segmentationmask.zarr`;
 // Source is 3D with axes (z, y, x), so we provide an interval in z
 const imageSource = new OmeZarrImageSource(imageUrl);
 const loader = await imageSource.open();
-const attributes = loader.getAttributes();
-const lods = attributes.length;
-const attributesForLastLod = attributes[lods - 1];
+const dimensionMap = loader.getSourceDimensionMap();
+const lods = dimensionMap.numLods;
+const lastLod = lods - 1;
 
 const zDimName = "z";
-const zAxisIndex = attributesForLastLod.dimensionNames.findIndex(
-  (dim) => dim === zDimName
-);
+const zDimension = dimensionMap.z;
+if (!zDimension) {
+  throw new Error(`Dimension ${zDimName} not found`);
+}
 const zMin = 0;
-const zMax = attributesForLastLod.shape[zAxisIndex];
+const zMax = zDimension.lods[lastLod].size;
 const region: Region = [
   { dimension: zDimName, index: { type: "full" } },
   { dimension: "x", index: { type: "full" } },

--- a/packages/core/examples/image_series_labels_overlay/main.ts
+++ b/packages/core/examples/image_series_labels_overlay/main.ts
@@ -23,37 +23,17 @@ const labelsSource = new OmeZarrImageSource(labelsUrl);
 
 const lod = 0;
 const loader = await imageSource.open();
-const dimensionMap = loader.getSourceDimensionMap();
+const dimensions = loader.getSourceDimensionMap();
 
 // Phase contrast limits were chosen qualitatively.
 const phaseChannelIndex = 0;
 const phaseContrastLimits: [number, number] = [20, 200];
 
-const dimensionExtent = (dimensionName: string) => {
-  const allDimensions = [
-    dimensionMap.x,
-    dimensionMap.y,
-    dimensionMap.z,
-    dimensionMap.c,
-    dimensionMap.t,
-  ].filter((d) => d !== undefined);
-
-  const dimension = allDimensions.find((d) => d.name === dimensionName);
-  if (!dimension) {
-    throw new Error(`Dimension ${dimensionName} not found`);
-  }
-
-  return {
-    size: dimension.lods[lod].size,
-    scale: dimension.lods[lod].scale,
-  };
-};
-
-const tExtent = dimensionExtent("T");
+const tLod = dimensions.t!.lods[lod];
 const tMin = 0;
-const tMax = tExtent.size;
-const zExtent = dimensionExtent("Z");
-const zMidPoint = 0.5 * zExtent.size * zExtent.scale;
+const tMax = tLod.size;
+const zLod = dimensions.z!.lods[lod];
+const zMidPoint = 0.5 * zLod.size * zLod.scale;
 
 const region: Region = [
   { dimension: "T", index: { type: "full" } },

--- a/packages/core/examples/image_series_labels_overlay/main.ts
+++ b/packages/core/examples/image_series_labels_overlay/main.ts
@@ -23,20 +23,29 @@ const labelsSource = new OmeZarrImageSource(labelsUrl);
 
 const lod = 0;
 const loader = await imageSource.open();
-const attributes = loader.getAttributes();
-const attributesAtLod = attributes[lod];
+const dimensionMap = loader.getSourceDimensionMap();
 
 // Phase contrast limits were chosen qualitatively.
 const phaseChannelIndex = 0;
 const phaseContrastLimits: [number, number] = [20, 200];
 
 const dimensionExtent = (dimensionName: string) => {
-  const index = attributesAtLod.dimensionNames.findIndex(
-    (d) => d === dimensionName
-  );
+  const allDimensions = [
+    dimensionMap.x,
+    dimensionMap.y,
+    dimensionMap.z,
+    dimensionMap.c,
+    dimensionMap.t,
+  ].filter((d) => d !== undefined);
+
+  const dimension = allDimensions.find((d) => d.name === dimensionName);
+  if (!dimension) {
+    throw new Error(`Dimension ${dimensionName} not found`);
+  }
+
   return {
-    size: attributesAtLod.shape[index],
-    scale: attributesAtLod.scale[index],
+    size: dimension.lods[lod].size,
+    scale: dimension.lods[lod].scale,
   };
 };
 

--- a/packages/core/examples/ome_zarr_v05/main.ts
+++ b/packages/core/examples/ome_zarr_v05/main.ts
@@ -16,34 +16,13 @@ const url =
   "https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/marmoset_neurons.ome.zarr";
 const source = new OmeZarrImageSource(url, "0.5");
 const loader = await source.open();
-const dimensionMap = loader.getSourceDimensionMap();
+const dimensions = loader.getSourceDimensionMap();
 const lod = 0;
 
-const dimensionInfo = (dimensionName: string) => {
-  const allDimensions = [
-    dimensionMap.x,
-    dimensionMap.y,
-    dimensionMap.z,
-    dimensionMap.c,
-    dimensionMap.t,
-  ].filter((d) => d !== undefined);
-
-  const dimension = allDimensions.find((d) => d.name === dimensionName);
-  if (!dimension) {
-    throw new Error(`Dimension ${dimensionName} not found`);
-  }
-
-  return {
-    size: dimension.lods[lod].size,
-    scale: dimension.lods[lod].scale,
-    offset: dimension.lods[lod].translation,
-  };
-};
-
-const zInfo = dimensionInfo("z");
-const zMidPoint = zInfo.offset + 0.5 * zInfo.size * zInfo.scale;
-const yInfo = dimensionInfo("y");
-const xInfo = dimensionInfo("x");
+const zLod = dimensions.z!.lods[lod];
+const zMidPoint = zLod.translation + 0.5 * zLod.size * zLod.scale;
+const yLod = dimensions.y.lods[lod];
+const xLod = dimensions.x.lods[lod];
 
 const sliceCoords = { z: zMidPoint };
 const channelProps: ChannelProps[] = [{ contrastLimits: [0, 200] }];
@@ -67,14 +46,14 @@ const layer = new ChunkedImageLayer({
   onPickValue,
 });
 const axes = new AxesLayer({
-  length: 0.75 * xInfo.scale * xInfo.size,
+  length: 0.75 * xLod.scale * xLod.size,
   width: 0.01,
 });
 const camera = new OrthographicCamera(
-  xInfo.offset,
-  xInfo.offset + xInfo.scale * xInfo.size,
-  yInfo.offset,
-  yInfo.offset + yInfo.scale * yInfo.size
+  xLod.translation,
+  xLod.translation + xLod.scale * xLod.size,
+  yLod.translation,
+  yLod.translation + yLod.scale * yLod.size
 );
 const cameraControls = new PanZoomControls(camera);
 
@@ -102,9 +81,9 @@ addDimensionSlider({
   gui,
   sliceCoords,
   dimensionName: "z",
-  minValue: zInfo.offset,
-  maxValue: zInfo.offset + (zInfo.size - 1) * zInfo.scale,
-  stepValue: zInfo.scale,
+  minValue: zLod.translation,
+  maxValue: zLod.translation + (zLod.size - 1) * zLod.scale,
+  stepValue: zLod.scale,
   playback: {},
 });
 

--- a/packages/core/examples/ome_zarr_v05/main.ts
+++ b/packages/core/examples/ome_zarr_v05/main.ts
@@ -16,17 +16,27 @@ const url =
   "https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/marmoset_neurons.ome.zarr";
 const source = new OmeZarrImageSource(url, "0.5");
 const loader = await source.open();
-const attributes = loader.getAttributes();
-const attributesAtLod0 = attributes[0];
+const dimensionMap = loader.getSourceDimensionMap();
+const lod = 0;
 
 const dimensionInfo = (dimensionName: string) => {
-  const index = attributesAtLod0.dimensionNames.findIndex(
-    (d) => d === dimensionName
-  );
+  const allDimensions = [
+    dimensionMap.x,
+    dimensionMap.y,
+    dimensionMap.z,
+    dimensionMap.c,
+    dimensionMap.t,
+  ].filter((d) => d !== undefined);
+
+  const dimension = allDimensions.find((d) => d.name === dimensionName);
+  if (!dimension) {
+    throw new Error(`Dimension ${dimensionName} not found`);
+  }
+
   return {
-    size: attributesAtLod0.shape[index],
-    scale: attributesAtLod0.scale[index],
-    offset: attributesAtLod0.translation[index],
+    size: dimension.lods[lod].size,
+    scale: dimension.lods[lod].scale,
+    offset: dimension.lods[lod].translation,
   };
 };
 

--- a/packages/core/examples/points/main.ts
+++ b/packages/core/examples/points/main.ts
@@ -189,16 +189,11 @@ virusLike.setDepth(INITIAL_Z_POSITION);
 
 const imageSource = new OmeZarrImageSource(imageUrl);
 const loader = await imageSource.open();
-const dimensionMap = loader.getSourceDimensionMap();
-const lastLod = dimensionMap.numLods - 1;
+const dimensions = loader.getSourceDimensionMap();
 
 const zDimName = "z";
-const zDimension = dimensionMap.z;
-if (!zDimension) {
-  throw new Error(`Dimension ${zDimName} not found`);
-}
 const zMin = 0;
-const zMax = zDimension.lods[lastLod].size;
+const zMax = dimensions.z!.lods[dimensions.numLods - 1].size;
 const zSlider = document.querySelector<HTMLInputElement>("#z-slider")!;
 zSlider.min = `${zMin}`;
 zSlider.max = `${zMax - 1}`;

--- a/packages/core/examples/points/main.ts
+++ b/packages/core/examples/points/main.ts
@@ -189,15 +189,16 @@ virusLike.setDepth(INITIAL_Z_POSITION);
 
 const imageSource = new OmeZarrImageSource(imageUrl);
 const loader = await imageSource.open();
-const attributes = loader.getAttributes();
-const attributesForLastLod = attributes[attributes.length - 1];
+const dimensionMap = loader.getSourceDimensionMap();
+const lastLod = dimensionMap.numLods - 1;
 
 const zDimName = "z";
-const zAxisIndex = attributesForLastLod.dimensionNames.findIndex(
-  (dim) => dim === zDimName
-);
+const zDimension = dimensionMap.z;
+if (!zDimension) {
+  throw new Error(`Dimension ${zDimName} not found`);
+}
 const zMin = 0;
-const zMax = attributesForLastLod.shape[zAxisIndex];
+const zMax = zDimension.lods[lastLod].size;
 const zSlider = document.querySelector<HTMLInputElement>("#z-slider")!;
 zSlider.min = `${zMin}`;
 zSlider.max = `${zMax - 1}`;

--- a/packages/core/src/data/chunk.ts
+++ b/packages/core/src/data/chunk.ts
@@ -104,15 +104,6 @@ export type ChunkSource = {
   open(): Promise<ChunkLoader>;
 };
 
-export type LoaderAttributes = {
-  dimensionNames: string[];
-  dimensionUnits: (string | undefined)[];
-  chunks: readonly number[];
-  shape: readonly number[];
-  scale: readonly number[];
-  translation: readonly number[];
-};
-
 export type ChunkLoader = {
   loadRegion(
     input: Region,
@@ -123,8 +114,6 @@ export type ChunkLoader = {
   getSourceDimensionMap(): SourceDimensionMap;
 
   loadChunkData(chunk: Chunk, signal: AbortSignal): Promise<void>;
-
-  getAttributes(): ReadonlyArray<LoaderAttributes>;
 };
 
 export function coordToIndex(lod: SourceDimensionLod, coord: number): number {

--- a/packages/core/src/data/ome_zarr/image_loader.ts
+++ b/packages/core/src/data/ome_zarr/image_loader.ts
@@ -7,7 +7,6 @@ import {
   SourceDimension,
   SourceDimensionMap,
   isChunkData,
-  LoaderAttributes,
   ChunkData,
   ChunkDataConstructor,
 } from "../chunk";
@@ -51,15 +50,13 @@ export class OmeZarrImageLoader {
   private readonly metadata_: OmeZarrImage["ome"]["multiscales"][number];
   private readonly arrays_: ReadonlyArray<zarr.Array<zarr.DataType, Readable>>;
   private readonly arrayParams_: ReadonlyArray<ZarrArrayParams>;
-  private readonly loaderAttributes_: ReadonlyArray<LoaderAttributes>;
   private readonly dimensions_: SourceDimensionMap;
 
   constructor(props: OmeZarrImageLoaderProps) {
     this.metadata_ = props.metadata;
     this.arrays_ = props.arrays;
     this.arrayParams_ = props.arrayParams;
-    this.loaderAttributes_ = getLoaderAttributes(this.metadata_, this.arrays_);
-    this.dimensions_ = inferSourceDimensionMap(this.loaderAttributes_);
+    this.dimensions_ = buildSourceDimensionMap(this.metadata_, this.arrays_);
   }
 
   public getSourceDimensionMap(): SourceDimensionMap {
@@ -175,9 +172,20 @@ export class OmeZarrImageLoader {
       );
     }
 
-    const attributes = this.loaderAttributes_[lod];
-    const indices = this.regionToIndices(region, attributes);
-    const { scale, translation } = attributes;
+    const indices = this.regionToIndices(region, lod);
+
+    // Build scale and translation arrays from SourceDimensionMap for this LOD
+    const allDimensions = [
+      this.dimensions_.x,
+      this.dimensions_.y,
+      this.dimensions_.z,
+      this.dimensions_.c,
+      this.dimensions_.t,
+    ].filter((d): d is SourceDimension => d !== undefined);
+    allDimensions.sort((a, b) => a.index - b.index);
+    const scale = allDimensions.map((d) => d.lods[lod].scale);
+    const translation = allDimensions.map((d) => d.lods[lod].translation);
+
     const array = this.arrays_[lod];
 
     let options = {};
@@ -249,15 +257,22 @@ export class OmeZarrImageLoader {
     return chunk;
   }
 
-  public getAttributes(): ReadonlyArray<LoaderAttributes> {
-    return this.loaderAttributes_;
-  }
+  private regionToIndices(region: Region, lod: number): Array<Slice | number> {
+    // Build arrays of dimension info from SourceDimensionMap for this LOD
+    const allDimensions = [
+      this.dimensions_.x,
+      this.dimensions_.y,
+      this.dimensions_.z,
+      this.dimensions_.c,
+      this.dimensions_.t,
+    ].filter((d): d is SourceDimension => d !== undefined);
 
-  private regionToIndices(
-    region: Region,
-    attributes: LoaderAttributes
-  ): Array<Slice | number> {
-    const { dimensionNames, scale, translation } = attributes;
+    // Sort by index to maintain original dimension order
+    allDimensions.sort((a, b) => a.index - b.index);
+
+    const dimensionNames = allDimensions.map((d) => d.name);
+    const scale = allDimensions.map((d) => d.lods[lod].scale);
+    const translation = allDimensions.map((d) => d.lods[lod].translation);
 
     const indices: Array<Slice | number> = [];
     for (const [i, dimName] of dimensionNames.entries()) {
@@ -284,78 +299,66 @@ export class OmeZarrImageLoader {
   }
 }
 
-function getLoaderAttributes(
+function buildSourceDimensionMap(
   image: OmeZarrImage["ome"]["multiscales"][number],
   arrays: ReadonlyArray<zarr.Array<zarr.DataType, Readable>>
-): LoaderAttributes[] {
-  const output: LoaderAttributes[] = [];
-  const numAxes = image.axes.length;
-  for (let i = 0; i < image.datasets.length; i++) {
-    const dataset = image.datasets[i];
-    const array = arrays[i];
-    const scale = dataset.coordinateTransformations[0].scale;
-    const translation =
-      dataset.coordinateTransformations.length === 2
-        ? dataset.coordinateTransformations[1].translation
-        : new Array(numAxes).fill(0);
-    output.push({
-      dimensionNames: image.axes.map((axis) => axis.name),
-      dimensionUnits: image.axes.map((axis) => axis.unit),
-      chunks: array.chunks,
-      shape: array.shape,
-      scale,
-      translation,
-    });
-  }
-  return output;
-}
-
-function inferSourceDimensionMap(
-  attrs: ReadonlyArray<LoaderAttributes>
 ): SourceDimensionMap {
-  const names = attrs[0].dimensionNames;
+  const dimensionNames = image.axes.map((axis) => axis.name);
+  const numAxes = image.axes.length;
 
-  const xIndex = findDimensionIndex(names, "x");
-  const yIndex = findDimensionIndex(names, "y");
-  const dims: SourceDimensionMap = {
-    x: getSourceDimension(names[xIndex], xIndex, attrs),
-    y: getSourceDimension(names[yIndex], yIndex, attrs),
-    numLods: attrs.length,
+  const xIndex = findDimensionIndex(dimensionNames, "x");
+  const yIndex = findDimensionIndex(dimensionNames, "y");
+
+  const buildSourceDimension = (
+    name: string,
+    index: number
+  ): SourceDimension => {
+    const lods = [];
+    for (let i = 0; i < image.datasets.length; i++) {
+      const dataset = image.datasets[i];
+      const array = arrays[i];
+      const scale = dataset.coordinateTransformations[0].scale;
+      const translation =
+        dataset.coordinateTransformations.length === 2
+          ? dataset.coordinateTransformations[1].translation
+          : new Array(numAxes).fill(0);
+      lods.push({
+        size: array.shape[index],
+        chunkSize: array.chunks[index],
+        scale: scale[index],
+        translation: translation[index],
+      });
+    }
+    return {
+      name,
+      index,
+      unit: image.axes[index].unit,
+      lods,
+    };
   };
 
-  const zIndex = findDimensionIndexSafe(names, "z");
+  const dims: SourceDimensionMap = {
+    x: buildSourceDimension(dimensionNames[xIndex], xIndex),
+    y: buildSourceDimension(dimensionNames[yIndex], yIndex),
+    numLods: arrays.length,
+  };
+
+  const zIndex = findDimensionIndexSafe(dimensionNames, "z");
   if (zIndex !== -1) {
-    dims.z = getSourceDimension(names[zIndex], zIndex, attrs);
+    dims.z = buildSourceDimension(dimensionNames[zIndex], zIndex);
   }
 
-  const cIndex = findDimensionIndexSafe(names, "c");
+  const cIndex = findDimensionIndexSafe(dimensionNames, "c");
   if (cIndex !== -1) {
-    dims.c = getSourceDimension(names[cIndex], cIndex, attrs);
+    dims.c = buildSourceDimension(dimensionNames[cIndex], cIndex);
   }
 
-  const tIndex = findDimensionIndexSafe(names, "t");
+  const tIndex = findDimensionIndexSafe(dimensionNames, "t");
   if (tIndex !== -1) {
-    dims.t = getSourceDimension(names[tIndex], tIndex, attrs);
+    dims.t = buildSourceDimension(dimensionNames[tIndex], tIndex);
   }
 
   return dims;
-}
-
-function getSourceDimension(
-  name: string,
-  index: number,
-  attrs: ReadonlyArray<LoaderAttributes>
-): SourceDimension {
-  return {
-    name,
-    index,
-    lods: attrs.map((attr) => ({
-      size: attr.shape[index],
-      chunkSize: attr.chunks[index],
-      scale: attr.scale[index],
-      translation: attr.translation[index],
-    })),
-  };
 }
 
 function compareDimensions(a: string, b: string): boolean {

--- a/packages/core/src/data/ome_zarr/image_loader.ts
+++ b/packages/core/src/data/ome_zarr/image_loader.ts
@@ -57,7 +57,7 @@ export class OmeZarrImageLoader {
     this.metadata_ = props.metadata;
     this.arrays_ = props.arrays;
     this.arrayParams_ = props.arrayParams;
-    this.dimensions_ = makeSourceDimensionMap(this.metadata_, this.arrays_);
+    this.dimensions_ = inferSourceDimensionMap(this.metadata_, this.arrays_);
   }
 
   public getSourceDimensionMap(): SourceDimensionMap {
@@ -289,7 +289,7 @@ export class OmeZarrImageLoader {
   }
 }
 
-function makeSourceDimensionMap(
+function inferSourceDimensionMap(
   image: OmeZarrImage["ome"]["multiscales"][number],
   arrays: ReadonlyArray<zarr.Array<zarr.DataType, Readable>>
 ): SourceDimensionMap {

--- a/packages/core/src/data/ome_zarr/image_loader.ts
+++ b/packages/core/src/data/ome_zarr/image_loader.ts
@@ -220,9 +220,9 @@ export class OmeZarrImageLoader {
     };
 
     const xLod = this.dimensions_.x.lods[lod];
-    const xIndex = indices[indices.length - 1];
+    const xIndex = indices[this.dimensions_.x.index];
     const xOffset = calculateOffset(xIndex, xLod);
-    const yIndex = indices[indices.length - 2];
+    const yIndex = indices[this.dimensions_.y.index];
     const yLod = this.dimensions_.y.lods[lod];
     const yOffset = calculateOffset(yIndex, yLod);
 

--- a/packages/core/src/data/ome_zarr/image_loader.ts
+++ b/packages/core/src/data/ome_zarr/image_loader.ts
@@ -9,6 +9,7 @@ import {
   isChunkData,
   ChunkData,
   ChunkDataConstructor,
+  SourceDimensionLod,
 } from "../chunk";
 import { isTextureUnpackRowAlignment } from "../../objects/textures/texture";
 import { PromiseScheduler } from "../promise_scheduler";
@@ -56,7 +57,7 @@ export class OmeZarrImageLoader {
     this.metadata_ = props.metadata;
     this.arrays_ = props.arrays;
     this.arrayParams_ = props.arrayParams;
-    this.dimensions_ = buildSourceDimensionMap(this.metadata_, this.arrays_);
+    this.dimensions_ = makeSourceDimensionMap(this.metadata_, this.arrays_);
   }
 
   public getSourceDimensionMap(): SourceDimensionMap {
@@ -174,18 +175,6 @@ export class OmeZarrImageLoader {
 
     const indices = this.regionToIndices(region, lod);
 
-    // Build scale and translation arrays from SourceDimensionMap for this LOD
-    const allDimensions = [
-      this.dimensions_.x,
-      this.dimensions_.y,
-      this.dimensions_.z,
-      this.dimensions_.c,
-      this.dimensions_.t,
-    ].filter((d): d is SourceDimension => d !== undefined);
-    allDimensions.sort((a, b) => a.index - b.index);
-    const scale = allDimensions.map((d) => d.lods[lod].scale);
-    const translation = allDimensions.map((d) => d.lods[lod].translation);
-
     const array = this.arrays_[lod];
 
     let options = {};
@@ -218,18 +207,24 @@ export class OmeZarrImageLoader {
       );
     }
 
-    const calculateOffset = (i: number) => {
-      const index = indices[i];
+    const calculateOffset = (
+      index: number | Slice,
+      lod: SourceDimensionLod
+    ) => {
       if (typeof index === "number") {
-        return index * scale[i] + translation[i];
+        return index * lod.scale + lod.translation;
       } else if (index.start === null) {
-        return translation[i];
+        return lod.translation;
       }
-      return index.start * scale[i] + translation[i];
+      return index.start * lod.scale + lod.translation;
     };
 
-    const xOffset = calculateOffset(indices.length - 1);
-    const yOffset = calculateOffset(indices.length - 2);
+    const xLod = this.dimensions_.x.lods[lod];
+    const xIndex = indices[indices.length - 1];
+    const xOffset = calculateOffset(xIndex, xLod);
+    const yIndex = indices[indices.length - 2];
+    const yLod = this.dimensions_.y.lods[lod];
+    const yOffset = calculateOffset(yIndex, yLod);
 
     const chunk: Chunk = {
       state: "loaded",
@@ -248,8 +243,8 @@ export class OmeZarrImageLoader {
       chunkIndex: { x: 0, y: 0, z: 0, c: 0, t: 0 },
       rowAlignmentBytes: rowAlignment,
       scale: {
-        x: scale[indices.length - 1],
-        y: scale[indices.length - 2],
+        x: xLod.scale,
+        y: yLod.scale,
         z: 1,
       },
       offset: { x: xOffset, y: yOffset, z: 0 },
@@ -258,39 +253,34 @@ export class OmeZarrImageLoader {
   }
 
   private regionToIndices(region: Region, lod: number): Array<Slice | number> {
-    // Build arrays of dimension info from SourceDimensionMap for this LOD
-    const allDimensions = [
+    const dimensions = [
       this.dimensions_.x,
       this.dimensions_.y,
       this.dimensions_.z,
       this.dimensions_.c,
       this.dimensions_.t,
-    ].filter((d): d is SourceDimension => d !== undefined);
-
-    // Sort by index to maintain original dimension order
-    allDimensions.sort((a, b) => a.index - b.index);
-
-    const dimensionNames = allDimensions.map((d) => d.name);
-    const scale = allDimensions.map((d) => d.lods[lod].scale);
-    const translation = allDimensions.map((d) => d.lods[lod].translation);
+    ]
+      .filter((d): d is SourceDimension => d !== undefined)
+      .sort((a, b) => a.index - b.index);
 
     const indices: Array<Slice | number> = [];
-    for (const [i, dimName] of dimensionNames.entries()) {
-      const match = region.find((s) => s.dimension == dimName);
+    for (const d of dimensions) {
+      const match = region.find((s) => compareDimensions(s.dimension, d.name));
       if (!match) {
-        throw new Error(`Region does not contain a slice for ${dimName}`);
+        throw new Error(`Region does not contain a slice for ${d.name}`);
       }
+      const dLod = d.lods[lod];
       let index: Slice | number;
       const regionIndex = match.index;
       if (regionIndex.type === "full") {
         // null slice is the complete extent of a dimension like Python's `slice(None)`.
         index = zarr.slice(null);
       } else if (regionIndex.type === "point") {
-        index = Math.round((regionIndex.value - translation[i]) / scale[i]);
+        index = Math.round((regionIndex.value - dLod.translation) / dLod.scale);
       } else {
         index = zarr.slice(
-          Math.floor((regionIndex.start - translation[i]) / scale[i]),
-          Math.ceil((regionIndex.stop - translation[i]) / scale[i])
+          Math.floor((regionIndex.start - dLod.translation) / dLod.scale),
+          Math.ceil((regionIndex.stop - dLod.translation) / dLod.scale)
         );
       }
       indices.push(index);
@@ -299,7 +289,7 @@ export class OmeZarrImageLoader {
   }
 }
 
-function buildSourceDimensionMap(
+function makeSourceDimensionMap(
   image: OmeZarrImage["ome"]["multiscales"][number],
   arrays: ReadonlyArray<zarr.Array<zarr.DataType, Readable>>
 ): SourceDimensionMap {
@@ -309,7 +299,7 @@ function buildSourceDimensionMap(
   const xIndex = findDimensionIndex(dimensionNames, "x");
   const yIndex = findDimensionIndex(dimensionNames, "y");
 
-  const buildSourceDimension = (
+  const makeSourceDimension = (
     name: string,
     index: number
   ): SourceDimension => {
@@ -338,24 +328,24 @@ function buildSourceDimensionMap(
   };
 
   const dims: SourceDimensionMap = {
-    x: buildSourceDimension(dimensionNames[xIndex], xIndex),
-    y: buildSourceDimension(dimensionNames[yIndex], yIndex),
+    x: makeSourceDimension(dimensionNames[xIndex], xIndex),
+    y: makeSourceDimension(dimensionNames[yIndex], yIndex),
     numLods: arrays.length,
   };
 
   const zIndex = findDimensionIndexSafe(dimensionNames, "z");
   if (zIndex !== -1) {
-    dims.z = buildSourceDimension(dimensionNames[zIndex], zIndex);
+    dims.z = makeSourceDimension(dimensionNames[zIndex], zIndex);
   }
 
   const cIndex = findDimensionIndexSafe(dimensionNames, "c");
   if (cIndex !== -1) {
-    dims.c = buildSourceDimension(dimensionNames[cIndex], cIndex);
+    dims.c = makeSourceDimension(dimensionNames[cIndex], cIndex);
   }
 
   const tIndex = findDimensionIndexSafe(dimensionNames, "t");
   if (tIndex !== -1) {
-    dims.t = buildSourceDimension(dimensionNames[tIndex], tIndex);
+    dims.t = makeSourceDimension(dimensionNames[tIndex], tIndex);
   }
 
   return dims;

--- a/packages/core/src/layers/image_layer.ts
+++ b/packages/core/src/layers/image_layer.ts
@@ -110,8 +110,8 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
     }
     this.setState("loading");
     const loader = await this.source_.open();
-    const attributes = loader.getAttributes();
-    const lod = this.lod_ ?? attributes.length - 1;
+    const dimensionMap = loader.getSourceDimensionMap();
+    const lod = this.lod_ ?? dimensionMap.numLods - 1;
 
     const chunk = await loader.loadRegion(region, lod);
     this.extent_ = {

--- a/packages/core/src/layers/image_layer.ts
+++ b/packages/core/src/layers/image_layer.ts
@@ -110,8 +110,7 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
     }
     this.setState("loading");
     const loader = await this.source_.open();
-    const dimensionMap = loader.getSourceDimensionMap();
-    const lod = this.lod_ ?? dimensionMap.numLods - 1;
+    const lod = this.lod_ ?? loader.getSourceDimensionMap().numLods - 1;
 
     const chunk = await loader.loadRegion(region, lod);
     this.extent_ = {

--- a/packages/core/src/layers/image_series_loader.ts
+++ b/packages/core/src/layers/image_series_loader.ts
@@ -105,19 +105,29 @@ export class ImageSeriesLoader {
       return this.seriesAttributes_;
     }
     const loader = await this.getLoader();
-    const attributes = loader.getAttributes();
-    const attributesForLOD = attributes[this.lod_ ?? attributes.length - 1];
+    const dimensionMap = loader.getSourceDimensionMap();
+    const lod = this.lod_ ?? dimensionMap.numLods - 1;
 
-    const seriesIndex = attributesForLOD.dimensionNames.findIndex(
-      (dim) => dim === this.seriesDimensionName_
+    // Find the series dimension in the SourceDimensionMap
+    const allDimensions = [
+      dimensionMap.x,
+      dimensionMap.y,
+      dimensionMap.z,
+      dimensionMap.c,
+      dimensionMap.t,
+    ].filter((d) => d !== undefined);
+
+    const seriesDimension = allDimensions.find(
+      (d) => d.name === this.seriesDimensionName_
     );
-    if (seriesIndex === -1) {
+    if (!seriesDimension) {
+      const availableDims = allDimensions.map((d) => d.name).join(", ");
       throw new Error(
-        `Series dimension "${this.seriesDimensionName_}" not found in loader dimensions: ${attributesForLOD.dimensionNames}`
+        `Series dimension "${this.seriesDimensionName_}" not found in loader dimensions: ${availableDims}`
       );
     }
-    const seriesDimScale = attributesForLOD.scale[seriesIndex];
-    const seriesMax = attributesForLOD.shape[seriesIndex] * seriesDimScale;
+    const seriesDimScale = seriesDimension.lods[lod].scale;
+    const seriesMax = seriesDimension.lods[lod].size * seriesDimScale;
 
     const indexIsFull = this.seriesIndex_.type === "full";
     const seriesStart = indexIsFull ? 0 : this.seriesIndex_.start;
@@ -156,8 +166,8 @@ export class ImageSeriesLoader {
     });
 
     const loader = await this.getLoader();
-    const attributes = loader.getAttributes();
-    const lod = this.lod_ ?? attributes.length - 1;
+    const dimensionMap = loader.getSourceDimensionMap();
+    const lod = this.lod_ ?? dimensionMap.numLods - 1;
 
     const chunk = await loader.loadRegion(pointRegion, lod, this.scheduler_);
     this.dataChunks_[index] = chunk;

--- a/packages/core/src/layers/image_series_loader.ts
+++ b/packages/core/src/layers/image_series_loader.ts
@@ -105,18 +105,16 @@ export class ImageSeriesLoader {
       return this.seriesAttributes_;
     }
     const loader = await this.getLoader();
-    const dimensionMap = loader.getSourceDimensionMap();
-    const lod = this.lod_ ?? dimensionMap.numLods - 1;
+    const dimensions = loader.getSourceDimensionMap();
+    const lod = this.lod_ ?? dimensions.numLods - 1;
 
-    // Find the series dimension in the SourceDimensionMap
     const allDimensions = [
-      dimensionMap.x,
-      dimensionMap.y,
-      dimensionMap.z,
-      dimensionMap.c,
-      dimensionMap.t,
+      dimensions.x,
+      dimensions.y,
+      dimensions.z,
+      dimensions.c,
+      dimensions.t,
     ].filter((d) => d !== undefined);
-
     const seriesDimension = allDimensions.find(
       (d) => d.name === this.seriesDimensionName_
     );
@@ -166,8 +164,7 @@ export class ImageSeriesLoader {
     });
 
     const loader = await this.getLoader();
-    const dimensionMap = loader.getSourceDimensionMap();
-    const lod = this.lod_ ?? dimensionMap.numLods - 1;
+    const lod = this.lod_ ?? loader.getSourceDimensionMap().numLods - 1;
 
     const chunk = await loader.loadRegion(pointRegion, lod, this.scheduler_);
     this.dataChunks_[index] = chunk;

--- a/packages/core/src/layers/label_image_layer.ts
+++ b/packages/core/src/layers/label_image_layer.ts
@@ -106,8 +106,7 @@ export class LabelImageLayer extends Layer {
     }
     this.setState("loading");
     const loader = await this.source_.open();
-    const dimensionMap = loader.getSourceDimensionMap();
-    const lod = this.lod_ ?? dimensionMap.numLods - 1;
+    const lod = this.lod_ ?? loader.getSourceDimensionMap().numLods - 1;
     const chunk = await loader.loadRegion(region, lod);
     this.image_ = this.createImage(chunk);
     this.addObject(this.image_);

--- a/packages/core/src/layers/label_image_layer.ts
+++ b/packages/core/src/layers/label_image_layer.ts
@@ -106,8 +106,8 @@ export class LabelImageLayer extends Layer {
     }
     this.setState("loading");
     const loader = await this.source_.open();
-    const attributes = loader.getAttributes();
-    const lod = this.lod_ ?? attributes.length - 1;
+    const dimensionMap = loader.getSourceDimensionMap();
+    const lod = this.lod_ ?? dimensionMap.numLods - 1;
     const chunk = await loader.loadRegion(region, lod);
     this.image_ = this.createImage(chunk);
     this.addObject(this.image_);


### PR DESCRIPTION
### Summary
This removes `LoaderAttributes` in favor of using `SourceDimensionMap`. This mostly simplifies existing logic in examples, but it may complicate logic in some of the old loading paths related to `Region`.

### Related Issue
Closes #417

### Tests & Checks
I manually tested all the examples.
