### PR TITLE
refactor: remove uniforms from volume layer

### DIFF
--- a/packages/core/src/core/layer.ts
+++ b/packages/core/src/core/layer.ts
@@ -125,12 +125,4 @@ export abstract class Layer {
   protected clearObjects() {
     this.objects_ = [];
   }
-
-  /**
-   * Get uniforms for shader program. Override in derived classes that need custom uniforms.
-   * @returns Object containing uniform name-value pairs
-   */
-  public getUniforms(): Record<string, unknown> {
-    return {}; // Default implementation returns no uniforms
-  }
 }

--- a/packages/core/src/layers/volume_layer.ts
+++ b/packages/core/src/layers/volume_layer.ts
@@ -211,12 +211,14 @@ export class VolumeLayer extends Layer implements ChannelsEnabled {
     ]);
   }
 
-  private updateVolumeUniforms(volume: VolumeRenderable) {
-    volume.debugShowDegenerateRays = this.debugShowDegenerateRays;
-    volume.relativeStepSize =
-      this.relativeStepSize * this.interactiveStepSizeScale_;
-    volume.opacityMultiplier = this.opacityMultiplier;
-    volume.earlyTerminationAlpha = this.earlyTerminationAlpha;
+  private updateVolumeUniforms() {
+    for (const volume of this.currentVolumes()) {
+      volume.debugShowDegenerateRays = this.debugShowDegenerateRays;
+      volume.relativeStepSize =
+        this.relativeStepSize * this.interactiveStepSizeScale_;
+      volume.opacityMultiplier = this.opacityMultiplier;
+      volume.earlyTerminationAlpha = this.earlyTerminationAlpha;
+    }
   }
 
   private releaseAndRemoveChunks(chunks: Iterable<Chunk>) {
@@ -251,9 +253,7 @@ export class VolumeLayer extends Layer implements ChannelsEnabled {
       : 1.0;
 
     this.updateChunks();
-    this.currentVolumes().forEach((volume) => {
-      this.updateVolumeUniforms(volume);
-    });
+    this.updateVolumeUniforms();
     sortFrontToBack(this.objects, context.viewport.camera);
   }
 }

--- a/packages/core/src/layers/volume_layer.ts
+++ b/packages/core/src/layers/volume_layer.ts
@@ -211,6 +211,14 @@ export class VolumeLayer extends Layer implements ChannelsEnabled {
     ]);
   }
 
+  private updateVolumeUniforms(volume: VolumeRenderable) {
+    volume.debugShowDegenerateRays = this.debugShowDegenerateRays;
+    volume.relativeStepSize =
+      this.relativeStepSize * this.interactiveStepSizeScale_;
+    volume.opacityMultiplier = this.opacityMultiplier;
+    volume.earlyTerminationAlpha = this.earlyTerminationAlpha;
+  }
+
   private releaseAndRemoveChunks(chunks: Iterable<Chunk>) {
     const releasedVolumes = new Set<VolumeRenderable>();
     for (const chunk of chunks) {
@@ -243,16 +251,10 @@ export class VolumeLayer extends Layer implements ChannelsEnabled {
       : 1.0;
 
     this.updateChunks();
+    this.currentVolumes().forEach((volume) => {
+      this.updateVolumeUniforms(volume);
+    });
     sortFrontToBack(this.objects, context.viewport.camera);
-  }
-
-  public getUniforms(): Record<string, unknown> {
-    return {
-      DebugShowDegenerateRays: Number(this.debugShowDegenerateRays),
-      RelativeStepSize: this.relativeStepSize * this.interactiveStepSizeScale_,
-      OpacityMultiplier: this.opacityMultiplier,
-      EarlyTerminationAlpha: this.earlyTerminationAlpha,
-    };
   }
 }
 

--- a/packages/core/src/objects/renderable/volume_renderable.ts
+++ b/packages/core/src/objects/renderable/volume_renderable.ts
@@ -14,6 +14,10 @@ import type { Chunk } from "../../data/chunk";
 
 export class VolumeRenderable extends RenderableObject {
   public voxelScale: vec3 = vec3.fromValues(1, 1, 1);
+  public debugShowDegenerateRays = false;
+  public relativeStepSize = 1.0;
+  public opacityMultiplier = 1.0;
+  public earlyTerminationAlpha = 0.99;
 
   private channels_: Required<Channel>[];
   private channelToTextureIndex_: Map<number, number> = new Map();
@@ -126,6 +130,10 @@ export class VolumeRenderable extends RenderableObject {
           this.voxelScale[1],
           this.voxelScale[2],
         ],
+        DebugShowDegenerateRays: Number(this.debugShowDegenerateRays),
+        RelativeStepSize: this.relativeStepSize,
+        OpacityMultiplier: this.opacityMultiplier,
+        EarlyTerminationAlpha: this.earlyTerminationAlpha,
       }
     );
   }

--- a/packages/core/src/renderers/webgl_renderer.ts
+++ b/packages/core/src/renderers/webgl_renderer.ts
@@ -188,7 +188,7 @@ export class WebGLRenderer extends Renderer {
     );
     const resolution = [this.canvas.width, this.canvas.height];
 
-    const objectUniforms = object.getUniforms();
+    const uniforms = object.getUniforms();
     for (const uniformName of program.uniformNames) {
       switch (uniformName) {
         case "ModelView":
@@ -222,8 +222,8 @@ export class WebGLRenderer extends Renderer {
           break;
         }
         default:
-          if (uniformName in objectUniforms) {
-            program.setUniform(uniformName, objectUniforms[uniformName]);
+          if (uniformName in uniforms) {
+            program.setUniform(uniformName, uniforms[uniformName]);
           }
       }
     }

--- a/packages/core/src/renderers/webgl_renderer.ts
+++ b/packages/core/src/renderers/webgl_renderer.ts
@@ -189,12 +189,6 @@ export class WebGLRenderer extends Renderer {
     const resolution = [this.canvas.width, this.canvas.height];
 
     const objectUniforms = object.getUniforms();
-    const layerUniforms = layer.getUniforms();
-    const allUniforms = {
-      ...layerUniforms,
-      ...objectUniforms,
-    };
-
     for (const uniformName of program.uniformNames) {
       switch (uniformName) {
         case "ModelView":
@@ -228,8 +222,8 @@ export class WebGLRenderer extends Renderer {
           break;
         }
         default:
-          if (uniformName in allUniforms) {
-            program.setUniform(uniformName, allUniforms[uniformName]);
+          if (uniformName in objectUniforms) {
+            program.setUniform(uniformName, objectUniforms[uniformName]);
           }
       }
     }


### PR DESCRIPTION
### Summary
Removes uniforms being at the layer level which was introduced for volume rendering. Instead moves those uniforms to the volume renderable, and reverts the changes made to the webgl renderer to support layer uniforms.

### Related Issue
Closes #555

### Tests & Checks
<!---
  How did you validate that your changes were implemented correctly?
  
  Please think about the following prompts:
  1. I wrote automated tests.
  2. I manually tested my changes, and here's what I did:
-->

Manually tested examples