### PR TITLE
chore: only remove stale volumes instead of clearing all

### DIFF
--- a/packages/core/src/layers/volume_layer.ts
+++ b/packages/core/src/layers/volume_layer.ts
@@ -145,7 +145,9 @@ export class VolumeLayer extends Layer implements ChannelsEnabled {
 
   public onDetached(_context: IdetikContext): void {
     if (!this.chunkStoreView_) return;
-    this.releaseAndRemoveVolumes(this.currentVolumes_.values());
+    for (const volume of this.currentVolumes_.values()) {
+      this.releaseAndRemoveVolume(volume);
+    }
     this.clearObjects();
     this.chunkStoreView_.dispose();
     this.chunkStoreView_ = undefined;
@@ -164,17 +166,16 @@ export class VolumeLayer extends Layer implements ChannelsEnabled {
       this.lastLoadedTime_ !== currentTime ||
       groupedChunks.size !== this.currentVolumes_.size ||
       this.lastNumRenderedChannelChunks_ !== chunksToRender.length;
-    this.lastNumRenderedChannelChunks_ = chunksToRender.length;
     if (!needsUpdate) return;
 
-    const volumesToRemove = Array.from(this.currentVolumes_.entries())
-      .filter(([key]) => !groupedChunks.has(key))
-      .map(([, volume]) => volume);
-    this.releaseAndRemoveVolumes(volumesToRemove);
+    for (const [key, volume] of this.currentVolumes_) {
+      if (!groupedChunks.has(key)) {
+        this.releaseAndRemoveVolume(volume);
+        this.currentVolumes_.delete(key);
+      }
+    }
 
-    this.currentVolumes_.clear();
     this.clearObjects();
-
     for (const [key, chunks] of groupedChunks) {
       const volume = this.getOrCreateVolume(key, chunks);
       volume.wireframeEnabled = this.debugShowWireframes;
@@ -183,6 +184,7 @@ export class VolumeLayer extends Layer implements ChannelsEnabled {
     }
 
     this.lastLoadedTime_ = currentTime;
+    this.lastNumRenderedChannelChunks_ = chunksToRender.length;
     if (this.state !== "ready") this.setState("ready");
   }
 
@@ -206,12 +208,10 @@ export class VolumeLayer extends Layer implements ChannelsEnabled {
     ]);
   }
 
-  private releaseAndRemoveVolumes(volumes: Iterable<VolumeRenderable>) {
-    for (const volume of volumes) {
-      volume.clearLoadedChannels();
-      this.pool_.release(this.volumeToPoolKey_.get(volume)!, volume);
-      this.volumeToPoolKey_.delete(volume);
-    }
+  private releaseAndRemoveVolume(volume: VolumeRenderable) {
+    volume.clearLoadedChannels();
+    this.pool_.release(this.volumeToPoolKey_.get(volume)!, volume);
+    this.volumeToPoolKey_.delete(volume);
   }
 
   public update(context?: RenderContext) {


### PR DESCRIPTION
### Summary

This PR fixes a performance issue in `VolumeLayer` where `updateChunks` was
clearing all volumes from `currentVolumes_` on every update, forcing full teardown
and recreation of every volume even when most volumes hadn't changed.

Original fix by @seankmartin https://github.com/chanzuckerberg/idetik/pull/628

### Tests & Checks

- All checks have passed
