### PR TITLE
feat: relax constraints on T and C chunk sizes

### DIFF
--- a/packages/core/src/core/chunk_store.ts
+++ b/packages/core/src/core/chunk_store.ts
@@ -246,11 +246,6 @@ export class ChunkStore {
     for (let lod = 0; lod < this.dimensions_.numLods; ++lod) {
       const tLod = this.dimensions_.t?.lods[lod];
       if (!tLod) continue;
-      if (tLod.chunkSize !== 1) {
-        throw new Error(
-          `ChunkStore only supports a chunk size of 1 in t. Found ${tLod.chunkSize} at LOD ${lod}`
-        );
-      }
       const prevTLod = this.dimensions_.t?.lods[lod - 1];
       if (!prevTLod) continue;
       if (tLod.size !== prevTLod.size) {
@@ -268,11 +263,6 @@ export class ChunkStore {
     for (let lod = 0; lod < this.dimensions_.numLods; ++lod) {
       const cLod = this.dimensions_.c?.lods[lod];
       if (!cLod) continue;
-      if (cLod.chunkSize !== 1) {
-        throw new Error(
-          `ChunkStore only supports a chunk size of 1 in c. Found ${cLod.chunkSize} at LOD ${lod}`
-        );
-      }
       if (cLod.scale !== 1) {
         throw new Error(
           `ChunkStore does not support scale in c. Found ${cLod.scale} at LOD ${lod}`

--- a/packages/core/src/data/ome_zarr/image_loader.ts
+++ b/packages/core/src/data/ome_zarr/image_loader.ts
@@ -104,7 +104,7 @@ export class OmeZarrImageLoader {
 
     validateTightlyPackedChunk(receivedChunk);
 
-    chunk.data = this.sliceSourceChunk(
+    chunk.data = this.sliceReceivedChunk(
       chunk,
       receivedChunk.data,
       receivedChunk.stride
@@ -121,10 +121,10 @@ export class OmeZarrImageLoader {
 
   // trim any padding (XYZ padding for edge chunks)
   // and extract the channel/timepoint
-  private sliceSourceChunk(
+  private sliceReceivedChunk(
     chunk: Chunk,
-    sourceData: ChunkData,
-    sourceStride: number[]
+    receivedChunkData: ChunkData,
+    receivedChunkStride: number[]
   ): ChunkData {
     const cLod = this.dimensions_.c?.lods[chunk.lod];
     const tLod = this.dimensions_.t?.lods[chunk.lod];
@@ -134,20 +134,19 @@ export class OmeZarrImageLoader {
 
     // internal chunks are compact 3D XYZ, with size 1 in C and T
     const compactSize = chunk.shape.x * chunk.shape.y * chunk.shape.z;
-    const compactData = new (sourceData.constructor as ChunkDataConstructor)(
-      compactSize
-    );
+    const compactData =
+      new (receivedChunkData.constructor as ChunkDataConstructor)(compactSize);
 
     const cStride = this.dimensions_.c
-      ? sourceStride[this.dimensions_.c.index]
+      ? receivedChunkStride[this.dimensions_.c.index]
       : 0;
     const tStride = this.dimensions_.t
-      ? sourceStride[this.dimensions_.t.index]
+      ? receivedChunkStride[this.dimensions_.t.index]
       : 0;
     const zStride = this.dimensions_.z
-      ? sourceStride[this.dimensions_.z.index]
+      ? receivedChunkStride[this.dimensions_.z.index]
       : 0;
-    const yStride = sourceStride[this.dimensions_.y.index];
+    const yStride = receivedChunkStride[this.dimensions_.y.index];
 
     // note: this assumes tczyx ordering
     const baseOffset = tOffsetInSource * tStride + cOffsetInSource * cStride;
@@ -157,7 +156,10 @@ export class OmeZarrImageLoader {
       for (let y = 0; y < chunk.shape.y; y++) {
         const srcStart = zStart + y * yStride;
         const srcEnd = srcStart + chunk.shape.x;
-        compactData.set(sourceData.subarray(srcStart, srcEnd), destOffset);
+        compactData.set(
+          receivedChunkData.subarray(srcStart, srcEnd),
+          destOffset
+        );
         destOffset += chunk.shape.x;
       }
     }

--- a/packages/core/src/data/ome_zarr/image_loader.ts
+++ b/packages/core/src/data/ome_zarr/image_loader.ts
@@ -71,15 +71,27 @@ export class OmeZarrImageLoader {
     if (this.dimensions_.z) {
       chunkCoords[this.dimensions_.z.index] = chunk.chunkIndex.z;
     }
+
+    // internal (ChunkStore) chunks have size 1 in C and T
+    // so divide by the actual chunkSize to get the chunkCoord here
     if (this.dimensions_.c) {
-      chunkCoords[this.dimensions_.c.index] = chunk.chunkIndex.c;
+      const cLod = this.dimensions_.c.lods[chunk.lod];
+      chunkCoords[this.dimensions_.c.index] = Math.floor(
+        chunk.chunkIndex.c / cLod.chunkSize
+      );
     }
     if (this.dimensions_.t) {
-      chunkCoords[this.dimensions_.t.index] = chunk.chunkIndex.t;
+      const tLod = this.dimensions_.t.lods[chunk.lod];
+      chunkCoords[this.dimensions_.t.index] = Math.floor(
+        chunk.chunkIndex.t / tLod.chunkSize
+      );
     }
 
     const array = this.arrays_[chunk.lod];
     const arrayParams = this.arrayParams_[chunk.lod];
+
+    // NOTE: if source chunks have multiple channels/timepoints
+    // this results in duplicate fetching and decompression
     const receivedChunk = await getChunk(array, arrayParams, chunkCoords, {
       signal,
     });
@@ -92,40 +104,11 @@ export class OmeZarrImageLoader {
 
     validateTightlyPackedChunk(receivedChunk);
 
-    const receivedShape = {
-      x: receivedChunk.shape[this.dimensions_.x.index],
-      y: receivedChunk.shape[this.dimensions_.y.index],
-      z: this.dimensions_.z
-        ? receivedChunk.shape[this.dimensions_.z.index]
-        : chunk.shape.z,
-    };
-
-    const receivedChunkTooSmall =
-      receivedShape.x < chunk.shape.x ||
-      receivedShape.y < chunk.shape.y ||
-      receivedShape.z < chunk.shape.z;
-
-    if (receivedChunkTooSmall) {
-      throw new Error(
-        `Received incompatible shape for chunkIndex ${JSON.stringify(chunk.chunkIndex)} at LOD ${chunk.lod}: ` +
-          `expected shape: ${JSON.stringify(chunk.shape)}, received shape: ${JSON.stringify(receivedShape)} (too small)`
-      );
-    }
-
-    const receivedChunkHasPadding =
-      receivedShape.x > chunk.shape.x ||
-      receivedShape.y > chunk.shape.y ||
-      receivedShape.z > chunk.shape.z;
-
-    if (receivedChunkHasPadding) {
-      chunk.data = this.trimChunkPadding(
-        chunk,
-        receivedChunk.data,
-        receivedChunk.stride
-      );
-    } else {
-      chunk.data = receivedChunk.data;
-    }
+    chunk.data = this.sliceSourceChunk(
+      chunk,
+      receivedChunk.data,
+      receivedChunk.stride
+    );
 
     const rowAlignment = chunk.data.BYTES_PER_ELEMENT;
     if (!isTextureUnpackRowAlignment(rowAlignment)) {
@@ -136,29 +119,49 @@ export class OmeZarrImageLoader {
     chunk.rowAlignmentBytes = rowAlignment;
   }
 
-  private trimChunkPadding(
+  // trim any padding (XYZ padding for edge chunks)
+  // and extract the channel/timepoint
+  private sliceSourceChunk(
     chunk: Chunk,
-    receivedChunkData: ChunkData,
-    receivedChunkStride: number[]
+    sourceData: ChunkData,
+    sourceStride: number[]
   ): ChunkData {
-    const compactSize = chunk.shape.x * chunk.shape.y * chunk.shape.z;
-    const compactData =
-      new (receivedChunkData.constructor as ChunkDataConstructor)(compactSize);
+    const cLod = this.dimensions_.c?.lods[chunk.lod];
+    const tLod = this.dimensions_.t?.lods[chunk.lod];
 
-    let offset = 0;
-    const zStride = this.dimensions_.z
-      ? receivedChunkStride[this.dimensions_.z.index]
+    const cOffsetInSource = cLod ? chunk.chunkIndex.c % cLod.chunkSize : 0;
+    const tOffsetInSource = tLod ? chunk.chunkIndex.t % tLod.chunkSize : 0;
+
+    // internal chunks are compact 3D XYZ, with size 1 in C and T
+    const compactSize = chunk.shape.x * chunk.shape.y * chunk.shape.z;
+    const compactData = new (sourceData.constructor as ChunkDataConstructor)(
+      compactSize
+    );
+
+    const cStride = this.dimensions_.c
+      ? sourceStride[this.dimensions_.c.index]
       : 0;
-    const yStride = receivedChunkStride[this.dimensions_.y.index];
+    const tStride = this.dimensions_.t
+      ? sourceStride[this.dimensions_.t.index]
+      : 0;
+    const zStride = this.dimensions_.z
+      ? sourceStride[this.dimensions_.z.index]
+      : 0;
+    const yStride = sourceStride[this.dimensions_.y.index];
+
+    // note: this assumes tczyx ordering
+    const baseOffset = tOffsetInSource * tStride + cOffsetInSource * cStride;
+    let destOffset = 0;
     for (let z = 0; z < chunk.shape.z; z++) {
-      const zStart = z * zStride;
+      const zStart = baseOffset + z * zStride;
       for (let y = 0; y < chunk.shape.y; y++) {
         const srcStart = zStart + y * yStride;
         const srcEnd = srcStart + chunk.shape.x;
-        compactData.set(receivedChunkData.subarray(srcStart, srcEnd), offset);
-        offset += chunk.shape.x;
+        compactData.set(sourceData.subarray(srcStart, srcEnd), destOffset);
+        destOffset += chunk.shape.x;
       }
     }
+
     return compactData;
   }
 

--- a/packages/core/src/data/ome_zarr/image_loader.ts
+++ b/packages/core/src/data/ome_zarr/image_loader.ts
@@ -104,6 +104,26 @@ export class OmeZarrImageLoader {
 
     validateTightlyPackedChunk(receivedChunk);
 
+    const receivedShape = {
+      x: receivedChunk.shape[this.dimensions_.x.index],
+      y: receivedChunk.shape[this.dimensions_.y.index],
+      z: this.dimensions_.z
+        ? receivedChunk.shape[this.dimensions_.z.index]
+        : chunk.shape.z,
+    };
+
+    const receivedChunkTooSmall =
+      receivedShape.x < chunk.shape.x ||
+      receivedShape.y < chunk.shape.y ||
+      receivedShape.z < chunk.shape.z;
+
+    if (receivedChunkTooSmall) {
+      throw new Error(
+        `Received incompatible shape for chunkIndex ${JSON.stringify(chunk.chunkIndex)} at LOD ${chunk.lod}: ` +
+          `expected shape: ${JSON.stringify(chunk.shape)}, received shape: ${JSON.stringify(receivedShape)} (too small)`
+      );
+    }
+
     chunk.data = this.sliceReceivedChunk(
       chunk,
       receivedChunk.data,

--- a/packages/core/src/data/ome_zarr/image_loader.ts
+++ b/packages/core/src/data/ome_zarr/image_loader.ts
@@ -124,11 +124,7 @@ export class OmeZarrImageLoader {
       );
     }
 
-    chunk.data = this.sliceReceivedChunk(
-      chunk,
-      receivedChunk.data,
-      receivedChunk.stride
-    );
+    chunk.data = this.sliceReceivedChunk(chunk, receivedChunk);
 
     const rowAlignment = chunk.data.BYTES_PER_ELEMENT;
     if (!isTextureUnpackRowAlignment(rowAlignment)) {
@@ -143,9 +139,19 @@ export class OmeZarrImageLoader {
   // and extract the channel/timepoint
   private sliceReceivedChunk(
     chunk: Chunk,
-    receivedChunkData: ChunkData,
-    receivedChunkStride: number[]
+    receivedChunk: zarr.Chunk<zarr.DataType>
   ): ChunkData {
+    const receivedChunkData = receivedChunk.data as ChunkData;
+    const receivedChunkStride = receivedChunk.stride;
+
+    const receivedShape = {
+      x: receivedChunk.shape[this.dimensions_.x.index],
+      y: receivedChunk.shape[this.dimensions_.y.index],
+      z: this.dimensions_.z
+        ? receivedChunk.shape[this.dimensions_.z.index]
+        : chunk.shape.z,
+    };
+
     const cLod = this.dimensions_.c?.lods[chunk.lod];
     const tLod = this.dimensions_.t?.lods[chunk.lod];
 
@@ -165,9 +171,16 @@ export class OmeZarrImageLoader {
     // note: this assumes tczyx ordering
     const srcOffset = tOffsetInSource * tStride + cOffsetInSource * cStride;
 
-    const alreadyCompact =
-      srcOffset === 0 && receivedChunkData.length === compactSize;
-    if (alreadyCompact) {
+    const receivedExactShape =
+      receivedShape.x === chunk.shape.x &&
+      receivedShape.y === chunk.shape.y &&
+      receivedShape.z === chunk.shape.z;
+
+    const noSlicingNeeded =
+      srcOffset === 0 &&
+      receivedChunkData.length === compactSize &&
+      receivedExactShape;
+    if (noSlicingNeeded) {
       return receivedChunkData;
     }
 

--- a/packages/core/src/data/ome_zarr/image_loader.ts
+++ b/packages/core/src/data/ome_zarr/image_loader.ts
@@ -96,7 +96,25 @@ export class OmeZarrImageLoader {
       signal,
     });
 
-    if (!isChunkData(receivedChunk.data)) {
+    chunk.data = this.sliceReceivedChunk(chunk, receivedChunk);
+
+    const rowAlignment = chunk.data.BYTES_PER_ELEMENT;
+    if (!isTextureUnpackRowAlignment(rowAlignment)) {
+      throw new Error(
+        "Invalid row alignment value. Possible values are 1, 2, 4, or 8"
+      );
+    }
+    chunk.rowAlignmentBytes = rowAlignment;
+  }
+
+  // trim any padding (XYZ padding for edge chunks)
+  // and extract the channel/timepoint
+  private sliceReceivedChunk(
+    chunk: Chunk,
+    receivedChunk: zarr.Chunk<zarr.DataType>
+  ): ChunkData {
+    const receivedChunkData = receivedChunk.data;
+    if (!isChunkData(receivedChunkData)) {
       throw new Error(
         `Received chunk has an unsupported data type, data=${receivedChunk.data.constructor.name}`
       );
@@ -124,33 +142,7 @@ export class OmeZarrImageLoader {
       );
     }
 
-    chunk.data = this.sliceReceivedChunk(chunk, receivedChunk);
-
-    const rowAlignment = chunk.data.BYTES_PER_ELEMENT;
-    if (!isTextureUnpackRowAlignment(rowAlignment)) {
-      throw new Error(
-        "Invalid row alignment value. Possible values are 1, 2, 4, or 8"
-      );
-    }
-    chunk.rowAlignmentBytes = rowAlignment;
-  }
-
-  // trim any padding (XYZ padding for edge chunks)
-  // and extract the channel/timepoint
-  private sliceReceivedChunk(
-    chunk: Chunk,
-    receivedChunk: zarr.Chunk<zarr.DataType>
-  ): ChunkData {
-    const receivedChunkData = receivedChunk.data as ChunkData;
     const receivedChunkStride = receivedChunk.stride;
-
-    const receivedShape = {
-      x: receivedChunk.shape[this.dimensions_.x.index],
-      y: receivedChunk.shape[this.dimensions_.y.index],
-      z: this.dimensions_.z
-        ? receivedChunk.shape[this.dimensions_.z.index]
-        : chunk.shape.z,
-    };
 
     const cLod = this.dimensions_.c?.lods[chunk.lod];
     const tLod = this.dimensions_.t?.lods[chunk.lod];

--- a/packages/core/src/data/ome_zarr/image_loader.ts
+++ b/packages/core/src/data/ome_zarr/image_loader.ts
@@ -154,8 +154,6 @@ export class OmeZarrImageLoader {
 
     // internal chunks are compact 3D XYZ, with size 1 in C and T
     const compactSize = chunk.shape.x * chunk.shape.y * chunk.shape.z;
-    const compactData =
-      new (receivedChunkData.constructor as ChunkDataConstructor)(compactSize);
 
     const cStride = this.dimensions_.c
       ? receivedChunkStride[this.dimensions_.c.index]
@@ -163,16 +161,26 @@ export class OmeZarrImageLoader {
     const tStride = this.dimensions_.t
       ? receivedChunkStride[this.dimensions_.t.index]
       : 0;
+
+    // note: this assumes tczyx ordering
+    const srcOffset = tOffsetInSource * tStride + cOffsetInSource * cStride;
+
+    const alreadyCompact =
+      srcOffset === 0 && receivedChunkData.length === compactSize;
+    if (alreadyCompact) {
+      return receivedChunkData;
+    }
+
+    const compactData =
+      new (receivedChunkData.constructor as ChunkDataConstructor)(compactSize);
+
     const zStride = this.dimensions_.z
       ? receivedChunkStride[this.dimensions_.z.index]
       : 0;
     const yStride = receivedChunkStride[this.dimensions_.y.index];
-
-    // note: this assumes tczyx ordering
-    const baseOffset = tOffsetInSource * tStride + cOffsetInSource * cStride;
     let destOffset = 0;
     for (let z = 0; z < chunk.shape.z; z++) {
-      const zStart = baseOffset + z * zStride;
+      const zStart = srcOffset + z * zStride;
       for (let y = 0; y < chunk.shape.y; y++) {
         const srcStart = zStart + y * yStride;
         const srcEnd = srcStart + chunk.shape.x;


### PR DESCRIPTION
### Summary
This changes the OME Zarr image loader to support loading channels and timepoints from datasets with chunking in T and/or C.

This is the simplest fix I could think of to unblock visualization of affected datasets, but it has known inefficiency. This will result in duplicate fetches and redundant chunk decompression. The detrimental effect on UX is mitigated by the browser cache and WebWorker decompression off the main thread.

This can be considered a temporary workaround, and a longer-term solution should be investigated. Some options may include:
* Simple in-flight request deduplication
* Opportunistic chunk filling (combined with less aggressive chunk disposal)
* Full source chunk cache

### Related Issue
Closes #600

### Tests & Checks
I tested locally by installing this in `idetik-dca-viewer` and accessing `NIST/exp0.zarr`, which has chunk size > 1 in T.

<img width="1499" height="1195" alt="Screenshot 2026-03-23 at 11 18 13 AM" src="https://github.com/user-attachments/assets/5c125541-aee3-42f6-9df9-4faf48708c3e" />
