### PR TITLE
refactor: Move ChunkStoreView ownership to ChunkStore

### DIFF
--- a/packages/core/examples/chunk_streaming/chunk_info_overlay.ts
+++ b/packages/core/examples/chunk_streaming/chunk_info_overlay.ts
@@ -18,15 +18,14 @@ export class ChunkInfoOverlay {
 
   public update(idetik: Idetik, _timestamp?: DOMHighResTimeStamp): void {
     if (this.textDiv_.style.display === "none") return;
-    const chunkStore = this.imageLayer_.chunkStoreView?.store;
     const chunkStoreView = this.imageLayer_.chunkStoreView;
-    if (!chunkStore || !chunkStoreView) {
+    if (!chunkStoreView) {
       this.textDiv_.textContent = "No chunk store";
       return;
     }
 
-    const chunksAtCurrentTime = chunkStore.getChunksAtTime(
-      chunkStore.getTimeIndex(this.imageLayer_.sliceCoords)
+    const chunksAtCurrentTime = chunkStoreView.getChunksAtTime(
+      chunkStoreView.getTimeIndex(this.imageLayer_.sliceCoords)
     );
     if (!chunksAtCurrentTime) {
       this.textDiv_.textContent = "No chunks available";
@@ -46,7 +45,7 @@ export class ChunkInfoOverlay {
       visible: number;
       rendered: number;
       prefetched: number;
-    }[] = Array.from({ length: chunkStore.lodCount }, () => ({
+    }[] = Array.from({ length: chunkStoreView.lodCount }, () => ({
       visible: 0,
       rendered: 0,
       prefetched: 0,

--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -14,14 +14,7 @@ export class ChunkManager {
     policy: ImageSourcePolicy
   ): Promise<ChunkStoreView> {
     const store = await this.getOrCreateStore(source);
-    const view = new ChunkStoreView(store, policy);
-    store.addView(view);
-
-    if (store.views.length === 1) {
-      this.stores_.set(source, store);
-      this.pendingStores_.delete(source);
-    }
-
+    const view = store.createView(policy);
     return view;
   }
 
@@ -43,7 +36,12 @@ export class ChunkManager {
 
     const newPending = initializeStore();
     this.pendingStores_.set(source, newPending);
-    return newPending;
+
+    const store = await newPending;
+    this.stores_.set(source, store);
+    this.pendingStores_.delete(source);
+
+    return store;
   }
 
   public update() {
@@ -64,7 +62,7 @@ export class ChunkManager {
     this.queue_.flush();
 
     for (const [source, store] of this.stores_) {
-      if (store.views.length === 0) {
+      if (store.canDispose()) {
         this.stores_.delete(source);
       }
     }

--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -1,5 +1,4 @@
-import { Logger } from "../utilities/logger";
-import { Chunk, ChunkSource } from "../data/chunk";
+import { ChunkSource } from "../data/chunk";
 import { ChunkQueue } from "../data/chunk_queue";
 import { ChunkStore } from "./chunk_store";
 import { ChunkStoreView } from "./chunk_store_view";
@@ -8,80 +7,48 @@ import { ImageSourcePolicy } from "./image_source_policy";
 export class ChunkManager {
   private readonly stores_ = new Map<ChunkSource, ChunkStore>();
   private readonly pendingStores_ = new Map<ChunkSource, Promise<ChunkStore>>();
-  private readonly views_ = new Map<ChunkStore, ChunkStoreView[]>();
   private readonly queue_ = new ChunkQueue();
 
   public async addView(
     source: ChunkSource,
     policy: ImageSourcePolicy
   ): Promise<ChunkStoreView> {
-    const store = await this.addSource(source);
+    const store = await this.getOrCreateStore(source);
     const view = new ChunkStoreView(store, policy);
-    this.views_.set(store, (this.views_.get(store) ?? []).concat(view));
+    store.addView(view);
+
+    if (store.views.length === 1) {
+      this.stores_.set(source, store);
+      this.pendingStores_.delete(source);
+    }
+
     return view;
   }
 
-  public removeView(view: ChunkStoreView): void {
-    const store = view.store;
-    const source = this.getSourceForStore(store);
-
-    const views = this.views_.get(store);
-    if (!views) {
-      throw new Error("Cannot remove view: store not managed by ChunkManager");
+  private async getOrCreateStore(source: ChunkSource): Promise<ChunkStore> {
+    const existing = this.stores_.get(source);
+    if (existing) {
+      return existing;
     }
 
-    const index = views.indexOf(view);
-    if (index === -1) {
-      throw new Error(
-        `Cannot remove view: view not found in store's view list (source: ${source})`
-      );
-    }
-
-    const affectedChunks = Array.from(view.chunkViewStates.keys());
-    views.splice(index, 1);
-
-    for (const chunk of affectedChunks) {
-      this.aggregateChunkViewStates(chunk, store);
-    }
-
-    if (views.length === 0) {
-      this.stores_.delete(source);
-      this.views_.delete(store);
-    }
-  }
-
-  private async addSource(source: ChunkSource): Promise<ChunkStore> {
-    const existingOrPending =
-      this.stores_.get(source) ?? this.pendingStores_.get(source);
-    if (existingOrPending) {
-      return existingOrPending;
+    const pending = this.pendingStores_.get(source);
+    if (pending) {
+      return pending;
     }
 
     const initializeStore = async () => {
       const loader = await source.open();
-      const store = new ChunkStore(loader);
-      this.stores_.set(source, store);
-      this.pendingStores_.delete(source);
-      return store;
+      return new ChunkStore(loader);
     };
 
-    const pending = initializeStore();
-    this.pendingStores_.set(source, pending);
-    return pending;
-  }
-
-  private getSourceForStore(store: ChunkStore): ChunkSource {
-    for (const [source, s] of this.stores_) {
-      if (s === store) {
-        return source;
-      }
-    }
-    throw new Error("Source not found for the given store.");
+    const newPending = initializeStore();
+    this.pendingStores_.set(source, newPending);
+    return newPending;
   }
 
   public update() {
     for (const [_, store] of this.stores_) {
-      const updatedChunks = this.updateAndCollectChunkChanges(store);
+      const updatedChunks = store.updateAndCollectChunkChanges();
 
       for (const chunk of updatedChunks) {
         if (chunk.priority === null) {
@@ -95,87 +62,11 @@ export class ChunkManager {
     }
 
     this.queue_.flush();
-  }
 
-  private updateAndCollectChunkChanges(store: ChunkStore): Set<Chunk> {
-    const views = this.views_.get(store);
-    if (!views) return new Set<Chunk>();
-    const affectedChunks = new Set<Chunk>();
-    for (const view of views) {
-      for (const [chunk, _viewState] of view.chunkViewStates) {
-        affectedChunks.add(chunk);
+    for (const [source, store] of this.stores_) {
+      if (store.views.length === 0) {
+        this.stores_.delete(source);
       }
-    }
-
-    for (const chunk of affectedChunks) {
-      this.aggregateChunkViewStates(chunk, store);
-    }
-
-    return affectedChunks;
-  }
-
-  private aggregateChunkViewStates(chunk: Chunk, store: ChunkStore): void {
-    const views = this.views_.get(store);
-    if (!views) return;
-    let anyVisible = false;
-    let anyPrefetch = false;
-    let minPriority: number | null = null;
-    let orderKeyForMinPriority: number | null = null;
-
-    for (const view of views) {
-      const viewState = view.chunkViewStates.get(chunk);
-      if (!viewState) continue;
-
-      if (viewState.visible) anyVisible = true;
-      if (viewState.prefetch) anyPrefetch = true;
-
-      if (viewState.priority !== null) {
-        if (minPriority === null || viewState.priority < minPriority) {
-          minPriority = viewState.priority;
-          orderKeyForMinPriority = viewState.orderKey;
-        }
-      }
-
-      if (
-        !viewState.visible &&
-        !viewState.prefetch &&
-        viewState.priority === null
-      ) {
-        view.maybeForgetChunk(chunk);
-      }
-    }
-
-    chunk.visible = anyVisible;
-    chunk.prefetch = anyPrefetch;
-    chunk.priority = minPriority;
-    chunk.orderKey = orderKeyForMinPriority;
-
-    const shouldEnqueueChunk =
-      chunk.priority !== null && chunk.state === "unloaded";
-    if (shouldEnqueueChunk) {
-      chunk.state = "queued";
-      return;
-    }
-
-    const shouldCancelQueuedChunk =
-      chunk.priority === null && chunk.state === "queued";
-    if (shouldCancelQueuedChunk) {
-      chunk.state = "unloaded";
-      return;
-    }
-
-    const shouldDisposeChunk =
-      chunk.state === "loaded" && !chunk.visible && !chunk.prefetch;
-    if (shouldDisposeChunk) {
-      chunk.data = undefined;
-      chunk.state = "unloaded";
-      chunk.priority = null;
-      chunk.orderKey = null;
-      chunk.prefetch = false;
-      Logger.debug(
-        "ChunkManager",
-        `Disposing chunk ${JSON.stringify(chunk.chunkIndex)} in LOD ${chunk.lod}`
-      );
     }
   }
 }

--- a/packages/core/src/core/chunk_store.ts
+++ b/packages/core/src/core/chunk_store.ts
@@ -6,12 +6,15 @@ import {
   coordToIndex,
 } from "../data/chunk";
 import { almostEqual } from "../utilities/almost_equal";
+import { Logger } from "../utilities/logger";
+import type { ChunkStoreView } from "./chunk_store_view";
 
 export class ChunkStore {
   private readonly chunks_: Chunk[][];
   private readonly loader_: ChunkLoader;
   private readonly lowestResLOD_: number;
   private readonly dimensions_: SourceDimensionMap;
+  private readonly views_: ChunkStoreView[] = [];
 
   constructor(loader: ChunkLoader) {
     this.loader_ = loader;
@@ -107,6 +110,108 @@ export class ChunkStore {
 
   public loadChunkData(chunk: Chunk, signal: AbortSignal) {
     return this.loader_.loadChunkData(chunk, signal);
+  }
+
+  public addView(view: ChunkStoreView): void {
+    this.views_.push(view);
+  }
+
+  public removeView(view: ChunkStoreView): void {
+    const index = this.views_.indexOf(view);
+    if (index === -1) {
+      throw new Error(
+        "Cannot remove view: view not found in store's view list"
+      );
+    }
+
+    const affectedChunks = Array.from(view.chunkViewStates.keys());
+    this.views_.splice(index, 1);
+
+    for (const chunk of affectedChunks) {
+      this.aggregateChunkViewStates(chunk);
+    }
+  }
+
+  public get views(): ReadonlyArray<ChunkStoreView> {
+    return this.views_;
+  }
+
+  public updateAndCollectChunkChanges(): Set<Chunk> {
+    const affectedChunks = new Set<Chunk>();
+    for (const view of this.views_) {
+      for (const [chunk, _viewState] of view.chunkViewStates) {
+        affectedChunks.add(chunk);
+      }
+    }
+
+    for (const chunk of affectedChunks) {
+      this.aggregateChunkViewStates(chunk);
+    }
+
+    return affectedChunks;
+  }
+
+  private aggregateChunkViewStates(chunk: Chunk): void {
+    let anyVisible = false;
+    let anyPrefetch = false;
+    let minPriority: number | null = null;
+    let orderKeyForMinPriority: number | null = null;
+
+    for (const view of this.views_) {
+      const viewState = view.chunkViewStates.get(chunk);
+      if (!viewState) continue;
+
+      if (viewState.visible) anyVisible = true;
+      if (viewState.prefetch) anyPrefetch = true;
+
+      if (viewState.priority !== null) {
+        if (minPriority === null || viewState.priority < minPriority) {
+          minPriority = viewState.priority;
+          orderKeyForMinPriority = viewState.orderKey;
+        }
+      }
+
+      if (
+        !viewState.visible &&
+        !viewState.prefetch &&
+        viewState.priority === null
+      ) {
+        view.maybeForgetChunk(chunk);
+      }
+    }
+
+    chunk.visible = anyVisible;
+    chunk.prefetch = anyPrefetch;
+    chunk.priority = minPriority;
+    chunk.orderKey = orderKeyForMinPriority;
+
+    const shouldEnqueueChunk =
+      chunk.priority !== null && chunk.state === "unloaded";
+    if (shouldEnqueueChunk) {
+      chunk.state = "queued";
+      return;
+    }
+
+    const shouldCancelQueuedChunk =
+      chunk.priority === null && chunk.state === "queued";
+    if (shouldCancelQueuedChunk) {
+      chunk.state = "unloaded";
+      return;
+    }
+
+    const shouldDisposeChunk =
+      chunk.state === "loaded" && !chunk.visible && !chunk.prefetch;
+    if (shouldDisposeChunk) {
+      chunk.data = undefined;
+      chunk.state = "unloaded";
+      chunk.priority = null;
+      chunk.orderKey = null;
+      chunk.prefetch = false;
+      Logger.debug(
+        "ChunkStore",
+        `Disposing chunk ${JSON.stringify(chunk.chunkIndex)} in LOD ${chunk.lod}`
+      );
+    }
   }
 
   private validateXYScaleRatios(): void {

--- a/packages/core/src/core/chunk_store.ts
+++ b/packages/core/src/core/chunk_store.ts
@@ -7,7 +7,8 @@ import {
 } from "../data/chunk";
 import { almostEqual } from "../utilities/almost_equal";
 import { Logger } from "../utilities/logger";
-import type { ChunkStoreView } from "./chunk_store_view";
+import { ChunkStoreView } from "./chunk_store_view";
+import { ImageSourcePolicy } from "./image_source_policy";
 
 export class ChunkStore {
   private readonly chunks_: Chunk[][];
@@ -15,6 +16,7 @@ export class ChunkStore {
   private readonly lowestResLOD_: number;
   private readonly dimensions_: SourceDimensionMap;
   private readonly views_: ChunkStoreView[] = [];
+  private hasHadViews_ = false;
 
   constructor(loader: ChunkLoader) {
     this.loader_ = loader;
@@ -112,8 +114,11 @@ export class ChunkStore {
     return this.loader_.loadChunkData(chunk, signal);
   }
 
-  public addView(view: ChunkStoreView): void {
+  public createView(policy: ImageSourcePolicy): ChunkStoreView {
+    const view = new ChunkStoreView(this, policy);
     this.views_.push(view);
+    this.hasHadViews_ = true;
+    return view;
   }
 
   public removeView(view: ChunkStoreView): void {
@@ -134,6 +139,10 @@ export class ChunkStore {
 
   public get views(): ReadonlyArray<ChunkStoreView> {
     return this.views_;
+  }
+
+  public canDispose(): boolean {
+    return this.hasHadViews_ && this.views_.length === 0;
   }
 
   public updateAndCollectChunkChanges(): Set<Chunk> {

--- a/packages/core/src/core/chunk_store_view.ts
+++ b/packages/core/src/core/chunk_store_view.ts
@@ -1,5 +1,5 @@
 import { Chunk, SliceCoordinates, ChunkViewState } from "../data/chunk";
-import { ChunkStore } from "./chunk_store";
+import type { ChunkStore } from "./chunk_store";
 import { Viewport } from "./viewport";
 import { OrthographicCamera } from "../objects/cameras/orthographic_camera";
 import { ImageSourcePolicy } from "./image_source_policy";

--- a/packages/core/src/core/chunk_store_view.ts
+++ b/packages/core/src/core/chunk_store_view.ts
@@ -47,12 +47,21 @@ export class ChunkStoreView {
     );
   }
 
-  public get store(): ChunkStore {
-    return this.store_;
-  }
-
   public get chunkViewStates(): ReadonlyMap<Chunk, ChunkViewState> {
     return this.chunkViewStates_;
+  }
+
+  // forwarding methods for chunk stats overlay while keeping store_ private
+  public getChunksAtTime(timeIndex: number): Chunk[] {
+    return this.store_.getChunksAtTime(timeIndex);
+  }
+
+  public getTimeIndex(sliceCoords: SliceCoordinates): number {
+    return this.store_.getTimeIndex(sliceCoords);
+  }
+
+  public get lodCount(): number {
+    return this.store_.lodCount;
   }
 
   public getChunksToRender(sliceCoords: SliceCoordinates): Chunk[] {
@@ -145,6 +154,10 @@ export class ChunkStoreView {
       return;
     }
     this.chunkViewStates_.delete(chunk);
+  }
+
+  public dispose(): void {
+    this.store_.removeView(this);
   }
 
   public setImageSourcePolicy(newPolicy: ImageSourcePolicy, key: symbol) {

--- a/packages/core/src/layers/chunked_image_layer.ts
+++ b/packages/core/src/layers/chunked_image_layer.ts
@@ -81,11 +81,11 @@ export class ChunkedImageLayer extends Layer implements ChannelsEnabled {
     );
   }
 
-  public onDetached(context: IdetikContext): void {
+  public onDetached(_context: IdetikContext): void {
     this.releaseAndRemoveChunks(this.visibleChunks_.keys());
     this.clearObjects();
     if (!this.chunkStoreView_) return;
-    context.chunkManager.removeView(this.chunkStoreView_);
+    this.chunkStoreView_.dispose();
     this.chunkStoreView_ = undefined;
   }
 


### PR DESCRIPTION
### Summary
This is a follow-up for #531 as discussed in https://github.com/chanzuckerberg/idetik/pull/531#issuecomment-3560334403.

The main purpose of this refactor is to transfer ownership of the `ChunkStoreView` instances to their corresponding `ChunkStore`, away from `ChunkManager`.
* Added natural `ChunkStore.views_ : ChunkStoreView[]` 
* Removed confusing mapping and reverse-lookup on `ChunkManager`
* Moved store-specific functions to `ChunkStore`:
  * `updateAndCollectChunkChanges`
  * `aggregateChunkViewStates`
* `ChunkStoreView.store` is no longer a public attribute
* Automated cleanup of `ChunkStore` when no views remain

### Related Issue
#486

### Tests & Checks
Tested all examples
