### PR TITLE
chore: make examples site build failure throw

### DIFF
--- a/.github/workflows/lint-test-build.yml
+++ b/.github/workflows/lint-test-build.yml
@@ -64,6 +64,3 @@ jobs:
 
       - name: Build
         run: npm run build
-
-      - name: Build examples
-        run: npm run build:examples

--- a/.github/workflows/lint-test-build.yml
+++ b/.github/workflows/lint-test-build.yml
@@ -64,3 +64,6 @@ jobs:
 
       - name: Build
         run: npm run build
+
+      - name: Build examples
+        run: npm run build:examples

--- a/packages/core/vite-plugin-examples-nav.js
+++ b/packages/core/vite-plugin-examples-nav.js
@@ -42,14 +42,9 @@ function examplesManifestPlugin() {
       if (!isExamplesBuild) {
         return;
       }
-
-      try {
-        generateExamplesManifest();
-        copyManifestToPublic();
-        console.log("Examples manifest generated and copied to public");
-      } catch (error) {
-        console.error("Failed to generate examples manifest:", error);
-      }
+      generateExamplesManifest();
+      copyManifestToPublic();
+      console.log("Examples manifest generated and copied to public");
     },
     configureServer(server) {
       const regenerateManifest = () => {


### PR DESCRIPTION
### Summary
This changes the initial build step to throw instead of log and error when generating the manifest fails. This causes the check to fail rather than log the error and pass.