### PR TITLE
feat: Downsampling during camera movement 

### DIFF
--- a/packages/core/examples/multi_viewport/main.ts
+++ b/packages/core/examples/multi_viewport/main.ts
@@ -1,18 +1,17 @@
+import { vec3 } from "gl-matrix";
+import GUI from "lil-gui";
 import {
-  Idetik,
   ChunkedImageLayer,
+  Idetik,
   OmeZarrImageSource,
   OrthographicCamera,
   PerspectiveCamera,
   VolumeLayer,
 } from "@";
+import { createPlaybackPolicy } from "@/core/image_source_policy";
 import { PanZoomControls } from "@/objects/cameras/controls";
 import { OrbitControls } from "@/objects/cameras/orbit_controls";
 import { addDimensionSlider } from "../lil_gui_utils";
-import { createPlaybackPolicy } from "@/core/image_source_policy";
-import { vec3 } from "gl-matrix";
-
-import GUI from "lil-gui";
 
 const url =
   "https://public.czbiohub.org/royerlab/zebrahub/imaging/single-objective/ZSNS001.ome.zarr/";
@@ -80,6 +79,7 @@ new Idetik({
         target: volumeCenter,
       }),
       layers: [volumeLayer],
+      downsamplingFactor: 4,
     },
     {
       id: "slice",

--- a/packages/core/examples/volume_rendering/main.ts
+++ b/packages/core/examples/volume_rendering/main.ts
@@ -56,6 +56,7 @@ const idetik = new Idetik({
         target: vec3.fromValues(40, 40, 10), // Volume center,
       }),
       layers: [volumeLayer],
+      downsamplingFactor: 4,
     },
   ],
   showStats: true,

--- a/packages/core/src/core/viewport.ts
+++ b/packages/core/src/core/viewport.ts
@@ -1,13 +1,15 @@
-import { Camera } from "../objects/cameras/camera";
-import { Layer } from "./layer";
-import { LayerManager } from "./layer_manager";
-import { CameraControls } from "../objects/cameras/controls";
-import { Box2 } from "../math/box2";
 import { vec2, vec3 } from "gl-matrix";
-import { generateUUID } from "../utilities/uuid_generator";
+import type { IdetikContext } from "../idetik";
+import { Box2 } from "../math/box2";
+import type { Camera } from "../objects/cameras/camera";
+import type { CameraControls } from "../objects/cameras/controls";
 import { Logger } from "../utilities/logger";
