### PR TITLE
Add sample density computation based on volume diagonal (longest ray)

### DIFF
--- a/packages/core/examples/multi_viewport/main.ts
+++ b/packages/core/examples/multi_viewport/main.ts
@@ -50,6 +50,7 @@ const volumeLayer = new VolumeLayer({
   source,
   sliceCoords: volumeCoords,
   policy: createPlaybackPolicy({ lod: { min: 2, max: 2 } }),
+  worldSize: vec3.fromValues(right - left, bottom - top, z.scale * z.shape),
 });
 
 const camera2D = new OrthographicCamera(left, right, top, bottom);

--- a/packages/core/examples/volume_rendering/main.ts
+++ b/packages/core/examples/volume_rendering/main.ts
@@ -66,7 +66,7 @@ gui
 const volumeFolder = gui.addFolder("Volume Rendering");
 volumeFolder
   .add(volumeLayer, "desiredSamplesPerUnit", 16, 512, 1)
-  .name("Samples per unit");
+  .name("Samples per unit along longest ray");
 volumeFolder.add(volumeLayer, "maxIntensity", 1, 255, 1).name("Max intensity");
 volumeFolder
   .add(volumeLayer, "opacityMultiplier", 0.01, 1.0, 0.01)

--- a/packages/core/examples/volume_rendering/main.ts
+++ b/packages/core/examples/volume_rendering/main.ts
@@ -23,6 +23,7 @@ const volumeLayer = new VolumeLayer({
   source,
   sliceCoords,
   policy,
+  worldSize: vec3.fromValues(1064, 955, 555),
 });
 const idetik = new Idetik({
   canvas: document.querySelector<HTMLCanvasElement>("#canvas")!,

--- a/packages/core/examples/volume_rendering/main.ts
+++ b/packages/core/examples/volume_rendering/main.ts
@@ -64,7 +64,7 @@ gui
 
 const volumeFolder = gui.addFolder("Volume Rendering");
 volumeFolder
-  .add(volumeLayer, "samplesPerUnit", 16, 512, 1)
+  .add(volumeLayer, "desiredSamplesPerUnit", 16, 512, 1)
   .name("Samples per unit");
 volumeFolder.add(volumeLayer, "maxIntensity", 1, 255, 1).name("Max intensity");
 volumeFolder

--- a/packages/core/src/core/chunk_store_view.ts
+++ b/packages/core/src/core/chunk_store_view.ts
@@ -185,6 +185,7 @@ export class ChunkStoreView {
     return this.currentLOD_;
   }
 
+  // that's strange to have this object that relates to chunks exposing the dimensions of the volume
   public get dimensions() {
     return this.store_.dimensions;
   }

--- a/packages/core/src/core/chunk_store_view.ts
+++ b/packages/core/src/core/chunk_store_view.ts
@@ -185,6 +185,10 @@ export class ChunkStoreView {
     return this.currentLOD_;
   }
 
+  public get dimensions() {
+    return this.store_.dimensions;
+  }
+
   public maybeForgetChunk(chunk: Chunk): void {
     const viewState = this.chunkViewStates_.get(chunk);
     if (

--- a/packages/core/src/layers/volume_layer.ts
+++ b/packages/core/src/layers/volume_layer.ts
@@ -31,7 +31,7 @@ export class VolumeLayer extends Layer {
   private debugShowWireframes_ = false;
   public debugShowDegenerateRays = false;
   public color = vec3.fromValues(1.0, 1.0, 1.0);
-  public samplesPerUnit = 128.0;
+  public desiredSamplesPerUnit = 128.0;
   public maxIntensity = 255.0;
   public opacityMultiplier = 0.1;
   public earlyTerminationAlpha = 0.99;
@@ -205,10 +205,37 @@ export class VolumeLayer extends Layer {
     });
   }
 
+  private getVolumeWorldSize(): vec3 {
+    if (!this.chunkStoreView_) {
+      return vec3.fromValues(1, 1, 1);
+    }
+    const dimensions = this.chunkStoreView_.dimensions;
+    const lod = this.chunkStoreView_.currentLOD;
+    const xLod = dimensions.x.lods[lod];
+    const yLod = dimensions.y.lods[lod];
+    const zLod = dimensions.z?.lods[lod];
+
+    return vec3.fromValues(
+      xLod.size * xLod.scale,
+      yLod.size * yLod.scale,
+      zLod ? zLod.size * zLod.scale : 1
+    );
+  }
+
+  private computeSamplePerWorldUnit() {
+    const volumeWorldSize = this.getVolumeWorldSize();
+    const meanDim =
+      (volumeWorldSize[0] + volumeWorldSize[1] + volumeWorldSize[2]) / 3;
+    if (meanDim > 0) {
+      return this.desiredSamplesPerUnit / meanDim;
+    }
+    return this.desiredSamplesPerUnit;
+  }
+
   public getUniforms(): Record<string, unknown> {
     return {
       DebugShowDegenerateRays: Number(this.debugShowDegenerateRays),
-      SamplesPerUnit: this.samplesPerUnit,
+      SamplesPerWorldUnit: this.computeSamplePerWorldUnit(),
       MaxIntensity: this.maxIntensity,
       OpacityMultiplier: this.opacityMultiplier,
       VolumeColor: this.color,

--- a/packages/core/src/layers/volume_layer.ts
+++ b/packages/core/src/layers/volume_layer.ts
@@ -231,12 +231,15 @@ export class VolumeLayer extends Layer {
 
   private computeSamplePerWorldUnit() {
     const volumeWorldSize = this.worldSize_;
-    const meanDim =
-      (volumeWorldSize[0] + volumeWorldSize[1] + volumeWorldSize[2]) / 3;
-    if (meanDim > 0) {
-      return this.desiredSamplesPerUnit / meanDim;
+    const diagonal = Math.sqrt(
+      volumeWorldSize[0] ** 2 +
+        volumeWorldSize[1] ** 2 +
+        volumeWorldSize[2] ** 2
+    );
+    if (diagonal <= 0) {
+      return this.desiredSamplesPerUnit;
     }
-    return this.desiredSamplesPerUnit;
+    return this.desiredSamplesPerUnit / diagonal;
   }
 
   public getUniforms(): Record<string, unknown> {

--- a/packages/core/src/layers/volume_layer.ts
+++ b/packages/core/src/layers/volume_layer.ts
@@ -13,6 +13,7 @@ export type VolumeLayerProps = {
   source: ChunkSource;
   sliceCoords: SliceCoordinates;
   policy: ImageSourcePolicy;
+  worldSize: vec3;
 };
 
 export class VolumeLayer extends Layer {
@@ -22,6 +23,7 @@ export class VolumeLayer extends Layer {
   private readonly sliceCoords_: SliceCoordinates;
   private readonly currentChunks_: Map<Chunk, VolumeRenderable> = new Map();
   private readonly pool_ = new RenderablePool<VolumeRenderable>();
+  private readonly worldSize_: vec3;
 
   private sourcePolicy_: ImageSourcePolicy;
   private chunkStoreView_?: ChunkStoreView;
@@ -66,11 +68,12 @@ export class VolumeLayer extends Layer {
     return volume;
   }
 
-  constructor({ source, sliceCoords, policy }: VolumeLayerProps) {
+  constructor({ source, sliceCoords, policy, worldSize }: VolumeLayerProps) {
     super({ transparent: true, blendMode: "premultiplied" });
     this.source_ = source;
     this.sliceCoords_ = sliceCoords;
     this.sourcePolicy_ = policy;
+    this.worldSize_ = worldSize;
     this.setState("initialized");
   }
 
@@ -205,25 +208,29 @@ export class VolumeLayer extends Layer {
     });
   }
 
-  private getVolumeWorldSize(): vec3 {
-    if (!this.chunkStoreView_) {
-      return vec3.fromValues(1, 1, 1);
-    }
-    const dimensions = this.chunkStoreView_.dimensions;
-    const lod = this.chunkStoreView_.currentLOD;
-    const xLod = dimensions.x.lods[lod];
-    const yLod = dimensions.y.lods[lod];
-    const zLod = dimensions.z?.lods[lod];
+  // // Ideally we would have something that doesn't rely on
+  // // the chunk store view that exposes the dimensions of the volume:
+  // // that's strange to have something related to chunks that exposes the dimensions of the volume.
+  // // Having the "getVolumeWorldSize" in the chunk store view would be equaly weird (if not more)
+  //   private getVolumeWorldSize(): vec3 {
+  //     if (!this.chunkStoreView_) {
+  //       return vec3.fromValues(1, 1, 1);
+  //     }
+  //     const dimensions = this.chunkStoreView_.dimensions;
+  //     const lod = this.chunkStoreView_.currentLOD;
+  //     const xLod = dimensions.x.lods[lod];
+  //     const yLod = dimensions.y.lods[lod];
+  //     const zLod = dimensions.z?.lods[lod];
 
-    return vec3.fromValues(
-      xLod.size * xLod.scale,
-      yLod.size * yLod.scale,
-      zLod ? zLod.size * zLod.scale : 1
-    );
-  }
+  //     return vec3.fromValues(
+  //       xLod.size * xLod.scale,
+  //       yLod.size * yLod.scale,
+  //       zLod ? zLod.size * zLod.scale : 1
+  //     );
+  //   }
 
   private computeSamplePerWorldUnit() {
-    const volumeWorldSize = this.getVolumeWorldSize();
+    const volumeWorldSize = this.worldSize_;
     const meanDim =
       (volumeWorldSize[0] + volumeWorldSize[1] + volumeWorldSize[2]) / 3;
     if (meanDim > 0) {

--- a/packages/core/src/layers/volume_layer.ts
+++ b/packages/core/src/layers/volume_layer.ts
@@ -138,15 +138,17 @@ export class VolumeLayer extends Layer {
   }
 
   private updateVolumeChunk(volume: VolumeRenderable, chunk: Chunk) {
-    volume.transform.setScale([
-      chunk.shape.x * chunk.scale.x,
-      chunk.shape.y * chunk.scale.y,
-      chunk.shape.z * chunk.scale.z,
-    ]);
+    const worldSize = {
+      x: chunk.shape.x * chunk.scale.x,
+      y: chunk.shape.y * chunk.scale.y,
+      z: chunk.shape.z * chunk.scale.z,
+    };
+    volume.transform.setScale([worldSize.x, worldSize.y, worldSize.z]);
+    vec3.set(volume.chunkWorldSize, worldSize.x, worldSize.y, worldSize.z);
     const originOffset = {
-      x: (chunk.shape.x * chunk.scale.x) / 2,
-      y: (chunk.shape.y * chunk.scale.y) / 2,
-      z: (chunk.shape.z * chunk.scale.z) / 2,
+      x: worldSize.x / 2,
+      y: worldSize.y / 2,
+      z: worldSize.z / 2,
     };
     volume.transform.setTranslation([
       chunk.offset.x + originOffset.x,

--- a/packages/core/src/objects/renderable/volume_renderable.ts
+++ b/packages/core/src/objects/renderable/volume_renderable.ts
@@ -3,8 +3,16 @@ import { RenderableObject } from "../../core/renderable_object";
 import { BoxGeometry } from "../geometry/box_geometry";
 import type { TextureDataType } from "../textures/texture";
 import type { Texture3D } from "../textures/texture_3d";
+import { vec3 } from "gl-matrix";
 
 export class VolumeRenderable extends RenderableObject {
+  /**
+   * The world-space size of this chunk.
+   * Used to scale the sampling density so that SamplesPerUnit is consistent
+   * across chunks of different sizes and LODs.
+   */
+  public chunkWorldSize: vec3 = vec3.fromValues(1, 1, 1);
+
   constructor(texture: Texture3D) {
     super();
     this.geometry = new BoxGeometry(1, 1, 1, 1, 1, 1);
@@ -16,6 +24,12 @@ export class VolumeRenderable extends RenderableObject {
 
   public get type() {
     return "VolumeRenderable";
+  }
+
+  public override getUniforms(): Record<string, unknown> {
+    return {
+      ChunkWorldSize: this.chunkWorldSize,
+    };
   }
 }
 

--- a/packages/core/src/renderers/shaders/volume_frag.glsl
+++ b/packages/core/src/renderers/shaders/volume_frag.glsl
@@ -22,15 +22,13 @@ vec3 boundingboxMax = vec3(0.50);
 
 // Volume rendering parameters
 uniform bool DebugShowDegenerateRays;
-uniform float SamplesPerUnit;
 uniform float MaxIntensity;
 uniform float OpacityMultiplier;
 uniform float EarlyTerminationAlpha;
 uniform vec3 VolumeColor;
 
-// This allows SamplesPerUnit to be interpreted as samples per world-space unit,
-// making sampling density consistent across chunks of different sizes and LODs.
 uniform vec3 ChunkWorldSize;
+uniform float SamplesPerWorldUnit;
 
 vec2 findBoxIntersectionsAlongRay(vec3 rayOrigin, vec3 rayDir, vec3 boxMin, vec3 boxMax) {
     vec3 reciprocalRayDir = 1.0 / rayDir;
@@ -69,22 +67,17 @@ void main() {
     exitPoint = clamp(exitPoint + 0.5, 0.0, 1.0);
 
     // Step 2 - calculate the number of samples based on the length of the ray
-    // The ray is in normalized texture space [0,1]. We scale by ChunkWorldSize to account
-    // for the world-space size of this chunk, ensuring consistent sampling density
-    // across chunks of different sizes and LODs. The normalization by maxChunkDim
-    // keeps SamplesPerUnit approximately consistent with the idea of having
-    // samples across the chunk's longest axis, while still making smaller chunks
-    // in world-space use fewer samples.
+    // The ray is in normalized texture space [0,1]. We scale by ChunkWorldSize to get
+    // the world-space length, then multiply by SamplesPerWorldUnit (which is the same
+    // across all chunks in a volume/LOD) to get a consistent number of samples.
+    // This ensures a ray through a skinny chunk gets fewer samples than a ray through
+    // a fat chunk, proportionally to their world-space sizes.
     vec3 rayWithinModel = exitPoint - entryPoint;
 
     // Convert ray from texture space (0, 1) to world space
     vec3 rayInWorldSpace = rayWithinModel * ChunkWorldSize;
     float rayLengthWorld = length(rayInWorldSpace);
-
-    // Normalize the ray length by the maximum chunk dimension to avoid oversampling large chunks
-    float maxChunkDim = max(max(ChunkWorldSize.x, ChunkWorldSize.y), ChunkWorldSize.z);
-    float normalizedRayLength = rayLengthWorld / max(maxChunkDim, 1.0);
-    int numSamples = max(int(ceil(normalizedRayLength * SamplesPerUnit)), 1);
+    int numSamples = max(int(ceil(rayLengthWorld * SamplesPerWorldUnit)), 1);
     vec3 stepIncrement = rayWithinModel / float(numSamples);
 
     // Step 3 - perform the ray marching and compositing in front to back order

--- a/packages/core/src/renderers/shaders/volume_frag.glsl
+++ b/packages/core/src/renderers/shaders/volume_frag.glsl
@@ -28,6 +28,10 @@ uniform float OpacityMultiplier;
 uniform float EarlyTerminationAlpha;
 uniform vec3 VolumeColor;
 
+// This allows SamplesPerUnit to be interpreted as samples per world-space unit,
+// making sampling density consistent across chunks of different sizes and LODs.
+uniform vec3 ChunkWorldSize;
+
 vec2 findBoxIntersectionsAlongRay(vec3 rayOrigin, vec3 rayDir, vec3 boxMin, vec3 boxMax) {
     vec3 reciprocalRayDir = 1.0 / rayDir;
     vec3 t0 = (boxMin - rayOrigin) * reciprocalRayDir;
@@ -65,9 +69,22 @@ void main() {
     exitPoint = clamp(exitPoint + 0.5, 0.0, 1.0);
 
     // Step 2 - calculate the number of samples based on the length of the ray
+    // The ray is in normalized texture space [0,1]. We scale by ChunkWorldSize to account
+    // for the world-space size of this chunk, ensuring consistent sampling density
+    // across chunks of different sizes and LODs. The normalization by maxChunkDim
+    // keeps SamplesPerUnit approximately consistent with the idea of having
+    // samples across the chunk's longest axis, while still making smaller chunks
+    // in world-space use fewer samples.
     vec3 rayWithinModel = exitPoint - entryPoint;
-    float rayLength = length(rayWithinModel);
-    int numSamples = max(int(ceil(rayLength * SamplesPerUnit)), 1);
+
+    // Convert ray from texture space (0, 1) to world space
+    vec3 rayInWorldSpace = rayWithinModel * ChunkWorldSize;
+    float rayLengthWorld = length(rayInWorldSpace);
+
+    // Normalize the ray length by the maximum chunk dimension to avoid oversampling large chunks
+    float maxChunkDim = max(max(ChunkWorldSize.x, ChunkWorldSize.y), ChunkWorldSize.z);
+    float normalizedRayLength = rayLengthWorld / max(maxChunkDim, 1.0);
+    int numSamples = max(int(ceil(normalizedRayLength * SamplesPerUnit)), 1);
     vec3 stepIncrement = rayWithinModel / float(numSamples);
 
     // Step 3 - perform the ray marching and compositing in front to back order


### PR DESCRIPTION
## Summary

This PR adds the computation of the density of samples for volume rendering based on the length of the ray. This enables the fragment shader to get a consistent number of samples to ensure that a ray through a small chunk gets fewer samples than a ray through a large chunk, proportionally to their world-space sizes.

## Notes

To perform the computation, the dimensions of the volume layer are passed to the `VolumeLayer` constructor. That's not ideal, but the other solution implemented (kept commented in the files to drive discussions) needed the information about the dimension of the full volume in world-space for the current LOD. The dimensions are held by the chunk store and are not directly accessible to the `VolumeLayer`, so basically two options were possible:

1. get the volume world-space dimensions for the current LOD from the chunk store view, which would be weird, the chunk store view is about chunks, not the full volume;
2. compute the world-space dimensions in the `VolumeLayer`, getting the current LOD and the volume dimensions from the chunk store view, which is slightly less weird, but weird anyway as it would expose the raw dimensions from the chunk store view. It's also a bit odd because although technically each LOD could have different bounds, in general the bounds of the whole volume at each LOD would be pretty constant, so having to use the current LOD at all is a bit misleading.

To enable discussions, we decided to pass the volume world-space size in the constructor and kept the solution 2 commented as this solution is slightly less weird as at least it concentrates computation related to the Volume inside a component related to the Volume.

## Related Issue

* This PR adds a new uniform in the `VolumeLayer` which is something that should be removed eventually (#555)

