### PR TITLE
chore: add repository URL for trusted publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,5 +44,6 @@
     "vite-plugin-eslint": "^1.8.1",
     "vite-plugin-glsl": "^1.3.0",
     "vitest": "^3.0.9"
-  }
+  },
+  "version": ""
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,6 +2,11 @@
   "name": "@idetik/core",
   "version": "0.1.0",
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/chanzuckerberg/idetik.git",
+    "directory": "packages/core"
+  },
   "scripts": {
     "dev": "vite",
     "compile": "tsc",


### PR DESCRIPTION
### Summary
There is an error in publishing. Perhaps because the repo is now public?
> npm error 422 Unprocessable Entity - PUT https://registry.npmjs.org/@idetik%2fcore - Error verifying sigstore provenance bundle: Failed to validate repository information: package.json: "repository.url" is "", expected to match "https://github.com/chanzuckerberg/idetik" from provenance

See also: https://docs.npmjs.com/cli/v11/configuring-npm/package-json#repository

I also ran `npm pkg fix` in both the root and the workspace, which added the empty "version" field in the root.

### Related Issue
[Failed release run](https://github.com/chanzuckerberg/idetik/actions/runs/24162292215)

### Tests & Checks
I'm not sure how to test without publishing a new release, so I guess let's just merge this and hope
