### PR TITLE
perf: early-return to reduce total chunk intersection tests

### DIFF
--- a/packages/core/src/core/chunk_store_view.ts
+++ b/packages/core/src/core/chunk_store_view.ts
@@ -347,8 +347,10 @@ export class ChunkStoreView {
       const isFallbackLOD = chunk.lod === fallbackLOD;
       if (!isCurrentLOD && !isFallbackLOD) continue;
 
-      const isInBounds = this.isChunkWithinBounds(chunk, viewBounds3D);
       const isChannelInSlice = this.isChunkChannelInSlice(chunk, sliceCoords);
+      if (!isChannelInSlice) continue;
+
+      const isInBounds = this.isChunkWithinBounds(chunk, viewBounds3D);
 
       const prefetch =
         !isInBounds &&

--- a/packages/core/src/core/chunk_store_view.ts
+++ b/packages/core/src/core/chunk_store_view.ts
@@ -216,13 +216,14 @@ export class ChunkStoreView {
     const fallbackLOD = this.fallbackLOD();
 
     for (const chunk of currentTimeChunks) {
-      if (chunk.lod !== this.currentLOD_) continue;
-      if (!this.isChunkChannelInSlice(chunk, sliceCoords)) continue;
-
+      const isCurrentLOD = chunk.lod === this.currentLOD_;
       const isFallbackLOD = chunk.lod === fallbackLOD;
+      if (!isCurrentLOD && !isFallbackLOD) continue;
+
+      if (!this.isChunkChannelInSlice(chunk, sliceCoords)) continue;
       const priority = this.computePriority(
         isFallbackLOD,
-        true, // isCurrentLOD
+        isCurrentLOD,
         true, // isVisible
         false, // isPrefetch
         true // isChannelInSlice
@@ -342,11 +343,12 @@ export class ChunkStoreView {
     const fallbackLOD = this.fallbackLOD();
 
     for (const chunk of currentTimeChunks) {
-      const isInBounds = this.isChunkWithinBounds(chunk, viewBounds3D);
-      const isChannelInSlice = this.isChunkChannelInSlice(chunk, sliceCoords);
-
       const isCurrentLOD = chunk.lod === this.currentLOD_;
       const isFallbackLOD = chunk.lod === fallbackLOD;
+      if (!isCurrentLOD && !isFallbackLOD) continue;
+
+      const isInBounds = this.isChunkWithinBounds(chunk, viewBounds3D);
+      const isChannelInSlice = this.isChunkChannelInSlice(chunk, sliceCoords);
 
       const prefetch =
         !isInBounds &&


### PR DESCRIPTION
### Summary
When viewing large multiscale datasets with many chunks (for example stitched OPS data for cellxstate) we see degraded pan/zoom responsiveness. I tracked this down and found this quick optimization to only perform intersection tests for the current and fallback LODs. This can be a significant reduction in total computation on the main thread, improving perceived performance.

I think there are more gains to be had here, probably by using a spatial data structure like an octree to determine visibility.

Another optimization in the layer-per-channel case would be to somehow cache/reuse the visibility results for separate channels.

### Related Issue
N/A

### Tests & Checks
Tested by installing @idetik/core with this change in the DCA viewer and viewing `cellstate/ops0006_20250121/phenotyping_v3.zarr/A/1/0` (`sci-data-staging` S3).