### PR TITLE
fix: fix base path in examples build for GH pages (again)

### DIFF
--- a/.github/workflows/deploy-examples.yml
+++ b/.github/workflows/deploy-examples.yml
@@ -36,7 +36,7 @@ jobs:
         run: npm run build --workspace=@idetik/core
 
       - name: Build examples for production
-        run: npm run build:examples --workspace=@idetik/core
+        run: npm run build:examples --workspace=@idetik/core -- --base=/idetik/
 
       - name: Setup Pages
         uses: actions/configure-pages@v4

--- a/packages/core/examples/navigation.ts
+++ b/packages/core/examples/navigation.ts
@@ -48,7 +48,7 @@ class IdetikNavigation {
 
   private async loadExamples(): Promise<void> {
     try {
-      const response = await fetch(`/examples-manifest.json?t=${Date.now()}`);
+      const response = await fetch(`examples-manifest.json?t=${Date.now()}`);
       const manifest: Manifest = await response.json();
       this.examples_ = manifest.examples || [];
       this.renderExamples();


### PR DESCRIPTION
### Summary
#633 seems to have not completely fixed the problem, so hopefully this does.
