### PR TITLE
feat: refactor volume rendering to use a relative step size parameter

### DIFF
--- a/packages/core/examples/volume_rendering/main.ts
+++ b/packages/core/examples/volume_rendering/main.ts
@@ -64,8 +64,8 @@ gui
 
 const volumeFolder = gui.addFolder("Volume Rendering");
 volumeFolder
-  .add(volumeLayer, "samplesPerUnit", 16, 512, 1)
-  .name("Samples per unit");
+  .add(volumeLayer, "relativeStepSize", 0.25, 3.0, 0.1)
+  .name("Relative step size (voxels)");
 volumeFolder.add(volumeLayer, "maxIntensity", 1, 255, 1).name("Max intensity");
 volumeFolder
   .add(volumeLayer, "opacityMultiplier", 0.01, 1.0, 0.01)

--- a/packages/core/examples/volume_rendering/main.ts
+++ b/packages/core/examples/volume_rendering/main.ts
@@ -67,9 +67,20 @@ volumeFolder
   .add(volumeLayer, "relativeStepSize", 0.25, 3.0, 0.1)
   .name("Relative step size (voxels)");
 volumeFolder.add(volumeLayer, "maxIntensity", 1, 255, 1).name("Max intensity");
+
+// maps 0-1 slider to [0.001, 10.0] logarithmically
+const opacityControls = {
+  get opacity() {
+    return (Math.log10(volumeLayer.opacityMultiplier) + 3) / 4;
+  },
+  set opacity(sliderValue: number) {
+    volumeLayer.opacityMultiplier = Math.pow(10, sliderValue * 4 - 3);
+  },
+};
 volumeFolder
-  .add(volumeLayer, "opacityMultiplier", 0.01, 1.0, 0.01)
-  .name("Opacity scale");
+  .add(opacityControls, "opacity", 0, 1, 0.01)
+  .name("Opacity")
+  .decimals(2);
 volumeFolder
   .add(volumeLayer, "earlyTerminationAlpha", 0.8, 1.0, 0.01)
   .name("Early termination threshold");

