### PR TITLE
feat: add damping to orbit controls

### DIFF
--- a/packages/core/src/idetik.ts
+++ b/packages/core/src/idetik.ts
@@ -10,7 +10,7 @@ import {
 import { PixelSizeObserver } from "./utilities/pixel_size_observer";
 
 type Overlay = {
-  update(idetik: Idetik, dt?: number): void;
+  update(idetik: Idetik): void;
 };
 
 type IdetikParams = {
@@ -34,7 +34,7 @@ export class Idetik {
   private readonly stats_?: Stats;
   private readonly sizeObserver_: PixelSizeObserver;
   private lastAnimationId_?: number;
-  private lastTimestamp_: number = 0;
+  private lastTimestampSinceStart_: number = 0;
 
   /**
    * Creates a new Idetik visualization runtime instance.
@@ -155,7 +155,7 @@ export class Idetik {
       this.sizeObserver_.connect();
 
       this.lastAnimationId_ = requestAnimationFrame((timestamp) => {
-        this.lastTimestamp_ = timestamp;
+        this.lastTimestampSinceStart_ = timestamp;
         this.animate(timestamp);
       });
     } else {
@@ -167,8 +167,10 @@ export class Idetik {
   private animate(timestamp: DOMHighResTimeStamp) {
     if (this.stats_) this.stats_.begin();
 
-    // cap at 100ms to prevent spiraling on tab switching
-    const dt = Math.min(timestamp - this.lastTimestamp_, 100) / 1000;
+    // cap dt to prevent large time-step jumps when resuming from background tabs
+    const dt = Math.min(timestamp - this.lastTimestampSinceStart_, 100) / 1000;
+
+    this.lastTimestampSinceStart_ = timestamp;
 
     for (const viewport of this.viewports_) {
       viewport.cameraControls?.onUpdate(dt);
@@ -178,7 +180,7 @@ export class Idetik {
     this.chunkManager_.update();
 
     for (const overlay of this.overlays) {
-      overlay.update(this, dt);
+      overlay.update(this);
     }
 
     if (this.stats_) this.stats_.end();

--- a/packages/core/src/idetik.ts
+++ b/packages/core/src/idetik.ts
@@ -34,7 +34,9 @@ export class Idetik {
   private readonly stats_?: Stats;
   private readonly sizeObserver_: PixelSizeObserver;
   private lastAnimationId_?: number;
-  private lastTimestampSinceStart_: number = 0;
+
+  // this value will be set after start
+  private lastTimestamp_: DOMHighResTimeStamp = 0;
 
   /**
    * Creates a new Idetik visualization runtime instance.
@@ -155,7 +157,7 @@ export class Idetik {
       this.sizeObserver_.connect();
 
       this.lastAnimationId_ = requestAnimationFrame((timestamp) => {
-        this.lastTimestampSinceStart_ = timestamp;
+        this.lastTimestamp_ = timestamp;
         this.animate(timestamp);
       });
     } else {
@@ -168,9 +170,9 @@ export class Idetik {
     if (this.stats_) this.stats_.begin();
 
     // cap dt to prevent large time-step jumps when resuming from background tabs
-    const dt = Math.min(timestamp - this.lastTimestampSinceStart_, 100) / 1000;
+    const dt = Math.min(timestamp - this.lastTimestamp_, 100) / 1000;
 
-    this.lastTimestampSinceStart_ = timestamp;
+    this.lastTimestamp_ = timestamp;
 
     for (const viewport of this.viewports_) {
       viewport.cameraControls?.onUpdate(dt);

--- a/packages/core/src/idetik.ts
+++ b/packages/core/src/idetik.ts
@@ -10,7 +10,7 @@ import {
 import { PixelSizeObserver } from "./utilities/pixel_size_observer";
 
 type Overlay = {
-  update(idetik: Idetik, timestamp?: DOMHighResTimeStamp): void;
+  update(idetik: Idetik, dt?: number): void;
 };
 
 type IdetikParams = {
@@ -25,7 +25,6 @@ export type IdetikContext = {
 };
 
 export class Idetik {
-  private lastAnimationId_?: number;
   private readonly chunkManager_: ChunkManager;
   private readonly context_: IdetikContext;
   private readonly renderer_: WebGLRenderer;
@@ -34,6 +33,8 @@ export class Idetik {
   public readonly overlays: Overlay[];
   private readonly stats_?: Stats;
   private readonly sizeObserver_: PixelSizeObserver;
+  private lastAnimationId_?: number;
+  private lastTimestamp_: number = 0;
 
   /**
    * Creates a new Idetik visualization runtime instance.
@@ -152,24 +153,32 @@ export class Idetik {
         viewport.events.connect();
       }
       this.sizeObserver_.connect();
-      this.animate();
+
+      this.lastAnimationId_ = requestAnimationFrame((timestamp) => {
+        this.lastTimestamp_ = timestamp;
+        this.animate(timestamp);
+      });
     } else {
       Logger.warn("Idetik", "Idetik runtime already started");
     }
     return this;
   }
 
-  private animate(timestamp?: DOMHighResTimeStamp) {
+  private animate(timestamp: DOMHighResTimeStamp) {
     if (this.stats_) this.stats_.begin();
 
+    // cap at 100ms to prevent spiraling on tab switching
+    const dt = Math.min(timestamp - this.lastTimestamp_, 100) / 1000;
+
     for (const viewport of this.viewports_) {
+      viewport.cameraControls?.onUpdate(dt);
       this.renderer_.render(viewport);
     }
 
     this.chunkManager_.update();
 
     for (const overlay of this.overlays) {
-      overlay.update(this, timestamp);
+      overlay.update(this, dt);
     }
 
     if (this.stats_) this.stats_.end();

--- a/packages/core/src/objects/cameras/controls.ts
+++ b/packages/core/src/objects/cameras/controls.ts
@@ -5,6 +5,7 @@ import { EventContext } from "../../core/event_dispatcher";
 const LEFT_MOUSE_BUTTON = 0;
 
 export interface CameraControls {
+  onUpdate(dt: number): void;
   onEvent(event: EventContext): void;
 }
 
@@ -34,6 +35,8 @@ export class PanZoomControls implements CameraControls {
         break;
     }
   }
+
+  public onUpdate(_delta: number) {}
 
   private onWheel(event: EventContext) {
     if (!event.worldPos || !event.clipPos) return;

--- a/packages/core/src/objects/cameras/orbit_controls.ts
+++ b/packages/core/src/objects/cameras/orbit_controls.ts
@@ -5,7 +5,6 @@ import { Spherical } from "../../math/spherical";
 
 import { glMatrix, vec3 } from "gl-matrix";
 import { clamp } from "../../utilities/clamp";
-import { lerp } from "../../utilities/lerp";
 
 const MOUSE_BUTTON_NONE = -1;
 const MOUSE_BUTTON_LEFT = 0;
@@ -14,7 +13,7 @@ const MOUSE_BUTTON_MIDDLE = 1;
 const ORBIT_SPEED = 0.009;
 const PAN_SPEED = 0.001;
 const ZOOM_SPEED = 0.0009;
-const DEFAULT_DAMPING_FACTOR = 3;
+const DEFAULT_DAMPING_FACTOR = 0.3;
 
 type OrbitParams = {
   radius?: number;
@@ -26,8 +25,9 @@ type OrbitParams = {
 export class OrbitControls implements CameraControls {
   private readonly camera_: PerspectiveCamera;
 
-  private readonly targetPos_: Spherical;
-  private readonly targetCenter_ = vec3.create();
+  private readonly orbitVelocity_ = new Spherical(0, 0, 0);
+  private readonly panVelocity_ = vec3.create();
+  private zoomVelocity_ = 0;
 
   private readonly currPos_: Spherical;
   private readonly currCenter_ = vec3.create();
@@ -39,19 +39,17 @@ export class OrbitControls implements CameraControls {
   constructor(camera: PerspectiveCamera, params?: OrbitParams) {
     this.camera_ = camera;
 
-    this.targetPos_ = new Spherical(
+    this.currPos_ = new Spherical(
       params?.radius ?? 1,
       params?.yaw ?? 0,
       params?.pitch ?? 0
     );
 
-    this.currPos_ = new Spherical(
-      this.targetPos_.radius,
-      this.targetPos_.phi,
-      this.targetPos_.theta
+    this.dampingFactor_ = clamp(
+      params?.dampingFactor ?? DEFAULT_DAMPING_FACTOR,
+      0,
+      1
     );
-
-    this.dampingFactor_ = params?.dampingFactor || DEFAULT_DAMPING_FACTOR;
   }
 
   public onEvent(event: EventContext): void {
@@ -73,22 +71,29 @@ export class OrbitControls implements CameraControls {
   }
 
   public onUpdate(dt: number) {
-    const t = 1.0 - Math.exp(-this.dampingFactor_ * dt);
+    this.currPos_.phi += this.orbitVelocity_.phi;
+    this.currPos_.theta += this.orbitVelocity_.theta;
+    this.currPos_.radius += this.zoomVelocity_ * this.currPos_.radius;
 
-    this.currPos_.radius = lerp(
-      this.currPos_.radius,
-      this.targetPos_.radius,
-      t
-    );
-    this.currPos_.phi = lerp(this.currPos_.phi, this.targetPos_.phi, t);
-    this.currPos_.theta = lerp(this.currPos_.theta, this.targetPos_.theta, t);
+    vec3.add(this.currCenter_, this.currCenter_, this.panVelocity_);
 
-    vec3.lerp(this.currCenter_, this.currCenter_, this.targetCenter_, t);
+    // Prevent the camera from reaching the poles (±π/2), where
+    // the view direction would flip and orbit controls would invert.
+    // We clamp the elevation angle slightly before ±π/2 to maintain
+    // stable rotation and avoid gimbal-like artifacts.
+    const limit = Math.PI / 2 - glMatrix.EPSILON;
+    this.currPos_.theta = clamp(this.currPos_.theta, -limit, limit);
+    this.currPos_.radius = Math.max(0.01, this.currPos_.radius);
 
     const p = vec3.add(vec3.create(), this.currCenter_, this.currPos_.toVec3());
-
     this.camera_.transform.setTranslation(p);
     this.camera_.transform.targetTo(this.currCenter_);
+
+    const damping = Math.pow(1.0 - this.dampingFactor_, dt * 60);
+    this.orbitVelocity_.phi *= damping;
+    this.orbitVelocity_.theta *= damping;
+    this.zoomVelocity_ *= damping;
+    vec3.scale(this.panVelocity_, this.panVelocity_, damping);
   }
 
   private onPointerDown(event: EventContext) {
@@ -130,32 +135,22 @@ export class OrbitControls implements CameraControls {
   }
 
   private orbit(dx: number, dy: number) {
-    this.targetPos_.phi -= dx * ORBIT_SPEED;
-    this.targetPos_.theta += dy * ORBIT_SPEED;
-
-    // Prevent the camera from reaching the poles (±π/2), where
-    // the view direction would flip and orbit controls would invert.
-    // We clamp the elevation angle slightly before ±π/2 to maintain
-    // stable rotation and avoid gimbal-like artifacts.
-    const limit = Math.PI / 2 - glMatrix.EPSILON;
-    this.targetPos_.theta = clamp(this.targetPos_.theta, -limit, limit);
+    this.orbitVelocity_.phi -= dx * ORBIT_SPEED;
+    this.orbitVelocity_.theta += dy * ORBIT_SPEED;
   }
 
   private pan(dx: number, dy: number) {
-    // Scale pan speed by distance so movement feels consistent
-    const speed = this.targetPos_.radius * PAN_SPEED;
+    const speed = this.currPos_.radius * PAN_SPEED;
     const delta = vec3.create();
 
     vec3.scaleAndAdd(delta, delta, this.camera_.right, dx);
     vec3.scaleAndAdd(delta, delta, this.camera_.up, dy);
     vec3.scale(delta, delta, speed);
 
-    vec3.sub(this.targetCenter_, this.targetCenter_, delta);
+    vec3.sub(this.panVelocity_, this.panVelocity_, delta);
   }
 
   private zoom(dy: number) {
-    // Exponential for smooth, distance-independent zoom
-    const scale = Math.exp(dy * ZOOM_SPEED);
-    this.targetPos_.radius = Math.max(0.01, this.targetPos_.radius * scale);
+    this.zoomVelocity_ += dy * ZOOM_SPEED;
   }
 }

--- a/packages/core/src/objects/cameras/orbit_controls.ts
+++ b/packages/core/src/objects/cameras/orbit_controls.ts
@@ -5,6 +5,7 @@ import { Spherical } from "../../math/spherical";
 
 import { glMatrix, vec3 } from "gl-matrix";
 import { clamp } from "../../utilities/clamp";
+import { lerp } from "../../utilities/lerp";
 
 const MOUSE_BUTTON_NONE = -1;
 const MOUSE_BUTTON_LEFT = 0;
@@ -13,6 +14,7 @@ const MOUSE_BUTTON_MIDDLE = 1;
 const ORBIT_SPEED = 0.009;
 const PAN_SPEED = 0.001;
 const ZOOM_SPEED = 0.0009;
+const DAMPING_FACTOR = 3;
 
 type OrbitParams = {
   radius?: number;
@@ -22,19 +24,29 @@ type OrbitParams = {
 
 export class OrbitControls implements CameraControls {
   private readonly camera_: PerspectiveCamera;
-  private readonly sphericalPos_: Spherical;
-  private readonly target_ = vec3.create();
+
+  private readonly targetPos_: Spherical;
+  private readonly targetCenter_ = vec3.create();
+
+  private readonly currPos_: Spherical;
+  private readonly currCenter_ = vec3.create();
 
   private currMouseButton_ = MOUSE_BUTTON_NONE;
 
   constructor(camera: PerspectiveCamera, params?: OrbitParams) {
     this.camera_ = camera;
-    this.sphericalPos_ = new Spherical(
+
+    this.targetPos_ = new Spherical(
       params?.radius ?? 1,
       params?.yaw ?? 0,
       params?.pitch ?? 0
     );
-    this.update();
+
+    this.currPos_ = new Spherical(
+      this.targetPos_.radius,
+      this.targetPos_.phi,
+      this.targetPos_.theta
+    );
   }
 
   public onEvent(event: EventContext): void {
@@ -53,6 +65,25 @@ export class OrbitControls implements CameraControls {
         this.onPointerEnd(event);
         break;
     }
+  }
+
+  public onUpdate(dt: number) {
+    const t = 1.0 - Math.exp(-DAMPING_FACTOR * dt);
+
+    this.currPos_.radius = lerp(
+      this.currPos_.radius,
+      this.targetPos_.radius,
+      t
+    );
+    this.currPos_.phi = lerp(this.currPos_.phi, this.targetPos_.phi, t);
+    this.currPos_.theta = lerp(this.currPos_.theta, this.targetPos_.theta, t);
+
+    vec3.lerp(this.currCenter_, this.currCenter_, this.targetCenter_, t);
+
+    const p = vec3.add(vec3.create(), this.currCenter_, this.currPos_.toVec3());
+
+    this.camera_.transform.setTranslation(p);
+    this.camera_.transform.targetTo(this.currCenter_);
   }
 
   private onPointerDown(event: EventContext) {
@@ -76,8 +107,6 @@ export class OrbitControls implements CameraControls {
 
     if (doOrbit) this.orbit(dx, dy);
     if (doPan) this.pan(dx, dy);
-
-    this.update();
   }
 
   private onWheel(event: EventContext) {
@@ -86,8 +115,6 @@ export class OrbitControls implements CameraControls {
 
     const dy = e.deltaY ?? 0;
     this.zoom(dy);
-
-    this.update();
   }
 
   private onPointerEnd(event: EventContext) {
@@ -98,45 +125,32 @@ export class OrbitControls implements CameraControls {
   }
 
   private orbit(dx: number, dy: number) {
-    this.sphericalPos_.phi -= dx * ORBIT_SPEED;
-    this.sphericalPos_.theta += dy * ORBIT_SPEED;
+    this.targetPos_.phi -= dx * ORBIT_SPEED;
+    this.targetPos_.theta += dy * ORBIT_SPEED;
 
     // Prevent the camera from reaching the poles (±π/2), where
     // the view direction would flip and orbit controls would invert.
     // We clamp the elevation angle slightly before ±π/2 to maintain
     // stable rotation and avoid gimbal-like artifacts.
     const limit = Math.PI / 2 - glMatrix.EPSILON;
-    this.sphericalPos_.theta = clamp(this.sphericalPos_.theta, -limit, limit);
+    this.targetPos_.theta = clamp(this.targetPos_.theta, -limit, limit);
   }
 
   private pan(dx: number, dy: number) {
     // Scale pan speed by distance so movement feels consistent
-    const speed = this.sphericalPos_.radius * PAN_SPEED;
+    const speed = this.targetPos_.radius * PAN_SPEED;
     const delta = vec3.create();
 
     vec3.scaleAndAdd(delta, delta, this.camera_.right, dx);
     vec3.scaleAndAdd(delta, delta, this.camera_.up, dy);
     vec3.scale(delta, delta, speed);
 
-    vec3.sub(this.target_, this.target_, delta);
+    vec3.sub(this.targetCenter_, this.targetCenter_, delta);
   }
 
   private zoom(dy: number) {
     // Exponential for smooth, distance-independent zoom
     const scale = Math.exp(dy * ZOOM_SPEED);
-    this.sphericalPos_.radius = Math.max(
-      0.01,
-      this.sphericalPos_.radius * scale
-    );
-  }
-
-  private update() {
-    const p = vec3.add(
-      vec3.create(),
-      this.target_,
-      this.sphericalPos_.toVec3()
-    );
-    this.camera_.transform.setTranslation(p);
-    this.camera_.transform.targetTo(this.target_);
+    this.targetPos_.radius = Math.max(0.01, this.targetPos_.radius * scale);
   }
 }

--- a/packages/core/src/objects/cameras/orbit_controls.ts
+++ b/packages/core/src/objects/cameras/orbit_controls.ts
@@ -13,7 +13,8 @@ const MOUSE_BUTTON_MIDDLE = 1;
 const ORBIT_SPEED = 0.009;
 const PAN_SPEED = 0.001;
 const ZOOM_SPEED = 0.0009;
-const DEFAULT_DAMPING_FACTOR = 0.3;
+const DEFAULT_DAMPING_FACTOR = 0.5;
+const DAMPING_FPS = 60; // Base FPS to normalize damping
 
 type OrbitParams = {
   radius?: number;
@@ -27,7 +28,6 @@ export class OrbitControls implements CameraControls {
 
   private readonly orbitVelocity_ = new Spherical(0, 0, 0);
   private readonly panVelocity_ = vec3.create();
-  private zoomVelocity_ = 0;
 
   private readonly currPos_: Spherical;
   private readonly currCenter_ = vec3.create();
@@ -50,6 +50,8 @@ export class OrbitControls implements CameraControls {
       0,
       1
     );
+
+    this.updateCamera();
   }
 
   public onEvent(event: EventContext): void {
@@ -71,9 +73,18 @@ export class OrbitControls implements CameraControls {
   }
 
   public onUpdate(dt: number) {
+    if (
+      this.orbitVelocity_.phi === 0 &&
+      this.orbitVelocity_.theta === 0 &&
+      this.orbitVelocity_.radius === 0 &&
+      vec3.equals(this.panVelocity_, vec3.fromValues(0, 0, 0))
+    ) {
+      return;
+    }
+
     this.currPos_.phi += this.orbitVelocity_.phi;
     this.currPos_.theta += this.orbitVelocity_.theta;
-    this.currPos_.radius += this.zoomVelocity_ * this.currPos_.radius;
+    this.currPos_.radius += this.orbitVelocity_.radius * this.currPos_.radius;
 
     vec3.add(this.currCenter_, this.currCenter_, this.panVelocity_);
 
@@ -85,15 +96,15 @@ export class OrbitControls implements CameraControls {
     this.currPos_.theta = clamp(this.currPos_.theta, -limit, limit);
     this.currPos_.radius = Math.max(0.01, this.currPos_.radius);
 
-    const p = vec3.add(vec3.create(), this.currCenter_, this.currPos_.toVec3());
-    this.camera_.transform.setTranslation(p);
-    this.camera_.transform.targetTo(this.currCenter_);
+    this.updateCamera();
 
-    const damping = Math.pow(1.0 - this.dampingFactor_, dt * 60);
+    const damping = Math.pow(1.0 - this.dampingFactor_, dt * DAMPING_FPS);
     this.orbitVelocity_.phi *= damping;
     this.orbitVelocity_.theta *= damping;
-    this.zoomVelocity_ *= damping;
+    this.orbitVelocity_.radius *= damping;
     vec3.scale(this.panVelocity_, this.panVelocity_, damping);
+
+    this.cutoffLowVelocity();
   }
 
   private onPointerDown(event: EventContext) {
@@ -151,6 +162,23 @@ export class OrbitControls implements CameraControls {
   }
 
   private zoom(dy: number) {
-    this.zoomVelocity_ += dy * ZOOM_SPEED;
+    this.orbitVelocity_.radius += dy * ZOOM_SPEED;
+  }
+
+  private updateCamera() {
+    const p = vec3.add(vec3.create(), this.currCenter_, this.currPos_.toVec3());
+    this.camera_.transform.setTranslation(p);
+    this.camera_.transform.targetTo(this.currCenter_);
+  }
+
+  private cutoffLowVelocity() {
+    if (Math.abs(this.orbitVelocity_.phi) < glMatrix.EPSILON)
+      this.orbitVelocity_.phi = 0;
+    if (Math.abs(this.orbitVelocity_.theta) < glMatrix.EPSILON)
+      this.orbitVelocity_.theta = 0;
+    if (Math.abs(this.orbitVelocity_.radius) < glMatrix.EPSILON)
+      this.orbitVelocity_.radius = 0;
+    if (vec3.length(this.panVelocity_) < glMatrix.EPSILON)
+      vec3.zero(this.panVelocity_);
   }
 }

--- a/packages/core/src/objects/cameras/orbit_controls.ts
+++ b/packages/core/src/objects/cameras/orbit_controls.ts
@@ -14,12 +14,13 @@ const MOUSE_BUTTON_MIDDLE = 1;
 const ORBIT_SPEED = 0.009;
 const PAN_SPEED = 0.001;
 const ZOOM_SPEED = 0.0009;
-const DAMPING_FACTOR = 3;
+const DEFAULT_DAMPING_FACTOR = 3;
 
 type OrbitParams = {
   radius?: number;
   yaw?: number;
   pitch?: number;
+  dampingFactor?: number;
 };
 
 export class OrbitControls implements CameraControls {
@@ -30,6 +31,8 @@ export class OrbitControls implements CameraControls {
 
   private readonly currPos_: Spherical;
   private readonly currCenter_ = vec3.create();
+
+  private readonly dampingFactor_: number;
 
   private currMouseButton_ = MOUSE_BUTTON_NONE;
 
@@ -47,6 +50,8 @@ export class OrbitControls implements CameraControls {
       this.targetPos_.phi,
       this.targetPos_.theta
     );
+
+    this.dampingFactor_ = params?.dampingFactor || DEFAULT_DAMPING_FACTOR;
   }
 
   public onEvent(event: EventContext): void {
@@ -68,7 +73,7 @@ export class OrbitControls implements CameraControls {
   }
 
   public onUpdate(dt: number) {
-    const t = 1.0 - Math.exp(-DAMPING_FACTOR * dt);
+    const t = 1.0 - Math.exp(-this.dampingFactor_ * dt);
 
     this.currPos_.radius = lerp(
       this.currPos_.radius,

--- a/packages/core/src/utilities/lerp.ts
+++ b/packages/core/src/utilities/lerp.ts
@@ -1,0 +1,3 @@
+export function lerp(start: number, end: number, t: number): number {
+  return start + (end - start) * t;
+}

--- a/packages/core/src/utilities/lerp.ts
+++ b/packages/core/src/utilities/lerp.ts
@@ -1,3 +1,0 @@
-export function lerp(start: number, end: number, t: number): number {
-  return start + (end - start) * t;
-}


### PR DESCRIPTION
### Summary

This PR adds inertial damping to `OrbitControls` to create smoother camera
interactions. To support this the `CameraControls` interface has been updated to
include an `onUpdate(dt)` method and the main runtime loop now calculates and
propagates delta time (in seconds).

I'll add damping to the zoom/pan camera in another PR.

### Tests & Checks

Visual verification. See video below

https://github.com/user-attachments/assets/ac2508bf-9552-4a13-be2d-946a94322f10

