### PR TITLE
fix: refactor size observer for immediate resizing

### DIFF
--- a/packages/core/src/idetik.ts
+++ b/packages/core/src/idetik.ts
@@ -112,7 +112,12 @@ export class Idetik {
         sizeDependents.push(viewport.element);
       }
     }
-    this.sizeObserver_ = new PixelSizeObserver(sizeDependents);
+    this.sizeObserver_ = new PixelSizeObserver(sizeDependents, () => {
+      this.updateSize();
+      for (const viewport of this.viewports_) {
+        this.renderer_.render(viewport);
+      }
+    });
   }
 
   public get renderedObjects() {
@@ -155,11 +160,6 @@ export class Idetik {
 
   private animate(timestamp?: DOMHighResTimeStamp) {
     if (this.stats_) this.stats_.begin();
-
-    // Must resize before render b/c changing canvas coordinate space clears it.
-    if (this.sizeObserver_.getAndResetChanged()) {
-      this.updateSize();
-    }
 
     for (const viewport of this.viewports_) {
       this.renderer_.render(viewport);

--- a/packages/core/src/idetik.ts
+++ b/packages/core/src/idetik.ts
@@ -113,8 +113,9 @@ export class Idetik {
       }
     }
     this.sizeObserver_ = new PixelSizeObserver(sizeDependents, () => {
-      this.updateSize();
+      this.renderer_.updateSize();
       for (const viewport of this.viewports_) {
+        viewport.updateSize();
         this.renderer_.render(viewport);
       }
     });
@@ -188,13 +189,6 @@ export class Idetik {
       }
       cancelAnimationFrame(this.lastAnimationId_);
       this.lastAnimationId_ = undefined;
-    }
-  }
-
-  private updateSize() {
-    this.renderer_.updateSize();
-    for (const viewport of this.viewports_) {
-      viewport.updateSize();
     }
   }
 }

--- a/packages/core/src/utilities/pixel_size_observer.ts
+++ b/packages/core/src/utilities/pixel_size_observer.ts
@@ -7,11 +7,11 @@ export class PixelSizeObserver {
   private resizeObserver_?: ResizeObserver;
   private mediaQuery_?: MediaQueryList;
   private onMediaQueryChange_?: () => void;
-  private onResize_: () => void;
+  private onChange_: () => void;
 
-  constructor(elements: ReadonlyArray<HTMLElement> = [], onResize: () => void) {
+  constructor(elements: ReadonlyArray<HTMLElement> = [], onChange: () => void) {
     this.elements_ = elements;
-    this.onResize_ = onResize;
+    this.onChange_ = onChange;
   }
 
   public connect() {
@@ -24,7 +24,7 @@ export class PixelSizeObserver {
     }
 
     this.resizeObserver_ = new ResizeObserver(() => {
-      this.onResize_();
+      this.onChange_();
     });
 
     for (const element of this.elements_) {
@@ -42,7 +42,7 @@ export class PixelSizeObserver {
       `(resolution: ${window.devicePixelRatio}dppx)`
     );
     this.onMediaQueryChange_ = () => {
-      this.onResize_();
+      this.onChange_();
       this.startDevicePixelRatioObserver();
     };
     this.mediaQuery_.addEventListener("change", this.onMediaQueryChange_, {

--- a/packages/core/src/utilities/pixel_size_observer.ts
+++ b/packages/core/src/utilities/pixel_size_observer.ts
@@ -7,10 +7,11 @@ export class PixelSizeObserver {
   private resizeObserver_?: ResizeObserver;
   private mediaQuery_?: MediaQueryList;
   private onMediaQueryChange_?: () => void;
-  private changed_ = false;
+  private onResize_: () => void;
 
-  constructor(elements: ReadonlyArray<HTMLElement> = []) {
+  constructor(elements: ReadonlyArray<HTMLElement> = [], onResize: () => void) {
     this.elements_ = elements;
+    this.onResize_ = onResize;
   }
 
   public connect() {
@@ -21,8 +22,9 @@ export class PixelSizeObserver {
       );
       return;
     }
+
     this.resizeObserver_ = new ResizeObserver(() => {
-      this.changed_ = true;
+      this.onResize_();
     });
 
     for (const element of this.elements_) {
@@ -30,12 +32,6 @@ export class PixelSizeObserver {
     }
 
     this.startDevicePixelRatioObserver();
-  }
-
-  public getAndResetChanged() {
-    const wasChanged = this.changed_;
-    this.changed_ = false;
-    return wasChanged;
   }
 
   private startDevicePixelRatioObserver() {
@@ -46,7 +42,7 @@ export class PixelSizeObserver {
       `(resolution: ${window.devicePixelRatio}dppx)`
     );
     this.onMediaQueryChange_ = () => {
-      this.changed_ = true;
+      this.onResize_();
       this.startDevicePixelRatioObserver();
     };
     this.mediaQuery_.addEventListener("change", this.onMediaQueryChange_, {


### PR DESCRIPTION
### Summary

This PR fixes a glitch where the canvas would look stretched for a moment when
resizing the viewport. The `PixelSizeObserver` relied on the animation loop
calling `getAndResetChanged()` for resizing which introduced a one frame delay.
I added a callback instead of waiting for the next animation frame to mitigate it.

### Tests & Checks

I verified this visually. See before/after videos below.

#### Before

https://github.com/user-attachments/assets/53ef7b6f-1acf-4fd5-aa89-fc324ba58db5

#### After

https://github.com/user-attachments/assets/0484675e-5caa-4fe6-91ef-bbcf6dadd2f2

