### PR TITLE
chore: generate a GitHub token for release from the Biohub GitHub helper

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -48,8 +47,15 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Generate token
+        id: generate_token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.GH_ACTIONS_HELPER_APP_ID }}
+          private-key: ${{ secrets.GH_ACTIONS_HELPER_PK }}
+
       - name: Release
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm exec semantic-release

--- a/README.md
+++ b/README.md
@@ -72,7 +72,6 @@ We use [semantic-release](https://github.com/semantic-release/semantic-release) 
 #### Pre-requirements
 
 - Repository secrets must be configured (already done for this repo):
-  - `RELEASE_TOKEN`: GitHub Personal Access Token with repo access
   - `NPM_TOKEN`: npm token with publish access to `@idetik` scope
 - You must be a member of the [idetik developer team](https://www.npmjs.com/settings/idetik/teams/team/developers/users) on NPM (for manual releases only)
 


### PR DESCRIPTION
### Summary
I noticed releases and PR comments are still being by @phoenixAja, which I believe is due to the PAT in the repo secrets.

I [asked in #help-infra](https://chanzuckerbergteam.slack.com/archives/C94RQ5SBV/p1771000992092589) and it sounds like we can generate a key dynamically with this action and the existing org-wide secrets.

Longer-term I think they'd like us to use "release-please" instead, but I don't think it's a high priority.

We should also create a new NPM token, but I'm not sure the best way to do that in a sustainable way. Maybe we add a machine user in 1Password we can share?