### PR TITLE
feat: dynamic lod computation for volume rendering

### DIFF
--- a/packages/core/examples/multi_viewport/main.ts
+++ b/packages/core/examples/multi_viewport/main.ts
@@ -49,7 +49,7 @@ const camera3D = new PerspectiveCamera();
 const volumeLayer = new VolumeLayer({
   source,
   sliceCoords: volumeCoords,
-  policy: createPlaybackPolicy({ lod: { min: 2, max: 2 } }),
+  policy: createPlaybackPolicy({ lod: { min: 0, max: 2 } }),
   channelProps: [{ contrastLimits: [0, 200] }],
 });
 

--- a/packages/core/examples/single_channel_volume/index.html
+++ b/packages/core/examples/single_channel_volume/index.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Volume Rendering</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        display: flex;
+        width: 100%;
+        height: 100%;
+        background-color: black;
+        font-family: monospace;
+        font-size: 12px;
+      }
+      #main {
+        display: flex;
+        flex-direction: column;
+        width: 100%;
+        height: 100%;
+      }
+      #canvas {
+        width: 100%;
+        height: 100%;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="main">
+      <canvas id="canvas"></canvas>
+    </div>
+    <script type="module" src="./main.ts"></script>
+  </body>
+</html>

--- a/packages/core/examples/single_channel_volume/index.html
+++ b/packages/core/examples/single_channel_volume/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Volume Rendering</title>
+    <title>Volume Rendering single channel</title>
     <style>
       html,
       body {

--- a/packages/core/examples/single_channel_volume/main.ts
+++ b/packages/core/examples/single_channel_volume/main.ts
@@ -1,0 +1,79 @@
+import { Idetik, VolumeLayer, PerspectiveCamera, OmeZarrImageSource } from "@";
+import { OrbitControls } from "@/objects/cameras/orbit_controls";
+import { createPlaybackPolicy } from "@/core/image_source_policy";
+import { addDimensionSlider } from "../lil_gui_utils";
+import GUI from "lil-gui";
+import { vec3 } from "gl-matrix";
+
+const url =
+  "https://public.czbiohub.org/royerlab/zebrahub/imaging/single-objective/ZSNS001.ome.zarr/";
+const source = OmeZarrImageSource.fromHttp({ url });
+const sliceCoords = {
+  t: 400,
+  z: undefined,
+  c: 0,
+};
+const controls = { lod: 2 };
+
+const camera = new PerspectiveCamera();
+const policy = createPlaybackPolicy({
+  lod: { min: controls.lod, max: controls.lod },
+});
+const volumeLayer = new VolumeLayer({
+  source,
+  sliceCoords,
+  policy,
+});
+const idetik = new Idetik({
+  canvas: document.querySelector<HTMLCanvasElement>("#canvas")!,
+  viewports: [
+    {
+      camera: camera,
+      cameraControls: new OrbitControls(camera, {
+        radius: 750,
+        target: vec3.fromValues(550, 500, 278), // Volume center,
+      }),
+      layers: [volumeLayer],
+    },
+  ],
+  showStats: true,
+});
+
+idetik.start();
+
+// Add GUI controls to manipulate rendering
+const gui = new GUI({ width: 500 });
+addDimensionSlider({
+  gui,
+  sliceCoords,
+  dimensionName: "t",
+  minValue: 0,
+  maxValue: 800,
+  stepValue: 1.0,
+  playback: {},
+});
+gui
+  .add(controls, "lod", 0, 2, 1)
+  .name("Level of Detail (LOD)")
+  .onChange(
+    (lod: number) =>
+      (volumeLayer.sourcePolicy = createPlaybackPolicy({
+        lod: { min: lod, max: lod },
+      }))
+  );
+
+const volumeFolder = gui.addFolder("Volume Rendering");
+volumeFolder
+  .add(volumeLayer, "opacityMultiplier", 0.01, 1.0, 0.01)
+  .name("Opacity scale");
+volumeFolder
+  .add(volumeLayer, "earlyTerminationAlpha", 0.8, 1.0, 0.01)
+  .name("Early termination threshold");
+
+const overlaysFolder = gui.addFolder("Debug");
+overlaysFolder
+  .add(volumeLayer, "debugShowWireframes")
+  .name("Show tile wireframes");
+overlaysFolder
+  .add(volumeLayer, "debugShowDegenerateRays")
+  .name("Show degenerate rays (length 0)");

--- a/packages/core/examples/single_channel_volume/main.ts
+++ b/packages/core/examples/single_channel_volume/main.ts
@@ -13,11 +13,10 @@ const sliceCoords = {
   z: undefined,
   c: 0,
 };
-const controls = { lod: 2 };
 
 const camera = new PerspectiveCamera();
 const policy = createPlaybackPolicy({
-  lod: { min: controls.lod, max: controls.lod },
+  lod: { min: 0, max: 2 },
 });
 const volumeLayer = new VolumeLayer({
   source,
@@ -52,15 +51,6 @@ addDimensionSlider({
   stepValue: 1.0,
   playback: {},
 });
-gui
-  .add(controls, "lod", 0, 2, 1)
-  .name("Level of Detail (LOD)")
-  .onChange(
-    (lod: number) =>
-      (volumeLayer.sourcePolicy = createPlaybackPolicy({
-        lod: { min: lod, max: lod },
-      }))
-  );
 
 const volumeFolder = gui.addFolder("Volume Rendering");
 volumeFolder

--- a/packages/core/examples/volume_rendering/main.ts
+++ b/packages/core/examples/volume_rendering/main.ts
@@ -13,11 +13,10 @@ const sliceCoords = {
   z: undefined,
   c: undefined, // Show all channels
 };
-const controls = { lod: 2 };
 
 const camera = new PerspectiveCamera();
 const policy = createExplorationPolicy({
-  lod: { min: controls.lod, max: controls.lod },
+  lod: { min: 0, max: 2 },
 });
 
 const channelNames = ["Phase 3D", "Prime DAPI", "Prime GFP"];
@@ -135,15 +134,6 @@ function createChannelControls(
 
 // Add GUI controls to manipulate rendering
 const gui = new GUI({ width: 500 });
-gui
-  .add(controls, "lod", 0, 2, 1)
-  .name("Level of Detail (LOD)")
-  .onChange(
-    (lod: number) =>
-      (volumeLayer.sourcePolicy = createExplorationPolicy({
-        lod: { min: lod, max: lod },
-      }))
-  );
 
 const volumeFolder = gui.addFolder("Volume Rendering");
 volumeFolder

--- a/packages/core/src/core/chunk_store_view.ts
+++ b/packages/core/src/core/chunk_store_view.ts
@@ -6,6 +6,7 @@ import { ImageSourcePolicy } from "./image_source_policy";
 import { ReadonlyVec2, vec2, vec3, mat4 } from "gl-matrix";
 import { Box2 } from "../math/box2";
 import { Box3 } from "../math/box3";
+import type { Frustum } from "../math/frustum";
 import { Logger } from "../utilities/logger";
 import { clamp } from "../utilities/clamp";
 
@@ -30,6 +31,10 @@ export class ChunkStoreView {
   private sourceMaxSquareDistance2D_: number;
   private maxSquareDistance3D_: number | null = null;
   private readonly chunkViewStates_: Map<Chunk, ChunkViewState> = new Map();
+  private readonly chunkBoundsCache_ = new Map<
+    Chunk,
+    { bounds: Box3; center: vec3 }
+  >();
 
   private isDisposed_ = false;
 
@@ -215,7 +220,8 @@ export class ChunkStoreView {
     this.chunkViewStates_.forEach(resetChunkViewState);
 
     const fallbackLOD = this.fallbackLOD();
-
+    const cameraFrustum = viewport.camera.frustum;
+    const cameraPosition = viewport.camera.position;
     this.maxSquareDistance3D_ = null;
     for (const chunk of currentTimeChunks) {
       const isCurrentLOD = chunk.lod === this.currentLOD_;
@@ -225,11 +231,9 @@ export class ChunkStoreView {
       // Check channel first to avoid more expensive frustum intersection test
       if (!this.isChunkChannelInSlice(chunk, sliceCoords)) continue;
 
-      if (
-        !viewport.camera.frustum.intersectsWithBox3(
-          this.computeChunkBounds(chunk)
-        )
-      ) {
+      const { bounds: chunkBounds, center: chunkCenter } =
+        this.getCachedChunkBoundsInfo(chunk);
+      if (!cameraFrustum.intersectsWithBox3(chunkBounds)) {
         continue;
       }
       const priority = this.computePriority(
@@ -241,7 +245,7 @@ export class ChunkStoreView {
       );
       if (priority === null) continue;
 
-      const orderKey = this.squareDistance3D(chunk, viewport.camera.position);
+      const orderKey = vec3.squaredDistance(chunkCenter, cameraPosition);
       this.maxSquareDistance3D_ = Math.max(
         this.maxSquareDistance3D_ ?? 0,
         orderKey
@@ -258,7 +262,8 @@ export class ChunkStoreView {
       this.markTimeChunksForPrefetchVolume(
         currentTimeIndex,
         sliceCoords,
-        viewport
+        cameraFrustum,
+        cameraPosition
       );
     }
 
@@ -298,6 +303,7 @@ export class ChunkStoreView {
   public dispose(): void {
     this.isDisposed_ = true;
     this.chunkViewStates_.forEach(resetChunkViewState);
+    this.chunkBoundsCache_.clear();
   }
 
   public setImageSourcePolicy(newPolicy: ImageSourcePolicy, key: symbol) {
@@ -444,7 +450,8 @@ export class ChunkStoreView {
   private markTimeChunksForPrefetchVolume(
     currentTimeIndex: number,
     sliceCoords: SliceCoordinates,
-    viewport: Viewport
+    frustum: Frustum,
+    cameraPosition: vec3
   ) {
     const numTimePoints = this.store_.dimensions.t?.lods[0].size ?? 1;
     const tEnd = Math.min(
@@ -459,17 +466,16 @@ export class ChunkStoreView {
       for (const chunk of this.store_.getChunksAtTime(t)) {
         if (chunk.lod !== fallbackLOD) continue;
         if (!this.isChunkChannelInSlice(chunk, sliceCoords)) continue;
-        if (
-          !viewport.camera.frustum.intersectsWithBox3(
-            this.computeChunkBounds(chunk)
-          )
-        ) {
+
+        const { bounds: chunkBounds, center: chunkCenter } =
+          this.getCachedChunkBoundsInfo(chunk);
+        if (!frustum.intersectsWithBox3(chunkBounds)) {
           continue;
         }
 
-        const squareDistance = this.squareDistance3D(
-          chunk,
-          viewport.camera.position
+        const squareDistance = vec3.squaredDistance(
+          chunkCenter,
+          cameraPosition
         );
         const normalizedDistance = clamp(
           squareDistance / (this.maxSquareDistance3D_ ?? 1),
@@ -477,7 +483,8 @@ export class ChunkStoreView {
           1 - Number.EPSILON
         );
         maxDistance = Math.max(maxDistance, squareDistance);
-        const orderKey = t - currentTimeIndex + normalizedDistance; // first order by time distance, then by spatial distance
+        // first order by time distance, then by spatial distance
+        const orderKey = t - currentTimeIndex + normalizedDistance;
 
         this.chunkViewStates_.set(chunk, {
           visible: false,
@@ -509,8 +516,14 @@ export class ChunkStoreView {
     return null;
   }
 
-  private computeChunkBounds(chunk: Chunk): Box3 {
-    return new Box3(
+  private getCachedChunkBoundsInfo(chunk: Chunk): {
+    bounds: Box3;
+    center: vec3;
+  } {
+    const cached = this.chunkBoundsCache_.get(chunk);
+    if (cached) return cached;
+
+    const bounds = new Box3(
       vec3.fromValues(chunk.offset.x, chunk.offset.y, chunk.offset.z),
       vec3.fromValues(
         chunk.offset.x + chunk.shape.x * chunk.scale.x,
@@ -518,10 +531,20 @@ export class ChunkStoreView {
         chunk.offset.z + chunk.shape.z * chunk.scale.z
       )
     );
+    const boundsInfo = {
+      bounds,
+      center: vec3.fromValues(
+        (bounds.min[0] + bounds.max[0]) * 0.5,
+        (bounds.min[1] + bounds.max[1]) * 0.5,
+        (bounds.min[2] + bounds.max[2]) * 0.5
+      ),
+    };
+    this.chunkBoundsCache_.set(chunk, boundsInfo);
+    return boundsInfo;
   }
 
   private isChunkWithinBounds(chunk: Chunk, bounds: Box3): boolean {
-    return Box3.intersects(this.computeChunkBounds(chunk), bounds);
+    return Box3.intersects(this.getCachedChunkBoundsInfo(chunk).bounds, bounds);
   }
 
   private fallbackLOD(): number {
@@ -614,15 +637,6 @@ export class ChunkStoreView {
     const dx = chunkCenter.x - center[0];
     const dy = chunkCenter.y - center[1];
     return dx * dx + dy * dy;
-  }
-
-  private squareDistance3D(chunk: Chunk, center: vec3): number {
-    const chunkCenter = vec3.fromValues(
-      chunk.offset.x + 0.5 * chunk.shape.x * chunk.scale.x,
-      chunk.offset.y + 0.5 * chunk.shape.y * chunk.scale.y,
-      chunk.offset.z + 0.5 * chunk.shape.z * chunk.scale.z
-    );
-    return vec3.squaredDistance(chunkCenter, center);
   }
 }
 

--- a/packages/core/src/core/chunk_store_view.ts
+++ b/packages/core/src/core/chunk_store_view.ts
@@ -1,5 +1,5 @@
 import { Chunk, SliceCoordinates, ChunkViewState } from "../data/chunk";
-import type { ChunkStore } from "./chunk_store";
+import { ChunkStore } from "./chunk_store";
 import { Viewport } from "./viewport";
 import { OrthographicCamera } from "../objects/cameras/orthographic_camera";
 import { ImageSourcePolicy } from "./image_source_policy";
@@ -9,6 +9,7 @@ import { Box3 } from "../math/box3";
 import type { Frustum } from "../math/frustum";
 import { Logger } from "../utilities/logger";
 import { clamp } from "../utilities/clamp";
+import { PerspectiveCamera } from "../objects/cameras/perspective_camera";
 
 /*
 Unique symbol used as a capability token to allow internal modules to update
@@ -42,6 +43,10 @@ export class ChunkStoreView {
     string,
     { bounds: Box3; inFrustum: boolean }
   >();
+  private volumeCenterCache_: { chunks: Chunk[] | null; center: vec3 } = {
+    chunks: null,
+    center: vec3.create(),
+  };
 
   private isDisposed_ = false;
 
@@ -123,14 +128,6 @@ export class ChunkStoreView {
 
     const orthoCamera = camera as OrthographicCamera;
     const viewBounds2D = orthoCamera.getWorldViewRect();
-    const virtualWidth = Math.abs(viewBounds2D.max[0] - viewBounds2D.min[0]);
-    const canvasElement = viewport.element as HTMLCanvasElement;
-    const bufferWidth = viewport.getBoxRelativeTo(canvasElement).toRect().width;
-    const virtualUnitsPerScreenPixel = virtualWidth / bufferWidth;
-    const lodFactor = Math.log2(1 / virtualUnitsPerScreenPixel);
-
-    this.setLOD(lodFactor);
-
     const zBounds = this.getZBounds(sliceCoords);
     const changed =
       this.policyChanged_ ||
@@ -139,6 +136,8 @@ export class ChunkStoreView {
       this.lastTCoord_ !== sliceCoords.t;
 
     if (!changed) return;
+    const lodFactor = this.computeOrtographicLODFactor(viewport, viewBounds2D);
+    this.setLOD(lodFactor);
 
     const currentTimeIndex = this.store_.getTimeIndex(sliceCoords);
     const currentTimeChunks = this.store_.getChunksAtTime(currentTimeIndex);
@@ -191,13 +190,20 @@ export class ChunkStoreView {
     sliceCoords: SliceCoordinates,
     viewport: Viewport
   ): void {
+    const camera = viewport.camera;
+    if (camera.type !== "PerspectiveCamera") {
+      throw new Error(
+        "ChunkStoreView for volume rendering currently supports only perspective cameras. " +
+          "Update the implementation before using an orthographic camera."
+      );
+    }
     // Each call allocates a new mat4 and computes projection * view.
     // This is intentional for simplicity. If this ever shows up in profiles
     // avoid multiply entirely by caching and comparing view/projection separately.
     const viewProjection = mat4.multiply(
       mat4.create(),
-      viewport.camera.projectionMatrix,
-      viewport.camera.viewMatrix
+      camera.projectionMatrix,
+      camera.viewMatrix
     );
 
     const changed =
@@ -219,14 +225,19 @@ export class ChunkStoreView {
       return;
     }
 
-    // TODO: Calculate LOD dynamically based on view frustum for volume rendering
-    // (similar to zoom-based LOD calculation in updateChunksForImage).
-    // Currently uses a fixed LOD from policy.
-    this.currentLOD_ = this.policy_.lod.min;
+    const fallbackLOD = this.fallbackLOD();
+    const volumeCenter = this.computeVolumeCenterCached(
+      currentTimeChunks.filter((chunk) => chunk.lod === fallbackLOD)
+    );
+    const lodFactor = this.computePerspectiveLODFactor(
+      camera as PerspectiveCamera,
+      viewport,
+      volumeCenter
+    );
+    this.setLOD(lodFactor);
 
     this.chunkViewStates_.forEach(resetChunkViewState);
 
-    const fallbackLOD = this.fallbackLOD();
     const cameraFrustum = viewport.camera.frustum;
     const cameraPosition = viewport.camera.position;
     this.maxSquareDistance3D_ = null;
@@ -344,10 +355,14 @@ export class ChunkStoreView {
   }
 
   private setLOD(lodFactor: number): void {
-    // `scale0` is the x pixel size (world units) at LOD 0.
+    // `scale0` is the smallest dimension pixel size (world units) at LOD 0.
     // With 2x downsampling per LOD, selection happens in log2 space.
     const dimensions = this.store_.dimensions;
-    const scale0 = dimensions.x.lods[0].scale;
+    const scale0 = Math.min(
+      dimensions.x.lods[0].scale,
+      dimensions.y.lods[0].scale,
+      dimensions.z?.lods[0].scale ?? Infinity
+    );
     const bias = this.policy_.lod.bias;
 
     // How many LOD 0 pixels per screen pixel, normalized by source scale and bias.
@@ -368,6 +383,10 @@ export class ChunkStoreView {
     const target = clamp(desiredLOD, minPolicyLOD, maxPolicyLOD);
     if (target !== this.currentLOD_) {
       this.currentLOD_ = target;
+      Logger.debug(
+        "ChunkStoreView",
+        `Set LOD to ${this.currentLOD_} (factor: ${lodFactor.toFixed(2)})`
+      );
     }
   }
 
@@ -680,6 +699,90 @@ export class ChunkStoreView {
     const dx = chunkCenter.x - center[0];
     const dy = chunkCenter.y - center[1];
     return dx * dx + dy * dy;
+  }
+
+  private computePerspectiveLODFactor(
+    camera: PerspectiveCamera,
+    viewport: Viewport,
+    volumeCenter: vec3
+  ): number {
+    const cameraToCenter = vec3.subtract(
+      vec3.create(),
+      volumeCenter,
+      camera.position
+    );
+    const distanceToVolumeCenter = vec3.length(cameraToCenter);
+
+    // Project line across screen vertical back into world space at volume center
+    // to determine how many world units the screen covers vertically
+    // For perspective projection: height = 2 * distance * tan(vertical fov/2)
+    const fovRadians = (camera.fov * Math.PI) / 180;
+    const worldHeightAtCenter =
+      2 * distanceToVolumeCenter * Math.tan(fovRadians / 2);
+
+    // Divide total world height by screen height in pixels to get per pixel value
+    const canvasElement = viewport.element as HTMLCanvasElement;
+    const screenHeightInPixels = viewport
+      .getBoxRelativeTo(canvasElement)
+      .toRect().height;
+    const worldUnitsPerPixel = worldHeightAtCenter / screenHeightInPixels;
+    return Math.log2(1 / worldUnitsPerPixel);
+  }
+
+  private computeOrtographicLODFactor(
+    viewport: Viewport,
+    viewBounds2D: Box2
+  ): number {
+    const virtualWidth = Math.abs(viewBounds2D.max[0] - viewBounds2D.min[0]);
+    const canvasElement = viewport.element as HTMLCanvasElement;
+    const bufferWidth = viewport.getBoxRelativeTo(canvasElement).toRect().width;
+    const virtualUnitsPerScreenPixel = virtualWidth / bufferWidth;
+    return Math.log2(1 / virtualUnitsPerScreenPixel);
+  }
+
+  private computeVolumeCenterCached(chunks: Chunk[]): vec3 {
+    if (this.volumeCenterCache_.chunks !== chunks) {
+      this.volumeCenterCache_.center = this.computeVolumeCenter(chunks);
+      this.volumeCenterCache_.chunks = chunks;
+    }
+    return this.volumeCenterCache_.center;
+  }
+
+  private computeVolumeCenter(chunks: Chunk[]): vec3 {
+    const fallbackLod = this.fallbackLOD();
+
+    let minX = Infinity;
+    let minY = Infinity;
+    let minZ = Infinity;
+    let maxX = -Infinity;
+    let maxY = -Infinity;
+    let maxZ = -Infinity;
+
+    for (const chunk of chunks) {
+      if (chunk.lod !== fallbackLod) continue;
+
+      const { bounds } = this.getCachedChunkBoundsInfo(chunk);
+
+      if (bounds.min[0] < minX) minX = bounds.min[0];
+      if (bounds.max[0] > maxX) maxX = bounds.max[0];
+      if (bounds.min[1] < minY) minY = bounds.min[1];
+      if (bounds.max[1] > maxY) maxY = bounds.max[1];
+      if (bounds.min[2] < minZ) minZ = bounds.min[2];
+      if (bounds.max[2] > maxZ) maxZ = bounds.max[2];
+    }
+    if (minX === Infinity || minY === Infinity || minZ === Infinity) {
+      Logger.warn(
+        "ChunkStoreView",
+        "Unable to compute volume center, no chunks found at fallback LOD"
+      );
+      return vec3.fromValues(0, 0, 0);
+    }
+
+    return vec3.fromValues(
+      0.5 * (minX + maxX),
+      0.5 * (minY + maxY),
+      0.5 * (minZ + maxZ)
+    );
   }
 }
 

--- a/packages/core/src/core/chunk_store_view.ts
+++ b/packages/core/src/core/chunk_store_view.ts
@@ -89,7 +89,10 @@ export class ChunkStoreView {
     return this.store_.lodCount;
   }
 
-  public getChunksToRender(sliceCoords: SliceCoordinates): Chunk[] {
+  public getChunksToRender(
+    sliceCoords: SliceCoordinates,
+    includeFallback: boolean = true
+  ): Chunk[] {
     const currentTimeIndex = this.store_.getTimeIndex(sliceCoords);
     const currentTimeChunks = this.store_.getChunksAtTime(currentTimeIndex);
     const currentLODChunks = currentTimeChunks.filter(
@@ -100,7 +103,7 @@ export class ChunkStoreView {
     );
 
     const fallbackLOD = this.fallbackLOD();
-    if (this.currentLOD_ === fallbackLOD) {
+    if (!includeFallback || this.currentLOD_ === fallbackLOD) {
       return currentLODChunks;
     }
 

--- a/packages/core/src/core/chunk_store_view.ts
+++ b/packages/core/src/core/chunk_store_view.ts
@@ -35,6 +35,13 @@ export class ChunkStoreView {
     Chunk,
     { bounds: Box3; center: vec3 }
   >();
+  // This frustum cache can be simplified if we can assume that
+  // chunks at the same xyz indices at a given LOD across time
+  // all share the same bounds (can remove the bounds here and bounds check)
+  private readonly frustumCheckCache_ = new Map<
+    string,
+    { bounds: Box3; inFrustum: boolean }
+  >();
 
   private isDisposed_ = false;
 
@@ -223,6 +230,7 @@ export class ChunkStoreView {
     const cameraFrustum = viewport.camera.frustum;
     const cameraPosition = viewport.camera.position;
     this.maxSquareDistance3D_ = null;
+
     for (const chunk of currentTimeChunks) {
       const isCurrentLOD = chunk.lod === this.currentLOD_;
       const isFallbackLOD = chunk.lod === fallbackLOD;
@@ -233,7 +241,19 @@ export class ChunkStoreView {
 
       const { bounds: chunkBounds, center: chunkCenter } =
         this.getCachedChunkBoundsInfo(chunk);
-      if (!cameraFrustum.intersectsWithBox3(chunkBounds)) {
+      const inFrustum = cameraFrustum.intersectsWithBox3(chunkBounds);
+
+      // If t-prefetch is enabled, cache frustum check results to avoid redundant
+      // checks for subsequent time points with the same spatial bounds
+      if (sliceCoords.t !== undefined) {
+        const spatialKey = this.getSpatialKey(chunk);
+        this.frustumCheckCache_.set(spatialKey, {
+          bounds: chunkBounds,
+          inFrustum,
+        });
+      }
+
+      if (!inFrustum) {
         continue;
       }
       const priority = this.computePriority(
@@ -469,8 +489,15 @@ export class ChunkStoreView {
 
         const { bounds: chunkBounds, center: chunkCenter } =
           this.getCachedChunkBoundsInfo(chunk);
-        if (!frustum.intersectsWithBox3(chunkBounds)) {
-          continue;
+
+        const spatialKey = this.getSpatialKey(chunk);
+        const cached = this.frustumCheckCache_.get(spatialKey);
+        // This check can be removed if we can guarantee that all chunks at the same
+        // xyz indices and LOD across time share the same bounds
+        if (cached && this.boundsEqual(cached.bounds, chunkBounds)) {
+          if (!cached.inFrustum) continue;
+        } else {
+          if (!frustum.intersectsWithBox3(chunkBounds)) continue;
         }
 
         const squareDistance = vec3.squaredDistance(
@@ -545,6 +572,22 @@ export class ChunkStoreView {
 
   private isChunkWithinBounds(chunk: Chunk, bounds: Box3): boolean {
     return Box3.intersects(this.getCachedChunkBoundsInfo(chunk).bounds, bounds);
+  }
+
+  private getSpatialKey(chunk: Chunk): string {
+    const { x, y, z } = chunk.chunkIndex;
+    return `${x}:${y}:${z}:lod${chunk.lod}`;
+  }
+
+  private boundsEqual(a: Box3, b: Box3): boolean {
+    return (
+      a.min[0] === b.min[0] &&
+      a.min[1] === b.min[1] &&
+      a.min[2] === b.min[2] &&
+      a.max[0] === b.max[0] &&
+      a.max[1] === b.max[1] &&
+      a.max[2] === b.max[2]
+    );
   }
 
   private fallbackLOD(): number {

--- a/packages/core/src/core/chunk_store_view.ts
+++ b/packages/core/src/core/chunk_store_view.ts
@@ -28,6 +28,7 @@ export class ChunkStoreView {
   private lastTCoord_?: number;
 
   private sourceMaxSquareDistance2D_: number;
+  private maxSquareDistance3D_: number | null = null;
   private readonly chunkViewStates_: Map<Chunk, ChunkViewState> = new Map();
 
   private isDisposed_ = false;
@@ -215,12 +216,22 @@ export class ChunkStoreView {
 
     const fallbackLOD = this.fallbackLOD();
 
+    this.maxSquareDistance3D_ = null;
     for (const chunk of currentTimeChunks) {
       const isCurrentLOD = chunk.lod === this.currentLOD_;
       const isFallbackLOD = chunk.lod === fallbackLOD;
       if (!isCurrentLOD && !isFallbackLOD) continue;
 
+      // Check channel first to avoid more expensive frustum intersection test
       if (!this.isChunkChannelInSlice(chunk, sliceCoords)) continue;
+
+      if (
+        !viewport.camera.frustum.intersectsWithBox3(
+          this.computeChunkBounds(chunk)
+        )
+      ) {
+        continue;
+      }
       const priority = this.computePriority(
         isFallbackLOD,
         isCurrentLOD,
@@ -228,17 +239,27 @@ export class ChunkStoreView {
         false, // isPrefetch
         true // isChannelInSlice
       );
+      if (priority === null) continue;
 
+      const orderKey = this.squareDistance3D(chunk, viewport.camera.position);
+      this.maxSquareDistance3D_ = Math.max(
+        this.maxSquareDistance3D_ ?? 0,
+        orderKey
+      );
       this.chunkViewStates_.set(chunk, {
         visible: true,
         prefetch: false,
         priority,
-        orderKey: 0, // All chunks have the same ordering for volume rendering
+        orderKey,
       });
     }
 
     if (sliceCoords.t !== undefined) {
-      this.markTimeChunksForPrefetchVolume(currentTimeIndex, sliceCoords);
+      this.markTimeChunksForPrefetchVolume(
+        currentTimeIndex,
+        sliceCoords,
+        viewport
+      );
     }
 
     this.policyChanged_ = false;
@@ -422,7 +443,8 @@ export class ChunkStoreView {
 
   private markTimeChunksForPrefetchVolume(
     currentTimeIndex: number,
-    sliceCoords: SliceCoordinates
+    sliceCoords: SliceCoordinates,
+    viewport: Viewport
   ) {
     const numTimePoints = this.store_.dimensions.t?.lods[0].size ?? 1;
     const tEnd = Math.min(
@@ -432,12 +454,30 @@ export class ChunkStoreView {
     const fallbackLOD = this.fallbackLOD();
     const priority = this.policy_.priorityMap["prefetchTime"];
 
+    let maxDistance = 0;
     for (let t = currentTimeIndex + 1; t <= tEnd; ++t) {
       for (const chunk of this.store_.getChunksAtTime(t)) {
         if (chunk.lod !== fallbackLOD) continue;
         if (!this.isChunkChannelInSlice(chunk, sliceCoords)) continue;
+        if (
+          !viewport.camera.frustum.intersectsWithBox3(
+            this.computeChunkBounds(chunk)
+          )
+        ) {
+          continue;
+        }
 
-        const orderKey = t - currentTimeIndex; // nearer future timepoints first
+        const squareDistance = this.squareDistance3D(
+          chunk,
+          viewport.camera.position
+        );
+        const normalizedDistance = clamp(
+          squareDistance / (this.maxSquareDistance3D_ ?? 1),
+          0,
+          1 - Number.EPSILON
+        );
+        maxDistance = Math.max(maxDistance, squareDistance);
+        const orderKey = t - currentTimeIndex + normalizedDistance; // first order by time distance, then by spatial distance
 
         this.chunkViewStates_.set(chunk, {
           visible: false,
@@ -447,6 +487,8 @@ export class ChunkStoreView {
         });
       }
     }
+    this.maxSquareDistance3D_ =
+      maxDistance > 0 ? maxDistance : this.maxSquareDistance3D_;
   }
 
   private computePriority(
@@ -467,8 +509,8 @@ export class ChunkStoreView {
     return null;
   }
 
-  private isChunkWithinBounds(chunk: Chunk, bounds: Box3): boolean {
-    const chunkBounds = new Box3(
+  private computeChunkBounds(chunk: Chunk): Box3 {
+    return new Box3(
       vec3.fromValues(chunk.offset.x, chunk.offset.y, chunk.offset.z),
       vec3.fromValues(
         chunk.offset.x + chunk.shape.x * chunk.scale.x,
@@ -476,7 +518,10 @@ export class ChunkStoreView {
         chunk.offset.z + chunk.shape.z * chunk.scale.z
       )
     );
-    return Box3.intersects(chunkBounds, bounds);
+  }
+
+  private isChunkWithinBounds(chunk: Chunk, bounds: Box3): boolean {
+    return Box3.intersects(this.computeChunkBounds(chunk), bounds);
   }
 
   private fallbackLOD(): number {
@@ -569,6 +614,15 @@ export class ChunkStoreView {
     const dx = chunkCenter.x - center[0];
     const dy = chunkCenter.y - center[1];
     return dx * dx + dy * dy;
+  }
+
+  private squareDistance3D(chunk: Chunk, center: vec3): number {
+    const chunkCenter = vec3.fromValues(
+      chunk.offset.x + 0.5 * chunk.shape.x * chunk.scale.x,
+      chunk.offset.y + 0.5 * chunk.shape.y * chunk.scale.y,
+      chunk.offset.z + 0.5 * chunk.shape.z * chunk.scale.z
+    );
+    return vec3.squaredDistance(chunkCenter, center);
   }
 }
 

--- a/packages/core/src/layers/volume_layer.ts
+++ b/packages/core/src/layers/volume_layer.ts
@@ -136,7 +136,9 @@ export class VolumeLayer extends Layer implements ChannelsEnabled {
 
   public onDetached(_context: IdetikContext): void {
     if (!this.chunkStoreView_) return;
-    this.releaseAndRemoveVolumes(this.currentVolumes_.values());
+    for (const volume of this.currentVolumes_.values()) {
+      this.releaseAndRemoveVolume(volume);
+    }
     this.clearObjects();
     this.chunkStoreView_.dispose();
     this.chunkStoreView_ = undefined;
@@ -155,17 +157,16 @@ export class VolumeLayer extends Layer implements ChannelsEnabled {
       this.lastLoadedTime_ !== currentTime ||
       groupedChunks.size !== this.currentVolumes_.size ||
       this.lastNumRenderedChannelChunks_ !== chunksToRender.length;
-    this.lastNumRenderedChannelChunks_ = chunksToRender.length;
     if (!needsUpdate) return;
 
-    const volumesToRemove = Array.from(this.currentVolumes_.entries())
-      .filter(([key]) => !groupedChunks.has(key))
-      .map(([, volume]) => volume);
-    this.releaseAndRemoveVolumes(volumesToRemove);
+    for (const [key, volume] of this.currentVolumes_) {
+      if (!groupedChunks.has(key)) {
+        this.releaseAndRemoveVolume(volume);
+        this.currentVolumes_.delete(key);
+      }
+    }
 
-    this.currentVolumes_.clear();
     this.clearObjects();
-
     for (const [key, chunks] of groupedChunks) {
       const volume = this.getOrCreateVolume(key, chunks);
       volume.wireframeEnabled = this.debugShowWireframes;
@@ -174,6 +175,7 @@ export class VolumeLayer extends Layer implements ChannelsEnabled {
     }
 
     this.lastLoadedTime_ = currentTime;
+    this.lastNumRenderedChannelChunks_ = chunksToRender.length;
     if (this.state !== "ready") this.setState("ready");
   }
 
@@ -197,12 +199,10 @@ export class VolumeLayer extends Layer implements ChannelsEnabled {
     ]);
   }
 
-  private releaseAndRemoveVolumes(volumes: Iterable<VolumeRenderable>) {
-    for (const volume of volumes) {
-      volume.clearLoadedChannels();
-      this.pool_.release(this.volumeToPoolKey_.get(volume)!, volume);
-      this.volumeToPoolKey_.delete(volume);
-    }
+  private releaseAndRemoveVolume(volume: VolumeRenderable) {
+    volume.clearLoadedChannels();
+    this.pool_.release(this.volumeToPoolKey_.get(volume)!, volume);
+    this.volumeToPoolKey_.delete(volume);
   }
 
   public update(context?: RenderContext) {
@@ -239,7 +239,7 @@ export class VolumeLayer extends Layer implements ChannelsEnabled {
 
 function spatialKey(chunk: Chunk): string {
   const { x, y, z, t } = chunk.chunkIndex;
-  return `${x}:${y}:${z}:${t}`;
+  return `${x}:${y}:${z}:${t}:lod${chunk.lod}`;
 }
 
 function groupBySpatialIndex(chunks: Chunk[]): Map<string, Chunk[]> {

--- a/packages/core/src/layers/volume_layer.ts
+++ b/packages/core/src/layers/volume_layer.ts
@@ -148,7 +148,8 @@ export class VolumeLayer extends Layer implements ChannelsEnabled {
     if (!this.chunkStoreView_) return;
 
     const chunksToRender = this.chunkStoreView_.getChunksToRender(
-      this.sliceCoords_
+      this.sliceCoords_,
+      false /* includeFallback */
     );
     const currentTime = this.sliceCoords_.t ?? -1;
     const groupedChunks = groupBySpatialIndex(chunksToRender);

--- a/packages/core/src/math/sort_by_distance.ts
+++ b/packages/core/src/math/sort_by_distance.ts
@@ -16,17 +16,20 @@ export function sortFrontToBack(
   camera: Camera
 ): RenderableObject[] {
   const cameraPosition = camera.position;
-  const centerA = vec3.create();
-  const centerB = vec3.create();
+
+  // Pre-compute bounding box centers to avoid repeated allocations during sort
+  const centers = new Map<RenderableObject, vec3>();
+  for (const obj of objects) {
+    const bbox = obj.boundingBox;
+    const center = vec3.create();
+    vec3.add(center, bbox.max, bbox.min);
+    vec3.scale(center, center, 0.5);
+    centers.set(obj, center);
+  }
 
   objects.sort((a, b) => {
-    vec3.add(centerA, a.boundingBox.max, a.boundingBox.min);
-    vec3.scale(centerA, centerA, 0.5);
-    vec3.add(centerB, b.boundingBox.max, b.boundingBox.min);
-    vec3.scale(centerB, centerB, 0.5);
-
-    const cam2aDistance = vec3.squaredDistance(cameraPosition, centerA);
-    const cam2bDistance = vec3.squaredDistance(cameraPosition, centerB);
+    const cam2aDistance = vec3.squaredDistance(cameraPosition, centers.get(a)!);
+    const cam2bDistance = vec3.squaredDistance(cameraPosition, centers.get(b)!);
 
     return cam2aDistance - cam2bDistance;
   });


### PR DESCRIPTION
### Summary
<!---
  Please try to cover the following questions in your summary:
  1. Describe the product (or technical) problem you are solving.
  2. Explain the engineering solution you have chosen.
  3. Discuss the implementation choices/tradeoffs you have made.
-->

Adds dynamic LOD selection to volume rendering. To do this, we compute how many world units one screen pixel covers at the volume center using perspective geometry. The downside is it ignores volume extent and orientation relative to the camera. Changes in this PR are on top of https://github.com/chanzuckerberg/idetik/pull/628 as the frustum culling is a pre-requisite, otherwise the performance makes this not usable.

Many thanks to @shlomnissan for looking through potential options here!

note, video before fixing that fallback LOD information was always in the volume layer
https://github.com/user-attachments/assets/f9f83919-cbb1-451b-b811-642c60ae6084

### Related Issue
Closes #<issue-number>

### Tests & Checks
<!---
  How did you validate that your changes were implemented correctly?
  
  Please think about the following prompts:
  1. I wrote automated tests.
  2. I manually tested my changes, and here's what I did:
-->
