### PR TITLE
fix: correct volume rendering examples time bound to 790

### DIFF
--- a/packages/core/examples/multi_viewport/main.ts
+++ b/packages/core/examples/multi_viewport/main.ts
@@ -100,7 +100,7 @@ addDimensionSlider({
   sliceCoords: sharedTime,
   dimensionName: "t",
   minValue: 0,
-  maxValue: 800,
+  maxValue: 790,
   stepValue: 1,
   playback: {
     maxRateHz: 30,

--- a/packages/core/examples/volume_rendering/main.ts
+++ b/packages/core/examples/volume_rendering/main.ts
@@ -55,7 +55,7 @@ addDimensionSlider({
   sliceCoords,
   dimensionName: "t",
   minValue: 0,
-  maxValue: 800,
+  maxValue: 790,
   stepValue: 1.0,
   playback: {},
 });


### PR DESCRIPTION
### Summary
<!---
  Please try to cover the following questions in your summary:
  1. Describe the product (or technical) problem you are solving.
  2. Explain the engineering solution you have chosen.
  3. Discuss the implementation choices/tradeoffs you have made.
-->

Currently the volume rendering examples can break from time going out of bounds near the max values on the time slider. This is to fix that to 790 as suggested by @andy-sweet

### Tests & Checks
<!---
  How did you validate that your changes were implemented correctly?
  
  Please think about the following prompts:
  1. I wrote automated tests.
  2. I manually tested my changes, and here's what I did:
-->

Manually tested chages