-import { EventContext, EventDispatcher } from "./event_dispatcher";
-import { IdetikContext } from "../idetik";
+import { generateUUID } from "../utilities/uuid_generator";
+import { type EventContext, EventDispatcher } from "./event_dispatcher";
+import type { Layer } from "./layer";
+import { LayerManager } from "./layer_manager";
+
+const NO_DOWNSAMPLING = 1;
 
 export interface ViewportConfig {
   id?: string;
@@ -15,6 +17,7 @@ export interface ViewportConfig {
   camera: Camera;
   layers?: Layer[];
   cameraControls?: CameraControls;
+  downsamplingFactor?: number;
 }
 
 interface ViewportProps extends ViewportConfig {
@@ -29,6 +32,7 @@ export class Viewport {
   public readonly camera: Camera;
   public readonly layerManager: LayerManager;
   public readonly events: EventDispatcher;
+  public readonly downsamplingFactor: number;
   public cameraControls?: CameraControls;
 
   constructor(props: ViewportProps) {
@@ -37,6 +41,7 @@ export class Viewport {
     this.camera = props.camera;
     this.layerManager = props.layerManager;
     this.cameraControls = props.cameraControls;
+    this.downsamplingFactor = props.downsamplingFactor ?? NO_DOWNSAMPLING;
     this.updateAspectRatio();
     this.events = new EventDispatcher(this.element);
     this.events.addEventListener((event: EventContext) => {

--- a/packages/core/src/idetik.ts
+++ b/packages/core/src/idetik.ts
@@ -1,9 +1,9 @@
 import { ChunkManager } from "./core/chunk_manager";
 import {
-    parseViewportConfigs,
-    type Viewport,
-    type ViewportConfig,
-    validateNewViewport,
+  parseViewportConfigs,
+  type Viewport,
+  type ViewportConfig,
+  validateNewViewport,
 } from "./core/viewport";
 import { WebGLRenderer } from "./renderers/webgl_renderer";
 import { Logger } from "./utilities/logger";
@@ -187,7 +187,6 @@ export class Idetik {
       }
     }
 
-    this.renderer_.disposeViewportResources(viewport);
     this.viewports_.splice(index, 1);
     Logger.info("Idetik", `Removed viewport "${viewport.id}"`);
     return true;

--- a/packages/core/src/idetik.ts
+++ b/packages/core/src/idetik.ts
@@ -1,14 +1,14 @@
+import { ChunkManager } from "./core/chunk_manager";
+import {
+    parseViewportConfigs,
+    type Viewport,
+    type ViewportConfig,
+    validateNewViewport,
+} from "./core/viewport";
 import { WebGLRenderer } from "./renderers/webgl_renderer";
 import { Logger } from "./utilities/logger";
-import { ChunkManager } from "./core/chunk_manager";
-import { createStats, type Stats } from "./utilities/stats";
-import {
-  parseViewportConfigs,
-  validateNewViewport,
-  Viewport,
-  ViewportConfig,
-} from "./core/viewport";
 import { PixelSizeObserver } from "./utilities/pixel_size_observer";
+import { createStats, type Stats } from "./utilities/stats";
 
 type Overlay = {
   update(idetik: Idetik): void;
@@ -187,6 +187,7 @@ export class Idetik {
       }
     }
 
+    this.renderer_.disposeViewportResources(viewport);
     this.viewports_.splice(index, 1);
     Logger.info("Idetik", `Removed viewport "${viewport.id}"`);
     return true;

--- a/packages/core/src/renderers/shaders/downsample_composite_frag.glsl
+++ b/packages/core/src/renderers/shaders/downsample_composite_frag.glsl
@@ -1,0 +1,12 @@
+#version 300 es
+
+precision mediump float;
+
+uniform sampler2D u_texture;
+
+in vec2 TexCoords;
+layout(location = 0) out vec4 fragColor;
+
+void main() {
+    fragColor = texture(u_texture, TexCoords);
+}

--- a/packages/core/src/renderers/shaders/downsample_composite_vert.glsl
+++ b/packages/core/src/renderers/shaders/downsample_composite_vert.glsl
@@ -1,0 +1,16 @@
+#version 300 es
+
+out vec2 TexCoords;
+
+void main() {
+    vec2 pos;
+    if (gl_VertexID == 0) {
+        pos = vec2(-1.0, -1.0);
+    } else if (gl_VertexID == 1) {
+        pos = vec2(3.0, -1.0);
+    } else {
+        pos = vec2(-1.0, 3.0);
+    }
+    TexCoords = pos * 0.5 + 0.5;
+    gl_Position = vec4(pos, 0.0, 1.0);
+}

--- a/packages/core/src/renderers/shaders/index.ts
+++ b/packages/core/src/renderers/shaders/index.ts
@@ -1,15 +1,17 @@
-import projectedLineVertexShader from "./projected_line_vert.glsl";
-import projectedLineFragmentShader from "./projected_line_frag.glsl";
-import meshVertexShader from "./mesh_vert.glsl";
-import scalarImageFragmentShader from "./scalar_image_frag.glsl";
-import scalarImageArrayFragmentShader from "./scalar_image_array_frag.glsl";
-import pointsVertexShader from "./points_vert.glsl";
-import pointsFragmentShader from "./points_frag.glsl";
-import wireframeVertexShader from "./wireframe_vert.glsl";
-import wireframeFragmentShader from "./wireframe_frag.glsl";
-import volumeVertexShader from "./volume_vert.glsl";
-import volumeFragmentShader from "./volume_frag.glsl";
+import downsampleCompositeFragmentShader from "./downsample_composite_frag.glsl";
+import downsampleCompositeVertexShader from "./downsample_composite_vert.glsl";
 import labelImage from "./label_image_frag.glsl";
+import meshVertexShader from "./mesh_vert.glsl";
+import pointsFragmentShader from "./points_frag.glsl";
+import pointsVertexShader from "./points_vert.glsl";
+import projectedLineFragmentShader from "./projected_line_frag.glsl";
+import projectedLineVertexShader from "./projected_line_vert.glsl";
+import scalarImageArrayFragmentShader from "./scalar_image_array_frag.glsl";
+import scalarImageFragmentShader from "./scalar_image_frag.glsl";
+import volumeFragmentShader from "./volume_frag.glsl";
+import volumeVertexShader from "./volume_vert.glsl";
+import wireframeFragmentShader from "./wireframe_frag.glsl";
+import wireframeVertexShader from "./wireframe_vert.glsl";
 
 export type Shader =
   | "floatScalarImage"
@@ -24,7 +26,8 @@ export type Shader =
   | "uintScalarImage"
   | "uintScalarImageArray"
   | "uintVolume"
-  | "wireframe";
+  | "wireframe"
+  | "downsampleComposite";
 
 type ShaderCode = {
   vertex: string;
@@ -91,5 +94,9 @@ export const shaderCode: Record<Shader, ShaderCode> = {
     vertex: volumeVertexShader,
     fragment: volumeFragmentShader,
     fragmentDefines: new Map([["TEXTURE_DATA_TYPE_UINT", "1"]]),
+  },
+  downsampleComposite: {
+    vertex: downsampleCompositeVertexShader,
+    fragment: downsampleCompositeFragmentShader,
   },
 };

--- a/packages/core/src/renderers/webgl_buffers.ts
+++ b/packages/core/src/renderers/webgl_buffers.ts
@@ -15,6 +15,10 @@ export class WebGLBuffers {
     this.gl_ = gl;
   }
 
+  public invalidateActiveGeometry() {
+    this.currentGeometry_ = null;
+  }
+
   public bindGeometry(geometry: Geometry) {
     if (this.alreadyActive(geometry)) return;
 

--- a/packages/core/src/renderers/webgl_framebuffers.ts
+++ b/packages/core/src/renderers/webgl_framebuffers.ts
@@ -71,9 +71,7 @@ export class DownsampledFramebuffer {
 
     const status = this.gl_.checkFramebufferStatus(this.gl_.FRAMEBUFFER);
     if (status !== this.gl_.FRAMEBUFFER_COMPLETE) {
-      throw new Error(
-        `DownsampledFramebuffer incomplete: status ${status}`
-      );
+      throw new Error(`DownsampledFramebuffer incomplete: status ${status}`);
     }
 
     this.gl_.bindFramebuffer(this.gl_.FRAMEBUFFER, null);

--- a/packages/core/src/renderers/webgl_framebuffers.ts
+++ b/packages/core/src/renderers/webgl_framebuffers.ts
@@ -1,0 +1,81 @@
+import { ImageTexture2D } from "./webgl_textures";
+
+export class DownsampledFramebuffer {
+  private readonly gl_: WebGL2RenderingContext;
+  private framebuffer_: WebGLFramebuffer;
+  private texture_: ImageTexture2D;
+  private width_: number;
+  private height_: number;
+
+  constructor(gl: WebGL2RenderingContext, width: number, height: number) {
+    this.gl_ = gl;
+    this.width_ = width;
+    this.height_ = height;
+
+    this.framebuffer_ = gl.createFramebuffer();
+
+    this.texture_ = new ImageTexture2D(gl, width, height);
+    this.attachTexture();
+  }
+
+  public get width() {
+    return this.width_;
+  }
+
+  public get height() {
+    return this.height_;
+  }
+
+  public resize(width: number, height: number) {
+    if (width === this.width_ && height === this.height_) return;
+    if (width <= 0 || height <= 0) return;
+
+    this.texture_.dispose();
+    this.texture_ = new ImageTexture2D(this.gl_, width, height);
+    this.width_ = width;
+    this.height_ = height;
+    this.attachTexture();
+  }
+
+  public begin() {
+    this.gl_.bindFramebuffer(this.gl_.FRAMEBUFFER, this.framebuffer_);
+    this.gl_.clearColor(0.0, 0.0, 0.0, 0.0);
+    this.gl_.clear(this.gl_.COLOR_BUFFER_BIT);
+  }
+
+  public end() {
+    this.gl_.bindFramebuffer(this.gl_.FRAMEBUFFER, null);
+  }
+
+  public bindTexture() {
+    this.gl_.activeTexture(this.gl_.TEXTURE0);
+    this.texture_.bind();
+  }
+
+  public dispose() {
+    this.texture_.dispose();
+    this.gl_.deleteFramebuffer(this.framebuffer_);
+  }
+
+  private attachTexture() {
+    this.gl_.bindFramebuffer(this.gl_.FRAMEBUFFER, this.framebuffer_);
+    this.gl_.activeTexture(this.gl_.TEXTURE0);
+    this.texture_.bind();
+    this.gl_.framebufferTexture2D(
+      this.gl_.FRAMEBUFFER,
+      this.gl_.COLOR_ATTACHMENT0,
+      this.gl_.TEXTURE_2D,
+      this.texture_.texture,
+      0
+    );
+
+    const status = this.gl_.checkFramebufferStatus(this.gl_.FRAMEBUFFER);
+    if (status !== this.gl_.FRAMEBUFFER_COMPLETE) {
+      throw new Error(
+        `DownsampledFramebuffer incomplete: status ${status}`
+      );
+    }
+
+    this.gl_.bindFramebuffer(this.gl_.FRAMEBUFFER, null);
+  }
+}

--- a/packages/core/src/renderers/webgl_renderer.ts
+++ b/packages/core/src/renderers/webgl_renderer.ts
@@ -140,6 +140,10 @@ export class WebGLRenderer extends Renderer {
       }
     }
 
+    for (const layer of transparent) {
+      layer.update(renderContext);
+    }
+
     if (viewportIsVisible) {
       const isDownsampling = this.beginDownsampling(
         viewport,
@@ -149,7 +153,6 @@ export class WebGLRenderer extends Renderer {
 
       this.state_.setDepthMask(false);
       for (const layer of transparent) {
-        layer.update(renderContext);
         if (layer.state === "ready") {
           this.renderLayer(layer, viewport.camera, frustum);
         }

--- a/packages/core/src/renderers/webgl_renderer.ts
+++ b/packages/core/src/renderers/webgl_renderer.ts
@@ -60,6 +60,7 @@ class DownsamplingCompositePass {
   }
 
   private end() {
+    this.gl_.bindVertexArray(null);
     this.state_.setDepthMask(true);
   }
 
@@ -226,6 +227,7 @@ export class WebGLRenderer extends Renderer {
     this.state_.setViewport(viewportBox);
     this.applyScissor(scissorBox);
     this.downsamplingPass_.draw(this.downsamplingFramebuffer_!, this.programs_);
+    this.bindings_.invalidateActiveGeometry();
   }
 
   // Returns the scissor box if clipping is needed,

--- a/packages/core/src/renderers/webgl_renderer.ts
+++ b/packages/core/src/renderers/webgl_renderer.ts
@@ -1,21 +1,19 @@
-import { Renderer } from "../core/renderer";
-import { WebGLShaderProgram } from "./webgl_shader_program";
-import { WebGLShaderPrograms } from "./webgl_shader_programs";
-import { Logger } from "../utilities/logger";
-
-import { WebGLBuffers } from "./webgl_buffers";
-import { WebGLTextures } from "./webgl_textures";
-
-import { Layer } from "../core/layer";
-import { WebGLState } from "./WebGLState";
-import { RenderableObject } from "../core/renderable_object";
-import { Geometry, Primitive } from "../core/geometry";
-import { Box2 } from "../math/box2";
-import { Viewport } from "../core/viewport";
-import { Camera } from "../objects/cameras/camera";
-
 import { mat4, vec2, vec3, vec4 } from "gl-matrix";
-import { Frustum } from "../math/frustum";
+import type { Geometry, Primitive } from "../core/geometry";
+import type { Layer } from "../core/layer";
+import type { RenderableObject } from "../core/renderable_object";
+import { Renderer } from "../core/renderer";
+import type { Viewport } from "../core/viewport";
+import { Box2 } from "../math/box2";
+import type { Frustum } from "../math/frustum";
+import type { Camera } from "../objects/cameras/camera";
+import { Logger } from "../utilities/logger";
+import { WebGLState } from "./WebGLState";
+import { WebGLBuffers } from "./webgl_buffers";
+import { DownsampledFramebuffer } from "./webgl_framebuffers";
+import type { WebGLShaderProgram } from "./webgl_shader_program";
+import { WebGLShaderPrograms } from "./webgl_shader_programs";
+import { WebGLTextures } from "./webgl_textures";
 
 // Idetik defines screen-space with +Y pointing downward.
 // With the default camera, the basis vectors are:
@@ -26,6 +24,31 @@ import { Frustum } from "../math/frustum";
 // To match this convention, we flip Y in the projection matrix.
 // This is a mirror transform, which also flips triangle winding.
 const axisDirection = mat4.fromScaling(mat4.create(), [1, -1, 1]);
+const DOWNSAMPLE_FACTOR = 4;
+
+class CompositePass {
+  private readonly gl_: WebGL2RenderingContext;
+  private readonly vao_: WebGLVertexArrayObject;
+
+  constructor(gl: WebGL2RenderingContext) {
+    this.gl_ = gl;
+    this.vao_ = gl.createVertexArray();
+  }
+
+  draw(buffer: DownsampledFramebuffer, programs: WebGLShaderPrograms) {
+    this.gl_.bindVertexArray(this.vao_);
+    buffer.bindTexture();
+    this.gl_.enable(this.gl_.BLEND);
+    this.gl_.blendFunc(this.gl_.ONE, this.gl_.ONE_MINUS_SRC_ALPHA);
+    const program = programs.use("downsampleComposite");
+    program.setUniform("u_texture", 0);
+    this.gl_.drawArrays(this.gl_.TRIANGLES, 0, 3);
+  }
+
+  dispose() {
+    this.gl_.deleteVertexArray(this.vao_);
+  }
+}
 
 export class WebGLRenderer extends Renderer {
   private readonly gl_: WebGL2RenderingContext;
@@ -33,6 +56,8 @@ export class WebGLRenderer extends Renderer {
   private readonly bindings_: WebGLBuffers;
   private readonly textures_: WebGLTextures;
   private readonly state_: WebGLState;
+  private readonly downsampledFrameBuffers_;
+  private readonly compositePass_: CompositePass;
   private renderedObjectsPerFrame_ = 0;
 
   constructor(canvas: HTMLCanvasElement) {
@@ -55,6 +80,8 @@ export class WebGLRenderer extends Renderer {
     this.programs_ = new WebGLShaderPrograms(gl);
     this.bindings_ = new WebGLBuffers(gl);
     this.textures_ = new WebGLTextures(gl);
+    this.downsampledFrameBuffers_ = new Map<Viewport, DownsampledFramebuffer>();
+    this.compositePass_ = new CompositePass(gl);
     this.state_ = new WebGLState(gl);
     this.initStencil();
     this.resize(this.canvas.width, this.canvas.height);
@@ -80,6 +107,7 @@ export class WebGLRenderer extends Renderer {
       );
       viewportIsVisible = false;
     }
+
     this.state_.setViewport(viewportBox);
     this.renderedObjectsPerFrame_ = 0;
     if (viewportIsVisible) {
@@ -100,20 +128,124 @@ export class WebGLRenderer extends Renderer {
       }
     }
 
-    this.state_.setDepthMask(false);
-    for (const layer of transparent) {
-      layer.update(renderContext);
-      if (layer.state === "ready" && viewportIsVisible) {
-        this.renderLayer(layer, viewport.camera, frustum);
-      }
+    const cameraIsMoving = viewport.cameraControls?.isMoving ?? false;
+    const shouldDownsample =
+      cameraIsMoving &&
+      transparent.length > 0 &&
+      viewportIsVisible &&
+      DOWNSAMPLE_FACTOR > 1;
+
+    if (shouldDownsample) {
+      this.renderTransparentDownsampled(
+        transparent,
+        viewport,
+        viewportBox,
+        rendererBox,
+        frustum,
+        renderContext
+      );
+    } else {
+      this.renderTransparentLayers(
+        transparent,
+        viewport.camera,
+        frustum,
+        renderContext,
+        viewportIsVisible
+      );
     }
-    this.state_.setDepthMask(true);
 
     this.renderedObjects_ = this.renderedObjectsPerFrame_;
   }
 
   public get textureInfo() {
     return this.textures_.textureInfo;
+  }
+
+  public disposeViewportResources(viewport: Viewport) {
+    const framebuffer = this.downsampledFrameBuffers_.get(viewport);
+    if (framebuffer) {
+      framebuffer.dispose();
+      this.downsampledFrameBuffers_.delete(viewport);
+    }
+  }
+
+  private renderTransparentLayers(
+    layers: Layer[],
+    camera: Camera,
+    frustum: Frustum,
+    renderContext: { viewport: Viewport },
+    viewportIsVisible: boolean
+  ) {
+    this.state_.setDepthMask(false);
+    for (const layer of layers) {
+      layer.update(renderContext);
+      if (layer.state === "ready" && viewportIsVisible) {
+        this.renderLayer(layer, camera, frustum);
+      }
+    }
+    this.state_.setDepthMask(true);
+  }
+
+  private renderTransparentDownsampled(
+    layers: Layer[],
+    viewport: Viewport,
+    viewportBox: Box2,
+    rendererBox: Box2,
+    frustum: Frustum,
+    renderContext: { viewport: Viewport }
+  ) {
+    const { width: vpWidth, height: vpHeight } = viewportBox.toRect();
+    const dsWeight = Math.max(1, Math.floor(vpWidth / DOWNSAMPLE_FACTOR));
+    const dsHeight = Math.max(1, Math.floor(vpHeight / DOWNSAMPLE_FACTOR));
+    const downscaledViewport = new Box2(
+      vec2.fromValues(0, 0),
+      vec2.fromValues(dsWeight, dsHeight)
+    );
+
+    // Switch to the framebuffer
+    const framebuffer = this.aquireFramebuffer(viewport, dsWeight, dsHeight);
+
+    framebuffer.begin();
+    this.state_.setViewport(downscaledViewport);
+    this.state_.setScissorTest(false);
+    this.renderTransparentLayers(
+      layers,
+      viewport.camera,
+      frustum,
+      renderContext,
+      true
+    );
+    framebuffer.end();
+
+    // Switch back to the original viewport
+    this.state_.setViewport(viewportBox);
+    // Apply ScissorTest if necessary
+    if (Box2.equals(viewportBox.floor(), rendererBox.floor())) {
+      this.state_.setScissorTest(false);
+    } else if (Box2.intersects(viewportBox, rendererBox)) {
+      this.state_.setScissor(viewportBox);
+      this.state_.setScissorTest(true);
+    }
+    this.state_.setDepthTesting(false);
+    this.state_.setDepthMask(false);
+    this.state_.setCullFaceMode("none");
+    this.state_.setStencilTest(false);
+    this.compositePass_.draw(framebuffer, this.programs_);
+    this.state_.setDepthMask(true);
+  }
+
+  private aquireFramebuffer(
+    viewport: Viewport,
+    width: number,
+    height: number
+  ): DownsampledFramebuffer {
+    let framebuffer = this.downsampledFrameBuffers_.get(viewport);
+    if (framebuffer) {
+      return framebuffer;
+    }
+    framebuffer = new DownsampledFramebuffer(this.gl_, width, height);
+    this.downsampledFrameBuffers_.set(viewport, framebuffer);
+    return framebuffer;
   }
 
   private initStencil() {

--- a/packages/core/src/renderers/webgl_renderer.ts
+++ b/packages/core/src/renderers/webgl_renderer.ts
@@ -24,18 +24,32 @@ import { WebGLTextures } from "./webgl_textures";
 // To match this convention, we flip Y in the projection matrix.
 // This is a mirror transform, which also flips triangle winding.
 const axisDirection = mat4.fromScaling(mat4.create(), [1, -1, 1]);
-const DOWNSAMPLE_FACTOR = 4;
 
-class CompositePass {
+class DownsamplingCompositePass {
   private readonly gl_: WebGL2RenderingContext;
+  private readonly state_: WebGLState;
   private readonly vao_: WebGLVertexArrayObject;
 
-  constructor(gl: WebGL2RenderingContext) {
+  constructor(gl: WebGL2RenderingContext, state: WebGLState) {
     this.gl_ = gl;
+    this.state_ = state;
     this.vao_ = gl.createVertexArray();
   }
 
+  private begin() {
+    this.state_.setDepthTesting(false);
+    this.state_.setDepthMask(false);
+    this.state_.setCullFaceMode("none");
+    this.state_.setStencilTest(false);
+  }
+
   draw(buffer: DownsampledFramebuffer, programs: WebGLShaderPrograms) {
+    this.begin();
+    this.draw_(buffer, programs);
+    this.end();
+  }
+
+  private draw_(buffer: DownsampledFramebuffer, programs: WebGLShaderPrograms) {
     this.gl_.bindVertexArray(this.vao_);
     buffer.bindTexture();
     this.gl_.enable(this.gl_.BLEND);
@@ -43,6 +57,10 @@ class CompositePass {
     const program = programs.use("downsampleComposite");
     program.setUniform("u_texture", 0);
     this.gl_.drawArrays(this.gl_.TRIANGLES, 0, 3);
+  }
+
+  private end() {
+    this.state_.setDepthMask(true);
   }
 
   dispose() {
@@ -56,8 +74,7 @@ export class WebGLRenderer extends Renderer {
   private readonly bindings_: WebGLBuffers;
   private readonly textures_: WebGLTextures;
   private readonly state_: WebGLState;
-  private readonly downsampledFrameBuffers_;
-  private readonly compositePass_: CompositePass;
+  private readonly downsamplingPass_: DownsamplingCompositePass;
   private renderedObjectsPerFrame_ = 0;
 
   constructor(canvas: HTMLCanvasElement) {
@@ -80,9 +97,8 @@ export class WebGLRenderer extends Renderer {
     this.programs_ = new WebGLShaderPrograms(gl);
     this.bindings_ = new WebGLBuffers(gl);
     this.textures_ = new WebGLTextures(gl);
-    this.downsampledFrameBuffers_ = new Map<Viewport, DownsampledFramebuffer>();
-    this.compositePass_ = new CompositePass(gl);
     this.state_ = new WebGLState(gl);
+    this.downsamplingPass_ = new DownsamplingCompositePass(gl, this.state_);
     this.initStencil();
     this.resize(this.canvas.width, this.canvas.height);
   }
@@ -91,22 +107,16 @@ export class WebGLRenderer extends Renderer {
     let viewportIsVisible =
       getComputedStyle(viewport.element).visibility !== "hidden";
     const viewportBox = viewport.getBoxRelativeTo(this.canvas);
-    const rendererBox = new Box2(
-      vec2.fromValues(0, 0),
-      vec2.fromValues(this.width, this.height)
-    );
-    if (Box2.equals(viewportBox.floor(), rendererBox.floor())) {
-      this.state_.setScissorTest(false);
-    } else if (Box2.intersects(viewportBox, rendererBox)) {
-      this.state_.setScissor(viewportBox);
-      this.state_.setScissorTest(true);
-    } else {
+    const scissorBox = this.computeScissorBox(viewportBox);
+
+    if (scissorBox === null) {
       Logger.warn(
         "WebGLRenderer",
         `Viewport ${viewport.id} is entirely outside canvas bounds, skipping render`
       );
       viewportIsVisible = false;
     }
+    this.applyScissor(scissorBox);
 
     this.state_.setViewport(viewportBox);
     this.renderedObjectsPerFrame_ = 0;
@@ -128,29 +138,14 @@ export class WebGLRenderer extends Renderer {
       }
     }
 
-    const cameraIsMoving = viewport.cameraControls?.isMoving ?? false;
-    const shouldDownsample =
-      cameraIsMoving &&
-      transparent.length > 0 &&
-      viewportIsVisible &&
-      DOWNSAMPLE_FACTOR > 1;
-
-    if (shouldDownsample) {
+    if (viewportIsVisible) {
       this.renderTransparentDownsampled(
         transparent,
         viewport,
         viewportBox,
-        rendererBox,
+        scissorBox,
         frustum,
         renderContext
-      );
-    } else {
-      this.renderTransparentLayers(
-        transparent,
-        viewport.camera,
-        frustum,
-        renderContext,
-        viewportIsVisible
       );
     }
 
@@ -161,25 +156,16 @@ export class WebGLRenderer extends Renderer {
     return this.textures_.textureInfo;
   }
 
-  public disposeViewportResources(viewport: Viewport) {
-    const framebuffer = this.downsampledFrameBuffers_.get(viewport);
-    if (framebuffer) {
-      framebuffer.dispose();
-      this.downsampledFrameBuffers_.delete(viewport);
-    }
-  }
-
   private renderTransparentLayers(
     layers: Layer[],
     camera: Camera,
     frustum: Frustum,
-    renderContext: { viewport: Viewport },
-    viewportIsVisible: boolean
+    renderContext: { viewport: Viewport }
   ) {
     this.state_.setDepthMask(false);
     for (const layer of layers) {
       layer.update(renderContext);
-      if (layer.state === "ready" && viewportIsVisible) {
+      if (layer.state === "ready") {
         this.renderLayer(layer, camera, frustum);
       }
     }
@@ -190,21 +176,35 @@ export class WebGLRenderer extends Renderer {
     layers: Layer[],
     viewport: Viewport,
     viewportBox: Box2,
-    rendererBox: Box2,
+    scissorBox: Box2 | null | undefined,
     frustum: Frustum,
     renderContext: { viewport: Viewport }
   ) {
+    const cameraIsMoving = viewport.cameraControls?.isMoving ?? false;
+    const shouldDownsample =
+      cameraIsMoving && layers.length > 0 && viewport.downsamplingFactor > 1;
+
+    if (!shouldDownsample) {
+      this.renderTransparentLayers(
+        layers,
+        viewport.camera,
+        frustum,
+        renderContext
+      );
+      return;
+    }
+
     const { width: vpWidth, height: vpHeight } = viewportBox.toRect();
-    const dsWeight = Math.max(1, Math.floor(vpWidth / DOWNSAMPLE_FACTOR));
-    const dsHeight = Math.max(1, Math.floor(vpHeight / DOWNSAMPLE_FACTOR));
+    const dsFactor = viewport.downsamplingFactor;
+    const dsWidth = Math.max(1, Math.floor(vpWidth / dsFactor));
+    const dsHeight = Math.max(1, Math.floor(vpHeight / dsFactor));
     const downscaledViewport = new Box2(
       vec2.fromValues(0, 0),
-      vec2.fromValues(dsWeight, dsHeight)
+      vec2.fromValues(dsWidth, dsHeight)
     );
 
-    // Switch to the framebuffer
-    const framebuffer = this.aquireFramebuffer(viewport, dsWeight, dsHeight);
-
+    // Render transparent layers into the downsampled framebuffer
+    const framebuffer = new DownsampledFramebuffer(this.gl_, dsWidth, dsHeight);
     framebuffer.begin();
     this.state_.setViewport(downscaledViewport);
     this.state_.setScissorTest(false);
@@ -212,40 +212,41 @@ export class WebGLRenderer extends Renderer {
       layers,
       viewport.camera,
       frustum,
-      renderContext,
-      true
+      renderContext
     );
     framebuffer.end();
 
-    // Switch back to the original viewport
+    // Composite back to the main framebuffer
     this.state_.setViewport(viewportBox);
-    // Apply ScissorTest if necessary
-    if (Box2.equals(viewportBox.floor(), rendererBox.floor())) {
-      this.state_.setScissorTest(false);
-    } else if (Box2.intersects(viewportBox, rendererBox)) {
-      this.state_.setScissor(viewportBox);
-      this.state_.setScissorTest(true);
-    }
-    this.state_.setDepthTesting(false);
-    this.state_.setDepthMask(false);
-    this.state_.setCullFaceMode("none");
-    this.state_.setStencilTest(false);
-    this.compositePass_.draw(framebuffer, this.programs_);
-    this.state_.setDepthMask(true);
+    this.applyScissor(scissorBox);
+    this.downsamplingPass_.draw(framebuffer, this.programs_);
+    framebuffer.dispose();
   }
 
-  private aquireFramebuffer(
-    viewport: Viewport,
-    width: number,
-    height: number
-  ): DownsampledFramebuffer {
-    let framebuffer = this.downsampledFrameBuffers_.get(viewport);
-    if (framebuffer) {
-      return framebuffer;
+  // Returns the scissor box if clipping is needed,
+  // - undefined if not
+  // - null if viewport is outside canvas
+  private computeScissorBox(viewportBox: Box2): Box2 | undefined | null {
+    const rendererBox = new Box2(
+      vec2.fromValues(0, 0),
+      vec2.fromValues(this.width, this.height)
+    );
+    if (Box2.equals(viewportBox.floor(), rendererBox.floor())) {
+      return undefined; // full canvas, no scissor needed
     }
-    framebuffer = new DownsampledFramebuffer(this.gl_, width, height);
-    this.downsampledFrameBuffers_.set(viewport, framebuffer);
-    return framebuffer;
+    if (Box2.intersects(viewportBox, rendererBox)) {
+      return viewportBox; // partial overlap, scissor to viewport
+    }
+    return null; // entirely outside
+  }
+
+  private applyScissor(scissorBox: Box2 | null | undefined) {
+    if (scissorBox) {
+      this.state_.setScissor(scissorBox);
+      this.state_.setScissorTest(true);
+      return;
+    }
+    this.state_.setScissorTest(false);
   }
 
   private initStencil() {

--- a/packages/core/src/renderers/webgl_renderer.ts
+++ b/packages/core/src/renderers/webgl_renderer.ts
@@ -147,12 +147,14 @@ export class WebGLRenderer extends Renderer {
         transparent.length > 0
       );
 
-      this.renderTransparentLayers(
-        transparent,
-        viewport.camera,
-        frustum,
-        renderContext
-      );
+      this.state_.setDepthMask(false);
+      for (const layer of transparent) {
+        layer.update(renderContext);
+        if (layer.state === "ready") {
+          this.renderLayer(layer, viewport.camera, frustum);
+        }
+      }
+      this.state_.setDepthMask(true);
 
       if (isDownsampling) {
         this.endDownsampling(viewportBox, scissorBox);
@@ -164,22 +166,6 @@ export class WebGLRenderer extends Renderer {
 
   public get textureInfo() {
     return this.textures_.textureInfo;
-  }
-
-  private renderTransparentLayers(
-    layers: Layer[],
-    camera: Camera,
-    frustum: Frustum,
-    renderContext: { viewport: Viewport }
-  ) {
-    this.state_.setDepthMask(false);
-    for (const layer of layers) {
-      layer.update(renderContext);
-      if (layer.state === "ready") {
-        this.renderLayer(layer, camera, frustum);
-      }
-    }
-    this.state_.setDepthMask(true);
   }
 
   private beginDownsampling(
@@ -239,12 +225,12 @@ export class WebGLRenderer extends Renderer {
       vec2.fromValues(this.width, this.height)
     );
     if (Box2.equals(viewportBox.floor(), rendererBox.floor())) {
-      return undefined; // full canvas, no scissor needed
+      return undefined;
     }
     if (Box2.intersects(viewportBox, rendererBox)) {
-      return viewportBox; // partial overlap, scissor to viewport
+      return viewportBox;
     }
-    return null; // entirely outside
+    return null;
   }
 
   private applyScissor(scissorBox: Box2 | null | undefined) {

--- a/packages/core/src/renderers/webgl_renderer.ts
+++ b/packages/core/src/renderers/webgl_renderer.ts
@@ -75,6 +75,7 @@ export class WebGLRenderer extends Renderer {
   private readonly textures_: WebGLTextures;
   private readonly state_: WebGLState;
   private readonly downsamplingPass_: DownsamplingCompositePass;
+  private downsamplingFramebuffer_: DownsampledFramebuffer | undefined;
   private renderedObjectsPerFrame_ = 0;
 
   constructor(canvas: HTMLCanvasElement) {
@@ -139,14 +140,22 @@ export class WebGLRenderer extends Renderer {
     }
 
     if (viewportIsVisible) {
-      this.renderTransparentDownsampled(
-        transparent,
+      const isDownsampling = this.beginDownsampling(
         viewport,
         viewportBox,
-        scissorBox,
+        transparent.length > 0
+      );
+
+      this.renderTransparentLayers(
+        transparent,
+        viewport.camera,
         frustum,
         renderContext
       );
+
+      if (isDownsampling) {
+        this.endDownsampling(viewportBox, scissorBox);
+      }
     }
 
     this.renderedObjects_ = this.renderedObjectsPerFrame_;
@@ -172,55 +181,51 @@ export class WebGLRenderer extends Renderer {
     this.state_.setDepthMask(true);
   }
 
-  private renderTransparentDownsampled(
-    layers: Layer[],
+  private beginDownsampling(
     viewport: Viewport,
     viewportBox: Box2,
-    scissorBox: Box2 | null | undefined,
-    frustum: Frustum,
-    renderContext: { viewport: Viewport }
-  ) {
+    hasLayers: boolean
+  ): boolean {
     const cameraIsMoving = viewport.cameraControls?.isMoving ?? false;
-    const shouldDownsample =
-      cameraIsMoving && layers.length > 0 && viewport.downsamplingFactor > 1;
-
-    if (!shouldDownsample) {
-      this.renderTransparentLayers(
-        layers,
-        viewport.camera,
-        frustum,
-        renderContext
-      );
-      return;
+    if (!cameraIsMoving || !hasLayers || viewport.downsamplingFactor <= 1) {
+      return false;
     }
 
     const { width: vpWidth, height: vpHeight } = viewportBox.toRect();
     const dsFactor = viewport.downsamplingFactor;
     const dsWidth = Math.max(1, Math.floor(vpWidth / dsFactor));
     const dsHeight = Math.max(1, Math.floor(vpHeight / dsFactor));
+
+    if (!this.downsamplingFramebuffer_) {
+      this.downsamplingFramebuffer_ = new DownsampledFramebuffer(
+        this.gl_,
+        dsWidth,
+        dsHeight
+      );
+    } else {
+      this.downsamplingFramebuffer_.resize(dsWidth, dsHeight);
+    }
+
+    this.downsamplingFramebuffer_.begin();
     const downscaledViewport = new Box2(
       vec2.fromValues(0, 0),
       vec2.fromValues(dsWidth, dsHeight)
     );
-
-    // Render transparent layers into the downsampled framebuffer
-    const framebuffer = new DownsampledFramebuffer(this.gl_, dsWidth, dsHeight);
-    framebuffer.begin();
     this.state_.setViewport(downscaledViewport);
     this.state_.setScissorTest(false);
-    this.renderTransparentLayers(
-      layers,
-      viewport.camera,
-      frustum,
-      renderContext
-    );
-    framebuffer.end();
 
-    // Composite back to the main framebuffer
+    return true;
+  }
+
+  private endDownsampling(
+    viewportBox: Box2,
+    scissorBox: Box2 | null | undefined
+  ) {
+    // null-assertions are ok here, we are sure downsamplingFramebuffer_ is not undefined
+    this.downsamplingFramebuffer_!.end();
     this.state_.setViewport(viewportBox);
     this.applyScissor(scissorBox);
-    this.downsamplingPass_.draw(framebuffer, this.programs_);
-    framebuffer.dispose();
+    this.downsamplingPass_.draw(this.downsamplingFramebuffer_!, this.programs_);
   }
 
   // Returns the scissor box if clipping is needed,

--- a/packages/core/src/renderers/webgl_shader_programs.ts
+++ b/packages/core/src/renderers/webgl_shader_programs.ts
@@ -45,7 +45,7 @@ function replaceSourceDefines(
   source: string,
   defines?: ReadonlyMap<string, string>
 ): string {
-  if (defines === undefined || defines.size == 0) return source;
+  if (defines === undefined || defines.size === 0) return source;
   if (!source.includes(pragmaInjectDefines)) {
     throw new Error(
       `Shader source does not contain "${pragmaInjectDefines}" directive`

--- a/packages/core/src/renderers/webgl_textures.ts
+++ b/packages/core/src/renderers/webgl_textures.ts
@@ -1,15 +1,14 @@
-import { Logger } from "../utilities/logger";
 import type {
   Texture,
+  TextureDataFormat,
+  TextureDataType,
   TextureFilter,
   TextureWrapMode,
-  TextureDataType,
-  TextureDataFormat,
 } from "../objects/textures/texture";
-
-import { Texture2D } from "../objects/textures/texture_2d";
-import { Texture2DArray } from "../objects/textures/texture_2d_array";
-import { Texture3D } from "../objects/textures/texture_3d";
+import type { Texture2D } from "../objects/textures/texture_2d";
+import type { Texture2DArray } from "../objects/textures/texture_2d_array";
+import type { Texture3D } from "../objects/textures/texture_3d";
+import { Logger } from "../utilities/logger";
 
 type TextureFormatInfo = {
   internalFormat: number;
@@ -361,5 +360,58 @@ export class WebGLTextures {
 
   private isTexture3D(texture: Texture): texture is Texture3D {
     return texture.type === "Texture3D";
+  }
+}
+
+export class ImageTexture2D {
+  public texture: WebGLTexture;
+
+  private readonly gl_: WebGL2RenderingContext;
+  private width_: number;
+  private height_: number;
+
+  constructor(gl: WebGL2RenderingContext, width: number, height: number) {
+    this.gl_ = gl;
+    this.width_ = width;
+    this.height_ = height;
+    this.texture = this.gl_.createTexture();
+    this.setupTexture();
+  }
+
+  public get width() {
+    return this.width_;
+  }
+
+  public get height() {
+    return this.height_;
+  }
+
+  private setupTexture() {
+    this.bind();
+    const gl = this.gl_;
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+    gl.texImage2D(
+      gl.TEXTURE_2D,
+      0,
+      gl.RGBA,
+      this.width_,
+      this.height_,
+      0,
+      gl.RGBA,
+      gl.UNSIGNED_BYTE,
+      null
+    );
+    gl.bindTexture(gl.TEXTURE_2D, null);
+  }
+
+  public bind() {
+    this.gl_.bindTexture(this.gl_.TEXTURE_2D, this.texture);
+  }
+
+  public dispose() {
+    this.gl_.deleteTexture(this.texture);
   }
 }


### PR DESCRIPTION
 ### Summary              

This PR adds XY downsampling for transparent layers (e.g. volumes) during camera movement (when the camera is actively rotating/panning). Transparent layers render into a smaller framebuffer (e.g. 4x fewer pixels), which is then composited back to the main canvas. When the camera stops, rendering returns to full resolution.     


https://github.com/user-attachments/assets/f07f1a65-15f8-4b95-888a-a0711a53d3f2

                                                                            
### Implementation                                                                                                                                  
 
`DownsampledFramebuffer` manages a frame buffer with a single RGBA color attachment (lazy resize with texture recreation), while `DownsamplingCompositePass` renders a fullscreen triangle that samples the downsampled texture. In the renderer `beginDownsampling` and `endDownsampling` wrap the `renderTransparentLayers` call. The framebuffer is owned by the renderer, created lazily on first use, and resized as needed. `downsamplingFactor` is a per-viewport config option (defaults to 1 = no downsampling). The `cameraControls.isMoving` signal controls when downsampling activates.                                                                                                                                        
                                                           
  ### Tests & Checks                                                                                                                                          
  
Manually tested with the volume_rendering and multi_viewport examples (both configured with downsamplingFactor: 4)                         