--- a/packages/core/src/layers/volume_layer.ts
+++ b/packages/core/src/layers/volume_layer.ts
@@ -31,7 +31,7 @@ export class VolumeLayer extends Layer {
   private debugShowWireframes_ = false;
   public debugShowDegenerateRays = false;
   public color = vec3.fromValues(1.0, 1.0, 1.0);
-  public samplesPerUnit = 128.0;
+  public relativeStepSize = 1.0;
   public maxIntensity = 255.0;
   public opacityMultiplier = 0.1;
   public earlyTerminationAlpha = 0.99;
@@ -138,11 +138,13 @@ export class VolumeLayer extends Layer {
   }
 
   private updateVolumeChunk(volume: VolumeRenderable, chunk: Chunk) {
-    volume.transform.setScale([
-      chunk.shape.x * chunk.scale.x,
-      chunk.shape.y * chunk.scale.y,
-      chunk.shape.z * chunk.scale.z,
-    ]);
+    const worldSize = {
+      x: chunk.shape.x * chunk.scale.x,
+      y: chunk.shape.y * chunk.scale.y,
+      z: chunk.shape.z * chunk.scale.z,
+    };
+    volume.transform.setScale([worldSize.x, worldSize.y, worldSize.z]);
+    vec3.set(volume.voxelScale, chunk.scale.x, chunk.scale.y, chunk.scale.z);
     const originOffset = {
       x: (chunk.shape.x * chunk.scale.x) / 2,
       y: (chunk.shape.y * chunk.scale.y) / 2,
@@ -206,7 +208,7 @@ export class VolumeLayer extends Layer {
   public getUniforms(): Record<string, unknown> {
     return {
       DebugShowDegenerateRays: Number(this.debugShowDegenerateRays),
-      SamplesPerUnit: this.samplesPerUnit,
+      RelativeStepSize: this.relativeStepSize,
       MaxIntensity: this.maxIntensity,
       OpacityMultiplier: this.opacityMultiplier,
       VolumeColor: this.color,

--- a/packages/core/src/objects/renderable/volume_renderable.ts
+++ b/packages/core/src/objects/renderable/volume_renderable.ts
@@ -3,8 +3,11 @@ import { RenderableObject } from "../../core/renderable_object";
 import { BoxGeometry } from "../geometry/box_geometry";
 import type { TextureDataType } from "../textures/texture";
 import type { Texture3D } from "../textures/texture_3d";
+import { vec3 } from "gl-matrix";
 
 export class VolumeRenderable extends RenderableObject {
+  public voxelScale: vec3 = vec3.fromValues(1, 1, 1);
+
   constructor(texture: Texture3D) {
     super();
     this.geometry = new BoxGeometry(1, 1, 1, 1, 1, 1);
@@ -16,6 +19,12 @@ export class VolumeRenderable extends RenderableObject {
 
   public get type() {
     return "VolumeRenderable";
+  }
+
+  public override getUniforms(): Record<string, unknown> {
+    return {
+      VoxelScale: this.voxelScale,
+    };
   }
 }
 

--- a/packages/core/src/renderers/shaders/volume_frag.glsl
+++ b/packages/core/src/renderers/shaders/volume_frag.glsl
@@ -93,6 +93,7 @@ void main() {
     // Scale intensity to opacity.
     // OpacityMultiplier and MaxIntensity control the transfer function.
     // worldSpaceStepSize corrects for anisotropic voxels.
+    // TODO: Replace with invlerp-based transfer function to add contrast limits (MinIntensity/MaxIntensity window)
     float intensityScale = (OpacityMultiplier / MaxIntensity) * worldSpaceStepSize;
 
     // March until we reach the number of samples or accumulate enough opacity

--- a/packages/core/src/renderers/shaders/volume_frag.glsl
+++ b/packages/core/src/renderers/shaders/volume_frag.glsl
@@ -22,11 +22,12 @@ vec3 boundingboxMax = vec3(0.50);
 
 // Volume rendering parameters
 uniform bool DebugShowDegenerateRays;
-uniform float SamplesPerUnit;
 uniform float MaxIntensity;
 uniform float OpacityMultiplier;
 uniform float EarlyTerminationAlpha;
 uniform vec3 VolumeColor;
+uniform float RelativeStepSize;
+uniform vec3 VoxelScale;
 
 vec2 findBoxIntersectionsAlongRay(vec3 rayOrigin, vec3 rayDir, vec3 boxMin, vec3 boxMax) {
     vec3 reciprocalRayDir = 1.0 / rayDir;
@@ -65,19 +66,34 @@ void main() {
     exitPoint = clamp(exitPoint + 0.5, 0.0, 1.0);
 
     // Step 2 - calculate the number of samples based on the length of the ray
+    // The ray is in normalized texture space [0,1]. Convert to voxel space to determine
+    // the appropriate number of samples. RelativeStepSize controls how many voxels to
+    // skip per sample (e.g., 1.0 = one sample per voxel, 0.5 = two samples per voxel).
     vec3 rayWithinModel = exitPoint - entryPoint;
-    float rayLength = length(rayWithinModel);
-    int numSamples = max(int(ceil(rayLength * SamplesPerUnit)), 1);
+
+    // Get texture dimensions and convert ray to voxel space
+    vec3 textureSize = vec3(textureSize(ImageSampler, 0));
+    vec3 rayInVoxels = rayWithinModel * textureSize;
+    float rayLengthInVoxels = length(rayInVoxels);
+    int numSamples = max(int(ceil(rayLengthInVoxels / RelativeStepSize)), 1);
     vec3 stepIncrement = rayWithinModel / float(numSamples);
+
+    // Calculate actual world-space step size for opacity correction.
+    // This accounts for anisotropic voxels so brightness stays constant regardless
+    // of viewing angle. For anisotropic voxels (e.g., 1x1x3 microns), rays along
+    // different axes traverse different amounts of material per step.
+    vec3 stepInWorldSpace = stepIncrement * textureSize * VoxelScale;
+    float worldSpaceStepSize = length(stepInWorldSpace);
 
     // Step 3 - perform the ray marching and compositing in front to back order
     vec3 position = entryPoint;
     vec4 accumulatedColor = vec4(0.0);
     float sampledData, sampleAlpha, blendedSampleAlpha;
 
-    // Later replace by an invlerp, but overall provides a way to map the incoming
-    // sampled texture value to an alpha value
-    float intensityScale = (1.0 / MaxIntensity) * OpacityMultiplier;
+    // Scale intensity to opacity.
+    // OpacityMultiplier and MaxIntensity control the transfer function.
+    // worldSpaceStepSize corrects for anisotropic voxels.
+    float intensityScale = (OpacityMultiplier / MaxIntensity) * worldSpaceStepSize;
 
     // March until we reach the number of samples or accumulate enough opacity
     for (int i = 0; i < numSamples && accumulatedColor.a < EarlyTerminationAlpha; i++) {


### PR DESCRIPTION
### Summary
This is an alternative to #574. Here I borrow the concept of "relative step size" from vispy. This is basically the step size relative to a single voxel. To me this is quite intuitive: you generally want the step size to be ~one voxel, because sampling the same voxel more than once you don't get new information beyond what you could estimate. I think a default of 1.0 is fine for now. Experimenting, you can also see the step-size artifacts generally disappear below 1.0:

https://github.com/user-attachments/assets/687a0357-0572-4af8-9818-10f7bb7c789a

A benefit here is not needing any volume-level uniforms - only the voxel scale which is already available on the chunk.

### Related Issue
Closes #557 

### Tests & Checks
I tested with manual visual inspection of the zebrafish dataset and adjusted the step size
I also added a debug mode to color voxels by the actual number of steps taken, or the initial calculated ray length (without early termination) to confirm the number of steps "looks" correct given the proxy geometry. Note how the "hot" spot aligns with the chunk diagonal.
<img width="998" height="947" alt="Screenshot 2026-02-04 at 11 28 25 AM" src="https://github.com/user-attachments/assets/b0951835-c033-46f1-b707-906ed413628b" />


https://github.com/user-attachments/assets/a8fa40ad-9391-449c-a3c7-a0f5685a7309
