### PR TITLE
chore: use npm "trusted publishing" for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,5 +57,4 @@ jobs:
       - name: Release
         env:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm exec semantic-release

--- a/README.md
+++ b/README.md
@@ -71,9 +71,13 @@ We use [semantic-release](https://github.com/semantic-release/semantic-release) 
 
 #### Pre-requirements
 
-- Repository secrets must be configured (already done for this repo):
-  - `NPM_TOKEN`: npm token with publish access to `@idetik` scope
-- You must be a member of the [idetik developer team](https://www.npmjs.com/settings/idetik/teams/team/developers/users) on NPM (for manual releases only)
+- For GH Actions:
+    - Set up "trusted publishing" for the repo/package pair on npm (uses OIDC to authenticate when publishing)
+    - Use `actions/create-github-app-token` to generate a GH token so `semantic-release` can comment
+      on the PR after release
+- For manual releases:
+    - Set `NPM_TOKEN` env var with an npm token with publish access to `@idetik` scope
+    - You must be a member of the [idetik developer team](https://www.npmjs.com/settings/idetik/teams/team/developers/users) on NPM (for manual releases only)
 
 ### Manual Release Process (Fallback)
 


### PR DESCRIPTION
### Summary
This removes the `NPM_TOKEN` secret, that appears to be no longer valid (see [this failed run](https://github.com/chanzuckerberg/idetik/actions/runs/22325021249/job/64593111942)). I think it was using a token from @phoenixAja's npm account?

I set up trusted publishing on npm, which I believe is [supported automatically by `semantic-relase`](https://github.com/semantic-release/npm?tab=readme-ov-file#official-registry) but I'm not sure how to test that without pushing this change.

### Related Issue
Closes N/A

### Tests & Checks
Test requires merge, I think