### PR TITLE
chore: move strict engine check

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-engine-strict=true


### PR DESCRIPTION
### Summary
This removes the strict check on the node/npm versions specified in package.json that were introduced in #566 because they broke the release action that runs on `main`. I did not revert that entire PR because it does at least sanitize the CI build process.
