### PR TITLE
feat: support multi-channel selection in slice coordinates

### DIFF
--- a/packages/core/examples/ca_wave_dynamics/main.ts
+++ b/packages/core/examples/ca_wave_dynamics/main.ts
@@ -33,14 +33,17 @@ const tRange = { min: tMin, max: tMax };
 const sliceCoords = {
   t: tMin,
   z: 0,
-  c: 1,
+  c: [1],
 };
 
-const channelColor = Color.GREEN;
 const channelProps: ChannelProps[] = [
   {
+    visible: false,
+  },
+  {
+    visible: true,
     contrastLimits: [409, 3000],
-    color: channelColor,
+    color: Color.GREEN,
   },
 ];
 

--- a/packages/core/examples/chunk_streaming/main.ts
+++ b/packages/core/examples/chunk_streaming/main.ts
@@ -27,7 +27,7 @@ const source = OmeZarrImageSource.fromHttp({ url });
 const sliceCoords = {
   t: 400,
   z: 300,
-  c: 0,
+  c: [0],
 };
 
 // values copied from source

--- a/packages/core/examples/image2d_from_omezarr4d_hcs/main.ts
+++ b/packages/core/examples/image2d_from_omezarr4d_hcs/main.ts
@@ -1,5 +1,6 @@
 import {
   Idetik,
+  ChannelProps,
   OrthographicCamera,
   OmeZarrImageSource,
   PanZoomControls,
@@ -70,16 +71,30 @@ const onImageChange = async () => {
     [omeroChannels[2].window!.start, omeroChannels[2].window!.end],
   ];
 
+  const channelProps: ChannelProps[] = [
+    { visible: false },
+    {
+      visible: true,
+      color: [0, 1, 1],
+      contrastLimits: contrastLimits[0],
+    },
+    {
+      visible: true,
+      color: [1, 0, 1],
+      contrastLimits: contrastLimits[1],
+    },
+  ];
+
   const layer1 = new ChunkedImageLayer({
     source,
-    sliceCoords: { t: 0, z: initZ, c: 1 },
-    channelProps: [{ color: [0, 1, 1], contrastLimits: contrastLimits[0] }],
+    sliceCoords: { t: 0, z: initZ, c: [1] },
+    channelProps,
     policy,
   });
   const layer2 = new ChunkedImageLayer({
     source,
-    sliceCoords: { t: 0, z: initZ, c: 2 },
-    channelProps: [{ color: [1, 0, 1], contrastLimits: contrastLimits[1] }],
+    sliceCoords: { t: 0, z: initZ, c: [2] },
+    channelProps,
     policy,
     transparent: true,
     blendMode: "additive",

--- a/packages/core/examples/image_labels_overlay_with_value_picking/main.ts
+++ b/packages/core/examples/image_labels_overlay_with_value_picking/main.ts
@@ -41,7 +41,7 @@ const yStopPoint = yLod.size * yLod.scale;
 
 const sliceCoords = {
   t: tStartPoint,
-  c: phaseChannelIndex,
+  c: [phaseChannelIndex],
   z: zMidPoint,
 };
 
@@ -75,7 +75,11 @@ const imageLayer = new ChunkedImageLayer({
   sliceCoords,
   policy: createExplorationPolicy(),
   transparent: true,
-  channelProps: [{ contrastLimits: phaseContrastLimits }],
+  channelProps: [
+    { visible: true, contrastLimits: phaseContrastLimits },
+    { visible: false },
+    { visible: false },
+  ],
 });
 
 // Function to create label layer with current mode

--- a/packages/core/examples/image_labels_overlay_with_value_picking/main.ts
+++ b/packages/core/examples/image_labels_overlay_with_value_picking/main.ts
@@ -26,10 +26,6 @@ const lod = 0;
 const loader = await imageSource.open();
 const dimensions = loader.getSourceDimensionMap();
 
-// Phase contrast limits were chosen qualitatively.
-const phaseChannelIndex = 0;
-const phaseContrastLimits: [number, number] = [20, 200];
-
 const tStartPoint = 0;
 
 const zLod = dimensions.z!.lods[0];
@@ -41,7 +37,7 @@ const yStopPoint = yLod.size * yLod.scale;
 
 const sliceCoords = {
   t: tStartPoint,
-  c: [phaseChannelIndex],
+  c: [0],
   z: zMidPoint,
 };
 
@@ -76,7 +72,7 @@ const imageLayer = new ChunkedImageLayer({
   policy: createExplorationPolicy(),
   transparent: true,
   channelProps: [
-    { visible: true, contrastLimits: phaseContrastLimits },
+    { visible: true, contrastLimits: [20, 200] },
     { visible: false },
     { visible: false },
   ],

--- a/packages/core/examples/image_series_labels_overlay/main.ts
+++ b/packages/core/examples/image_series_labels_overlay/main.ts
@@ -25,10 +25,6 @@ const lod = 0;
 const loader = await imageSource.open();
 const dimensions = loader.getSourceDimensionMap();
 
-// Phase contrast limits were chosen qualitatively.
-const phaseChannelIndex = 0;
-const phaseContrastLimits: [number, number] = [20, 200];
-
 const tLod = dimensions.t!.lods[lod];
 const tMin = 0;
 const tMax = tLod.size;
@@ -37,7 +33,7 @@ const zMidPoint = 0.5 * zLod.size * zLod.scale;
 
 const region: Region = [
   { dimension: "T", index: { type: "full" } },
-  { dimension: "C", index: { type: "point", value: phaseChannelIndex } },
+  { dimension: "C", index: { type: "point", value: 0 } },
   { dimension: "Z", index: { type: "point", value: zMidPoint } },
   { dimension: "X", index: { type: "full" } },
   { dimension: "Y", index: { type: "full" } },
@@ -52,7 +48,7 @@ const imageLayer = new ImageSeriesLayer({
     {
       visible: true,
       color: Color.WHITE,
-      contrastLimits: phaseContrastLimits,
+      contrastLimits: [20, 200],
     },
   ],
 });

--- a/packages/core/examples/multi_viewport/main.ts
+++ b/packages/core/examples/multi_viewport/main.ts
@@ -43,7 +43,7 @@ const volumeCoords = {
   get t() {
     return sharedTime.t;
   },
-  c: 0,
+  c: [0],
 };
 const camera3D = new PerspectiveCamera();
 const volumeLayer = new VolumeLayer({
@@ -59,7 +59,7 @@ const sliceCoords = {
     return sharedTime.t;
   },
   z: 300,
-  c: 0,
+  c: [0],
 };
 const imageLayer = new ChunkedImageLayer({
   source,

--- a/packages/core/examples/volume_rendering/main.ts
+++ b/packages/core/examples/volume_rendering/main.ts
@@ -11,7 +11,7 @@ const source = OmeZarrImageSource.fromHttp({ url });
 const sliceCoords = {
   t: 0,
   z: undefined,
-  c: [], // Show all channels
+  c: undefined, // Show all channels
 };
 const controls = { lod: 2 };
 

--- a/packages/core/examples/volume_rendering/main.ts
+++ b/packages/core/examples/volume_rendering/main.ts
@@ -11,7 +11,7 @@ const source = OmeZarrImageSource.fromHttp({ url });
 const sliceCoords = {
   t: 0,
   z: undefined,
-  c: undefined, // Show all channels
+  c: [], // Show all channels
 };
 const controls = { lod: 2 };
 

--- a/packages/core/src/core/chunk_store.ts
+++ b/packages/core/src/core/chunk_store.ts
@@ -102,6 +102,10 @@ export class ChunkStore {
     return this.lowestResLOD_ + 1;
   }
 
+  public get channelCount(): number {
+    return this.dimensions_.c?.lods[0].size ?? 1;
+  }
+
   public get dimensions() {
     return this.dimensions_;
   }

--- a/packages/core/src/core/chunk_store_view.ts
+++ b/packages/core/src/core/chunk_store_view.ts
@@ -26,6 +26,7 @@ export class ChunkStoreView {
   private lastViewProjection_: mat4 | null = null;
   private lastZBounds_?: [number, number];
   private lastTCoord_?: number;
+  private lastCCoords_?: number[];
 
   private sourceMaxSquareDistance2D_: number;
   private readonly chunkViewStates_: Map<Chunk, ChunkViewState> = new Map();
@@ -69,6 +70,10 @@ export class ChunkStoreView {
 
   public get lodCount(): number {
     return this.store_.lodCount;
+  }
+
+  public get channelCount(): number {
+    return this.store_.channelCount;
   }
 
   public getChunksToRender(sliceCoords: SliceCoordinates): Chunk[] {
@@ -123,7 +128,8 @@ export class ChunkStoreView {
       this.policyChanged_ ||
       this.viewBounds2DChanged(viewBounds2D) ||
       this.zBoundsChanged(zBounds) ||
-      this.lastTCoord_ !== sliceCoords.t;
+      this.lastTCoord_ !== sliceCoords.t ||
+      this.cCoordsChanged(sliceCoords.c);
 
     if (!changed) return;
 
@@ -172,6 +178,7 @@ export class ChunkStoreView {
     this.lastViewBounds2D_ = viewBounds2D.clone();
     this.lastZBounds_ = zBounds;
     this.lastTCoord_ = sliceCoords.t;
+    this.lastCCoords_ = sliceCoords.c ? [...sliceCoords.c] : undefined;
   }
 
   public updateChunksForVolume(
@@ -190,7 +197,8 @@ export class ChunkStoreView {
     const changed =
       this.policyChanged_ ||
       this.hasViewProjectionChanged(viewProjection) ||
-      this.lastTCoord_ !== sliceCoords.t;
+      this.lastTCoord_ !== sliceCoords.t ||
+      this.cCoordsChanged(sliceCoords.c);
 
     if (!changed) return;
 
@@ -243,6 +251,7 @@ export class ChunkStoreView {
 
     this.policyChanged_ = false;
     this.lastTCoord_ = sliceCoords.t;
+    this.lastCCoords_ = sliceCoords.c ? [...sliceCoords.c] : undefined;
     this.lastViewProjection_ = viewProjection;
   }
 
@@ -328,7 +337,8 @@ export class ChunkStoreView {
     chunk: Chunk,
     sliceCoords: SliceCoordinates
   ): boolean {
-    return sliceCoords.c === undefined || sliceCoords.c === chunk.chunkIndex.c;
+    if (!sliceCoords.c || sliceCoords.c.length === 0) return true;
+    return sliceCoords.c.includes(chunk.chunkIndex.c);
   }
 
   private updateChunksAtTimeIndex(
@@ -531,6 +541,13 @@ export class ChunkStoreView {
 
   private zBoundsChanged(newBounds: [number, number]): boolean {
     return !this.lastZBounds_ || !vec2.equals(this.lastZBounds_, newBounds);
+  }
+
+  private cCoordsChanged(newC?: number[]): boolean {
+    if (!this.lastCCoords_ && !newC) return false;
+    if (!this.lastCCoords_ || !newC) return true;
+    if (this.lastCCoords_.length !== newC.length) return true;
+    return !this.lastCCoords_.every((v, i) => v === newC[i]);
   }
 
   private getPaddedBounds(bounds: Box3): Box3 {

--- a/packages/core/src/core/chunk_store_view.ts
+++ b/packages/core/src/core/chunk_store_view.ts
@@ -337,7 +337,8 @@ export class ChunkStoreView {
     chunk: Chunk,
     sliceCoords: SliceCoordinates
   ): boolean {
-    if (!sliceCoords.c || sliceCoords.c.length === 0) return true;
+    if (sliceCoords.c === undefined) return true;
+    if (sliceCoords.c.length === 0) return false;
     return sliceCoords.c.includes(chunk.chunkIndex.c);
   }
 

--- a/packages/core/src/data/chunk.ts
+++ b/packages/core/src/data/chunk.ts
@@ -96,7 +96,7 @@ export type SourceDimensionLod = {
 
 export type SliceCoordinates = {
   z?: number;
-  c?: number;
+  c?: number[];
   t?: number;
 };
 

--- a/packages/core/src/layers/chunked_image_layer.ts
+++ b/packages/core/src/layers/chunked_image_layer.ts
@@ -3,7 +3,11 @@ import type { IdetikContext } from "../idetik";
 import { Chunk, ChunkSource, SliceCoordinates } from "../data/chunk";
 import { ChunkStoreView, INTERNAL_POLICY_KEY } from "../core/chunk_store_view";
 import { ImageSourcePolicy } from "../core/image_source_policy";
-import { ChannelProps, ChannelsEnabled } from "../objects/textures/channel";
+import {
+  ChannelProps,
+  ChannelsEnabled,
+  validateChannelPropsCount,
+} from "../objects/textures/channel";
 import { ImageRenderable } from "../objects/renderable/image_renderable";
 import { Texture2DArray } from "../objects/textures/texture_2d_array";
 import { Logger } from "../utilities/logger";
@@ -79,6 +83,17 @@ export class ChunkedImageLayer extends Layer implements ChannelsEnabled {
       this.source_,
       this.policy_
     );
+
+    const channelCount = this.chunkStoreView_.channelCount;
+    validateChannelPropsCount(this.channelProps_, channelCount);
+
+    if (channelCount > 1 && this.sliceCoords_.c?.length !== 1) {
+      throw new Error(
+        `ChunkedImageLayer requires exactly one channel in sliceCoords.c ` +
+          `for multi-channel sources (found ${channelCount} channels). ` +
+          `Use one layer per channel.`
+      );
+    }
   }
 
   public onDetached(_context: IdetikContext): void {
@@ -232,13 +247,16 @@ export class ChunkedImageLayer extends Layer implements ChannelsEnabled {
       const texture = pooled.textures[0] as Texture2DArray;
       texture.updateWithChunk(chunk, this.getDataForImage(chunk));
       this.updateImageChunk(pooled, chunk);
-      if (this.channelProps_) {
-        pooled.setChannelProps(this.channelProps_);
-      }
+      pooled.setChannelProps(this.getChannelPropsForChunk(chunk));
       return pooled;
     }
 
     return this.createImage(chunk);
+  }
+
+  private getChannelPropsForChunk(chunk: Chunk): ChannelProps[] {
+    if (!this.channelProps_) return [{}];
+    return [this.channelProps_[chunk.chunkIndex.c] ?? {}];
   }
 
   private createImage(chunk: Chunk) {
@@ -246,7 +264,7 @@ export class ChunkedImageLayer extends Layer implements ChannelsEnabled {
       chunk.shape.x,
       chunk.shape.y,
       Texture2DArray.createWithChunk(chunk, this.getDataForImage(chunk)),
-      this.channelProps_ ?? [{}]
+      this.getChannelPropsForChunk(chunk)
     );
     this.updateImageChunk(image, chunk);
     return image;
@@ -348,8 +366,8 @@ export class ChunkedImageLayer extends Layer implements ChannelsEnabled {
 
   public setChannelProps(channelProps: ChannelProps[]) {
     this.channelProps_ = channelProps;
-    this.visibleChunks_.forEach((image) => {
-      image.setChannelProps(channelProps);
+    this.visibleChunks_.forEach((image, chunk) => {
+      image.setChannelProps(this.getChannelPropsForChunk(chunk));
     });
     this.channelChangeCallbacks_.forEach((callback) => {
       callback();

--- a/packages/core/src/layers/chunked_image_layer.ts
+++ b/packages/core/src/layers/chunked_image_layer.ts
@@ -87,7 +87,11 @@ export class ChunkedImageLayer extends Layer implements ChannelsEnabled {
     const channelCount = this.chunkStoreView_.channelCount;
     validateChannelPropsCount(this.channelProps_, channelCount);
 
-    if (channelCount > 1 && this.sliceCoords_.c?.length !== 1) {
+    if (
+      channelCount > 1 &&
+      this.sliceCoords_.c !== undefined &&
+      this.sliceCoords_.c.length > 1
+    ) {
       throw new Error(
         `ChunkedImageLayer requires exactly one channel in sliceCoords.c ` +
           `for multi-channel sources (found ${channelCount} channels). ` +

--- a/packages/core/src/layers/volume_layer.ts
+++ b/packages/core/src/layers/volume_layer.ts
@@ -7,7 +7,11 @@ import { ImageSourcePolicy } from "../core/image_source_policy";
 import { RenderablePool } from "../utilities/renderable_pool";
 import { vec3 } from "gl-matrix";
 import { sortFrontToBack } from "../math/sort_by_distance";
-import { ChannelProps, ChannelsEnabled } from "../objects/textures/channel";
+import {
+  ChannelProps,
+  ChannelsEnabled,
+  validateChannelPropsCount,
+} from "../objects/textures/channel";
 
 export type VolumeLayerProps = {
   source: ChunkSource;
@@ -131,6 +135,11 @@ export class VolumeLayer extends Layer implements ChannelsEnabled {
     this.chunkStoreView_ = await context.chunkManager.addView(
       this.source_,
       this.sourcePolicy_
+    );
+
+    validateChannelPropsCount(
+      this.channelProps_,
+      this.chunkStoreView_.channelCount
     );
   }
 

--- a/packages/core/src/objects/textures/channel.ts
+++ b/packages/core/src/objects/textures/channel.ts
@@ -78,6 +78,18 @@ export function validateChannels(
   return channelProps.map((props) => validateChannel(texture, props));
 }
 
+export function validateChannelPropsCount(
+  channelProps: ChannelProps[] | undefined,
+  sourceChannelCount: number
+): void {
+  if (channelProps && channelProps.length !== sourceChannelCount) {
+    throw new Error(
+      `channelProps length (${channelProps.length}) must match ` +
+        `source channel count (${sourceChannelCount}).`
+    );
+  }
+}
+
 function validateContrastLimits(
   contrastLimits: [number, number] | undefined,
   texture: Texture

--- a/packages/core/test/chunk_store_view.test.ts
+++ b/packages/core/test/chunk_store_view.test.ts
@@ -13,7 +13,7 @@ describe("ChunkStoreView disposal", () => {
     const viewport = createTestViewport();
 
     // mark some chunks as visible/needed
-    view.updateChunksForImage({ z: 0, c: 0, t: 0 }, viewport);
+    view.updateChunksForImage({ z: 0, c: [0], t: 0 }, viewport);
     expect(view.chunkViewStates.size).toBeGreaterThan(0);
 
     // aggregate states and set priority
@@ -49,8 +49,8 @@ describe("ChunkStoreView disposal", () => {
     const viewport = createTestViewport();
 
     // Both views mark same chunks as needed
-    view1.updateChunksForImage({ z: 0, c: 0, t: 0 }, viewport);
-    view2.updateChunksForImage({ z: 0, c: 0, t: 0 }, viewport);
+    view1.updateChunksForImage({ z: 0, c: [0], t: 0 }, viewport);
+    view2.updateChunksForImage({ z: 0, c: [0], t: 0 }, viewport);
 
     store.updateAndCollectChunkChanges();
 


### PR DESCRIPTION
### Summary

The public API for channels is probably best configured as follows:

- Each layer accepts a channel props array that covers configs for all channels.
- `SliceCoordinates::c` should always be an array.
- `SliceCoordinates` decides what gets downloaded, decoupled from channel visibility.

This gives us a unified and explicit API.

This PR updates the API so each layer includes channel props for all channels, makes `SliceCoordinates::c` an array, and handles loading individual channels for volume rendering.

This PR replaces #617. It's smaller but more files changed because it required updating examples.  **Note this PR breaks the public API**.

### Tests & Checks

All checks have passed.