### PR TITLE
fix: warn but allow non-unity scale in c

### DIFF
--- a/packages/core/src/core/chunk_store.ts
+++ b/packages/core/src/core/chunk_store.ts
@@ -264,8 +264,9 @@ export class ChunkStore {
       const cLod = this.dimensions_.c?.lods[lod];
       if (!cLod) continue;
       if (cLod.scale !== 1) {
-        throw new Error(
-          `ChunkStore does not support scale in c. Found ${cLod.scale} at LOD ${lod}`
+        Logger.warn(
+          "ChunkStore",
+          `Idetik does not make use of non-unity scale in c. Found ${cLod.scale} at LOD ${lod}`
         );
       }
       if (cLod.translation !== 0) {


### PR DESCRIPTION
### Summary
We have one dataset with scale `3.0` in the channel dimension, and this causes loading to fail. I'm not sure what scale in the channel dimension could mean (could be just a mistake) but because it's the _same_ scale across LODs, it shouldn't interfere with anything.

### Related Issue
N/A

### Tests & Checks
I will test locally with a problematic dataset, but the dataset is not public
