### PR TITLE
chore: refactor chunk update methods for clarity (small)

### DIFF
--- a/packages/core/src/core/chunk_store_view.ts
+++ b/packages/core/src/core/chunk_store_view.ts
@@ -95,47 +95,7 @@ export class ChunkStoreView {
     return [...currentLODChunks, ...lowResChunks];
   }
 
-  // TODO: Eventually unify visibility calculations using the camera frustum for both
-  // orthographic (2D slices) and perspective (volume rendering) cameras. This would
-  // replace both updateChunkStates and updateChunkStatesForVolume with a single method
-  // that performs frustum culling based on the camera type.
-  public updateChunkStatesForVolume(sliceCoords: SliceCoordinates): void {
-    const currentTimeIndex = this.store_.getTimeIndex(sliceCoords);
-    const currentTimeChunks = this.store_.getChunksAtTime(currentTimeIndex);
-
-    if (currentTimeChunks.length === 0) {
-      Logger.warn(
-        "ChunkStoreView",
-        "updateChunkStatesForVolume called with no chunks initialized"
-      );
-      this.chunkViewStates_.clear();
-      return;
-    }
-
-    // TODO: allow volume rendering to calculate an LOD factor
-    this.setLOD(0);
-    this.chunkViewStates_.forEach(resetChunkViewState);
-
-    for (const chunk of currentTimeChunks) {
-      if (chunk.lod !== this.currentLOD_) continue;
-
-      const isChannelMatch =
-        sliceCoords.c === undefined || sliceCoords.c === chunk.chunkIndex.c;
-      if (!isChannelMatch) continue;
-
-      const priority = this.policy_.priorityMap["visibleCurrent"];
-      this.chunkViewStates_.set(chunk, {
-        visible: true,
-        prefetch: false,
-        priority,
-        orderKey: 0, // All chunks have the same ordering for volume rendering
-      });
-    }
-
-    this.lastTCoord_ = sliceCoords.t;
-  }
-
-  public updateChunkStates(
+  public updateChunksForImage(
     sliceCoords: SliceCoordinates,
     viewport: Viewport
   ): void {
@@ -164,14 +124,92 @@ export class ChunkStoreView {
       this.zBoundsChanged(zBounds) ||
       this.lastTCoord_ !== sliceCoords.t;
 
-    if (changed) {
-      this.updateChunkViewStates(sliceCoords, viewBounds2D);
+    if (!changed) return;
 
-      this.policyChanged_ = false;
-      this.lastViewBounds2D_ = viewBounds2D.clone();
-      this.lastZBounds_ = zBounds;
-      this.lastTCoord_ = sliceCoords.t;
+    const currentTimeIndex = this.store_.getTimeIndex(sliceCoords);
+    const currentTimeChunks = this.store_.getChunksAtTime(currentTimeIndex);
+
+    if (currentTimeChunks.length === 0) {
+      Logger.warn(
+        "ChunkStoreView",
+        "updateChunkViewStates called with no chunks initialized"
+      );
+      this.chunkViewStates_.clear();
+      return;
     }
+
+    const viewBoundsCenter2D = vec2.create();
+    vec2.lerp(viewBoundsCenter2D, viewBounds2D.min, viewBounds2D.max, 0.5);
+
+    const [zMin, zMax] = this.getZBounds(sliceCoords);
+    const viewBounds3D = new Box3(
+      vec3.fromValues(viewBounds2D.min[0], viewBounds2D.min[1], zMin),
+      vec3.fromValues(viewBounds2D.max[0], viewBounds2D.max[1], zMax)
+    );
+
+    // reset all existing chunk view states to "not needed" to start
+    // logic below will override this for chunks that are actually visible/prefetch
+    this.chunkViewStates_.forEach(resetChunkViewState);
+
+    this.updateChunksAtTimeIndex(
+      currentTimeIndex,
+      sliceCoords,
+      viewBounds3D,
+      viewBoundsCenter2D
+    );
+
+    if (sliceCoords.t !== undefined) {
+      this.markTimeChunksForPrefetch(
+        currentTimeIndex,
+        sliceCoords,
+        viewBounds3D,
+        viewBoundsCenter2D
+      );
+    }
+
+    this.policyChanged_ = false;
+    this.lastViewBounds2D_ = viewBounds2D.clone();
+    this.lastZBounds_ = zBounds;
+    this.lastTCoord_ = sliceCoords.t;
+  }
+
+  public updateChunksForVolume(sliceCoords: SliceCoordinates): void {
+    const currentTimeIndex = this.store_.getTimeIndex(sliceCoords);
+    const currentTimeChunks = this.store_.getChunksAtTime(currentTimeIndex);
+
+    if (currentTimeChunks.length === 0) {
+      Logger.warn(
+        "ChunkStoreView",
+        "updateChunksForVolume called with no chunks initialized"
+      );
+      this.chunkViewStates_.clear();
+      return;
+    }
+
+    // TODO: Calculate LOD dynamically based on view frustum for volume rendering
+    // (similar to zoom-based LOD calculation in updateChunksForImage).
+    // Currently uses a fixed LOD from policy.
+    this.currentLOD_ = this.policy_.lod.min;
+
+    this.chunkViewStates_.forEach(resetChunkViewState);
+
+    for (const chunk of currentTimeChunks) {
+      if (chunk.lod !== this.currentLOD_) continue;
+
+      const isChannelMatch =
+        sliceCoords.c === undefined || sliceCoords.c === chunk.chunkIndex.c;
+      if (!isChannelMatch) continue;
+
+      const priority = this.policy_.priorityMap["visibleCurrent"];
+      this.chunkViewStates_.set(chunk, {
+        visible: true,
+        prefetch: false,
+        priority,
+        orderKey: 0, // All chunks have the same ordering for volume rendering
+      });
+    }
+
+    this.lastTCoord_ = sliceCoords.t;
   }
 
   public allVisibleFallbackLODLoaded(sliceCoords: SliceCoordinates): boolean {
@@ -249,52 +287,6 @@ export class ChunkStoreView {
     const target = clamp(desiredLOD, minPolicyLOD, maxPolicyLOD);
     if (target !== this.currentLOD_) {
       this.currentLOD_ = target;
-    }
-  }
-
-  private updateChunkViewStates(
-    sliceCoords: SliceCoordinates,
-    viewBounds2D: Box2
-  ): void {
-    const currentTimeIndex = this.store_.getTimeIndex(sliceCoords);
-    const currentTimeChunks = this.store_.getChunksAtTime(currentTimeIndex);
-
-    if (currentTimeChunks.length === 0) {
-      Logger.warn(
-        "ChunkStoreView",
-        "updateChunkViewStates called with no chunks initialized"
-      );
-      this.chunkViewStates_.clear();
-      return;
-    }
-
-    const viewBoundsCenter2D = vec2.create();
-    vec2.lerp(viewBoundsCenter2D, viewBounds2D.min, viewBounds2D.max, 0.5);
-
-    const [zMin, zMax] = this.getZBounds(sliceCoords);
-    const viewBounds3D = new Box3(
-      vec3.fromValues(viewBounds2D.min[0], viewBounds2D.min[1], zMin),
-      vec3.fromValues(viewBounds2D.max[0], viewBounds2D.max[1], zMax)
-    );
-
-    // reset all existing chunk view states to "not needed" to start
-    // logic below will override this for chunks that are actually visible/prefetch
-    this.chunkViewStates_.forEach(resetChunkViewState);
-
-    this.updateChunksAtTimeIndex(
-      currentTimeIndex,
-      sliceCoords,
-      viewBounds3D,
-      viewBoundsCenter2D
-    );
-
-    if (sliceCoords.t !== undefined) {
-      this.markTimeChunksForPrefetch(
-        currentTimeIndex,
-        sliceCoords,
-        viewBounds3D,
-        viewBoundsCenter2D
-      );
     }
   }
 

--- a/packages/core/src/layers/chunked_image_layer.ts
+++ b/packages/core/src/layers/chunked_image_layer.ts
@@ -92,7 +92,10 @@ export class ChunkedImageLayer extends Layer implements ChannelsEnabled {
   public update(context?: RenderContext) {
     if (!context || !this.chunkStoreView_) return;
 
-    this.chunkStoreView_.updateChunkStates(this.sliceCoords_, context.viewport);
+    this.chunkStoreView_.updateChunksForImage(
+      this.sliceCoords_,
+      context.viewport
+    );
 
     this.updateChunks();
     this.resliceIfZChanged();

--- a/packages/core/src/layers/volume_layer.ts
+++ b/packages/core/src/layers/volume_layer.ts
@@ -175,7 +175,7 @@ export class VolumeLayer extends Layer {
       this.reorderObjects(context.viewport.camera);
     }
 
-    this.chunkStoreView_.updateChunkStatesForVolume(this.sliceCoords_);
+    this.chunkStoreView_.updateChunksForVolume(this.sliceCoords_);
     this.updateChunks();
   }
 

--- a/packages/core/test/chunk_store_view.test.ts
+++ b/packages/core/test/chunk_store_view.test.ts
@@ -13,7 +13,7 @@ describe("ChunkStoreView disposal", () => {
     const viewport = createTestViewport();
 
     // mark some chunks as visible/needed
-    view.updateChunkStates({ z: 0, c: 0, t: 0 }, viewport);
+    view.updateChunksForImage({ z: 0, c: 0, t: 0 }, viewport);
     expect(view.chunkViewStates.size).toBeGreaterThan(0);
 
     // aggregate states and set priority
@@ -49,8 +49,8 @@ describe("ChunkStoreView disposal", () => {
     const viewport = createTestViewport();
 
     // Both views mark same chunks as needed
-    view1.updateChunkStates({ z: 0, c: 0, t: 0 }, viewport);
-    view2.updateChunkStates({ z: 0, c: 0, t: 0 }, viewport);
+    view1.updateChunksForImage({ z: 0, c: 0, t: 0 }, viewport);
+    view2.updateChunksForImage({ z: 0, c: 0, t: 0 }, viewport);
 
     store.updateAndCollectChunkChanges();
 


### PR DESCRIPTION
### Summary

Renamed and inlined chunk state update methods to make the two rendering 
paths more obvious:

- `updateChunkStates` → `updateChunksForImage` (2D slice rendering)
- `updateChunkViewStatesForVolume` → `updateChunksForVolume` (3D volume rendering)
- Inlined `updateChunkViewStates` into `updateChunksForImage` to reduce indirection

The new names make it clear these are parallel entry points for different 
rendering modes, each handling LOD calculation and chunk marking differently.

I also removed an unnecessary call `setLOD(0)` and updated the comment so its clearer.

Otherwise, no functional changes.

### Tests & Checks

- All tests have passed.
