### PR TITLE
fix: remove deprecated baseUrl from tsconfig

### DIFF
--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -5,10 +5,9 @@
     "module": "ESNext",
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "skipLibCheck": true,
-    "baseUrl": "./src",
     "paths": {
-      "@": ["."],
-      "@/*": ["./*"]
+      "@": ["./src"],
+      "@/*": ["./src/*"]
     },
     /* Bundler mode */
     "moduleResolution": "bundler",


### PR DESCRIPTION
### Summary

This PR removes the `baseUrl` parameter from `tsconfig.json`. I kept seeing
warnings that its deprecated and will be removed in TS7, but I don't think we
need it.