### PR TITLE
feat: add channel prop support to the volume layer

### DIFF
--- a/packages/core/examples/multi_viewport/main.ts
+++ b/packages/core/examples/multi_viewport/main.ts
@@ -50,13 +50,7 @@ const volumeLayer = new VolumeLayer({
   source,
   sliceCoords: volumeCoords,
   policy: createPlaybackPolicy({ lod: { min: 2, max: 2 } }),
-  channelProps: [
-    {
-      visible: true,
-      color: [1, 1, 1] as [number, number, number],
-      contrastLimits: [0, 512] as [number, number],
-    },
-  ],
+  channelProps: [{ contrastLimits: [0, 200] }],
 });
 
 const camera2D = new OrthographicCamera(left, right, top, bottom);

--- a/packages/core/examples/multi_viewport/main.ts
+++ b/packages/core/examples/multi_viewport/main.ts
@@ -50,6 +50,13 @@ const volumeLayer = new VolumeLayer({
   source,
   sliceCoords: volumeCoords,
   policy: createPlaybackPolicy({ lod: { min: 2, max: 2 } }),
+  channelProps: [
+    {
+      visible: true,
+      color: [1, 1, 1] as [number, number, number],
+      contrastLimits: [0, 512] as [number, number],
+    },
+  ],
 });
 
 const camera2D = new OrthographicCamera(left, right, top, bottom);

