### PR TITLE
feat: support dynamically adding and removing viewports at runtime

### DIFF
--- a/packages/core/src/core/viewport.ts
+++ b/packages/core/src/core/viewport.ts
@@ -135,29 +135,33 @@ export class Viewport {
   }
 }
 
-function validateViewportProps(viewportProps: ViewportProps[]): void {
-  const elementToViewportId = new Map<HTMLElement, string>();
-  const seenViewportIds = new Set<string>();
-
-  for (const props of viewportProps) {
-    if (seenViewportIds.has(props.id)) {
+export function validateNewViewport(
+  viewport: { id: string; element: HTMLElement },
+  existingViewports: { id: string; element: HTMLElement }[]
+): void {
+  for (const existing of existingViewports) {
+    if (existing.id === viewport.id) {
       throw new Error(
-        `Duplicate viewport ID "${props.id}". Each viewport must have a unique ID.`
+        `Duplicate viewport ID "${viewport.id}". Each viewport must have a unique ID.`
       );
     }
-    seenViewportIds.add(props.id);
-
-    if (elementToViewportId.has(props.element)) {
-      const existingViewportId = elementToViewportId.get(props.element)!;
+    if (existing.element === viewport.element) {
       const elementDescription =
-        props.element.tagName.toLowerCase() +
-        (props.element.id ? `#${props.element.id}` : "[element has no id]");
+        viewport.element.tagName.toLowerCase() +
+        (viewport.element.id
+          ? `#${viewport.element.id}`
+          : "[element has no id]");
       throw new Error(
         "Multiple viewports cannot share the same HTML element: " +
-          `viewports "${existingViewportId}" and "${props.id}" both use ${elementDescription}`
+          `viewports "${existing.id}" and "${viewport.id}" both use ${elementDescription}`
       );
     }
-    elementToViewportId.set(props.element, props.id);
+  }
+}
+
+function validateViewportProps(viewportProps: ViewportProps[]): void {
+  for (let i = 0; i < viewportProps.length; i++) {
+    validateNewViewport(viewportProps[i], viewportProps.slice(0, i));
   }
 }
 

--- a/packages/core/src/idetik.ts
+++ b/packages/core/src/idetik.ts
@@ -71,6 +71,7 @@ export class Idetik {
    *   viewports: [
    *     {
    *       id: 'main',
+   *       // element omitted - defaults to canvas
    *       camera: camera1,
    *       layers: [layer1]
    *     },
@@ -164,15 +165,16 @@ export class Idetik {
     return viewport;
   }
 
-  public removeViewport(id: string): boolean {
-    const index = this.viewports_.findIndex((v) => v.id === id);
+  public removeViewport(viewport: Viewport): boolean {
+    const index = this.viewports_.indexOf(viewport);
 
     if (index === -1) {
-      Logger.warn("Idetik", `Viewport "${id}" not found, nothing to remove`);
+      Logger.warn(
+        "Idetik",
+        `Viewport "${viewport.id}" not found, nothing to remove`
+      );
       return false;
     }
-
-    const viewport = this.viewports_[index];
 
     if (this.lastAnimationId_ !== undefined) {
       viewport.events.disconnect();
@@ -182,7 +184,7 @@ export class Idetik {
     }
 
     this.viewports_.splice(index, 1);
-    Logger.info("Idetik", `Removed viewport "${id}"`);
+    Logger.info("Idetik", `Removed viewport "${viewport.id}"`);
     return true;
   }
 

--- a/packages/core/src/idetik.ts
+++ b/packages/core/src/idetik.ts
@@ -244,7 +244,8 @@ export class Idetik {
       for (const viewport of this.viewports_) {
         viewport.events.disconnect();
       }
-      cancelAnimationFrame(this.lastAnimationId_);
+      // safe non-null assertion: this.running is true, so lastAnimationId_ is defined
+      cancelAnimationFrame(this.lastAnimationId_!);
       this.lastAnimationId_ = undefined;
     }
   }

--- a/packages/core/src/idetik.ts
+++ b/packages/core/src/idetik.ts
@@ -140,6 +140,10 @@ export class Idetik {
     return this.viewports_;
   }
 
+  public get running(): boolean {
+    return this.lastAnimationId_ !== undefined;
+  }
+
   public getViewport(id: string): Viewport | undefined {
     return this.viewports_.find((v) => v.id === id);
   }
@@ -154,7 +158,7 @@ export class Idetik {
     validateNewViewport(viewport, this.viewports_);
     this.viewports_.push(viewport);
 
-    if (this.lastAnimationId_ !== undefined) {
+    if (this.running) {
       viewport.events.connect();
       if (viewport.element !== this.canvas) {
         this.sizeObserver_.observe(viewport.element);
@@ -176,7 +180,7 @@ export class Idetik {
       return false;
     }
 
-    if (this.lastAnimationId_ !== undefined) {
+    if (this.running) {
       viewport.events.disconnect();
       if (viewport.element !== this.canvas) {
         this.sizeObserver_.unobserve(viewport.element);
@@ -190,7 +194,7 @@ export class Idetik {
 
   public start() {
     Logger.info("Idetik", "Idetik runtime starting");
-    if (this.lastAnimationId_ === undefined) {
+    if (!this.running) {
       for (const viewport of this.viewports_) {
         viewport.events.connect();
       }
@@ -233,7 +237,7 @@ export class Idetik {
 
   public stop() {
     Logger.info("Idetik", "Idetik runtime stopping");
-    if (this.lastAnimationId_ === undefined) {
+    if (!this.running) {
       Logger.warn("Idetik", "Idetik runtime not started");
     } else {
       this.sizeObserver_.disconnect();

--- a/packages/core/src/idetik.ts
+++ b/packages/core/src/idetik.ts
@@ -4,6 +4,7 @@ import { ChunkManager } from "./core/chunk_manager";
 import { createStats, type Stats } from "./utilities/stats";
 import {
   parseViewportConfigs,
+  validateNewViewport,
   Viewport,
   ViewportConfig,
 } from "./core/viewport";
@@ -15,7 +16,7 @@ type Overlay = {
 
 type IdetikParams = {
   canvas: HTMLCanvasElement;
-  viewports: [ViewportConfig, ...ViewportConfig[]]; // at least one viewport required
+  viewports?: ViewportConfig[];
   overlays?: Overlay[];
   showStats?: boolean;
 };
@@ -28,7 +29,7 @@ export class Idetik {
   private readonly chunkManager_: ChunkManager;
   private readonly context_: IdetikContext;
   private readonly renderer_: WebGLRenderer;
-  private readonly viewports_: Viewport[];
+  private viewports_: Viewport[];
   public readonly canvas: HTMLCanvasElement;
   public readonly overlays: Overlay[];
   private readonly stats_?: Stats;
@@ -43,7 +44,7 @@ export class Idetik {
    *
    * @param params - Configuration parameters for the Idetik instance
    * @param params.canvas - HTMLCanvasElement to render to
-   * @param params.viewports - Array of viewport configurations. (At least one required.)
+   * @param params.viewports - Optional array of viewport configurations.
    *   Each viewport renders with its own camera, layers, and controls.
    *   The `element` property is optional and defaults to the canvas if not provided.
    *   Elements must be unique across viewports.
@@ -70,7 +71,6 @@ export class Idetik {
    *   viewports: [
    *     {
    *       id: 'main',
-   *       // element omitted - defaults to canvas
    *       camera: camera1,
    *       layers: [layer1]
    *     },
@@ -83,15 +83,10 @@ export class Idetik {
    *   ]
    * });
    *
-   * @throws {Error} If viewports array is empty or not provided
    * @throws {Error} If viewports have duplicate IDs or shared elements
    */
   constructor(params: IdetikParams) {
     this.canvas = params.canvas;
-
-    if (params.viewports.length === 0) {
-      throw new Error("At least one viewport config must be specified.");
-    }
 
     this.renderer_ = new WebGLRenderer(this.canvas);
     this.chunkManager_ = new ChunkManager();
@@ -100,7 +95,7 @@ export class Idetik {
     };
 
     this.viewports_ = parseViewportConfigs(
-      params.viewports,
+      params.viewports ?? [],
       this.canvas,
       this.context_
     );
@@ -146,6 +141,49 @@ export class Idetik {
 
   public getViewport(id: string): Viewport | undefined {
     return this.viewports_.find((v) => v.id === id);
+  }
+
+  public addViewport(config: ViewportConfig): Viewport {
+    const [viewport] = parseViewportConfigs(
+      [config],
+      this.canvas,
+      this.context_
+    );
+
+    validateNewViewport(viewport, this.viewports_);
+    this.viewports_.push(viewport);
+
+    if (this.lastAnimationId_ !== undefined) {
+      viewport.events.connect();
+      if (viewport.element !== this.canvas) {
+        this.sizeObserver_.observe(viewport.element);
+      }
+    }
+
+    Logger.info("Idetik", `Added viewport "${viewport.id}"`);
+    return viewport;
+  }
+
+  public removeViewport(id: string): boolean {
+    const index = this.viewports_.findIndex((v) => v.id === id);
+
+    if (index === -1) {
+      Logger.warn("Idetik", `Viewport "${id}" not found, nothing to remove`);
+      return false;
+    }
+
+    const viewport = this.viewports_[index];
+
+    if (this.lastAnimationId_ !== undefined) {
+      viewport.events.disconnect();
+      if (viewport.element !== this.canvas) {
+        this.sizeObserver_.unobserve(viewport.element);
+      }
+    }
+
+    this.viewports_.splice(index, 1);
+    Logger.info("Idetik", `Removed viewport "${id}"`);
+    return true;
   }
 
   public start() {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,6 +4,7 @@ export { WebGLRenderer } from "./renderers/webgl_renderer";
 export { OrthographicCamera } from "./objects/cameras/orthographic_camera";
 export { PerspectiveCamera } from "./objects/cameras/perspective_camera";
 export { PanZoomControls } from "./objects/cameras/controls";
+export { OrbitControls } from "./objects/cameras/orbit_controls";
 export type { CameraControls } from "./objects/cameras/controls";
 
 export { Layer } from "./core/layer";
@@ -11,7 +12,11 @@ export type { LayerState } from "./core/layer";
 export { LayerManager } from "./core/layer_manager";
 export type { EventContext } from "./core/event_dispatcher";
 
-export { Viewport, parseViewportConfigs } from "./core/viewport";
+export {
+  Viewport,
+  parseViewportConfigs,
+  validateNewViewport,
+} from "./core/viewport";
 export type { ViewportConfig } from "./core/viewport";
 
 export { AxesLayer } from "./layers/axes_layer";

--- a/packages/core/src/renderers/webgl_renderer.ts
+++ b/packages/core/src/renderers/webgl_renderer.ts
@@ -61,6 +61,8 @@ export class WebGLRenderer extends Renderer {
   }
 
   public render(viewport: Viewport) {
+    let viewportIsVisible =
+      getComputedStyle(viewport.element).visibility !== "hidden";
     const viewportBox = viewport.getBoxRelativeTo(this.canvas);
     const rendererBox = new Box2(
       vec2.fromValues(0, 0),
@@ -76,11 +78,13 @@ export class WebGLRenderer extends Renderer {
         "WebGLRenderer",
         `Viewport ${viewport.id} is entirely outside canvas bounds, skipping render`
       );
-      return;
+      viewportIsVisible = false;
     }
     this.state_.setViewport(viewportBox);
     this.renderedObjectsPerFrame_ = 0;
-    this.clear();
+    if (viewportIsVisible) {
+      this.clear();
+    }
 
     const { opaque, transparent } = viewport.layerManager.partitionLayers();
 
@@ -91,7 +95,7 @@ export class WebGLRenderer extends Renderer {
 
     for (const layer of opaque) {
       layer.update(renderContext);
-      if (layer.state === "ready") {
+      if (layer.state === "ready" && viewportIsVisible) {
         this.renderLayer(layer, viewport.camera, frustum);
       }
     }
@@ -99,8 +103,9 @@ export class WebGLRenderer extends Renderer {
     this.state_.setDepthMask(false);
     for (const layer of transparent) {
       layer.update(renderContext);
-      if (layer.state !== "ready") continue;
-      this.renderLayer(layer, viewport.camera, frustum);
+      if (layer.state === "ready" && viewportIsVisible) {
+        this.renderLayer(layer, viewport.camera, frustum);
+      }
     }
     this.state_.setDepthMask(true);
 

--- a/packages/core/src/utilities/pixel_size_observer.ts
+++ b/packages/core/src/utilities/pixel_size_observer.ts
@@ -3,14 +3,14 @@ import { Logger } from "./logger";
 // Observes changes to the pixel size of HTML elements, including changes due to
 // window/device pixel ratio changes.
 export class PixelSizeObserver {
-  private elements_: ReadonlyArray<HTMLElement>;
+  private elements_: HTMLElement[];
   private resizeObserver_?: ResizeObserver;
   private mediaQuery_?: MediaQueryList;
   private onMediaQueryChange_?: () => void;
   private onChange_: () => void;
 
   constructor(elements: ReadonlyArray<HTMLElement> = [], onChange: () => void) {
-    this.elements_ = elements;
+    this.elements_ = [...elements];
     this.onChange_ = onChange;
   }
 
@@ -61,6 +61,29 @@ export class PixelSizeObserver {
     this.resizeObserver_?.disconnect();
     if (this.mediaQuery_ && this.onMediaQueryChange_) {
       this.mediaQuery_.removeEventListener("change", this.onMediaQueryChange_);
+    }
+  }
+
+  public observe(element: HTMLElement) {
+    if (this.elements_.includes(element)) {
+      Logger.warn("PixelSizeObserver", "Element already being observed");
+      return;
+    }
+    this.elements_.push(element);
+    if (this.resizeObserver_) {
+      this.resizeObserver_.observe(element);
+    }
+  }
+
+  public unobserve(element: HTMLElement) {
+    const index = this.elements_.indexOf(element);
+    if (index === -1) {
+      Logger.warn("PixelSizeObserver", "Element not being observed");
+      return;
+    }
+    this.elements_.splice(index, 1);
+    if (this.resizeObserver_) {
+      this.resizeObserver_.unobserve(element);
     }
   }
 }


### PR DESCRIPTION
### Summary
Adds support for dynamically adding and removing viewports at runtime. Previously viewports could only be configured at initialization - now you can call `addViewport()` and `removeViewport()` on an Idetik instance while it's running.

This flexibility is helpful for using Idetik with React, where we may need to wait for components to mount before using them as viewport elements. The constructor no longer requires at least one viewport, and the `PixelSizeObserver` now supports observing/unobserving individual elements to handle dynamic viewports properly. Also exports `OrbitControls` and `validateNewViewport` from the core package.

Notably not included here is any cleanup. `removeViewport` takes a reference to the `Viewport` object, but it's currently up to a user to do any layer removal, disposal, etc. if the viewport will be actually discarded, for example.

### Tests & Checks
Manually tested adding/removing viewports in https://github.com/chanzuckerberg/idetik-react/pull/57. Existing validation still works to prevent duplicate IDs or shared elements.

Existing tests and examples all pass with no other changes (backward-compatible).

