### PR TITLE
fix: improve typing of WebGL context

### DIFF
--- a/packages/core/src/renderers/webgl_renderer.ts
+++ b/packages/core/src/renderers/webgl_renderer.ts
@@ -30,7 +30,7 @@ import { Frustum } from "../math/frustum";
 const axisDirection = mat4.fromScaling(mat4.create(), [1, -1, 1]);
 
 export class WebGLRenderer extends Renderer {
-  private readonly gl_: WebGL2RenderingContext | null = null;
+  private readonly gl_: WebGL2RenderingContext;
   private readonly programs_: WebGLShaderPrograms;
   private readonly bindings_: WebGLBuffers;
   private readonly textures_: WebGLTextures;
@@ -40,22 +40,23 @@ export class WebGLRenderer extends Renderer {
   constructor(canvas: HTMLCanvasElement) {
     super(canvas);
 
-    this.gl_ = this.canvas.getContext("webgl2", {
+    const gl = this.canvas.getContext("webgl2", {
       depth: true,
       antialias: true,
     });
-    if (!this.gl_) {
+    if (!gl) {
       throw new Error(`Failed to initialize WebGL2 context`);
     }
+    this.gl_ = gl;
     Logger.info(
       "WebGLRenderer",
-      `WebGL version ${this.gl.getParameter(this.gl.VERSION)}`
+      `WebGL version ${gl.getParameter(gl.VERSION)}`
     );
 
-    this.programs_ = new WebGLShaderPrograms(this.gl);
-    this.bindings_ = new WebGLBuffers(this.gl);
-    this.textures_ = new WebGLTextures(this.gl);
-    this.state_ = new WebGLState(this.gl);
+    this.programs_ = new WebGLShaderPrograms(gl);
+    this.bindings_ = new WebGLBuffers(gl);
+    this.textures_ = new WebGLTextures(gl);
+    this.state_ = new WebGLState(gl);
     this.resize(this.canvas.width, this.canvas.height);
   }
 
@@ -193,20 +194,20 @@ export class WebGLRenderer extends Renderer {
     const primitive = this.glGetPrimitive(geometry.primitive);
     const index = geometry.indexData;
     if (index.length) {
-      this.gl.drawElements(primitive, index.length, this.gl.UNSIGNED_INT, 0);
+      this.gl_.drawElements(primitive, index.length, this.gl_.UNSIGNED_INT, 0);
     } else {
-      this.gl.drawArrays(primitive, 0, geometry.vertexCount);
+      this.gl_.drawArrays(primitive, 0, geometry.vertexCount);
     }
   }
 
   private glGetPrimitive(type: Primitive) {
     switch (type) {
       case "points":
-        return this.gl.POINTS;
+        return this.gl_.POINTS;
       case "triangles":
-        return this.gl.TRIANGLES;
+        return this.gl_.TRIANGLES;
       case "lines":
-        return this.gl.LINES;
+        return this.gl_.LINES;
       default: {
         const exhaustiveCheck: never = type;
         throw new Error(`Unknown Primitive type: ${exhaustiveCheck}`);
@@ -223,13 +224,9 @@ export class WebGLRenderer extends Renderer {
   }
 
   protected clear() {
-    this.gl.clearColor(...this.backgroundColor.rgba);
-    this.gl.clear(this.gl.COLOR_BUFFER_BIT | this.gl.DEPTH_BUFFER_BIT);
+    this.gl_.clearColor(...this.backgroundColor.rgba);
+    this.gl_.clear(this.gl_.COLOR_BUFFER_BIT | this.gl_.DEPTH_BUFFER_BIT);
     this.state_.setDepthTesting(true);
-    this.gl.depthFunc(this.gl.LEQUAL);
-  }
-
-  private get gl() {
-    return this.gl_!;
+    this.gl_.depthFunc(this.gl_.LEQUAL);
   }
 }


### PR DESCRIPTION
### Summary
This makes `WebGLRenderer.gl_` non-nullable, but assigning the return of `getContext` to a local `gl` and checking that before assigning it to `gl_`. This allows us to remove the private `WebGLRenderer.gl` property that performs a static cast.

### Related Issue
Came up when writing #548 

### Tests & Checks
I manually tested the examples.