--- a/packages/core/examples/volume_rendering/main.ts
+++ b/packages/core/examples/volume_rendering/main.ts
@@ -23,6 +23,13 @@ const volumeLayer = new VolumeLayer({
   source,
   sliceCoords,
   policy,
+  channelProps: [
+    {
+      visible: true,
+      color: [1, 1, 1] as [number, number, number],
+      contrastLimits: [0, 512] as [number, number],
+    },
+  ],
 });
 const idetik = new Idetik({
   canvas: document.querySelector<HTMLCanvasElement>("#canvas")!,
@@ -66,7 +73,6 @@ const volumeFolder = gui.addFolder("Volume Rendering");
 volumeFolder
   .add(volumeLayer, "relativeStepSize", 0.25, 3.0, 0.1)
   .name("Relative step size (voxels)");
-volumeFolder.add(volumeLayer, "maxIntensity", 1, 255, 1).name("Max intensity");
 
 // maps 0-1 slider to [0.001, 10.0] logarithmically
 const opacityControls = {

--- a/packages/core/src/layers/volume_layer.ts
+++ b/packages/core/src/layers/volume_layer.ts
@@ -63,10 +63,13 @@ export class VolumeLayer extends Layer implements ChannelsEnabled {
     }
   }
 
-  public setChannelProps(newProps: ChannelProps[]) {
-    this.channelProps_ = newProps;
+  public setChannelProps(channelProps: ChannelProps[]) {
+    this.channelProps_ = channelProps;
     this.currentChunks_.forEach((chunk) => {
-      chunk.setChannelProps(newProps);
+      chunk.setChannelProps(channelProps);
+    });
+    this.channelChangeCallbacks_.forEach((callback) => {
+      callback();
     });
   }
 

--- a/packages/core/src/layers/volume_layer.ts
+++ b/packages/core/src/layers/volume_layer.ts
@@ -123,6 +123,9 @@ export class VolumeLayer extends Layer implements ChannelsEnabled {
       const texture = pooled.textures[0] as Texture3D;
       texture.updateWithChunk(chunk);
       this.updateVolumeChunk(pooled, chunk);
+      if (this.channelProps_) {
+        pooled.setChannelProps(this.channelProps_);
+      }
       return pooled;
     }
 

--- a/packages/core/src/layers/volume_layer.ts
+++ b/packages/core/src/layers/volume_layer.ts
@@ -8,7 +8,7 @@ import { Texture3D } from "../objects/textures/texture_3d";
 import { RenderablePool } from "../utilities/renderable_pool";
 import { glMatrix, vec3 } from "gl-matrix";
 import { Camera } from "../objects/cameras/camera";
-import { ChannelProps, ChannelsEnabled } from "@/objects/textures/channel";
+import { ChannelProps, ChannelsEnabled } from "../objects/textures/channel";
 
 export type VolumeLayerProps = {
   source: ChunkSource;

--- a/packages/core/src/layers/volume_layer.ts
+++ b/packages/core/src/layers/volume_layer.ts
@@ -8,31 +8,34 @@ import { Texture3D } from "../objects/textures/texture_3d";
 import { RenderablePool } from "../utilities/renderable_pool";
 import { glMatrix, vec3 } from "gl-matrix";
 import { Camera } from "../objects/cameras/camera";
+import { ChannelProps, ChannelsEnabled } from "@/objects/textures/channel";
 
 export type VolumeLayerProps = {
   source: ChunkSource;
   sliceCoords: SliceCoordinates;
   policy: ImageSourcePolicy;
+  channelProps?: ChannelProps[];
 };
 
-export class VolumeLayer extends Layer {
+export class VolumeLayer extends Layer implements ChannelsEnabled {
   public readonly type = "VolumeLayer";
 
   private readonly source_: ChunkSource;
   private readonly sliceCoords_: SliceCoordinates;
   private readonly currentChunks_: Map<Chunk, VolumeRenderable> = new Map();
   private readonly pool_ = new RenderablePool<VolumeRenderable>();
+  private readonly initialChannelProps_?: ChannelProps[];
+  private readonly channelChangeCallbacks_: Array<() => void> = [];
 
   private sourcePolicy_: ImageSourcePolicy;
   private chunkStoreView_?: ChunkStoreView;
+  private channelProps_?: ChannelProps[];
 
   private lastLoadedTime_: number | undefined = undefined;
   // TODO: Make a debug config object to manage debug options
   private debugShowWireframes_ = false;
   public debugShowDegenerateRays = false;
-  public color = vec3.fromValues(1.0, 1.0, 1.0);
   public relativeStepSize = 1.0;
-  public maxIntensity = 255.0;
   public opacityMultiplier = 0.1;
   public earlyTerminationAlpha = 0.99;
 
@@ -60,17 +63,51 @@ export class VolumeLayer extends Layer {
     }
   }
 
+  public setChannelProps(newProps: ChannelProps[]) {
+    this.channelProps_ = newProps;
+    this.currentChunks_.forEach((chunk) => {
+      chunk.setChannelProps(newProps);
+    });
+  }
+
+  public get channelProps(): ChannelProps[] | undefined {
+    return this.channelProps_;
+  }
+
+  public resetChannelProps(): void {
+    if (this.initialChannelProps_ !== undefined) {
+      this.setChannelProps(this.initialChannelProps_);
+    }
+  }
+
+  public addChannelChangeCallback(callback: () => void): void {
+    this.channelChangeCallbacks_.push(callback);
+  }
+
+  public removeChannelChangeCallback(callback: () => void): void {
+    const index = this.channelChangeCallbacks_.indexOf(callback);
+    if (index === undefined) {
+      throw new Error(`Callback to remove could not be found: ${callback}`);
+    }
+    this.channelChangeCallbacks_.splice(index, 1);
+  }
+
   private createVolume(chunk: Chunk) {
-    const volume = new VolumeRenderable(Texture3D.createWithChunk(chunk));
+    const volume = new VolumeRenderable(
+      Texture3D.createWithChunk(chunk),
+      this.channelProps_
+    );
     this.updateVolumeChunk(volume, chunk);
     return volume;
   }
 
-  constructor({ source, sliceCoords, policy }: VolumeLayerProps) {
+  constructor({ source, sliceCoords, policy, channelProps }: VolumeLayerProps) {
     super({ transparent: true, blendMode: "premultiplied" });
     this.source_ = source;
     this.sliceCoords_ = sliceCoords;
     this.sourcePolicy_ = policy;
+    this.initialChannelProps_ = channelProps;
+    this.channelProps_ = channelProps;
     this.setState("initialized");
   }
 
@@ -212,9 +249,7 @@ export class VolumeLayer extends Layer {
     return {
       DebugShowDegenerateRays: Number(this.debugShowDegenerateRays),
       RelativeStepSize: this.relativeStepSize,
-      MaxIntensity: this.maxIntensity,
       OpacityMultiplier: this.opacityMultiplier,
-      VolumeColor: this.color,
       EarlyTerminationAlpha: this.earlyTerminationAlpha,
     };
   }

--- a/packages/core/src/objects/renderable/volume_renderable.ts
+++ b/packages/core/src/objects/renderable/volume_renderable.ts
@@ -4,17 +4,27 @@ import { BoxGeometry } from "../geometry/box_geometry";
 import type { TextureDataType } from "../textures/texture";
 import type { Texture3D } from "../textures/texture_3d";
 import { vec3 } from "gl-matrix";
+import {
+  Channel,
+  ChannelProps,
+  validateChannel,
+  validateChannels,
+} from "../textures/channel";
 
 export class VolumeRenderable extends RenderableObject {
   public voxelScale: vec3 = vec3.fromValues(1, 1, 1);
 
-  constructor(texture: Texture3D) {
+  private channels_: Required<Channel>[];
+
+  constructor(texture: Texture3D, channels: ChannelProps[] = []) {
     super();
     this.geometry = new BoxGeometry(1, 1, 1, 1, 1, 1);
     this.setTexture(0, texture);
     this.programName = dataTypeToVolumeShader(texture.dataType);
     this.cullFaceMode = "front";
     this.depthTest = false;
+    // TODO handle visibility property of channels
+    this.channels_ = validateChannels(texture, channels);
   }
 
   public get type() {
@@ -22,9 +32,31 @@ export class VolumeRenderable extends RenderableObject {
   }
 
   public override getUniforms(): Record<string, unknown> {
+    const channel = this.channels_[0] ?? validateChannel(this.textures[0], {});
+    const { color, contrastLimits } = channel;
     return {
       VoxelScale: this.voxelScale,
+      Color: color.rgb,
+      ValueOffset: -contrastLimits[0],
+      ValueScale: 1 / (contrastLimits[1] - contrastLimits[0]),
     };
+  }
+
+  public setChannelProps(channels: ChannelProps[]) {
+    this.channels_ = validateChannels(this.textures[0], channels);
+  }
+
+  public setChannelProperty<K extends keyof ChannelProps>(
+    channelIndex: number,
+    property: K,
+    value: Required<ChannelProps>[K]
+  ) {
+    const newChannel = validateChannel(this.textures[0], {
+      ...this.channels_[channelIndex],
+      [property]: value,
+    });
+
+    this.channels_[channelIndex] = newChannel;
   }
 }
 

--- a/packages/core/src/renderers/shaders/volume_frag.glsl
+++ b/packages/core/src/renderers/shaders/volume_frag.glsl
@@ -22,11 +22,12 @@ vec3 boundingboxMax = vec3(0.50);
 
 // Volume rendering parameters
 uniform bool DebugShowDegenerateRays;
-uniform float MaxIntensity;
 uniform float OpacityMultiplier;
 uniform float EarlyTerminationAlpha;
-uniform vec3 VolumeColor;
 uniform float RelativeStepSize;
+uniform float ValueScale;
+uniform float ValueOffset;
+uniform vec3 Color;
 uniform vec3 VoxelScale;
 
 vec2 findBoxIntersectionsAlongRay(vec3 rayOrigin, vec3 rayDir, vec3 boxMin, vec3 boxMax) {
@@ -93,18 +94,17 @@ void main() {
     // Scale intensity to opacity.
     // OpacityMultiplier and MaxIntensity control the transfer function.
     // worldSpaceStepSize corrects for anisotropic voxels.
-    // TODO: Replace with invlerp-based transfer function to add contrast limits (MinIntensity/MaxIntensity window)
-    float intensityScale = (OpacityMultiplier / MaxIntensity) * worldSpaceStepSize;
+    float intensityScale = OpacityMultiplier * worldSpaceStepSize * ValueScale;
 
     // March until we reach the number of samples or accumulate enough opacity
     for (int i = 0; i < numSamples && accumulatedColor.a < EarlyTerminationAlpha; i++) {
         sampledData = vec4(texture(ImageSampler, position)).r;
-        sampleAlpha = sampledData * intensityScale;
+        sampleAlpha = (sampledData + ValueOffset) * intensityScale;
         blendedSampleAlpha = (1.0 - accumulatedColor.a) * sampleAlpha;
 
         // Front-to-back compositing
         accumulatedColor.a += blendedSampleAlpha;
-        accumulatedColor.rgb += VolumeColor * blendedSampleAlpha;
+        accumulatedColor.rgb += Color * blendedSampleAlpha;
         position += stepIncrement;
     }
 


### PR DESCRIPTION


### Summary
<!---
  Please try to cover the following questions in your summary:
  1. Describe the product (or technical) problem you are solving.
  2. Explain the engineering solution you have chosen.
  3. Discuss the implementation choices/tradeoffs you have made.
-->

One thing is common to both https://github.com/chanzuckerberg/idetik/pull/564 and https://github.com/chanzuckerberg/idetik/pull/583 - which is that there needs to be some way to define the properties of the channels for volume rendering. We've extracted that common piece here, as it is more self contained and would be helpful to get feedback on so then #564 and #583 can be adding on top of that.

The `VolumeLayer` has copied some of the `channelProps` functionality from the other image layers with the callbacks on channel change, how to set channels etc. And how the `VolumeRenderable` sets those as a uniform is similar to the `ImageRenderable`. This also helps in moving towards https://github.com/chanzuckerberg/idetik/issues/555 and removing uniforms from the volume layer. In this only the first channel would be supported for passing the uniforms, but it lays the framework for using channel props for multi-channel rendering.

### Tests & Checks
<!---
  How did you validate that your changes were implemented correctly?
  
  Please think about the following prompts:
  1. I wrote automated tests.
  2. I manually tested my changes, and here's what I did:
-->

I manually tested the volume rendering examples and checked other examples to see if still working. Visually this shouldn't really change much, outside of the transfer function bounds being a little different for the invlerp mapping.

New:
<img width="1852" height="889" alt="image" src="https://github.com/user-attachments/assets/e5220349-fb3d-4c03-8d03-5407bb820c1a" />

Old:
<img width="1852" height="889" alt="image" src="https://github.com/user-attachments/assets/b8001b5a-cb46-47ea-b078-80fc1245f6c1" />
