### PR TITLE
fix: ensure presence of public directory for examples build

### DIFF
--- a/packages/core/vite-plugin-examples-nav.js
+++ b/packages/core/vite-plugin-examples-nav.js
@@ -1,6 +1,6 @@
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
-import { copyFileSync } from "node:fs";
+import { copyFileSync, existsSync, mkdirSync } from "node:fs";
 import { generateExamplesManifest, discoverExamples } from "./generate-examples-manifest.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -21,7 +21,11 @@ function getExampleInputs() {
 
 function copyManifestToPublic() {
   const manifestPath = resolve(__dirname, "examples", "examples-manifest.json");
-  const publicManifestPath = resolve(__dirname, "public", "examples-manifest.json");
+  const publicDir = resolve(__dirname, "public");
+  const publicManifestPath = resolve(publicDir, "examples-manifest.json");
+  if (!existsSync(publicDir)) {
+    mkdirSync(publicDir);
+  }
   copyFileSync(manifestPath, publicManifestPath);
 }
 


### PR DESCRIPTION
### Summary
@andy-sweet noticed the examples page deployed to gh pages is broken with a 404 on the `examples-manifest.json`. I found an [error in the build log](https://github.com/chanzuckerberg/idetik/actions/runs/20136400605/job/57790829006#step:6:26) regarding the copying of this file:
```
Failed to generate examples manifest: Error: ENOENT: no such file or directory, copyfile '/home/runner/work/idetik/idetik/packages/core/examples/examples-manifest.json' -> '/home/runner/work/idetik/idetik/packages/core/public/examples-manifest.json'
```

I believe the problem is that #541 removed the `public` directory, which is expected in the build stage for the examples deployment. This PR ensures the existence of that directory in the examples build. 

### Related Issue
N/A

### Tests & Checks
Will check the build log and artifact for this branch to ensure the presence of `examples-manifest.json`

Edit: the [initial build log](https://github.com/chanzuckerberg/idetik/actions/runs/20175769303/job/57923311969?pr=551#step:6:26) looks good
