### PR TITLE
feat: add `getVisibleDataRange` to `ChunkedImageLayer` and `VolumeLayer`

### DIFF
--- a/packages/core/src/data/chunk.ts
+++ b/packages/core/src/data/chunk.ts
@@ -34,8 +34,14 @@ export type ChunkViewState = {
   orderKey: number | null;
 };
 
+export type ChunkDataStats = {
+  min: number;
+  max: number;
+};
+
 export type Chunk = {
   data?: ChunkData;
+  dataStats?: ChunkDataStats;
   state: "unloaded" | "queued" | "loading" | "loaded";
   lod: number;
   shape: {
@@ -115,6 +121,37 @@ export type ChunkLoader = {
 
   loadChunkData(chunk: Chunk, signal: AbortSignal): Promise<void>;
 };
+
+export function computeChunkDataStats(data: ChunkData): ChunkDataStats {
+  let min = Infinity;
+  let max = -Infinity;
+  for (let i = 0; i < data.length; i++) {
+    const v = data[i];
+    if (v < min) min = v;
+    if (v > max) max = v;
+  }
+  return { min, max };
+}
+
+export type ChannelDataStats = Record<number, ChunkDataStats>;
+
+export function computeChannelDataStats(
+  chunks: Iterable<Chunk>
+): ChannelDataStats {
+  const result: ChannelDataStats = {};
+  for (const chunk of chunks) {
+    if (!chunk.dataStats) continue;
+    const c = chunk.chunkIndex.c;
+    const existing = result[c];
+    if (!existing) {
+      result[c] = { min: chunk.dataStats.min, max: chunk.dataStats.max };
+    } else {
+      existing.min = Math.min(existing.min, chunk.dataStats.min);
+      existing.max = Math.max(existing.max, chunk.dataStats.max);
+    }
+  }
+  return result;
+}
 
 export function coordToIndex(lod: SourceDimensionLod, coord: number): number {
   return Math.round((coord - lod.translation) / lod.scale);

--- a/packages/core/src/data/chunk.ts
+++ b/packages/core/src/data/chunk.ts
@@ -34,14 +34,14 @@ export type ChunkViewState = {
   orderKey: number | null;
 };
 
-export type ChunkDataStats = {
+export type ChunkDataRange = {
   min: number;
   max: number;
 };
 
 export type Chunk = {
   data?: ChunkData;
-  dataStats?: ChunkDataStats;
+  dataRange?: ChunkDataRange;
   state: "unloaded" | "queued" | "loading" | "loaded";
   lod: number;
   shape: {
@@ -122,7 +122,7 @@ export type ChunkLoader = {
   loadChunkData(chunk: Chunk, signal: AbortSignal): Promise<void>;
 };
 
-export function computeChunkDataStats(data: ChunkData): ChunkDataStats {
+export function computeChunkDataRange(data: ChunkData): ChunkDataRange {
   let min = Infinity;
   let max = -Infinity;
   for (let i = 0; i < data.length; i++) {
@@ -133,21 +133,21 @@ export function computeChunkDataStats(data: ChunkData): ChunkDataStats {
   return { min, max };
 }
 
-export type ChannelDataStats = Record<number, ChunkDataStats>;
+type ChannelDataRange = Record<number, ChunkDataRange>;
 
-export function computeChannelDataStats(
+export function computeChannelDataRange(
   chunks: Iterable<Chunk>
-): ChannelDataStats {
-  const result: ChannelDataStats = {};
+): ChannelDataRange {
+  const result: ChannelDataRange = {};
   for (const chunk of chunks) {
-    if (!chunk.dataStats) continue;
+    if (!chunk.dataRange) continue;
     const c = chunk.chunkIndex.c;
     const existing = result[c];
     if (!existing) {
-      result[c] = { min: chunk.dataStats.min, max: chunk.dataStats.max };
+      result[c] = { min: chunk.dataRange.min, max: chunk.dataRange.max };
     } else {
-      existing.min = Math.min(existing.min, chunk.dataStats.min);
-      existing.max = Math.max(existing.max, chunk.dataStats.max);
+      existing.min = Math.min(existing.min, chunk.dataRange.min);
+      existing.max = Math.max(existing.max, chunk.dataRange.max);
     }
   }
   return result;

--- a/packages/core/src/data/ome_zarr/image_loader.ts
+++ b/packages/core/src/data/ome_zarr/image_loader.ts
@@ -5,10 +5,11 @@ import {
   Chunk,
   SourceDimension,
   SourceDimensionMap,
-  isChunkData,
   ChunkData,
   ChunkDataConstructor,
   SourceDimensionLod,
+  computeChunkDataStats,
+  isChunkData,
 } from "../chunk";
 import { isTextureUnpackRowAlignment } from "../../objects/textures/texture";
 import { PromiseScheduler } from "../promise_scheduler";
@@ -105,6 +106,7 @@ export class OmeZarrImageLoader {
       );
     }
     chunk.rowAlignmentBytes = rowAlignment;
+    chunk.dataStats = computeChunkDataStats(chunk.data);
   }
 
   // trim any padding (XYZ padding for edge chunks)

--- a/packages/core/src/data/ome_zarr/image_loader.ts
+++ b/packages/core/src/data/ome_zarr/image_loader.ts
@@ -8,7 +8,7 @@ import {
   ChunkData,
   ChunkDataConstructor,
   SourceDimensionLod,
-  computeChunkDataStats,
+  computeChunkDataRange,
   isChunkData,
 } from "../chunk";
 import { isTextureUnpackRowAlignment } from "../../objects/textures/texture";
@@ -105,8 +105,9 @@ export class OmeZarrImageLoader {
         "Invalid row alignment value. Possible values are 1, 2, 4, or 8"
       );
     }
+
     chunk.rowAlignmentBytes = rowAlignment;
-    chunk.dataStats = computeChunkDataStats(chunk.data);
+    chunk.dataRange = computeChunkDataRange(chunk.data);
   }
 
   // trim any padding (XYZ padding for edge chunks)

--- a/packages/core/src/layers/chunked_image_layer.ts
+++ b/packages/core/src/layers/chunked_image_layer.ts
@@ -1,6 +1,12 @@
 import { Layer, LayerOptions, RenderContext } from "../core/layer";
 import type { IdetikContext } from "../idetik";
-import { Chunk, ChunkSource, SliceCoordinates } from "../data/chunk";
+import {
+  Chunk,
+  ChunkSource,
+  ChannelDataStats,
+  SliceCoordinates,
+  computeChannelDataStats,
+} from "../data/chunk";
 import { ChunkStoreView, INTERNAL_POLICY_KEY } from "../core/chunk_store_view";
 import { ImageSourcePolicy } from "../core/image_source_policy";
 import {
@@ -394,6 +400,10 @@ export class ChunkedImageLayer extends Layer implements ChannelsEnabled {
       throw new Error(`Callback to remove could not be found: ${callback}`);
     }
     this.channelChangeCallbacks_.splice(index, 1);
+  }
+
+  public getVisibleDataRange(): ChannelDataStats {
+    return computeChannelDataStats(this.visibleChunks_.keys());
   }
 
   private releaseAndRemoveChunks(chunks: Iterable<Chunk>): void {

--- a/packages/core/src/layers/chunked_image_layer.ts
+++ b/packages/core/src/layers/chunked_image_layer.ts
@@ -3,9 +3,8 @@ import type { IdetikContext } from "../idetik";
 import {
   Chunk,
   ChunkSource,
-  ChannelDataStats,
   SliceCoordinates,
-  computeChannelDataStats,
+  computeChannelDataRange,
 } from "../data/chunk";
 import { ChunkStoreView, INTERNAL_POLICY_KEY } from "../core/chunk_store_view";
 import { ImageSourcePolicy } from "../core/image_source_policy";
@@ -402,8 +401,8 @@ export class ChunkedImageLayer extends Layer implements ChannelsEnabled {
     this.channelChangeCallbacks_.splice(index, 1);
   }
 
-  public getVisibleDataRange(): ChannelDataStats {
-    return computeChannelDataStats(this.visibleChunks_.keys());
+  public getVisibleDataRange() {
+    return computeChannelDataRange(this.visibleChunks_.keys());
   }
 
   private releaseAndRemoveChunks(chunks: Iterable<Chunk>): void {

--- a/packages/core/src/layers/volume_layer.ts
+++ b/packages/core/src/layers/volume_layer.ts
@@ -1,4 +1,10 @@
-import { Chunk, ChunkSource, SliceCoordinates } from "../data/chunk";
+import {
+  Chunk,
+  ChunkSource,
+  ChannelDataStats,
+  SliceCoordinates,
+  computeChannelDataStats,
+} from "../data/chunk";
 import { Layer, RenderContext } from "../core/layer";
 import { VolumeRenderable } from "../objects/renderable/volume_renderable";
 import { IdetikContext } from "../idetik";
@@ -32,11 +38,11 @@ export class VolumeLayer extends Layer implements ChannelsEnabled {
   private readonly pool_ = new RenderablePool<VolumeRenderable>();
   private readonly initialChannelProps_?: ChannelProps[];
   private readonly channelChangeCallbacks_: Array<() => void> = [];
-
   private sourcePolicy_: ImageSourcePolicy;
   private chunkStoreView_?: ChunkStoreView;
   private channelProps_?: ChannelProps[];
 
+  private visibleChunks_: Chunk[] = [];
   private lastLoadedTime_: number | undefined = undefined;
   private lastNumRenderedChannelChunks_: number | undefined = undefined;
   private interactiveStepSizeScale_ = 1.0;
@@ -104,6 +110,10 @@ export class VolumeLayer extends Layer implements ChannelsEnabled {
     this.channelChangeCallbacks_.splice(index, 1);
   }
 
+  public getVisibleDataRange(): ChannelDataStats {
+    return computeChannelDataStats(this.visibleChunks_);
+  }
+
   constructor({ source, sliceCoords, policy, channelProps }: VolumeLayerProps) {
     super({ transparent: true, blendMode: "premultiplied" });
     this.source_ = source;
@@ -159,6 +169,7 @@ export class VolumeLayer extends Layer implements ChannelsEnabled {
     const chunksToRender = this.chunkStoreView_.getChunksToRender(
       this.sliceCoords_
     );
+    this.visibleChunks_ = chunksToRender;
     const currentTime = this.sliceCoords_.t ?? -1;
     const groupedChunks = groupBySpatialIndex(chunksToRender);
 

--- a/packages/core/src/layers/volume_layer.ts
+++ b/packages/core/src/layers/volume_layer.ts
@@ -1,9 +1,8 @@
 import {
   Chunk,
   ChunkSource,
-  ChannelDataStats,
   SliceCoordinates,
-  computeChannelDataStats,
+  computeChannelDataRange,
 } from "../data/chunk";
 import { Layer, RenderContext } from "../core/layer";
 import { VolumeRenderable } from "../objects/renderable/volume_renderable";
@@ -110,8 +109,8 @@ export class VolumeLayer extends Layer implements ChannelsEnabled {
     this.channelChangeCallbacks_.splice(index, 1);
   }
 
-  public getVisibleDataRange(): ChannelDataStats {
-    return computeChannelDataStats(this.visibleChunks_);
+  public getVisibleDataRange() {
+    return computeChannelDataRange(this.visibleChunks_);
   }
 
   constructor({ source, sliceCoords, policy, channelProps }: VolumeLayerProps) {


### PR DESCRIPTION
### Summary
This PR adds per-channel min/max statistics derived from currently visible chunks. This is intended to support basic auto-contrast adjustment in downstream apps.

Per-chunk min/max is computed once when chunk data loads and cached on the chunk itself. `getVisibleDataRange()` iterates the already-tracked visible chunks and aggregates by channel index, returns {} when no chunks have loaded yet; callers are expected to handle this. Downstream apps already access dtype range via the loader as a fallback (though it may be nice to make this more ergonomic, it requires an async call to get the loader).

To keep the core implementation light, this does not add any kind of callback or notification when it may have changed (e.g. new chunks loaded, changing camera, timepoint, slice, etc.). This means downstream applications may need to poll or have user interaction (e.g. "auto" button next to contrast sliders).

### Related Issue
Closes N/A

### Tests & Checks
Tested with logging and by installing locally in `idetik-dca-viewer`, where I implemented some basic auto-contrast features.
