### PR TITLE
fix: protect against out bounds time index setting breaking volume image rendering

### DIFF
--- a/packages/core/src/core/chunk_store.ts
+++ b/packages/core/src/core/chunk_store.ts
@@ -89,7 +89,7 @@ export class ChunkStore {
   }
 
   public getChunksAtTime(timeIndex: number): Chunk[] {
-    return this.chunks_[timeIndex];
+    return this.chunks_?.[timeIndex];
   }
 
   public getTimeIndex(sliceCoords: SliceCoordinates): number {

--- a/packages/core/src/core/chunk_store_view.ts
+++ b/packages/core/src/core/chunk_store_view.ts
@@ -74,6 +74,9 @@ export class ChunkStoreView {
   public getChunksToRender(sliceCoords: SliceCoordinates): Chunk[] {
     const currentTimeIndex = this.store_.getTimeIndex(sliceCoords);
     const currentTimeChunks = this.store_.getChunksAtTime(currentTimeIndex);
+    if (currentTimeChunks === undefined) {
+      return [];
+    }
     const currentLODChunks = currentTimeChunks.filter(
       (chunk) =>
         chunk.lod === this.currentLOD_ &&
@@ -129,6 +132,10 @@ export class ChunkStoreView {
 
     const currentTimeIndex = this.store_.getTimeIndex(sliceCoords);
     const currentTimeChunks = this.store_.getChunksAtTime(currentTimeIndex);
+
+    if (currentTimeChunks === undefined) {
+      return;
+    }
 
     if (currentTimeChunks.length === 0) {
       Logger.warn(
@@ -197,6 +204,10 @@ export class ChunkStoreView {
     const currentTimeIndex = this.store_.getTimeIndex(sliceCoords);
     const currentTimeChunks = this.store_.getChunksAtTime(currentTimeIndex);
 
+    if (currentTimeChunks === undefined) {
+      return;
+    }
+
     if (currentTimeChunks.length === 0) {
       Logger.warn(
         "ChunkStoreView",
@@ -251,10 +262,10 @@ export class ChunkStoreView {
     const fallbackLOD = this.fallbackLOD();
     const visibleChunks = this.store_
       .getChunksAtTime(timeIndex)
-      .filter((c) => c.visible && c.lod === fallbackLOD);
+      ?.filter((c) => c.visible && c.lod === fallbackLOD);
     // Return false if there are no visible chunks (empty array .every() returns true)
     return (
-      visibleChunks.length > 0 &&
+      visibleChunks?.length > 0 &&
       visibleChunks.every((c) => c.state === "loaded")
     );
   }
@@ -340,6 +351,9 @@ export class ChunkStoreView {
     const paddedBounds = this.getPaddedBounds(viewBounds3D);
 
     const currentTimeChunks = this.store_.getChunksAtTime(timeIndex);
+    if (currentTimeChunks === undefined) {
+      return;
+    }
     const fallbackLOD = this.fallbackLOD();
 
     for (const chunk of currentTimeChunks) {
@@ -395,7 +409,11 @@ export class ChunkStoreView {
     const priority = this.policy_.priorityMap["prefetchTime"];
 
     for (let t = currentTimeIndex + 1; t <= tEnd; ++t) {
-      for (const chunk of this.store_.getChunksAtTime(t)) {
+      const currentTimeChunks = this.store_.getChunksAtTime(t);
+      if (currentTimeChunks === undefined) {
+        return;
+      }
+      for (const chunk of currentTimeChunks) {
         if (chunk.lod !== fallbackLOD) continue;
         if (!this.isChunkChannelInSlice(chunk, sliceCoords)) continue;
         if (!this.isChunkWithinBounds(chunk, viewBounds3D)) continue;
@@ -433,7 +451,11 @@ export class ChunkStoreView {
     const priority = this.policy_.priorityMap["prefetchTime"];
 
     for (let t = currentTimeIndex + 1; t <= tEnd; ++t) {
-      for (const chunk of this.store_.getChunksAtTime(t)) {
+      const currentTimeChunks = this.store_.getChunksAtTime(t);
+      if (currentTimeChunks === undefined) {
+        return;
+      }
+      for (const chunk of currentTimeChunks) {
         if (chunk.lod !== fallbackLOD) continue;
         if (!this.isChunkChannelInSlice(chunk, sliceCoords)) continue;
 


### PR DESCRIPTION
### Summary
<!---
  Please try to cover the following questions in your summary:
  1. Describe the product (or technical) problem you are solving.
  2. Explain the engineering solution you have chosen.
  3. Discuss the implementation choices/tradeoffs you have made.
-->

There was a bug that could be triggered from the volume rendering example or multi-viewport example by setting `t` to the max on the time slider. We fixed that in https://github.com/chanzuckerberg/idetik/pull/597 along with @andy-sweet. 

This PR is not pressing due to the above fix. We originally opened this PR instead of #597. Leaving this open to discuss the possibility to protect against that and other time co-ords being out of bounds.

### Tests & Checks
<!---
  How did you validate that your changes were implemented correctly?
  
  Please think about the following prompts:
  1. I wrote automated tests.
  2. I manually tested my changes, and here's what I did:
-->

Manually tested changes.