### PR TITLE
feat: volume frustum chunk culling and performance improvements

### DIFF
--- a/packages/core/examples/single_channel_volume/index.html
+++ b/packages/core/examples/single_channel_volume/index.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Volume Rendering</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        display: flex;
+        width: 100%;
+        height: 100%;
+        background-color: black;
+        font-family: monospace;
+        font-size: 12px;
+      }
+      #main {
+        display: flex;
+        flex-direction: column;
+        width: 100%;
+        height: 100%;
+      }
+      #canvas {
+        width: 100%;
+        height: 100%;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="main">
+      <canvas id="canvas"></canvas>
+    </div>
+    <script type="module" src="./main.ts"></script>
+  </body>
+</html>

--- a/packages/core/examples/single_channel_volume/index.html
+++ b/packages/core/examples/single_channel_volume/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Volume Rendering</title>
+    <title>Volume Rendering single channel</title>
     <style>
       html,
       body {

--- a/packages/core/examples/single_channel_volume/main.ts
+++ b/packages/core/examples/single_channel_volume/main.ts
@@ -1,0 +1,79 @@
+import { Idetik, VolumeLayer, PerspectiveCamera, OmeZarrImageSource } from "@";
+import { OrbitControls } from "@/objects/cameras/orbit_controls";
+import { createPlaybackPolicy } from "@/core/image_source_policy";
+import { addDimensionSlider } from "../lil_gui_utils";
+import GUI from "lil-gui";
+import { vec3 } from "gl-matrix";
+
+const url =
+  "https://public.czbiohub.org/royerlab/zebrahub/imaging/single-objective/ZSNS001.ome.zarr/";
+const source = OmeZarrImageSource.fromHttp({ url });
+const sliceCoords = {
+  t: 400,
+  z: undefined,
+  c: 0,
+};
+const controls = { lod: 2 };
+
+const camera = new PerspectiveCamera();
+const policy = createPlaybackPolicy({
+  lod: { min: controls.lod, max: controls.lod },
+});
+const volumeLayer = new VolumeLayer({
+  source,
+  sliceCoords,
+  policy,
+});
+const idetik = new Idetik({
+  canvas: document.querySelector<HTMLCanvasElement>("#canvas")!,
+  viewports: [
+    {
+      camera: camera,
+      cameraControls: new OrbitControls(camera, {
+        radius: 750,
+        target: vec3.fromValues(550, 500, 278), // Volume center,
+      }),
+      layers: [volumeLayer],
+    },
+  ],
+  showStats: true,
+});
+
+idetik.start();
+
+// Add GUI controls to manipulate rendering
+const gui = new GUI({ width: 500 });
+addDimensionSlider({
+  gui,
+  sliceCoords,
+  dimensionName: "t",
+  minValue: 0,
+  maxValue: 800,
+  stepValue: 1.0,
+  playback: {},
+});
+gui
+  .add(controls, "lod", 0, 2, 1)
+  .name("Level of Detail (LOD)")
+  .onChange(
+    (lod: number) =>
+      (volumeLayer.sourcePolicy = createPlaybackPolicy({
+        lod: { min: lod, max: lod },
+      }))
+  );
+
+const volumeFolder = gui.addFolder("Volume Rendering");
+volumeFolder
+  .add(volumeLayer, "opacityMultiplier", 0.01, 1.0, 0.01)
+  .name("Opacity scale");
+volumeFolder
+  .add(volumeLayer, "earlyTerminationAlpha", 0.8, 1.0, 0.01)
+  .name("Early termination threshold");
+
+const overlaysFolder = gui.addFolder("Debug");
+overlaysFolder
+  .add(volumeLayer, "debugShowWireframes")
+  .name("Show tile wireframes");
+overlaysFolder
+  .add(volumeLayer, "debugShowDegenerateRays")
+  .name("Show degenerate rays (length 0)");

--- a/packages/core/src/core/chunk_store_view.ts
+++ b/packages/core/src/core/chunk_store_view.ts
@@ -6,6 +6,7 @@ import { ImageSourcePolicy } from "./image_source_policy";
 import { ReadonlyVec2, vec2, vec3, mat4 } from "gl-matrix";
 import { Box2 } from "../math/box2";
 import { Box3 } from "../math/box3";
+import type { Frustum } from "../math/frustum";
 import { Logger } from "../utilities/logger";
 import { clamp } from "../utilities/clamp";
 
@@ -30,6 +31,10 @@ export class ChunkStoreView {
   private sourceMaxSquareDistance2D_: number;
   private maxSquareDistance3D_: number | null = null;
   private readonly chunkViewStates_: Map<Chunk, ChunkViewState> = new Map();
+  private readonly chunkBoundsCache_ = new Map<
+    Chunk,
+    { bounds: Box3; center: vec3 }
+  >();
 
   private isDisposed_ = false;
 
@@ -215,7 +220,8 @@ export class ChunkStoreView {
     this.chunkViewStates_.forEach(resetChunkViewState);
 
     const fallbackLOD = this.fallbackLOD();
-
+    const cameraFrustum = viewport.camera.frustum;
+    const cameraPosition = viewport.camera.position;
     this.maxSquareDistance3D_ = null;
     for (const chunk of currentTimeChunks) {
       const isCurrentLOD = chunk.lod === this.currentLOD_;
@@ -225,11 +231,9 @@ export class ChunkStoreView {
       // Check channel first to avoid more expensive frustum intersection test
       if (!this.isChunkChannelInSlice(chunk, sliceCoords)) continue;
 
-      if (
-        !viewport.camera.frustum.intersectsWithBox3(
-          this.computeChunkBounds(chunk)
-        )
-      ) {
+      const { bounds: chunkBounds, center: chunkCenter } =
+        this.getCachedChunkBoundsInfo(chunk);
+      if (!cameraFrustum.intersectsWithBox3(chunkBounds)) {
         continue;
       }
       const priority = this.computePriority(
@@ -241,7 +245,7 @@ export class ChunkStoreView {
       );
       if (priority === null) continue;
 
-      const orderKey = this.squareDistance3D(chunk, viewport.camera.position);
+      const orderKey = vec3.squaredDistance(chunkCenter, cameraPosition);
       this.maxSquareDistance3D_ = Math.max(
         this.maxSquareDistance3D_ ?? 0,
         orderKey
@@ -258,7 +262,8 @@ export class ChunkStoreView {
       this.markTimeChunksForPrefetchVolume(
         currentTimeIndex,
         sliceCoords,
-        viewport
+        cameraFrustum,
+        cameraPosition
       );
     }
 
@@ -298,6 +303,7 @@ export class ChunkStoreView {
   public dispose(): void {
     this.isDisposed_ = true;
     this.chunkViewStates_.forEach(resetChunkViewState);
+    this.chunkBoundsCache_.clear();
   }
 
   public setImageSourcePolicy(newPolicy: ImageSourcePolicy, key: symbol) {
@@ -444,7 +450,8 @@ export class ChunkStoreView {
   private markTimeChunksForPrefetchVolume(
     currentTimeIndex: number,
     sliceCoords: SliceCoordinates,
-    viewport: Viewport
+    frustum: Frustum,
+    cameraPosition: vec3
   ) {
     const numTimePoints = this.store_.dimensions.t?.lods[0].size ?? 1;
     const tEnd = Math.min(
@@ -459,17 +466,16 @@ export class ChunkStoreView {
       for (const chunk of this.store_.getChunksAtTime(t)) {
         if (chunk.lod !== fallbackLOD) continue;
         if (!this.isChunkChannelInSlice(chunk, sliceCoords)) continue;
-        if (
-          !viewport.camera.frustum.intersectsWithBox3(
-            this.computeChunkBounds(chunk)
-          )
-        ) {
+
+        const { bounds: chunkBounds, center: chunkCenter } =
+          this.getCachedChunkBoundsInfo(chunk);
+        if (!frustum.intersectsWithBox3(chunkBounds)) {
           continue;
         }
 
-        const squareDistance = this.squareDistance3D(
-          chunk,
-          viewport.camera.position
+        const squareDistance = vec3.squaredDistance(
+          chunkCenter,
+          cameraPosition
         );
         const normalizedDistance = clamp(
           squareDistance / (this.maxSquareDistance3D_ ?? 1),
@@ -477,7 +483,8 @@ export class ChunkStoreView {
           1 - Number.EPSILON
         );
         maxDistance = Math.max(maxDistance, squareDistance);
-        const orderKey = t - currentTimeIndex + normalizedDistance; // first order by time distance, then by spatial distance
+        // first order by time distance, then by spatial distance
+        const orderKey = t - currentTimeIndex + normalizedDistance;
 
         this.chunkViewStates_.set(chunk, {
           visible: false,
@@ -509,8 +516,14 @@ export class ChunkStoreView {
     return null;
   }
 
-  private computeChunkBounds(chunk: Chunk): Box3 {
-    return new Box3(
+  private getCachedChunkBoundsInfo(chunk: Chunk): {
+    bounds: Box3;
+    center: vec3;
+  } {
+    const cached = this.chunkBoundsCache_.get(chunk);
+    if (cached) return cached;
+
+    const bounds = new Box3(
       vec3.fromValues(chunk.offset.x, chunk.offset.y, chunk.offset.z),
       vec3.fromValues(
         chunk.offset.x + chunk.shape.x * chunk.scale.x,
@@ -518,10 +531,20 @@ export class ChunkStoreView {
         chunk.offset.z + chunk.shape.z * chunk.scale.z
       )
     );
+    const boundsInfo = {
+      bounds,
+      center: vec3.fromValues(
+        (bounds.min[0] + bounds.max[0]) * 0.5,
+        (bounds.min[1] + bounds.max[1]) * 0.5,
+        (bounds.min[2] + bounds.max[2]) * 0.5
+      ),
+    };
+    this.chunkBoundsCache_.set(chunk, boundsInfo);
+    return boundsInfo;
   }
 
   private isChunkWithinBounds(chunk: Chunk, bounds: Box3): boolean {
-    return Box3.intersects(this.computeChunkBounds(chunk), bounds);
+    return Box3.intersects(this.getCachedChunkBoundsInfo(chunk).bounds, bounds);
   }
 
   private fallbackLOD(): number {
@@ -614,15 +637,6 @@ export class ChunkStoreView {
     const dx = chunkCenter.x - center[0];
     const dy = chunkCenter.y - center[1];
     return dx * dx + dy * dy;
-  }
-
-  private squareDistance3D(chunk: Chunk, center: vec3): number {
-    const chunkCenter = vec3.fromValues(
-      chunk.offset.x + 0.5 * chunk.shape.x * chunk.scale.x,
-      chunk.offset.y + 0.5 * chunk.shape.y * chunk.scale.y,
-      chunk.offset.z + 0.5 * chunk.shape.z * chunk.scale.z
-    );
-    return vec3.squaredDistance(chunkCenter, center);
   }
 }
 

--- a/packages/core/src/core/chunk_store_view.ts
+++ b/packages/core/src/core/chunk_store_view.ts
@@ -35,6 +35,13 @@ export class ChunkStoreView {
     Chunk,
     { bounds: Box3; center: vec3 }
   >();
+  // This frustum cache can be simplified if we can assume that
+  // chunks at the same xyz indices at a given LOD across time
+  // all share the same bounds (can remove the bounds here and bounds check)
+  private readonly frustumCheckCache_ = new Map<
+    string,
+    { bounds: Box3; inFrustum: boolean }
+  >();
 
   private isDisposed_ = false;
 
@@ -223,6 +230,7 @@ export class ChunkStoreView {
     const cameraFrustum = viewport.camera.frustum;
     const cameraPosition = viewport.camera.position;
     this.maxSquareDistance3D_ = null;
+
     for (const chunk of currentTimeChunks) {
       const isCurrentLOD = chunk.lod === this.currentLOD_;
       const isFallbackLOD = chunk.lod === fallbackLOD;
@@ -233,7 +241,19 @@ export class ChunkStoreView {
 
       const { bounds: chunkBounds, center: chunkCenter } =
         this.getCachedChunkBoundsInfo(chunk);
-      if (!cameraFrustum.intersectsWithBox3(chunkBounds)) {
+      const inFrustum = cameraFrustum.intersectsWithBox3(chunkBounds);
+
+      // If t-prefetch is enabled, cache frustum check results to avoid redundant
+      // checks for subsequent time points with the same spatial bounds
+      if (sliceCoords.t !== undefined) {
+        const spatialKey = this.getSpatialKey(chunk);
+        this.frustumCheckCache_.set(spatialKey, {
+          bounds: chunkBounds,
+          inFrustum,
+        });
+      }
+
+      if (!inFrustum) {
         continue;
       }
       const priority = this.computePriority(
@@ -469,8 +489,15 @@ export class ChunkStoreView {
 
         const { bounds: chunkBounds, center: chunkCenter } =
           this.getCachedChunkBoundsInfo(chunk);
-        if (!frustum.intersectsWithBox3(chunkBounds)) {
-          continue;
+
+        const spatialKey = this.getSpatialKey(chunk);
+        const cached = this.frustumCheckCache_.get(spatialKey);
+        // This check can be removed if we can guarantee that all chunks at the same
+        // xyz indices and LOD across time share the same bounds
+        if (cached && this.boundsEqual(cached.bounds, chunkBounds)) {
+          if (!cached.inFrustum) continue;
+        } else {
+          if (!frustum.intersectsWithBox3(chunkBounds)) continue;
         }
 
         const squareDistance = vec3.squaredDistance(
@@ -545,6 +572,22 @@ export class ChunkStoreView {
 
   private isChunkWithinBounds(chunk: Chunk, bounds: Box3): boolean {
     return Box3.intersects(this.getCachedChunkBoundsInfo(chunk).bounds, bounds);
+  }
+
+  private getSpatialKey(chunk: Chunk): string {
+    const { x, y, z } = chunk.chunkIndex;
+    return `${x}:${y}:${z}:lod${chunk.lod}`;
+  }
+
+  private boundsEqual(a: Box3, b: Box3): boolean {
+    return (
+      a.min[0] === b.min[0] &&
+      a.min[1] === b.min[1] &&
+      a.min[2] === b.min[2] &&
+      a.max[0] === b.max[0] &&
+      a.max[1] === b.max[1] &&
+      a.max[2] === b.max[2]
+    );
   }
 
   private fallbackLOD(): number {

--- a/packages/core/src/core/chunk_store_view.ts
+++ b/packages/core/src/core/chunk_store_view.ts
@@ -28,6 +28,7 @@ export class ChunkStoreView {
   private lastTCoord_?: number;
 
   private sourceMaxSquareDistance2D_: number;
+  private maxSquareDistance3D_: number | null = null;
   private readonly chunkViewStates_: Map<Chunk, ChunkViewState> = new Map();
 
   private isDisposed_ = false;
@@ -215,12 +216,22 @@ export class ChunkStoreView {
 
     const fallbackLOD = this.fallbackLOD();
 
+    this.maxSquareDistance3D_ = null;
     for (const chunk of currentTimeChunks) {
       const isCurrentLOD = chunk.lod === this.currentLOD_;
       const isFallbackLOD = chunk.lod === fallbackLOD;
       if (!isCurrentLOD && !isFallbackLOD) continue;
 
+      // Check channel first to avoid more expensive frustum intersection test
       if (!this.isChunkChannelInSlice(chunk, sliceCoords)) continue;
+
+      if (
+        !viewport.camera.frustum.intersectsWithBox3(
+          this.computeChunkBounds(chunk)
+        )
+      ) {
+        continue;
+      }
       const priority = this.computePriority(
         isFallbackLOD,
         isCurrentLOD,
@@ -228,17 +239,27 @@ export class ChunkStoreView {
         false, // isPrefetch
         true // isChannelInSlice
       );
+      if (priority === null) continue;
 
+      const orderKey = this.squareDistance3D(chunk, viewport.camera.position);
+      this.maxSquareDistance3D_ = Math.max(
+        this.maxSquareDistance3D_ ?? 0,
+        orderKey
+      );
       this.chunkViewStates_.set(chunk, {
         visible: true,
         prefetch: false,
         priority,
-        orderKey: 0, // All chunks have the same ordering for volume rendering
+        orderKey,
       });
     }
 
     if (sliceCoords.t !== undefined) {
-      this.markTimeChunksForPrefetchVolume(currentTimeIndex, sliceCoords);
+      this.markTimeChunksForPrefetchVolume(
+        currentTimeIndex,
+        sliceCoords,
+        viewport
+      );
     }
 
     this.policyChanged_ = false;
@@ -422,7 +443,8 @@ export class ChunkStoreView {
 
   private markTimeChunksForPrefetchVolume(
     currentTimeIndex: number,
-    sliceCoords: SliceCoordinates
+    sliceCoords: SliceCoordinates,
+    viewport: Viewport
   ) {
     const numTimePoints = this.store_.dimensions.t?.lods[0].size ?? 1;
     const tEnd = Math.min(
@@ -432,12 +454,30 @@ export class ChunkStoreView {
     const fallbackLOD = this.fallbackLOD();
     const priority = this.policy_.priorityMap["prefetchTime"];
 
+    let maxDistance = 0;
     for (let t = currentTimeIndex + 1; t <= tEnd; ++t) {
       for (const chunk of this.store_.getChunksAtTime(t)) {
         if (chunk.lod !== fallbackLOD) continue;
         if (!this.isChunkChannelInSlice(chunk, sliceCoords)) continue;
+        if (
+          !viewport.camera.frustum.intersectsWithBox3(
+            this.computeChunkBounds(chunk)
+          )
+        ) {
+          continue;
+        }
 
-        const orderKey = t - currentTimeIndex; // nearer future timepoints first
+        const squareDistance = this.squareDistance3D(
+          chunk,
+          viewport.camera.position
+        );
+        const normalizedDistance = clamp(
+          squareDistance / (this.maxSquareDistance3D_ ?? 1),
+          0,
+          1 - Number.EPSILON
+        );
+        maxDistance = Math.max(maxDistance, squareDistance);
+        const orderKey = t - currentTimeIndex + normalizedDistance; // first order by time distance, then by spatial distance
 
         this.chunkViewStates_.set(chunk, {
           visible: false,
@@ -447,6 +487,8 @@ export class ChunkStoreView {
         });
       }
     }
+    this.maxSquareDistance3D_ =
+      maxDistance > 0 ? maxDistance : this.maxSquareDistance3D_;
   }
 
   private computePriority(
@@ -467,8 +509,8 @@ export class ChunkStoreView {
     return null;
   }
 
-  private isChunkWithinBounds(chunk: Chunk, bounds: Box3): boolean {
-    const chunkBounds = new Box3(
+  private computeChunkBounds(chunk: Chunk): Box3 {
+    return new Box3(
       vec3.fromValues(chunk.offset.x, chunk.offset.y, chunk.offset.z),
       vec3.fromValues(
         chunk.offset.x + chunk.shape.x * chunk.scale.x,
@@ -476,7 +518,10 @@ export class ChunkStoreView {
         chunk.offset.z + chunk.shape.z * chunk.scale.z
       )
     );
-    return Box3.intersects(chunkBounds, bounds);
+  }
+
+  private isChunkWithinBounds(chunk: Chunk, bounds: Box3): boolean {
+    return Box3.intersects(this.computeChunkBounds(chunk), bounds);
   }
 
   private fallbackLOD(): number {
@@ -569,6 +614,15 @@ export class ChunkStoreView {
     const dx = chunkCenter.x - center[0];
     const dy = chunkCenter.y - center[1];
     return dx * dx + dy * dy;
+  }
+
+  private squareDistance3D(chunk: Chunk, center: vec3): number {
+    const chunkCenter = vec3.fromValues(
+      chunk.offset.x + 0.5 * chunk.shape.x * chunk.scale.x,
+      chunk.offset.y + 0.5 * chunk.shape.y * chunk.scale.y,
+      chunk.offset.z + 0.5 * chunk.shape.z * chunk.scale.z
+    );
+    return vec3.squaredDistance(chunkCenter, center);
   }
 }
 

--- a/packages/core/src/layers/volume_layer.ts
+++ b/packages/core/src/layers/volume_layer.ts
@@ -136,7 +136,9 @@ export class VolumeLayer extends Layer implements ChannelsEnabled {
 
   public onDetached(_context: IdetikContext): void {
     if (!this.chunkStoreView_) return;
-    this.releaseAndRemoveVolumes(this.currentVolumes_.values());
+    for (const volume of this.currentVolumes_.values()) {
+      this.releaseAndRemoveVolume(volume);
+    }
     this.clearObjects();
     this.chunkStoreView_.dispose();
     this.chunkStoreView_ = undefined;
@@ -155,17 +157,16 @@ export class VolumeLayer extends Layer implements ChannelsEnabled {
       this.lastLoadedTime_ !== currentTime ||
       groupedChunks.size !== this.currentVolumes_.size ||
       this.lastNumRenderedChannelChunks_ !== chunksToRender.length;
-    this.lastNumRenderedChannelChunks_ = chunksToRender.length;
     if (!needsUpdate) return;
 
-    const volumesToRemove = Array.from(this.currentVolumes_.entries())
-      .filter(([key]) => !groupedChunks.has(key))
-      .map(([, volume]) => volume);
-    this.releaseAndRemoveVolumes(volumesToRemove);
+    for (const [key, volume] of this.currentVolumes_) {
+      if (!groupedChunks.has(key)) {
+        this.releaseAndRemoveVolume(volume);
+        this.currentVolumes_.delete(key);
+      }
+    }
 
-    this.currentVolumes_.clear();
     this.clearObjects();
-
     for (const [key, chunks] of groupedChunks) {
       const volume = this.getOrCreateVolume(key, chunks);
       volume.wireframeEnabled = this.debugShowWireframes;
@@ -174,6 +175,7 @@ export class VolumeLayer extends Layer implements ChannelsEnabled {
     }
 
     this.lastLoadedTime_ = currentTime;
+    this.lastNumRenderedChannelChunks_ = chunksToRender.length;
     if (this.state !== "ready") this.setState("ready");
   }
 
@@ -197,12 +199,10 @@ export class VolumeLayer extends Layer implements ChannelsEnabled {
     ]);
   }
 
-  private releaseAndRemoveVolumes(volumes: Iterable<VolumeRenderable>) {
-    for (const volume of volumes) {
-      volume.clearLoadedChannels();
-      this.pool_.release(this.volumeToPoolKey_.get(volume)!, volume);
-      this.volumeToPoolKey_.delete(volume);
-    }
+  private releaseAndRemoveVolume(volume: VolumeRenderable) {
+    volume.clearLoadedChannels();
+    this.pool_.release(this.volumeToPoolKey_.get(volume)!, volume);
+    this.volumeToPoolKey_.delete(volume);
   }
 
   public update(context?: RenderContext) {
@@ -239,7 +239,7 @@ export class VolumeLayer extends Layer implements ChannelsEnabled {
 
 function spatialKey(chunk: Chunk): string {
   const { x, y, z, t } = chunk.chunkIndex;
-  return `${x}:${y}:${z}:${t}`;
+  return `${x}:${y}:${z}:${t}:lod${chunk.lod}`;
 }
 
 function groupBySpatialIndex(chunks: Chunk[]): Map<string, Chunk[]> {

--- a/packages/core/src/math/sort_by_distance.ts
+++ b/packages/core/src/math/sort_by_distance.ts
@@ -16,17 +16,20 @@ export function sortFrontToBack(
   camera: Camera
 ): RenderableObject[] {
   const cameraPosition = camera.position;
-  const centerA = vec3.create();
-  const centerB = vec3.create();
+
+  // Pre-compute bounding box centers to avoid repeated allocations during sort
+  const centers = new Map<RenderableObject, vec3>();
+  for (const obj of objects) {
+    const bbox = obj.boundingBox;
+    const center = vec3.create();
+    vec3.add(center, bbox.max, bbox.min);
+    vec3.scale(center, center, 0.5);
+    centers.set(obj, center);
+  }
 
   objects.sort((a, b) => {
-    vec3.add(centerA, a.boundingBox.max, a.boundingBox.min);
-    vec3.scale(centerA, centerA, 0.5);
-    vec3.add(centerB, b.boundingBox.max, b.boundingBox.min);
-    vec3.scale(centerB, centerB, 0.5);
-
-    const cam2aDistance = vec3.squaredDistance(cameraPosition, centerA);
-    const cam2bDistance = vec3.squaredDistance(cameraPosition, centerB);
+    const cam2aDistance = vec3.squaredDistance(cameraPosition, centers.get(a)!);
+    const cam2bDistance = vec3.squaredDistance(cameraPosition, centers.get(b)!);
 
     return cam2aDistance - cam2bDistance;
   });


### PR DESCRIPTION
### Summary
<!---
  Please try to cover the following questions in your summary:
  1. Describe the product (or technical) problem you are solving.
  2. Explain the engineering solution you have chosen.
  3. Discuss the implementation choices/tradeoffs you have made.
-->

The primary goal of this PR was to add frustum culling at the chunk level for volume rendering. I had originally also aimed to harmonize the slice and volume paths in the chunk store view a little, similar to https://github.com/chanzuckerberg/idetik/pull/579 (thanks for the pointer to this Ashley!). But with the performance issues mentioned below, that kind of blew this PR up in size. So scaled back to just modifying the culling of chunks for volumes and aiming to improve performance.

This change brought up some pretty major performance issues when directly implemented. Most of these weren't introduced by the frustum culling, but the frustum culling either highlighted the issue or the frustum culling extra operations were compounding with some performance problems already there. I'll note which ones were pre-existing because they could be pulled out of this PR as separate improvements if needed.

From profiling these seemed to be (in rough order):
1. Volume layer memory management inefficiencies (pre-existing issue). The volume layer was previously clearing all volumes whenever there were different chunks coming from the chunk store view. This didn't have a huge impact before, but with chunks updating rapidly this caused a very large bottleneck with new object creation and texture updates. Fixing this was likely the biggest improvement.
2. Recomputing the frustum and camera position (new issue). The first version of this PR obtained the frustum and position directly from the camera. But the first operation creates a new frustum each time, and the latter operation clones the camera position vector. These operations happened for each chunk, and sometimes also per timepoint. This inefficiency was removed at the chunk store level, not modifying the camera.
3. Recomputing chunk bounds and centers regularly in the chunk store view (pre-existing issue, compounded with frustum culling). The chunk store view was regularly recomputing the chunk bounds and center. Since the chunk is created once, we can cache these bounds. Right now, they are cached in the chunk store view, but we could alternatively lazily compute and then cache it on the chunk itself. As a note, the 2D code also uses this.
4. Volume sorting was recomputing the proxy geometry centers on each comparison (pre-existing issue, compounded because with frustum culling we can now use higher res LODs). The centers are now all computed before the sort, not during the sort.
5. Frustum intersection checks repeated across time (new issue). For time prefetching, we were doing many frustum intersection for chunks that shared the same spatial position and bounds. We introduced a cache for these results. Because we don't want to enforce that across t everything is chunked the same (unsure if a requirement or not for Idetik), the bounds are also cached and checked for equality on top of a spatial index + lod key. If we know that everything is chunked the same across t that check could be removed, but the performance impact is quite low of this check. Definitely the map access + bounds check is lower cost than the full frustum intersection test.

### Related Issue
Closes #<issue-number>

### Tests & Checks
<!---
  How did you validate that your changes were implemented correctly?
  
  Please think about the following prompts:
  1. I wrote automated tests.
  2. I manually tested my changes, and here's what I did:
-->

Manually tested changes. Introduced the old example for this, but that can be removed, just something that anyone can use to test the feel of the perf changes. Verified chunk culling through logs, breakpoints, and network requests.

Right now the image mask example fails to load the data but that's the same on main branch.