### PR TITLE
fix: do not temporally prefetch out of channel chunks

### DIFF
--- a/packages/core/src/core/chunk_store_view.ts
+++ b/packages/core/src/core/chunk_store_view.ts
@@ -284,6 +284,7 @@ export class ChunkStoreView {
     if (sliceCoords.t !== undefined) {
       this.markTimeChunksForPrefetch(
         currentTimeIndex,
+        sliceCoords,
         viewBounds3D,
         viewBoundsCenter2D
       );
@@ -344,6 +345,7 @@ export class ChunkStoreView {
 
   private markTimeChunksForPrefetch(
     currentTimeIndex: number,
+    sliceCoords: SliceCoordinates,
     viewBounds3D: Box3,
     viewBoundsCenter2D: ReadonlyVec2
   ): void {
@@ -355,6 +357,7 @@ export class ChunkStoreView {
     for (let t = currentTimeIndex + 1; t <= tEnd; ++t) {
       for (const chunk of this.store_.getChunksAtTime(t)) {
         if (chunk.lod !== this.store_.getLowestResLOD()) continue;
+        if (!this.isChunkChannelInSlice(chunk, sliceCoords)) continue;
         if (!this.isChunkWithinBounds(chunk, viewBounds3D)) continue;
 
         const priority = this.policy_.priorityMap["prefetchTime"];


### PR DESCRIPTION
### Summary
This ensures that only chunks in the channel specified in `SliceCoordinates` are temporally prefetched. If no channels are specified, then all channels will be prefetched, which is unchanged from `main`.

### Related Issue
Closes #569

### Tests & Checks
I tested the examples.