### PR TITLE
fix: Correct volume sorting for volume rendering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -160,7 +160,6 @@
       "version": "7.26.8",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.2",
@@ -483,7 +482,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -505,7 +503,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1392,7 +1389,6 @@
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -2196,7 +2192,6 @@
       "version": "10.4.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -2261,7 +2256,6 @@
       "version": "24.3.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.10.0"
       }
@@ -2318,7 +2312,6 @@
       "version": "8.24.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.24.0",
         "@typescript-eslint/types": "8.24.0",
@@ -2466,7 +2459,6 @@
       "version": "3.0.9",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@testing-library/dom": "^10.4.0",
         "@testing-library/user-event": "^14.6.1",
@@ -2632,7 +2624,6 @@
       "version": "8.15.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2832,7 +2823,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001688",
         "electron-to-chromium": "^1.5.73",
@@ -3821,7 +3811,6 @@
       "version": "9.33.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4992,7 +4981,6 @@
       "version": "24.1.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.0.1",
         "data-urls": "^5.0.0",
@@ -5278,7 +5266,6 @@
       "version": "15.0.12",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -7669,7 +7656,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8157,7 +8143,6 @@
       "version": "1.56.1",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "playwright-core": "1.56.1"
       },
@@ -8489,7 +8474,6 @@
       "version": "4.34.9",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.6"
       },
@@ -8598,7 +8582,6 @@
       "integrity": "sha512-6qGjWccl5yoyugHt3jTgztJ9Y0JVzyH8/Voc/D8PlLat9pwxQYXz7W1Dpnq5h0/G5GCYGUaDSlYcyk3AMh5A6g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^13.0.1",
         "@semantic-release/error": "^4.0.0",
@@ -9488,7 +9471,6 @@
       "version": "4.0.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9589,8 +9571,7 @@
     "node_modules/tslib": {
       "version": "2.8.1",
       "dev": true,
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/tunnel": {
       "version": "0.0.6",
@@ -9628,7 +9609,6 @@
       "version": "5.7.3",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9823,7 +9803,6 @@
       "version": "6.4.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -10023,7 +10002,6 @@
       "version": "4.0.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10035,7 +10013,6 @@
       "version": "3.0.9",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "3.0.9",
         "@vitest/mocker": "3.0.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -160,6 +160,7 @@
       "version": "7.26.8",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.2",
@@ -482,6 +483,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -503,6 +505,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1389,6 +1392,7 @@
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -2192,6 +2196,7 @@
       "version": "10.4.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -2256,6 +2261,7 @@
       "version": "24.3.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.10.0"
       }
@@ -2312,6 +2318,7 @@
       "version": "8.24.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.24.0",
         "@typescript-eslint/types": "8.24.0",
@@ -2459,6 +2466,7 @@
       "version": "3.0.9",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@testing-library/dom": "^10.4.0",
         "@testing-library/user-event": "^14.6.1",
@@ -2624,6 +2632,7 @@
       "version": "8.15.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2823,6 +2832,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001688",
         "electron-to-chromium": "^1.5.73",
@@ -3811,6 +3821,7 @@
       "version": "9.33.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4981,6 +4992,7 @@
       "version": "24.1.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.0.1",
         "data-urls": "^5.0.0",
@@ -5266,6 +5278,7 @@
       "version": "15.0.12",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -7656,6 +7669,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8143,6 +8157,7 @@
       "version": "1.56.1",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "playwright-core": "1.56.1"
       },
@@ -8474,6 +8489,7 @@
       "version": "4.34.9",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.6"
       },
@@ -8582,6 +8598,7 @@
       "integrity": "sha512-6qGjWccl5yoyugHt3jTgztJ9Y0JVzyH8/Voc/D8PlLat9pwxQYXz7W1Dpnq5h0/G5GCYGUaDSlYcyk3AMh5A6g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^13.0.1",
         "@semantic-release/error": "^4.0.0",
