### PR TITLE
fix: Prevent unwanted disposal of fallback chunks and add sanity check

### DIFF
--- a/packages/core/src/core/chunk_store.ts
+++ b/packages/core/src/core/chunk_store.ts
@@ -209,13 +209,18 @@ export class ChunkStore {
     }
 
     const shouldDisposeChunk =
-      chunk.state === "loaded" && !chunk.visible && !chunk.prefetch;
+      chunk.state === "loaded" && chunk.priority === null;
     if (shouldDisposeChunk) {
+      if (chunk.visible || chunk.prefetch) {
+        throw new Error(
+          `Chunk state inconsistency detected: priority is null but visible=${chunk.visible} or prefetch=${chunk.prefetch} ` +
+            `for chunk ${JSON.stringify(chunk.chunkIndex)} in LOD ${chunk.lod}`
+        );
+      }
+
       chunk.data = undefined;
       chunk.state = "unloaded";
-      chunk.priority = null;
       chunk.orderKey = null;
-      chunk.prefetch = false;
       Logger.debug(
         "ChunkStore",
         `Disposing chunk ${JSON.stringify(chunk.chunkIndex)} in LOD ${chunk.lod}`


### PR DESCRIPTION
### Summary
This is intended to fix #538, unwanted disposal of fallback chunks (not visible or prefetch, but assigned a priority) by disposing all chunks with null priority. This also adds a logic sanity check and will throw an error if any visible or prefetch chunks have null priority. See `chunk_store.ts`: 202-219.

### Related Issue
Closes #538

### Tests & Checks
Tested all examples, in particular the OME-Zarr v0.5 example that was exhibiting the bug
