### PR TITLE
chore: fix release workflow by using npm exec instead of npx

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,4 +52,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npx semantic-release
+        run: npm exec semantic-release

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true


### PR DESCRIPTION
### Summary
Fixes the release workflow failure caused by npx using its bundled npm version (10.9.4) instead of the system npm (11.6.2), which failed the engine-strict check introduced in #566.

This PR:
- Restores `.npmrc` with `engine-strict=true` (removed in #567)
- Changes the release workflow to use `npm exec semantic-release` instead of `npx semantic-release`

### Background
PR #566 added `engine-strict=true` to enforce the npm >=11.3.0 requirement in package.json, which broke the release action. PR #567 temporarily removed `.npmrc` to unblock releases, but this defeated the purpose of strict engine enforcement.

The root cause: **npx bundles its own npm version (10.9.4)** and always uses it, regardless of the system npm version installed by `setup-node`. According to npm documentation, "the --npm option is removed. npx will always use the npm it ships with."

### Solution
`npm exec` uses the current npm environment (11.6.2 from setup-node) instead of a bundled version, allowing engine-strict checks to pass while maintaining strict version enforcement for developers and CI.

### Testing
- All other npm commands in the workflow (npm ci, npm run build, etc.) already pass with engine-strict
- Local dry run of `npm exec semantic-release` works correctly (fails only on missing tokens, as expected)
- The fix will be verified when the release workflow runs in CI