### PR TITLE
refactor: restrict s3 store types

### DIFF
--- a/packages/core/src/data/ome_zarr/image_source.ts
+++ b/packages/core/src/data/ome_zarr/image_source.ts
@@ -88,7 +88,6 @@ export class OmeZarrImageSource {
    *
    * @param url URL of Zarr root
    * @param version OME-Zarr version
-   * @param fetchOptions Optional fetch configuration (e.g., authentication headers for private S3 data)
    */
   public static fromHttp(props: HttpOmeZarrImageSourceProps) {
     const store = new FetchStore(props.url);
@@ -99,11 +98,14 @@ export class OmeZarrImageSource {
   }
 
   /**
-   * Creates an OmeZarrImageSource from an S3 HTTP(S) URL with credentials.
+   * Creates an OmeZarrImageSource from an S3 HTTP(S) URL.
    *
    * @param url URL of Zarr root
    * @param version OME-Zarr version
-   * @param fetchOptions Optional fetch configuration (e.g., authentication headers for private S3 data)
+   * @param credentials AWS credentials for S3 authentication (will generate signatures per-request)
+   * @param region AWS region for S3 bucket (e.g., 'us-east-1')
+   * @param overrides RequestInit overrides to customize fetch behavior (e.g., custom headers for S3 authentication)
+   * @param useSuffixRequest Whether to use suffix requests for range queries
    */
   public static fromS3(props: S3OmeZarrImageSourceProps) {
     const store = new S3FetchStore(props);

--- a/packages/core/src/data/ome_zarr/image_source.ts
+++ b/packages/core/src/data/ome_zarr/image_source.ts
@@ -1,5 +1,6 @@
 import { Location } from "@zarrita/core";
 import { Readable } from "@zarrita/storage";
+import FetchStore from "@zarrita/storage/fetch";
 import {
   openArrayFromParams,
   openGroup,
@@ -12,30 +13,20 @@ import {
   parseOmeZarrImage,
   Version as OmeZarrVersion,
 } from "./metadata_loaders";
-import { createFetchStore, type AwsCredentials } from "../zarr/s3_fetch_store";
-
-/** Options for customizing fetch requests, such as adding authentication headers for private S3 data */
-export type FetchOptions = {
-  /** RequestInit overrides to customize fetch behavior (e.g., custom headers for S3 authentication) */
-  overrides?: RequestInit;
-  /** Whether to use suffix requests for range queries */
-  useSuffixRequest?: boolean;
-  /** AWS credentials for S3 authentication (will generate signatures per-request) */
-  credentials?: AwsCredentials;
-  /** AWS region for S3 bucket (e.g., 'us-east-1') */
-  region?: string;
-};
+import { S3FetchStore, type S3FetchStoreProps } from "../zarr/s3_fetch_store";
 
 type OmeZarrImageSourceProps = {
   location: Location<Readable>;
   version?: OmeZarrVersion;
-  fetchOptions?: FetchOptions;
 };
 
 type HttpOmeZarrImageSourceProps = {
   url: string;
   version?: OmeZarrVersion;
-  fetchOptions?: FetchOptions;
+};
+
+type S3OmeZarrImageSourceProps = S3FetchStoreProps & {
+  version?: OmeZarrVersion;
 };
 
 type FileSystemOmeZarrImageSourceProps = {
@@ -48,12 +39,10 @@ type FileSystemOmeZarrImageSourceProps = {
 export class OmeZarrImageSource {
   readonly location: Location<Readable>;
   readonly version?: OmeZarrVersion;
-  readonly fetchOptions?: FetchOptions;
 
   private constructor(props: OmeZarrImageSourceProps) {
     this.location = props.location;
     this.version = props.version;
-    this.fetchOptions = props.fetchOptions;
   }
 
   public async open(): Promise<OmeZarrImageLoader> {
@@ -74,12 +63,7 @@ export class OmeZarrImageSource {
       zarrVersion = omeZarrToZarrVersion(adaptedOmeImage.originalVersion);
     }
     const arrayParams = metadata.datasets.map((d) =>
-      createZarrArrayParams(
-        this.location,
-        d.path,
-        zarrVersion,
-        this.fetchOptions
-      )
+      createZarrArrayParams(this.location, d.path, zarrVersion)
     );
     const arrays = await Promise.all(
       arrayParams.map((params) => openArrayFromParams(params))
@@ -107,11 +91,25 @@ export class OmeZarrImageSource {
    * @param fetchOptions Optional fetch configuration (e.g., authentication headers for private S3 data)
    */
   public static fromHttp(props: HttpOmeZarrImageSourceProps) {
-    const store = createFetchStore(props.url, props.fetchOptions);
+    const store = new FetchStore(props.url);
     return new OmeZarrImageSource({
       location: new Location(store),
       version: props.version,
-      fetchOptions: props.fetchOptions,
+    });
+  }
+
+  /**
+   * Creates an OmeZarrImageSource from an S3 HTTP(S) URL with credentials.
+   *
+   * @param url URL of Zarr root
+   * @param version OME-Zarr version
+   * @param fetchOptions Optional fetch configuration (e.g., authentication headers for private S3 data)
+   */
+  public static fromS3(props: S3OmeZarrImageSourceProps) {
+    const store = new S3FetchStore(props);
+    return new OmeZarrImageSource({
+      location: new Location(store),
+      version: props.version,
     });
   }
 

--- a/packages/core/src/data/ome_zarr/metadata_loaders.ts
+++ b/packages/core/src/data/ome_zarr/metadata_loaders.ts
@@ -7,7 +7,6 @@ import { Plate } from "./0.5/plate";
 import { Well } from "./0.5/well";
 import { OmeZarrImageSource } from "./image_source";
 import { Version as ZarrVersion, openGroup } from "../zarr/open";
-import { createFetchStore, type AwsCredentials } from "../zarr/s3_fetch_store";
 
 const versions = ["0.4", "0.5"] as const;
 const versionsSet: ReadonlySet<string> = new Set(versions);
@@ -56,15 +55,9 @@ function removeProperty<O, P extends keyof O>(obj: O, prop: P): Omit<O, P> {
 
 export async function loadOmeZarrPlate(
   url: string,
-  version?: Version,
-  fetchOptions?: {
-    credentials?: AwsCredentials;
-    region?: string;
-    overrides?: RequestInit;
-    useSuffixRequest?: boolean;
-  }
+  version?: Version
 ): Promise<AdaptedOme<Plate["ome"]>> {
-  const store = createFetchStore(url, fetchOptions);
+  const store = new zarr.FetchStore(url);
   const location = new zarr.Location(store);
   const zarrVersion = omeZarrToZarrVersion(version);
   const group = await openGroup(location, zarrVersion);
@@ -138,16 +131,10 @@ function parseWell(attrs: Record<string, unknown>): AdaptedOme<Well["ome"]> {
 export async function loadOmeZarrWell(
   url: string,
   path: string,
-  version?: Version,
-  fetchOptions?: {
-    credentials?: AwsCredentials;
-    region?: string;
-    overrides?: RequestInit;
-    useSuffixRequest?: boolean;
-  }
+  version?: Version
 ): Promise<AdaptedOme<Well["ome"]>> {
   const fullUrl = url + "/" + path;
-  const store = createFetchStore(fullUrl, fetchOptions);
+  const store = new zarr.FetchStore(fullUrl);
   const location = new zarr.Location(store);
   const zarrVersion = omeZarrToZarrVersion(version);
   const group = await openGroup(location, zarrVersion);

--- a/packages/core/src/data/ome_zarr/worker_kernel.ts
+++ b/packages/core/src/data/ome_zarr/worker_kernel.ts
@@ -142,6 +142,6 @@ async function getOrOpenArray(
 }
 
 function getArrayCacheKey(params: ZarrArrayParams): string {
-  const storeKey = params.type === "fetch" ? params.url : params.path;
+  const storeKey = params.type === "filesystem" ? params.path : params.url;
   return `${params.type}::${storeKey}::${params.arrayPath}`;
 }

--- a/packages/core/src/data/zarr/open.ts
+++ b/packages/core/src/data/zarr/open.ts
@@ -3,11 +3,7 @@ import { Location } from "@zarrita/core";
 import { Readable } from "@zarrita/storage";
 import FetchStore from "@zarrita/storage/fetch";
 import WebFileSystemStore from "./web_file_system_store";
-import {
-  S3FetchStore,
-  createFetchStore,
-  type AwsCredentials,
-} from "./s3_fetch_store";
+import { S3FetchStore, type S3FetchStoreProps } from "./s3_fetch_store";
 
 export type Version = "v2" | "v3";
 
@@ -18,13 +14,10 @@ export type ZarrArrayParams = {
   | {
       type: "fetch";
       url: string;
-      fetchOptions?: {
-        overrides?: RequestInit;
-        useSuffixRequest?: boolean;
-        credentials?: AwsCredentials;
-        region?: string;
-      };
     }
+  | ({
+      type: "s3";
+    } & S3FetchStoreProps)
   | {
       type: "filesystem";
       directoryHandle: FileSystemDirectoryHandle;
@@ -89,7 +82,12 @@ export async function openArrayFromParams(
 
   switch (params.type) {
     case "fetch": {
-      const store = createFetchStore(params.url, params.fetchOptions);
+      const store = new FetchStore(params.url);
+      rootLocation = new Location(store);
+      break;
+    }
+    case "s3": {
+      const store = new S3FetchStore(params);
       rootLocation = new Location(store);
       break;
     }
@@ -116,29 +114,25 @@ export async function openArrayFromParams(
 export function createZarrArrayParams(
   location: Location<Readable>,
   arrayPath: string,
-  zarrVersion: Version | undefined,
-  fetchOptions?: { overrides?: RequestInit; useSuffixRequest?: boolean }
+  zarrVersion: Version | undefined
 ): ZarrArrayParams {
   if (location.store instanceof S3FetchStore) {
-    // Extract credentials and region from S3FetchStore
     return {
-      type: "fetch",
+      type: "s3",
       arrayPath,
       zarrVersion,
       url: location.store.url.toString(),
-      fetchOptions: {
-        ...fetchOptions,
-        credentials: location.store.credentials,
-        region: location.store.region,
-      },
+      region: location.store.region,
+      credentials: location.store.credentials,
+      overrides: location.store.overrides,
+      useSuffixRequest: location.store.useSuffixRequest,
     };
   } else if (location.store instanceof FetchStore) {
     return {
       type: "fetch",
       arrayPath,
       zarrVersion,
-      url: (location.store as FetchStore).url.toString(),
-      fetchOptions,
+      url: location.store.url.toString(),
     };
   } else if (location.store instanceof WebFileSystemStore) {
     return {

--- a/packages/core/src/data/zarr/s3_fetch_store.ts
+++ b/packages/core/src/data/zarr/s3_fetch_store.ts
@@ -1,15 +1,19 @@
 import FetchStore from "@zarrita/storage/fetch";
-import type { FetchOptions } from "../ome_zarr/image_source";
 
-export type AwsCredentials = {
+type AwsCredentials = {
   accessKeyId: string;
   secretAccessKey: string;
   sessionToken?: string;
 };
 
-export type S3FetchOptions = FetchOptions & {
-  credentials?: AwsCredentials;
+export type S3FetchStoreProps = {
+  url: string;
   region?: string;
+  credentials?: AwsCredentials;
+  /** RequestInit overrides to customize fetch behavior (e.g., custom headers for S3 authentication) */
+  overrides?: RequestInit;
+  /** Whether to use suffix requests for range queries */
+  useSuffixRequest?: boolean;
 };
 
 /**
@@ -48,29 +52,27 @@ function checkLocalOnlyEnvironment(): void {
  * Do not use in production - implement a secure backend proxy instead.
  */
 export class S3FetchStore extends FetchStore {
-  private credentials_?: AwsCredentials;
-  private region_?: string;
+  public readonly credentials?: AwsCredentials;
+  public readonly region?: string;
   // Cache signing keys per date/region combination (valid for 24 hours)
   private signingKeyCache_ = new Map<string, Uint8Array>();
+  public readonly overrides?: RequestInit;
+  public readonly useSuffixRequest?: boolean;
 
-  constructor(url: string, options?: S3FetchOptions) {
+  constructor(props: S3FetchStoreProps) {
     // Safety check: only allow in local development environments
     checkLocalOnlyEnvironment();
 
     // Don't pass static headers to parent - we'll generate them per-request
-    const { credentials, region, ...fetchOptions } = options || {};
-    super(url, fetchOptions);
+    super(props.url, {
+      overrides: props.overrides,
+      useSuffixRequest: props.useSuffixRequest,
+    });
 
-    this.credentials_ = credentials;
-    this.region_ = region;
-  }
-
-  public get credentials(): AwsCredentials | undefined {
-    return this.credentials_;
-  }
-
-  public get region(): string | undefined {
-    return this.region_;
+    this.credentials = props.credentials;
+    this.region = props.region;
+    this.overrides = props.overrides;
+    this.useSuffixRequest = props.useSuffixRequest;
   }
 
   /**
@@ -80,7 +82,7 @@ export class S3FetchStore extends FetchStore {
     key: `/${string}`,
     options?: RequestInit
   ): Promise<Uint8Array | undefined> {
-    if (this.credentials_ && this.region_) {
+    if (this.credentials && this.region) {
       // Generate fresh headers for this specific request
       // Remove trailing slash from url if present to avoid double slashes
       const baseUrl = this.url.toString().replace(/\/$/, "");
@@ -111,7 +113,7 @@ export class S3FetchStore extends FetchStore {
     range: { offset: number; length: number } | { suffixLength: number },
     options?: RequestInit
   ): Promise<Uint8Array | undefined> {
-    if (this.credentials_ && this.region_) {
+    if (this.credentials && this.region) {
       const baseUrl = this.url.toString().replace(/\/$/, "");
       const fullUrl = `${baseUrl}${key}`;
 
@@ -165,12 +167,12 @@ export class S3FetchStore extends FetchStore {
     url: string,
     method: string = "GET"
   ): Promise<Record<string, string>> {
-    if (!this.credentials_ || !this.region_) {
+    if (!this.credentials || !this.region) {
       return {};
     }
 
-    const { accessKeyId, secretAccessKey, sessionToken } = this.credentials_;
-    const region = this.region_;
+    const { accessKeyId, secretAccessKey, sessionToken } = this.credentials;
+    const region = this.region;
     const service = "s3"; // Always S3 for this implementation
 
     const amzDate = this.getAmzDate();
@@ -312,17 +314,4 @@ export class S3FetchStore extends FetchStore {
       .map((b) => b.toString(16).padStart(2, "0"))
       .join("");
   }
-}
-
-/**
- * Creates an appropriate FetchStore based on whether authentication credentials are provided.
- * Returns S3FetchStore if credentials and region are present, otherwise returns FetchStore.
- */
-export function createFetchStore(
-  url: string,
-  options?: S3FetchOptions
-): FetchStore | S3FetchStore {
-  return options?.credentials && options?.region
-    ? new S3FetchStore(url, options)
-    : new FetchStore(url, options);
 }

--- a/packages/core/src/data/zarr/s3_fetch_store.ts
+++ b/packages/core/src/data/zarr/s3_fetch_store.ts
@@ -10,9 +10,7 @@ export type S3FetchStoreProps = {
   url: string;
   region?: string;
   credentials?: AwsCredentials;
-  /** RequestInit overrides to customize fetch behavior (e.g., custom headers for S3 authentication) */
   overrides?: RequestInit;
-  /** Whether to use suffix requests for range queries */
   useSuffixRequest?: boolean;
 };
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -25,12 +25,6 @@ export { LabelImageLayer } from "./layers/label_image_layer";
 export type { PointPickingResult } from "./layers/point_picking";
 export { ImageSeriesLayer } from "./layers/image_series_layer";
 export { OmeZarrImageSource } from "./data/ome_zarr/image_source";
-export type { FetchOptions } from "./data/ome_zarr/image_source";
-export { S3FetchStore } from "./data/zarr/s3_fetch_store";
-export type {
-  AwsCredentials,
-  S3FetchOptions,
-} from "./data/zarr/s3_fetch_store";
 
 export type {
   PriorityCategory,


### PR DESCRIPTION
This restricts the types used by the `S3FetchStore` in the `OmeZarrImageSource` by limiting the associated properties to a corresponding factory method `OmeZarrImageSource.fromS3` instead of sharing that with `fromHttp` which may have nothing to do with AWS or S3.

It also removes some of the associated exports in the main index for similar reasons.