### PR TITLE
feat: change detection and time prefetch for volume rendering

### DIFF
--- a/packages/core/examples/volume_rendering/main.ts
+++ b/packages/core/examples/volume_rendering/main.ts
@@ -1,6 +1,6 @@
 import { Idetik, VolumeLayer, PerspectiveCamera, OmeZarrImageSource } from "@";
 import { OrbitControls } from "@/objects/cameras/orbit_controls";
-import { createExplorationPolicy } from "@/core/image_source_policy";
+import { createPlaybackPolicy } from "@/core/image_source_policy";
 import { addDimensionSlider } from "../lil_gui_utils";
 import GUI from "lil-gui";
 import { vec3 } from "gl-matrix";
@@ -16,7 +16,7 @@ const sliceCoords = {
 const controls = { lod: 2 };
 
 const camera = new PerspectiveCamera();
-const policy = createExplorationPolicy({
+const policy = createPlaybackPolicy({
   lod: { min: controls.lod, max: controls.lod },
 });
 const volumeLayer = new VolumeLayer({
@@ -57,7 +57,7 @@ gui
   .name("Level of Detail (LOD)")
   .onChange(
     (lod: number) =>
-      (volumeLayer.sourcePolicy = createExplorationPolicy({
+      (volumeLayer.sourcePolicy = createPlaybackPolicy({
         lod: { min: lod, max: lod },
       }))
   );

--- a/packages/core/src/core/chunk_store_view.ts
+++ b/packages/core/src/core/chunk_store_view.ts
@@ -1,7 +1,6 @@
 import { Chunk, SliceCoordinates, ChunkViewState } from "../data/chunk";
 import type { ChunkStore } from "./chunk_store";
 import { Viewport } from "./viewport";
-import { Camera } from "../objects/cameras/camera";
 import { OrthographicCamera } from "../objects/cameras/orthographic_camera";
 import { ImageSourcePolicy } from "./image_source_policy";
 import { ReadonlyVec2, vec2, vec3, mat4 } from "gl-matrix";
@@ -179,9 +178,18 @@ export class ChunkStoreView {
     sliceCoords: SliceCoordinates,
     viewport: Viewport
   ): void {
+    // Each call allocates a new mat4 and computes projection * view.
+    // This is intentional for simplicity. If this ever shows up in profiles
+    // avoid multiply entirely by caching and comparing view/projection separately.
+    const viewProjection = mat4.multiply(
+      mat4.create(),
+      viewport.camera.projectionMatrix,
+      viewport.camera.viewMatrix
+    );
+
     const changed =
       this.policyChanged_ ||
-      this.viewProjectionChanged(viewport.camera) ||
+      this.hasViewProjectionChanged(viewProjection) ||
       this.lastTCoord_ !== sliceCoords.t;
 
     if (!changed) return;
@@ -205,14 +213,21 @@ export class ChunkStoreView {
 
     this.chunkViewStates_.forEach(resetChunkViewState);
 
+    const fallbackLOD = this.fallbackLOD();
+
     for (const chunk of currentTimeChunks) {
       if (chunk.lod !== this.currentLOD_) continue;
+      if (!this.isChunkChannelInSlice(chunk, sliceCoords)) continue;
 
-      const isChannelMatch =
-        sliceCoords.c === undefined || sliceCoords.c === chunk.chunkIndex.c;
-      if (!isChannelMatch) continue;
+      const isFallbackLOD = chunk.lod === fallbackLOD;
+      const priority = this.computePriority(
+        isFallbackLOD,
+        true, // isCurrentLOD
+        true, // isVisible
+        false, // isPrefetch
+        true // isChannelInSlice
+      );
 
-      const priority = this.policy_.priorityMap["visibleCurrent"];
       this.chunkViewStates_.set(chunk, {
         visible: true,
         prefetch: false,
@@ -227,6 +242,7 @@ export class ChunkStoreView {
 
     this.policyChanged_ = false;
     this.lastTCoord_ = sliceCoords.t;
+    this.lastViewProjection_ = viewProjection;
   }
 
   public allVisibleFallbackLODLoaded(sliceCoords: SliceCoordinates): boolean {
@@ -502,28 +518,11 @@ export class ChunkStoreView {
     );
   }
 
-  private viewProjectionChanged(camera: Camera) {
-    // Each call allocates a new mat4 and computes projection * view.
-    // This is intentional for simplicity. If this ever shows up in profiles:
-    //   - Avoid the allocation by reusing a temporary mat4.
-    //   - Avoid the multiply entirely by caching and comparing view/projection separately.
-    const viewProjection = mat4.multiply(
-      mat4.create(),
-      camera.projectionMatrix,
-      camera.viewMatrix
+  private hasViewProjectionChanged(viewProjection: mat4) {
+    return (
+      this.lastViewProjection_ === null ||
+      !mat4.equals(this.lastViewProjection_, viewProjection)
     );
-
-    if (this.lastViewProjection_ === null) {
-      this.lastViewProjection_ = mat4.clone(viewProjection);
-      return true;
-    }
-
-    if (!mat4.equals(this.lastViewProjection_, viewProjection)) {
-      mat4.copy(this.lastViewProjection_, viewProjection);
-      return true;
-    }
-
-    return false;
   }
 
   private zBoundsChanged(newBounds: [number, number]): boolean {

--- a/packages/core/src/core/chunk_store_view.ts
+++ b/packages/core/src/core/chunk_store_view.ts
@@ -1,9 +1,10 @@
 import { Chunk, SliceCoordinates, ChunkViewState } from "../data/chunk";
 import type { ChunkStore } from "./chunk_store";
 import { Viewport } from "./viewport";
+import { Camera } from "../objects/cameras/camera";
 import { OrthographicCamera } from "../objects/cameras/orthographic_camera";
 import { ImageSourcePolicy } from "./image_source_policy";
-import { ReadonlyVec2, vec2, vec3 } from "gl-matrix";
+import { ReadonlyVec2, vec2, vec3, mat4 } from "gl-matrix";
 import { Box2 } from "../math/box2";
 import { Box3 } from "../math/box3";
 import { Logger } from "../utilities/logger";
@@ -23,6 +24,7 @@ export class ChunkStoreView {
   private policyChanged_ = false;
   private currentLOD_: number = 0;
   private lastViewBounds2D_: Box2 | null = null;
+  private lastViewProjection_: mat4 | null = null;
   private lastZBounds_?: [number, number];
   private lastTCoord_?: number;
 
@@ -159,7 +161,7 @@ export class ChunkStoreView {
     );
 
     if (sliceCoords.t !== undefined) {
-      this.markTimeChunksForPrefetch(
+      this.markTimeChunksForPrefetchImage(
         currentTimeIndex,
         sliceCoords,
         viewBounds3D,
@@ -173,7 +175,17 @@ export class ChunkStoreView {
     this.lastTCoord_ = sliceCoords.t;
   }
 
-  public updateChunksForVolume(sliceCoords: SliceCoordinates): void {
+  public updateChunksForVolume(
+    sliceCoords: SliceCoordinates,
+    viewport: Viewport
+  ): void {
+    const changed =
+      this.policyChanged_ ||
+      this.viewProjectionChanged(viewport.camera) ||
+      this.lastTCoord_ !== sliceCoords.t;
+
+    if (!changed) return;
+
     const currentTimeIndex = this.store_.getTimeIndex(sliceCoords);
     const currentTimeChunks = this.store_.getChunksAtTime(currentTimeIndex);
 
@@ -209,6 +221,11 @@ export class ChunkStoreView {
       });
     }
 
+    if (sliceCoords.t !== undefined) {
+      this.markTimeChunksForPrefetchVolume(currentTimeIndex, sliceCoords);
+    }
+
+    this.policyChanged_ = false;
     this.lastTCoord_ = sliceCoords.t;
   }
 
@@ -343,7 +360,7 @@ export class ChunkStoreView {
     }
   }
 
-  private markTimeChunksForPrefetch(
+  private markTimeChunksForPrefetchImage(
     currentTimeIndex: number,
     sliceCoords: SliceCoordinates,
     viewBounds3D: Box3,
@@ -355,13 +372,14 @@ export class ChunkStoreView {
       currentTimeIndex + this.policy_.prefetch.t
     );
     const fallbackLOD = this.fallbackLOD();
+    const priority = this.policy_.priorityMap["prefetchTime"];
+
     for (let t = currentTimeIndex + 1; t <= tEnd; ++t) {
       for (const chunk of this.store_.getChunksAtTime(t)) {
         if (chunk.lod !== fallbackLOD) continue;
         if (!this.isChunkChannelInSlice(chunk, sliceCoords)) continue;
         if (!this.isChunkWithinBounds(chunk, viewBounds3D)) continue;
 
-        const priority = this.policy_.priorityMap["prefetchTime"];
         const squareDistance = this.squareDistance2D(chunk, viewBoundsCenter2D);
         const normalizedDistance = clamp(
           squareDistance / this.sourceMaxSquareDistance2D_,
@@ -372,6 +390,35 @@ export class ChunkStoreView {
 
         // Always set priority/orderKey to keep loaded chunks alive
         // Only unloaded chunks will be queued for loading
+        this.chunkViewStates_.set(chunk, {
+          visible: false,
+          prefetch: true,
+          priority,
+          orderKey,
+        });
+      }
+    }
+  }
+
+  private markTimeChunksForPrefetchVolume(
+    currentTimeIndex: number,
+    sliceCoords: SliceCoordinates
+  ) {
+    const numTimePoints = this.store_.dimensions.t?.lods[0].size ?? 1;
+    const tEnd = Math.min(
+      numTimePoints - 1,
+      currentTimeIndex + this.policy_.prefetch.t
+    );
+    const fallbackLOD = this.fallbackLOD();
+    const priority = this.policy_.priorityMap["prefetchTime"];
+
+    for (let t = currentTimeIndex + 1; t <= tEnd; ++t) {
+      for (const chunk of this.store_.getChunksAtTime(t)) {
+        if (chunk.lod !== fallbackLOD) continue;
+        if (!this.isChunkChannelInSlice(chunk, sliceCoords)) continue;
+
+        const orderKey = t - currentTimeIndex; // nearer future timepoints first
+
         this.chunkViewStates_.set(chunk, {
           visible: false,
           prefetch: true,
@@ -453,6 +500,30 @@ export class ChunkStoreView {
       !vec2.equals(this.lastViewBounds2D_.min, newBounds.min) ||
       !vec2.equals(this.lastViewBounds2D_.max, newBounds.max)
     );
+  }
+
+  private viewProjectionChanged(camera: Camera) {
+    // Each call allocates a new mat4 and computes projection * view.
+    // This is intentional for simplicity. If this ever shows up in profiles:
+    //   - Avoid the allocation by reusing a temporary mat4.
+    //   - Avoid the multiply entirely by caching and comparing view/projection separately.
+    const viewProjection = mat4.multiply(
+      mat4.create(),
+      camera.projectionMatrix,
+      camera.viewMatrix
+    );
+
+    if (this.lastViewProjection_ === null) {
+      this.lastViewProjection_ = mat4.clone(viewProjection);
+      return true;
+    }
+
+    if (!mat4.equals(this.lastViewProjection_, viewProjection)) {
+      mat4.copy(this.lastViewProjection_, viewProjection);
+      return true;
+    }
+
+    return false;
   }
 
   private zBoundsChanged(newBounds: [number, number]): boolean {

--- a/packages/core/src/layers/volume_layer.ts
+++ b/packages/core/src/layers/volume_layer.ts
@@ -175,7 +175,10 @@ export class VolumeLayer extends Layer {
       this.reorderObjects(context.viewport.camera);
     }
 
-    this.chunkStoreView_.updateChunksForVolume(this.sliceCoords_);
+    this.chunkStoreView_.updateChunksForVolume(
+      this.sliceCoords_,
+      context.viewport
+    );
     this.updateChunks();
   }
 


### PR DESCRIPTION
### Summary

This PR refines `ChunkStoreView` to better align image and volume
update paths while avoiding unnecessary per-frame work.

- Add camera change detection for volume rendering using cached
view-projection matrices.
- Skip volume updates when policy, camera, and time are unchanged.
- Add timepoint prefetching for volume rendering at fallback LOD.
- Split image and volume time prefetch logic for clarity.

### Tests & Checks
- All checks have passed
- Manual verification (playback works as expected in the volume rendering examples)
