### PR TITLE
feat: publicly expose chunk queue stats on runtime

### DIFF
--- a/packages/core/src/core/chunk_manager.ts
+++ b/packages/core/src/core/chunk_manager.ts
@@ -1,5 +1,10 @@
 import { ChunkSource } from "../data/chunk";
 import { ChunkQueue } from "../data/chunk_queue";
+
+export type QueueStats = {
+  pending: number;
+  running: number;
+};
 import { ChunkStore } from "./chunk_store";
 import { ChunkStoreView } from "./chunk_store_view";
 import { ImageSourcePolicy } from "./image_source_policy";
@@ -8,6 +13,13 @@ export class ChunkManager {
   private readonly stores_ = new Map<ChunkSource, ChunkStore>();
   private readonly pendingStores_ = new Map<ChunkSource, Promise<ChunkStore>>();
   private readonly queue_ = new ChunkQueue();
+
+  public get queueStats(): QueueStats {
+    return {
+      pending: this.queue_.pendingCount,
+      running: this.queue_.runningCount,
+    };
+  }
 
   public async addView(
     source: ChunkSource,

--- a/packages/core/src/idetik.ts
+++ b/packages/core/src/idetik.ts
@@ -10,7 +10,7 @@ import {
 } from "./core/viewport";
 import { PixelSizeObserver } from "./utilities/pixel_size_observer";
 
-type Overlay = {
+export type Overlay = {
   update(idetik: Idetik): void;
 };
 
@@ -118,6 +118,10 @@ export class Idetik {
         this.renderer_.render(viewport);
       }
     });
+  }
+
+  public get chunkQueueStats() {
+    return this.chunkManager_.queueStats;
   }
 
   public get renderedObjects() {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,5 @@
 export { Idetik } from "./idetik";
+export type { Overlay } from "./idetik";
 
 export { WebGLRenderer } from "./renderers/webgl_renderer";
 export { OrthographicCamera } from "./objects/cameras/orthographic_camera";
@@ -26,6 +27,7 @@ export { ChunkedImageLayer } from "./layers/chunked_image_layer";
 export { VolumeLayer } from "./layers/volume_layer";
 export { ImageLayer } from "./layers/image_layer";
 export type { Chunk, ChunkLoader, SliceCoordinates } from "./data/chunk";
+export type { QueueStats } from "./core/chunk_manager";
 export { LabelImageLayer } from "./layers/label_image_layer";
 export type { PointPickingResult } from "./layers/point_picking";
 export { ImageSeriesLayer } from "./layers/image_series_layer";


### PR DESCRIPTION
### Summary
This exposes the chunk queue stats via the runtime. The goal is to allow applications to understand loading states to be able to communicate loading/progress.

This also exposes the `Overlay` type for external implementors.

### Related Issue
N/A

### Tests & Checks
Tested in a downstream application using the chunk queue stats to create a loading indicator