### PR TITLE
fix: use loading policy LOD min and max to define fallback LOD

### DIFF
--- a/packages/core/examples/ca_wave_dynamics/main.ts
+++ b/packages/core/examples/ca_wave_dynamics/main.ts
@@ -5,7 +5,7 @@ import {
   OmeZarrImageSource,
   OrthographicCamera,
   Color,
-  createExplorationPolicy,
+  createNoPrefetchPolicy,
   createPlaybackPolicy,
 } from "@";
 import { PanZoomControls } from "@/objects/cameras/controls";
@@ -44,11 +44,18 @@ const channelProps: ChannelProps[] = [
   },
 ];
 
+const pausedPolicy = createNoPrefetchPolicy({
+  lod: { min: 0, max: 1 },
+});
+const playbackPolicy = createPlaybackPolicy({
+  lod: { min: 1, max: 2 },
+});
+
 const camera = new OrthographicCamera(left, right, top, bottom);
 const imageLayer = new ChunkedImageLayer({
   source,
   sliceCoords,
-  policy: createExplorationPolicy(),
+  policy: pausedPolicy,
   channelProps,
 });
 imageLayer.debugMode = true;
@@ -90,8 +97,7 @@ addDimensionSlider({
   stepValue: t.scale,
   playback: {
     onRateChange: (rateHz: number) => {
-      imageLayer.imageSourcePolicy =
-        rateHz > 0 ? createPlaybackPolicy() : createExplorationPolicy();
+      imageLayer.imageSourcePolicy = rateHz > 0 ? playbackPolicy : pausedPolicy;
     },
   },
 });

--- a/packages/core/src/core/chunk_store_view.ts
+++ b/packages/core/src/core/chunk_store_view.ts
@@ -75,14 +75,14 @@ export class ChunkStoreView {
     );
 
     // If we're at the lowest resolution LOD, only return current LOD chunks
-    const lowestResLOD = this.store_.getLowestResLOD();
-    if (this.currentLOD_ === lowestResLOD) {
+    const fallbackLOD = this.fallbackLOD();
+    if (this.currentLOD_ === fallbackLOD) {
       return currentLODChunks;
     }
 
     const lowResChunks = currentTimeChunks.filter(
       (chunk) =>
-        chunk.lod === lowestResLOD &&
+        chunk.lod === fallbackLOD &&
         this.chunkViewStates_.get(chunk)?.visible === true &&
         chunk.state === "loaded"
     );
@@ -169,11 +169,12 @@ export class ChunkStoreView {
     }
   }
 
-  public allVisibleLowestLODLoaded(sliceCoords: SliceCoordinates): boolean {
+  public allVisibleFallbackLODLoaded(sliceCoords: SliceCoordinates): boolean {
     const timeIndex = this.store_.getTimeIndex(sliceCoords);
+    const fallbackLOD = this.fallbackLOD();
     const visibleChunks = this.store_
       .getChunksAtTime(timeIndex)
-      .filter((c) => c.visible && c.lod === this.store_.getLowestResLOD());
+      .filter((c) => c.visible && c.lod === fallbackLOD);
     // Return false if there are no visible chunks (empty array .every() returns true)
     return (
       visibleChunks.length > 0 &&
@@ -307,13 +308,14 @@ export class ChunkStoreView {
     const paddedBounds = this.getPaddedBounds(viewBounds3D);
 
     const currentTimeChunks = this.store_.getChunksAtTime(timeIndex);
+    const fallbackLOD = this.fallbackLOD();
 
     for (const chunk of currentTimeChunks) {
       const isInBounds = this.isChunkWithinBounds(chunk, viewBounds3D);
       const isChannelInSlice = this.isChunkChannelInSlice(chunk, sliceCoords);
 
       const isCurrentLOD = chunk.lod === this.currentLOD_;
-      const isFallbackLOD = chunk.lod === this.store_.getLowestResLOD();
+      const isFallbackLOD = chunk.lod === fallbackLOD;
 
       const prefetch =
         !isInBounds &&
@@ -354,9 +356,10 @@ export class ChunkStoreView {
       numTimePoints - 1,
       currentTimeIndex + this.policy_.prefetch.t
     );
+    const fallbackLOD = this.fallbackLOD();
     for (let t = currentTimeIndex + 1; t <= tEnd; ++t) {
       for (const chunk of this.store_.getChunksAtTime(t)) {
-        if (chunk.lod !== this.store_.getLowestResLOD()) continue;
+        if (chunk.lod !== fallbackLOD) continue;
         if (!this.isChunkChannelInSlice(chunk, sliceCoords)) continue;
         if (!this.isChunkWithinBounds(chunk, viewBounds3D)) continue;
 
@@ -409,6 +412,10 @@ export class ChunkStoreView {
       )
     );
     return Box3.intersects(chunkBounds, bounds);
+  }
+
+  private fallbackLOD(): number {
+    return Math.min(this.policy_.lod.max, this.store_.getLowestResLOD());
   }
 
   private getZBounds(sliceCoords: SliceCoordinates): [number, number] {

--- a/packages/core/src/core/chunk_store_view.ts
+++ b/packages/core/src/core/chunk_store_view.ts
@@ -80,7 +80,6 @@ export class ChunkStoreView {
         chunk.state === "loaded"
     );
 
-    // If we're at the lowest resolution LOD, only return current LOD chunks
     const fallbackLOD = this.fallbackLOD();
     if (this.currentLOD_ === fallbackLOD) {
       return currentLODChunks;

--- a/packages/core/src/layers/chunked_image_layer.ts
+++ b/packages/core/src/layers/chunked_image_layer.ts
@@ -104,7 +104,7 @@ export class ChunkedImageLayer extends Layer implements ChannelsEnabled {
 
     if (
       this.visibleChunks_.size > 0 &&
-      !this.chunkStoreView_.allVisibleLowestLODLoaded(this.sliceCoords_) &&
+      !this.chunkStoreView_.allVisibleFallbackLODLoaded(this.sliceCoords_) &&
       !this.isPresentationStale()
     ) {
       return;


### PR DESCRIPTION
### Summary
This uses the loading policy's LOD min and max to always define the fallback LOD, instead of using the lowest resolution LOD from the store.

This is motivated by the need for some applications to increase the minimum LOD that should be loaded/presented in cases when the lowest resolution LOD in the source is not useful. This is particularly important for the crude temporal prefetching logic, which only fetches the fallback LOD.

### Related Issue
Closes #577

### Tests & Checks
I manually tested the main examples that use chunk streaming, with particular attention on the one modified here that sets the LOD min and max based on the playback state.