@@ -9471,6 +9488,7 @@
       "version": "4.0.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9571,7 +9589,8 @@
     "node_modules/tslib": {
       "version": "2.8.1",
       "dev": true,
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/tunnel": {
       "version": "0.0.6",
@@ -9609,6 +9628,7 @@
       "version": "5.7.3",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9803,6 +9823,7 @@
       "version": "6.4.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -10002,6 +10023,7 @@
       "version": "4.0.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10013,6 +10035,7 @@
       "version": "3.0.9",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "3.0.9",
         "@vitest/mocker": "3.0.9",

--- a/packages/core/src/layers/volume_layer.ts
+++ b/packages/core/src/layers/volume_layer.ts
@@ -7,7 +7,6 @@ import { ImageSourcePolicy } from "../core/image_source_policy";
 import { Texture3D } from "../objects/textures/texture_3d";
 import { RenderablePool } from "../utilities/renderable_pool";
 import { vec3 } from "gl-matrix";
-import { Camera } from "../objects/cameras/camera";
 import { sortFrontToBack } from "../math/sort_by_distance";
 import { ChannelProps, ChannelsEnabled } from "../objects/textures/channel";
 

--- a/packages/core/src/layers/volume_layer.ts
+++ b/packages/core/src/layers/volume_layer.ts
@@ -6,8 +6,9 @@ import { ChunkStoreView, INTERNAL_POLICY_KEY } from "../core/chunk_store_view";
 import { ImageSourcePolicy } from "../core/image_source_policy";
 import { Texture3D } from "../objects/textures/texture_3d";
 import { RenderablePool } from "../utilities/renderable_pool";
-import { glMatrix, vec3 } from "gl-matrix";
+import { vec3 } from "gl-matrix";
 import { Camera } from "../objects/cameras/camera";
+import { sortFrontToBack } from "../math/sort_by_distance";
 
 export type VolumeLayerProps = {
   source: ChunkSource;
@@ -185,27 +186,7 @@ export class VolumeLayer extends Layer {
   }
 
   public reorderObjects(camera: Camera) {
-    const cameraPos = camera.position;
-    const centerA = vec3.create();
-    const centerB = vec3.create();
-
-    this.objects.sort((a, b) => {
-      vec3.add(centerA, a.boundingBox.max, a.boundingBox.min);
-      vec3.scale(centerA, centerA, 0.5);
-
-      vec3.add(centerB, b.boundingBox.max, b.boundingBox.min);
-      vec3.scale(centerB, centerB, 0.5);
-
-      const cam2aDistance = vec3.squaredDistance(cameraPos, centerA);
-      const cam2bDistance = vec3.squaredDistance(cameraPos, centerB);
-      const diff = cam2bDistance - cam2aDistance;
-
-      if (Math.abs(diff) < glMatrix.EPSILON) {
-        return 0;
-      }
-
-      return diff;
-    });
+    sortFrontToBack(this.objects, camera);
   }
 
   public getUniforms(): Record<string, unknown> {

--- a/packages/core/src/layers/volume_layer.ts
+++ b/packages/core/src/layers/volume_layer.ts
@@ -234,11 +234,7 @@ export class VolumeLayer extends Layer implements ChannelsEnabled {
       : 1.0;
 
     this.updateChunks();
-    this.reorderObjects(context.viewport.camera);
-  }
-
-  public reorderObjects(camera: Camera) {
-    sortFrontToBack(this.objects, camera);
+    sortFrontToBack(this.objects, context.viewport.camera);
   }
 
   public getUniforms(): Record<string, unknown> {

--- a/packages/core/src/layers/volume_layer.ts
+++ b/packages/core/src/layers/volume_layer.ts
@@ -174,8 +174,6 @@ export class VolumeLayer extends Layer {
       throw new Error(
         "RenderContext is required for the VolumeLayer update as camera information is used to reorder the chunks."
       );
-    } else {
-      this.reorderObjects(context.viewport.camera);
     }
 
     this.chunkStoreView_.updateChunksForVolume(
@@ -183,6 +181,7 @@ export class VolumeLayer extends Layer {
       context.viewport
     );
     this.updateChunks();
+    this.reorderObjects(context.viewport.camera);
   }
 
   public reorderObjects(camera: Camera) {

--- a/packages/core/src/math/sort_by_distance.ts
+++ b/packages/core/src/math/sort_by_distance.ts
@@ -1,0 +1,35 @@
+import { vec3 } from "gl-matrix";
+import type { Camera } from "../objects/cameras/camera";
+import type { RenderableObject } from "../core/renderable_object";
+
+/**
+ * Sorts objects front-to-back based on their distance from a camera
+ *
+ * Uses the camera position compared to the center of each object's
+ * bounding box to determine distance.
+ * @param objects - Array of renderable objects to sort.
+ * @param camera - The camera to calculate distances from
+ * @returns Input objects sorted-in-place from closest to farthest
+ */
+export function sortFrontToBack(
+  objects: RenderableObject[],
+  camera: Camera
+): RenderableObject[] {
+  const cameraPosition = camera.position;
+  const centerA = vec3.create();
+  const centerB = vec3.create();
+
+  objects.sort((a, b) => {
+    vec3.add(centerA, a.boundingBox.max, a.boundingBox.min);
+    vec3.scale(centerA, centerA, 0.5);
+    vec3.add(centerB, b.boundingBox.max, b.boundingBox.min);
+    vec3.scale(centerB, centerB, 0.5);
+
+    const cam2aDistance = vec3.squaredDistance(cameraPosition, centerA);
+    const cam2bDistance = vec3.squaredDistance(cameraPosition, centerB);
+
+    return cam2aDistance - cam2bDistance;
+  });
+
+  return objects;
+}

--- a/packages/core/test/sort_by_distance.test.ts
+++ b/packages/core/test/sort_by_distance.test.ts
@@ -57,16 +57,16 @@ test("handles equidistant objects maintaining stable order", () => {
 test("handles objects with very small distance differences", () => {
   const camera = new PerspectiveCamera();
 
-  const obj1 = new MockRenderableObject([1.0, 0, 0]);
-  const obj2 = new MockRenderableObject([1.0001, 0, 0]);
-  const obj3 = new MockRenderableObject([1.0002, 0, 0]);
+  const near = new MockRenderableObject([1.0, 0, 0]);
+  const mid = new MockRenderableObject([1.0001, 0, 0]);
+  const far = new MockRenderableObject([1.0002, 0, 0]);
 
-  const objects = [obj3, obj1, obj2];
+  const objects = [far, near, mid];
   sortFrontToBack(objects, camera);
 
-  expect(objects[0]).toBe(obj1);
-  expect(objects[1]).toBe(obj2);
-  expect(objects[2]).toBe(obj3);
+  expect(objects[0]).toBe(near);
+  expect(objects[1]).toBe(mid);
+  expect(objects[2]).toBe(far);
 });
 
 test("handles large coordinate values", () => {
@@ -106,14 +106,14 @@ test("handles objects in 3D space with camera not at origin", () => {
 test("handles objects with negative coordinates", () => {
   const camera = new PerspectiveCamera();
 
-  const obj1 = new MockRenderableObject([-1, 0, 0]);
-  const obj2 = new MockRenderableObject([-5, 0, 0]);
-  const obj3 = new MockRenderableObject([-10, 0, 0]);
+  const near = new MockRenderableObject([-1, 0, 0]);
+  const mid = new MockRenderableObject([-5, 0, 0]);
+  const far = new MockRenderableObject([-10, 0, 0]);
 
-  const objects = [obj3, obj1, obj2];
+  const objects = [far, near, mid];
   sortFrontToBack(objects, camera);
 
-  expect(objects[0]).toBe(obj1);
-  expect(objects[1]).toBe(obj2);
-  expect(objects[2]).toBe(obj3);
+  expect(objects[0]).toBe(near);
+  expect(objects[1]).toBe(mid);
+  expect(objects[2]).toBe(far);
 });

--- a/packages/core/test/sort_by_distance.test.ts
+++ b/packages/core/test/sort_by_distance.test.ts
@@ -1,0 +1,119 @@
+import { expect, test } from "vitest";
+import { vec3 } from "gl-matrix";
+import { sortFrontToBack } from "@/math/sort_by_distance";
+import { PerspectiveCamera } from "@/index";
+import { RenderableObject } from "@/core/renderable_object";
+import { BoxGeometry } from "@/objects/geometry/box_geometry";
+
+class MockRenderableObject extends RenderableObject {
+  constructor(centre: number[], size: number = 1) {
+    super();
+    const centreVec = vec3.fromValues(centre[0], centre[1], centre[2]);
+    this.geometry = new BoxGeometry(1, 1, 1, 1, 1, 1);
+    this.transform.setTranslation(
+      vec3.add(
+        vec3.create(),
+        centreVec,
+        vec3.fromValues(-size / 2, -size / 2, -size / 2)
+      )
+    );
+  }
+  get type() {
+    return "MockRenderableObject";
+  }
+}
+
+test("sorts objects from closest to farthest", () => {
+  const camera = new PerspectiveCamera();
+
+  const near = new MockRenderableObject([1, 0, 0]);
+  const mid = new MockRenderableObject([5, 0, 0]);
+  const far = new MockRenderableObject([10, 0, 0]);
+
+  const objects = [far, mid, near];
+  sortFrontToBack(objects, camera);
+
+  expect(objects[0]).toBe(near);
+  expect(objects[1]).toBe(mid);
+  expect(objects[2]).toBe(far);
+});
+
+test("handles equidistant objects maintaining stable order", () => {
+  const camera = new PerspectiveCamera();
+
+  const obj1 = new MockRenderableObject([5, 0, 0]);
+  const obj2 = new MockRenderableObject([0, 5, 0]);
+  const obj3 = new MockRenderableObject([0, 0, 5]);
+
+  const objects = [obj1, obj2, obj3];
+  sortFrontToBack(objects, camera);
+  // All should be at the same distance, so order should be unchanged
+  expect(objects[0]).toBe(obj1);
+  expect(objects[1]).toBe(obj2);
+  expect(objects[2]).toBe(obj3);
+});
+
+test("handles objects with very small distance differences", () => {
+  const camera = new PerspectiveCamera();
+
+  // Create objects very close to each other
+  const obj1 = new MockRenderableObject([1.0, 0, 0]);
+  const obj2 = new MockRenderableObject([1.0001, 0, 0]);
+  const obj3 = new MockRenderableObject([1.0002, 0, 0]);
+
+  const objects = [obj3, obj1, obj2];
+  sortFrontToBack(objects, camera);
+
+  expect(objects[0]).toBe(obj1);
+  expect(objects[1]).toBe(obj2);
+  expect(objects[2]).toBe(obj3);
+});
+
+test("handles large coordinate values", () => {
+  const camera = new PerspectiveCamera({
+    position: vec3.fromValues(1000, 1000, 1000),
+  });
+
+  const near = new MockRenderableObject([1001, 1000, 1000]);
+  const mid = new MockRenderableObject([1100, 1000, 1000]);
+  const far = new MockRenderableObject([2000, 1000, 1000]);
+
+  const objects = [mid, far, near];
+  sortFrontToBack(objects, camera);
+
+  expect(objects[0]).toBe(near);
+  expect(objects[1]).toBe(mid);
+  expect(objects[2]).toBe(far);
+});
+
+test("handles objects in 3D space with camera not at origin", () => {
+  const camera = new PerspectiveCamera({
+    position: vec3.fromValues(10, 10, 10),
+  });
+
+  const near = new MockRenderableObject([11, 11, 11]); // distance ≈ 1.73
+  const mid = new MockRenderableObject([15, 10, 10]); // distance = 5
+  const far = new MockRenderableObject([20, 20, 20]); // distance ≈ 17.32
+
+  const objects = [far, near, mid];
+  sortFrontToBack(objects, camera);
+
+  expect(objects[0]).toBe(near);
+  expect(objects[1]).toBe(mid);
+  expect(objects[2]).toBe(far);
+});
+
+test("handles objects with negative coordinates", () => {
+  const camera = new PerspectiveCamera();
+
+  const obj1 = new MockRenderableObject([-1, 0, 0]);
+  const obj2 = new MockRenderableObject([-5, 0, 0]);
+  const obj3 = new MockRenderableObject([-10, 0, 0]);
+
+  const objects = [obj3, obj1, obj2];
+  sortFrontToBack(objects, camera);
+
+  expect(objects[0]).toBe(obj1); // distance 1
+  expect(objects[1]).toBe(obj2); // distance 5
+  expect(objects[2]).toBe(obj3); // distance 10
+});

--- a/packages/core/test/sort_by_distance.test.ts
+++ b/packages/core/test/sort_by_distance.test.ts
@@ -47,6 +47,7 @@ test("handles equidistant objects maintaining stable order", () => {
 
   const objects = [obj1, obj2, obj3];
   sortFrontToBack(objects, camera);
+
   // All should be at the same distance, so order should be unchanged
   expect(objects[0]).toBe(obj1);
   expect(objects[1]).toBe(obj2);
@@ -56,7 +57,6 @@ test("handles equidistant objects maintaining stable order", () => {
 test("handles objects with very small distance differences", () => {
   const camera = new PerspectiveCamera();
 
-  // Create objects very close to each other
   const obj1 = new MockRenderableObject([1.0, 0, 0]);
   const obj2 = new MockRenderableObject([1.0001, 0, 0]);
   const obj3 = new MockRenderableObject([1.0002, 0, 0]);
@@ -96,6 +96,11 @@ test("handles objects in 3D space with camera not at origin", () => {
   const far = new MockRenderableObject([20, 20, 20]); // distance ≈ 17.32
 
   const objects = [far, near, mid];
+  const distances = objects.map((obj) => {
+    const objPos = obj.transform.translation;
+    return vec3.distance(camera.position, objPos);
+  });
+  console.log("Distances from camera:", distances);
   sortFrontToBack(objects, camera);
 
   expect(objects[0]).toBe(near);
@@ -113,7 +118,7 @@ test("handles objects with negative coordinates", () => {
   const objects = [obj3, obj1, obj2];
   sortFrontToBack(objects, camera);
 
-  expect(objects[0]).toBe(obj1); // distance 1
-  expect(objects[1]).toBe(obj2); // distance 5
-  expect(objects[2]).toBe(obj3); // distance 10
+  expect(objects[0]).toBe(obj1);
+  expect(objects[1]).toBe(obj2);
+  expect(objects[2]).toBe(obj3);
 });

--- a/packages/core/test/sort_by_distance.test.ts
+++ b/packages/core/test/sort_by_distance.test.ts
@@ -96,11 +96,6 @@ test("handles objects in 3D space with camera not at origin", () => {
   const far = new MockRenderableObject([20, 20, 20]); // distance ≈ 17.32
 
   const objects = [far, near, mid];
-  const distances = objects.map((obj) => {
-    const objPos = obj.transform.translation;
-    return vec3.distance(camera.position, objPos);
-  });
-  console.log("Distances from camera:", distances);
   sortFrontToBack(objects, camera);
 
   expect(objects[0]).toBe(near);


### PR DESCRIPTION
### Summary
<!---
  Please try to cover the following questions in your summary:
  1. Describe the product (or technical) problem you are solving.
  2. Explain the engineering solution you have chosen.
  3. Discuss the implementation choices/tradeoffs you have made.
-->

Corrects the sorting order to front-to-back in the volume layer to match the expectation in the blending mode set for volume rendering and the compositing in the volume shader. Have also written some tests to ensure this doesn't happen again, I think we had it right before and then broke it in refactoring.

Have also fixed an issue that the chunks were sorted, and then updated, which could cause an annoying flickering if the chunks were being updated pretty regularly. Now the chunks are updated, and then sorted. So this should be more consistent.

Finally, removed a check on if the distances were within a delta to just return 0 instead. I don't expect this is actually needed, but if I'm missing a case where that's needed then happy to revert it.

### Tests & Checks
<!---
  How did you validate that your changes were implemented correctly?
  
  Please think about the following prompts:
  1. I wrote automated tests.
  2. I manually tested my changes, and here's what I did:
-->

I wrote automated tests and manually tested. To manually test I bumped the opacity up very high to see if the data closest to the camera appeared to be occluding what was behind it.