### PR TITLE
feat: downsample volume rendering on camera movement (1/2)

### DIFF
--- a/packages/core/src/layers/volume_layer.ts
+++ b/packages/core/src/layers/volume_layer.ts
@@ -15,6 +15,8 @@ export type VolumeLayerProps = {
   policy: ImageSourcePolicy;
 };
 
+const INTERACTIVE_STEP_SIZE_SCALE = 2.0;
+
 export class VolumeLayer extends Layer {
   public readonly type = "VolumeLayer";
 
@@ -27,6 +29,8 @@ export class VolumeLayer extends Layer {
   private chunkStoreView_?: ChunkStoreView;
 
   private lastLoadedTime_: number | undefined = undefined;
+  private interactiveStepSizeScale_ = 1.0;
+
   // TODO: Make a debug config object to manage debug options
   private debugShowWireframes_ = false;
   public debugShowDegenerateRays = false;
@@ -181,6 +185,12 @@ export class VolumeLayer extends Layer {
       this.sliceCoords_,
       context.viewport
     );
+
+    const isCameraMoving = context.viewport.cameraControls?.isMoving ?? false;
+    this.interactiveStepSizeScale_ = isCameraMoving
+      ? INTERACTIVE_STEP_SIZE_SCALE
+      : 1.0;
+
     this.updateChunks();
   }
 
@@ -211,7 +221,7 @@ export class VolumeLayer extends Layer {
   public getUniforms(): Record<string, unknown> {
     return {
       DebugShowDegenerateRays: Number(this.debugShowDegenerateRays),
-      RelativeStepSize: this.relativeStepSize,
+      RelativeStepSize: this.relativeStepSize * this.interactiveStepSizeScale_,
       MaxIntensity: this.maxIntensity,
       OpacityMultiplier: this.opacityMultiplier,
       VolumeColor: this.color,

--- a/packages/core/src/objects/cameras/controls.ts
+++ b/packages/core/src/objects/cameras/controls.ts
@@ -5,6 +5,7 @@ import { EventContext } from "../../core/event_dispatcher";
 const LEFT_MOUSE_BUTTON = 0;
 
 export interface CameraControls {
+  readonly isMoving: boolean;
   onUpdate(dt: number): void;
   onEvent(event: EventContext): void;
 }
@@ -16,6 +17,10 @@ export class PanZoomControls implements CameraControls {
 
   constructor(camera: OrthographicCamera) {
     this.camera_ = camera;
+  }
+
+  public get isMoving(): boolean {
+    return this.dragActive_;
   }
 
   public onEvent(event: EventContext): void {

--- a/packages/core/src/objects/cameras/orbit_controls.ts
+++ b/packages/core/src/objects/cameras/orbit_controls.ts
@@ -59,6 +59,17 @@ export class OrbitControls implements CameraControls {
     this.updateCamera();
   }
 
+  public get isMoving(): boolean {
+    return (
+      this.orbitVelocity_.phi !== 0 ||
+      this.orbitVelocity_.theta !== 0 ||
+      this.orbitVelocity_.radius !== 0 ||
+      this.panVelocity_[0] !== 0 ||
+      this.panVelocity_[1] !== 0 ||
+      this.panVelocity_[2] !== 0
+    );
+  }
+
   public onEvent(event: EventContext): void {
     switch (event.type) {
       case "pointerdown":


### PR DESCRIPTION
### Summary

Increases the ray march step size during camera interaction to improve volume rendering
responsiveness. When the camera is moving `RelativeStepSize` is scaled up to `2x`
halving the number of samples per ray. Full quality is restored when the camera stops.

This is the first of two changes:
1. **This PR**: Reduce number of ray march steps per fragment
2. **Next PR**: Render to a lower-resolution framebuffer and blit to screen

Together they reduce both fragment cost and fragment count during interaction.

### Tests & Checks

- Manual verification / downsampled step size when camera is moving.
- All checks have passed.