### PR TITLE
chore: fix base path in examples build for GH pages

### DIFF
--- a/.github/workflows/deploy-examples.yml
+++ b/.github/workflows/deploy-examples.yml
@@ -36,7 +36,7 @@ jobs:
         run: npm run build --workspace=@idetik/core
 
       - name: Build examples for production
-        run: npm run build:examples --workspace=@idetik/core
+        run: npm run build:examples --workspace=@idetik/core -- --base=/idetik/
 
       - name: Setup Pages
         uses: actions/configure-pages@v4


### PR DESCRIPTION
### Summary
We publish our "examples" site to GH Pages, but it's broken now that the repo is published.
Previously it was hosted at https://vigilant-adventure-prk33kk.pages.github.io/, which worked.
Now that it's public, it's hosted at https://chanzuckerberg.github.io/idetik/, but it's broken because it's no longer at the root path.

### Related Issue
Closes N/A

### Tests & Checks
Tested the build locally and confirmed paths are prefixed with `/idetik`.
