### PR TITLE
fix: cancel chunk loads when store is removed

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "lint": "npm run lint --workspace=@idetik/core",
     "format": "npm run format --workspace=@idetik/core",
     "format-check": "npm run format-check --workspace=@idetik/core",
+    "test": "npm run test --workspace=@idetik/core",
     "test-with-coverage": "npm run test-with-coverage --workspace=@idetik/core"
   },
   "devDependencies": {

--- a/packages/core/src/core/chunk_store.ts
+++ b/packages/core/src/core/chunk_store.ts
@@ -121,22 +121,6 @@ export class ChunkStore {
     return view;
   }
 
-  public removeView(view: ChunkStoreView): void {
-    const index = this.views_.indexOf(view);
-    if (index === -1) {
-      throw new Error(
-        "Cannot remove view: view not found in store's view list"
-      );
-    }
-
-    const affectedChunks = Array.from(view.chunkViewStates.keys());
-    this.views_.splice(index, 1);
-
-    for (const chunk of affectedChunks) {
-      this.aggregateChunkViewStates(chunk);
-    }
-  }
-
   public get views(): ReadonlyArray<ChunkStoreView> {
     return this.views_;
   }
@@ -157,7 +141,17 @@ export class ChunkStore {
       this.aggregateChunkViewStates(chunk);
     }
 
+    this.removeDisposedViews();
+
     return affectedChunks;
+  }
+
+  private removeDisposedViews(): void {
+    for (let i = this.views_.length - 1; i >= 0; i--) {
+      if (this.views_[i].isDisposed) {
+        this.views_.splice(i, 1);
+      }
+    }
   }
 
   private aggregateChunkViewStates(chunk: Chunk): void {

--- a/packages/core/src/core/chunk_store_view.ts
+++ b/packages/core/src/core/chunk_store_view.ts
@@ -29,6 +29,8 @@ export class ChunkStoreView {
   private sourceMaxSquareDistance2D_: number;
   private readonly chunkViewStates_: Map<Chunk, ChunkViewState> = new Map();
 
+  private isDisposed_ = false;
+
   constructor(store: ChunkStore, policy: ImageSourcePolicy) {
     this.store_ = store;
     this.policy_ = policy;
@@ -49,6 +51,10 @@ export class ChunkStoreView {
 
   public get chunkViewStates(): ReadonlyMap<Chunk, ChunkViewState> {
     return this.chunkViewStates_;
+  }
+
+  public get isDisposed(): boolean {
+    return this.isDisposed_;
   }
 
   // forwarding methods for chunk stats overlay while keeping store_ private
@@ -197,7 +203,8 @@ export class ChunkStoreView {
   }
 
   public dispose(): void {
-    this.store_.removeView(this);
+    this.isDisposed_ = true;
+    this.chunkViewStates_.forEach(resetChunkViewState);
   }
 
   public setImageSourcePolicy(newPolicy: ImageSourcePolicy, key: symbol) {

--- a/packages/core/test/chunk_store_view.test.ts
+++ b/packages/core/test/chunk_store_view.test.ts
@@ -67,9 +67,8 @@ describe("ChunkStoreView disposal", () => {
 });
 
 function createMockLoader(): ChunkLoader {
-  const dimensions = createSimpleDimensions();
   return {
-    getSourceDimensionMap: () => dimensions,
+    getSourceDimensionMap: createSimpleDimensions,
     loadChunkData: vi.fn(),
     loadRegion: vi.fn(),
   };

--- a/packages/core/test/chunk_store_view.test.ts
+++ b/packages/core/test/chunk_store_view.test.ts
@@ -27,12 +27,12 @@ describe("ChunkStoreView disposal", () => {
 
     view.dispose();
 
-    // next ChunkManager.update() should collect the disposed view's chunks with priority=null
+    // collection should return affected chunks from the disposed view
+    // chunks should have priority=null and visible=false (ready for cancellation)
     collectedChunks = store.updateAndCollectChunkChanges();
 
     expect(collectedChunks.size).toBeGreaterThan(0);
 
-    // chunks should have priority=null and visible=false (ready for cancellation)
     for (const chunk of collectedChunks) {
       expect(chunk.priority).toBe(null);
       expect(chunk.visible).toBe(false);

--- a/packages/core/test/chunk_store_view.test.ts
+++ b/packages/core/test/chunk_store_view.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, test, vi } from "vitest";
+import { ChunkStore } from "@/core/chunk_store";
+import { ChunkLoader, SourceDimensionMap } from "@/data/chunk";
+import { createNoPrefetchPolicy } from "@/core/image_source_policy";
+import { createTestViewport } from "./helpers";
+
+describe("ChunkStoreView disposal", () => {
+  test("disposed view's chunks ready for cancellation", () => {
+    const loader = createMockLoader();
+    const store = new ChunkStore(loader);
+    const policy = createNoPrefetchPolicy();
+    const view = store.createView(policy);
+    const viewport = createTestViewport();
+
+    // mark some chunks as visible/needed
+    view.updateChunkStates({ z: 0, c: 0, t: 0 }, viewport);
+    expect(view.chunkViewStates.size).toBeGreaterThan(0);
+
+    // aggregate states and set priority
+    let collectedChunks = store.updateAndCollectChunkChanges();
+    expect(collectedChunks.size).toBeGreaterThan(0);
+
+    // verify some chunks have priority (are needed)
+    for (const chunk of collectedChunks) {
+      expect(chunk.priority).not.toBe(null);
+    }
+
+    view.dispose();
+
+    // next ChunkManager.update() should collect the disposed view's chunks with priority=null
+    collectedChunks = store.updateAndCollectChunkChanges();
+
+    expect(collectedChunks.size).toBeGreaterThan(0);
+
+    // chunks should have priority=null and visible=false (ready for cancellation)
+    for (const chunk of collectedChunks) {
+      expect(chunk.priority).toBe(null);
+      expect(chunk.visible).toBe(false);
+    }
+  });
+
+  test("disposed view's chunks needed by another view", () => {
+    const loader = createMockLoader();
+    const store = new ChunkStore(loader);
+    const policy = createNoPrefetchPolicy();
+
+    const view1 = store.createView(policy);
+    const view2 = store.createView(policy);
+    const viewport = createTestViewport();
+
+    // Both views mark same chunks as needed
+    view1.updateChunkStates({ z: 0, c: 0, t: 0 }, viewport);
+    view2.updateChunkStates({ z: 0, c: 0, t: 0 }, viewport);
+
+    store.updateAndCollectChunkChanges();
+
+    view1.dispose();
+
+    const collectedChunks = store.updateAndCollectChunkChanges();
+    expect(collectedChunks.size).toBeGreaterThan(0);
+
+    // chunks should still have priority because view2 still needs them
+    for (const chunk of collectedChunks) {
+      expect(chunk.priority).not.toBe(null);
+    }
+  });
+});
+
+function createMockLoader(): ChunkLoader {
+  const dimensions = createSimpleDimensions();
+  return {
+    getSourceDimensionMap: () => dimensions,
+    loadChunkData: vi.fn(),
+    loadRegion: vi.fn(),
+  };
+}
+
+function createSimpleDimensions(): SourceDimensionMap {
+  return {
+    x: {
+      name: "x",
+      index: 0,
+      lods: [
+        {
+          size: 512,
+          scale: 1,
+          chunkSize: 256,
+          translation: 0,
+        },
+      ],
+    },
+    y: {
+      name: "y",
+      index: 1,
+      lods: [
+        {
+          size: 512,
+          scale: 1,
+          chunkSize: 256,
+          translation: 0,
+        },
+      ],
+    },
+    z: {
+      name: "z",
+      index: 2,
+      lods: [
+        {
+          size: 10,
+          scale: 1,
+          chunkSize: 5,
+          translation: 0,
+        },
+      ],
+    },
+    numLods: 1,
+  };
+}

--- a/packages/core/test/helpers.ts
+++ b/packages/core/test/helpers.ts
@@ -87,7 +87,6 @@ export async function waitFor(
   }
 }
 
-// Viewport and context test helpers
 export function createTestElement(id: string = "test-element"): HTMLElement {
   const element = document.createElement("div");
   element.id = id;

--- a/packages/core/test/helpers.ts
+++ b/packages/core/test/helpers.ts
@@ -1,4 +1,9 @@
 import type { Chunk } from "../src/data/chunk";
+import { Viewport } from "@/core/viewport";
+import { OrthographicCamera } from "@/objects/cameras/orthographic_camera";
+import { LayerManager } from "@/core/layer_manager";
+import { ChunkManager } from "@/core/chunk_manager";
+import type { IdetikContext } from "@/idetik";
 
 type ChunkOverrides = Partial<
   Omit<Chunk, "shape" | "chunkIndex" | "scale" | "offset">
@@ -80,4 +85,32 @@ export async function waitFor(
     if (Date.now() - start > timeout) throw new Error("waitFor timeout");
     await new Promise((r) => setTimeout(r, interval));
   }
+}
+
+// Viewport and context test helpers
+export function createTestElement(id: string = "test-element"): HTMLElement {
+  const element = document.createElement("div");
+  element.id = id;
+  return element;
+}
+
+export function createTestCamera(): OrthographicCamera {
+  return new OrthographicCamera(-1, 1, -1, 1);
+}
+
+export function createTestContext(): IdetikContext {
+  return { chunkManager: new ChunkManager() };
+}
+
+export function createTestLayerManager(): LayerManager {
+  return new LayerManager(createTestContext());
+}
+
+export function createTestViewport(id: string = "test-viewport"): Viewport {
+  return new Viewport({
+    id,
+    element: createTestElement(id),
+    camera: createTestCamera(),
+    layerManager: createTestLayerManager(),
+  });
 }

--- a/packages/core/test/viewport.test.ts
+++ b/packages/core/test/viewport.test.ts
@@ -1,32 +1,12 @@
 import { expect, test } from "vitest";
 
+import { Viewport, ViewportConfig, parseViewportConfigs } from "@";
 import {
-  Viewport,
-  ViewportConfig,
-  parseViewportConfigs,
-  LayerManager,
-  OrthographicCamera,
-} from "@";
-import type { IdetikContext } from "@/idetik";
-import { ChunkManager } from "@/core/chunk_manager";
-
-function createTestElement(id: string): HTMLElement {
-  const element = document.createElement("div");
-  element.id = id;
-  return element;
-}
-
-function createTestCamera(): OrthographicCamera {
-  return new OrthographicCamera(-1, 1, -1, 1);
-}
-
-function createTestContext(): IdetikContext {
-  return { chunkManager: new ChunkManager() };
-}
-
-function createTestLayerManager(): LayerManager {
-  return new LayerManager(createTestContext());
-}
+  createTestElement,
+  createTestCamera,
+  createTestContext,
+  createTestLayerManager,
+} from "./helpers";
 
 test("Viewport constructor uses provided ID", () => {
   const element = createTestElement("test-element");


### PR DESCRIPTION
### Summary
This addresses the bug discovered in the DCA Viewer where switching datasets with loading in-progress does not cancel queued or in-flight chunk requests. The problem is the affected chunks of a disposed view are not processed in the normal aggregation flow via `updateAndCollectChunkChanges`, so the `ChunkManager` is not made aware of the changes. The fix is to move disposal logic into the normal aggregation path.

A possible TODO here would be to raise an error if trying to use a `ChunkStoreView` after disposal.

### Related Issue
Closes #571 

### Tests & Checks
I added automated tests to capture the desired behavior.
I also tested locally with the DCA viewer to confirm changing sources stops loading from a previous source.