### PR TITLE
perf: move Zarr chunk processing to web worker, decrease worker count

### DIFF
--- a/src/data/ome_zarr/chunk_processing.ts
+++ b/src/data/ome_zarr/chunk_processing.ts
@@ -1,0 +1,113 @@
+import {
+  ChunkData,
+  ChunkDataConstructor,
+  ChunkDataRange,
+  computeChunkDataRange,
+} from "../chunk";
+
+export type SliceSpec = {
+  targetShape: { x: number; y: number; z: number };
+  chunkIndex: { c: number; t: number };
+  dimIndices: { x: number; y: number; z?: number; c?: number; t?: number };
+  cChunkSize?: number;
+  tChunkSize?: number;
+};
+
+export type ProcessedChunk = {
+  data: ChunkData;
+  dataRange: ChunkDataRange;
+};
+
+export function processChunk(
+  receivedData: ChunkData,
+  receivedShape: number[],
+  receivedStride: number[],
+  spec: SliceSpec
+): ProcessedChunk {
+  const data = sliceReceivedChunk(
+    receivedData,
+    receivedShape,
+    receivedStride,
+    spec
+  );
+  const dataRange = computeChunkDataRange(data);
+  return { data, dataRange };
+}
+
+function sliceReceivedChunk(
+  receivedData: ChunkData,
+  receivedShape: number[],
+  receivedStride: number[],
+  spec: SliceSpec
+): ChunkData {
+  const { targetShape, chunkIndex, dimIndices } = spec;
+
+  let stride = 1;
+  for (let i = receivedShape.length - 1; i >= 0; i--) {
+    if (receivedStride[i] !== stride) {
+      throw new Error(
+        `Chunk data is not tightly packed, stride=${JSON.stringify(receivedStride)}, shape=${JSON.stringify(receivedShape)}`
+      );
+    }
+    stride *= receivedShape[i];
+  }
+
+  const receivedSpatialShape = {
+    x: receivedShape[dimIndices.x],
+    y: receivedShape[dimIndices.y],
+    z: dimIndices.z !== undefined ? receivedShape[dimIndices.z] : targetShape.z,
+  };
+
+  if (
+    receivedSpatialShape.x < targetShape.x ||
+    receivedSpatialShape.y < targetShape.y ||
+    receivedSpatialShape.z < targetShape.z
+  ) {
+    throw new Error(
+      `Received chunk too small: expected ${JSON.stringify(targetShape)}, got ${JSON.stringify(receivedSpatialShape)}`
+    );
+  }
+
+  const cOffsetInSource = spec.cChunkSize ? chunkIndex.c % spec.cChunkSize : 0;
+  const tOffsetInSource = spec.tChunkSize ? chunkIndex.t % spec.tChunkSize : 0;
+
+  const compactSize = targetShape.x * targetShape.y * targetShape.z;
+
+  const cStride = dimIndices.c !== undefined ? receivedStride[dimIndices.c] : 0;
+  const tStride = dimIndices.t !== undefined ? receivedStride[dimIndices.t] : 0;
+
+  const srcOffset = tOffsetInSource * tStride + cOffsetInSource * cStride;
+
+  const receivedExactShape =
+    receivedSpatialShape.x === targetShape.x &&
+    receivedSpatialShape.y === targetShape.y &&
+    receivedSpatialShape.z === targetShape.z;
+
+  const noSlicingNeeded =
+    srcOffset === 0 &&
+    receivedData.length === compactSize &&
+    receivedExactShape;
+
+  if (noSlicingNeeded) {
+    return receivedData;
+  }
+
+  const compactData = new (receivedData.constructor as ChunkDataConstructor)(
+    compactSize
+  );
+
+  const zStride = dimIndices.z !== undefined ? receivedStride[dimIndices.z] : 0;
+  const yStride = receivedStride[dimIndices.y];
+  let destOffset = 0;
+  for (let z = 0; z < targetShape.z; z++) {
+    const zStart = srcOffset + z * zStride;
+    for (let y = 0; y < targetShape.y; y++) {
+      const srcStart = zStart + y * yStride;
+      const srcEnd = srcStart + targetShape.x;
+      compactData.set(receivedData.subarray(srcStart, srcEnd), destOffset);
+      destOffset += targetShape.x;
+    }
+  }
+
+  return compactData;
+}

--- a/src/data/ome_zarr/image_loader.ts
+++ b/src/data/ome_zarr/image_loader.ts
@@ -5,10 +5,7 @@ import {
   Chunk,
   SourceDimension,
   SourceDimensionMap,
-  ChunkData,
-  ChunkDataConstructor,
   SourceDimensionLod,
-  computeChunkDataRange,
   isChunkData,
 } from "../chunk";
 import { isTextureUnpackRowAlignment } from "../../objects/textures/texture";
@@ -17,7 +14,8 @@ import { PromiseScheduler } from "../promise_scheduler";
 import { Image as OmeZarrImage } from "./0.5/image";
 
 import { ZarrArrayParams } from "../zarr/open";
-import { getChunk } from "./worker_pool";
+import { SliceSpec } from "./chunk_processing";
+import { fetchAndProcessChunk } from "./worker_pool";
 
 // Implements the interface required for getting array chunks in zarrita:
 // https://github.com/manzt/zarrita.js/blob/c15c1a14e42a83516972368ac962ebdf56a6dcdb/packages/indexing/src/types.ts#L52
@@ -91,116 +89,42 @@ export class OmeZarrImageLoader {
     const array = this.arrays_[chunk.lod];
     const arrayParams = this.arrayParams_[chunk.lod];
 
+    const cLod = this.dimensions_.c?.lods[chunk.lod];
+    const tLod = this.dimensions_.t?.lods[chunk.lod];
+
+    const sliceSpec: SliceSpec = {
+      targetShape: chunk.shape,
+      chunkIndex: { c: chunk.chunkIndex.c, t: chunk.chunkIndex.t },
+      dimIndices: {
+        x: this.dimensions_.x.index,
+        y: this.dimensions_.y.index,
+        z: this.dimensions_.z?.index,
+        c: this.dimensions_.c?.index,
+        t: this.dimensions_.t?.index,
+      },
+      cChunkSize: cLod?.chunkSize,
+      tChunkSize: tLod?.chunkSize,
+    };
+
     // NOTE: if source chunks have multiple channels/timepoints
     // this results in duplicate fetching and decompression
-    const receivedChunk = await getChunk(array, arrayParams, chunkCoords, {
-      signal,
-    });
+    const { data, dataRange } = await fetchAndProcessChunk(
+      array,
+      arrayParams,
+      chunkCoords,
+      sliceSpec,
+      { signal }
+    );
 
-    chunk.data = this.sliceReceivedChunk(chunk, receivedChunk);
-
-    const rowAlignment = chunk.data.BYTES_PER_ELEMENT;
+    const rowAlignment = data.BYTES_PER_ELEMENT;
     if (!isTextureUnpackRowAlignment(rowAlignment)) {
       throw new Error(
         "Invalid row alignment value. Possible values are 1, 2, 4, or 8"
       );
     }
-
     chunk.rowAlignmentBytes = rowAlignment;
-    chunk.dataRange = computeChunkDataRange(chunk.data);
-  }
-
-  // trim any padding (XYZ padding for edge chunks)
-  // and extract the channel/timepoint
-  private sliceReceivedChunk(
-    chunk: Chunk,
-    receivedChunk: zarr.Chunk<zarr.DataType>
-  ): ChunkData {
-    const receivedChunkData = receivedChunk.data;
-    if (!isChunkData(receivedChunkData)) {
-      throw new Error(
-        `Received chunk has an unsupported data type, data=${receivedChunk.data.constructor.name}`
-      );
-    }
-
-    validateTightlyPackedChunk(receivedChunk);
-
-    const receivedShape = {
-      x: receivedChunk.shape[this.dimensions_.x.index],
-      y: receivedChunk.shape[this.dimensions_.y.index],
-      z: this.dimensions_.z
-        ? receivedChunk.shape[this.dimensions_.z.index]
-        : chunk.shape.z,
-    };
-
-    const receivedChunkTooSmall =
-      receivedShape.x < chunk.shape.x ||
-      receivedShape.y < chunk.shape.y ||
-      receivedShape.z < chunk.shape.z;
-
-    if (receivedChunkTooSmall) {
-      throw new Error(
-        `Received incompatible shape for chunkIndex ${JSON.stringify(chunk.chunkIndex)} at LOD ${chunk.lod}: ` +
-          `expected shape: ${JSON.stringify(chunk.shape)}, received shape: ${JSON.stringify(receivedShape)} (too small)`
-      );
-    }
-
-    const receivedChunkStride = receivedChunk.stride;
-
-    const cLod = this.dimensions_.c?.lods[chunk.lod];
-    const tLod = this.dimensions_.t?.lods[chunk.lod];
-
-    const cOffsetInSource = cLod ? chunk.chunkIndex.c % cLod.chunkSize : 0;
-    const tOffsetInSource = tLod ? chunk.chunkIndex.t % tLod.chunkSize : 0;
-
-    // internal chunks are compact 3D XYZ, with size 1 in C and T
-    const compactSize = chunk.shape.x * chunk.shape.y * chunk.shape.z;
-
-    const cStride = this.dimensions_.c
-      ? receivedChunkStride[this.dimensions_.c.index]
-      : 0;
-    const tStride = this.dimensions_.t
-      ? receivedChunkStride[this.dimensions_.t.index]
-      : 0;
-
-    // note: this assumes tczyx ordering
-    const srcOffset = tOffsetInSource * tStride + cOffsetInSource * cStride;
-
-    const receivedExactShape =
-      receivedShape.x === chunk.shape.x &&
-      receivedShape.y === chunk.shape.y &&
-      receivedShape.z === chunk.shape.z;
-
-    const noSlicingNeeded =
-      srcOffset === 0 &&
-      receivedChunkData.length === compactSize &&
-      receivedExactShape;
-    if (noSlicingNeeded) {
-      return receivedChunkData;
-    }
-
-    const compactData =
-      new (receivedChunkData.constructor as ChunkDataConstructor)(compactSize);
-
-    const zStride = this.dimensions_.z
-      ? receivedChunkStride[this.dimensions_.z.index]
-      : 0;
-    const yStride = receivedChunkStride[this.dimensions_.y.index];
-    let destOffset = 0;
-    for (let z = 0; z < chunk.shape.z; z++) {
-      const zStart = srcOffset + z * zStride;
-      for (let y = 0; y < chunk.shape.y; y++) {
-        const srcStart = zStart + y * yStride;
-        const srcEnd = srcStart + chunk.shape.x;
-        compactData.set(
-          receivedChunkData.subarray(srcStart, srcEnd),
-          destOffset
-        );
-        destOffset += chunk.shape.x;
-      }
-    }
-
-    return compactData;
+    chunk.data = data;
+    chunk.dataRange = dataRange;
   }
 
   public async loadRegion(

--- a/src/data/ome_zarr/worker_kernel.ts
+++ b/src/data/ome_zarr/worker_kernel.ts
@@ -2,6 +2,8 @@
 
 import * as zarr from "zarrita";
 import { openArrayFromParams, ZarrArrayParams } from "../zarr/open";
+import { isChunkData, ChunkData, ChunkDataRange } from "../chunk";
+import { SliceSpec, processChunk } from "./chunk_processing";
 
 type ZarrWorkerMessageType = "getChunk" | "cancel";
 
@@ -12,6 +14,7 @@ export type ZarrWorkerRequest = {
       type: "getChunk";
       arrayParams: ZarrArrayParams;
       index: number[];
+      sliceSpec: SliceSpec;
     }
   | {
       type: "cancel";
@@ -24,7 +27,8 @@ export type ZarrWorkerResponse = {
   | {
       success: true;
       type: "getChunk";
-      chunk: zarr.Chunk<zarr.DataType>;
+      data: ChunkData;
+      dataRange: ChunkDataRange;
     }
   | {
       success: false;
@@ -42,8 +46,8 @@ self.addEventListener("message", async (e: MessageEvent<ZarrWorkerRequest>) => {
 
   try {
     if (type === "getChunk") {
-      const { arrayParams, index } = e.data;
-      await handleGetChunkMessage(id, arrayParams, index);
+      const { arrayParams, index, sliceSpec } = e.data;
+      await handleGetChunkMessage(id, arrayParams, index, sliceSpec);
     } else if (type === "cancel") {
       await handleCancelMessage(id);
     } else {
@@ -69,7 +73,8 @@ async function handleCancelMessage(id: number): Promise<void> {
 async function handleGetChunkMessage(
   id: number,
   arrayParams: ZarrArrayParams,
-  index: number[]
+  index: number[],
+  sliceSpec: SliceSpec
 ): Promise<void> {
   const abortController = new AbortController();
   activeRequests.set(id, abortController);
@@ -90,20 +95,25 @@ async function handleGetChunkMessage(
     activeRequests.delete(id);
   }
 
-  if (!ArrayBuffer.isView(chunk.data)) {
-    throw new Error(`Expected TypedArray, got ${typeof chunk.data}`);
+  if (!isChunkData(chunk.data)) {
+    throw new Error(
+      `Unsupported chunk data type: ${chunk.data.constructor.name}`
+    );
   }
 
+  const processStart = performance.now();
+  const { data, dataRange } = processChunk(
+    chunk.data,
+    chunk.shape,
+    chunk.stride,
+    sliceSpec
+  );
+  performance.measure("processChunk", { start: processStart });
+
   try {
-    self.postMessage(
-      {
-        id,
-        success: true,
-        type: "getChunk",
-        chunk,
-      },
-      [chunk.data.buffer]
-    );
+    self.postMessage({ id, success: true, type: "getChunk", data, dataRange }, [
+      data.buffer,
+    ]);
   } catch (postError) {
     throw new Error(
       `Failed to send result: ${postError instanceof Error ? postError.message : String(postError)}`

--- a/src/data/ome_zarr/worker_pool.ts
+++ b/src/data/ome_zarr/worker_pool.ts
@@ -1,14 +1,16 @@
 import * as zarr from "zarrita";
 import { Logger } from "../../utilities/logger";
 import { ZarrArrayParams } from "../zarr/open";
+import { isChunkData } from "../chunk";
 import { ZarrWorkerRequest, ZarrWorkerResponse } from "./worker_kernel";
+import { SliceSpec, ProcessedChunk, processChunk } from "./chunk_processing";
 // "inline" import to ensure worker code works in dependent projects
 // this is a workaround for a vite limitation when building a library
 // see https://github.com/vitejs/vite/issues/11672
 import WorkerKernel from "./worker_kernel.ts?worker&inline";
 
 type PendingGetChunkRequest = {
-  resolve: (value: zarr.Chunk<zarr.DataType>) => void;
+  resolve: (value: ProcessedChunk) => void;
   reject: (error: Error) => void;
   abortListener?: () => void;
   abortSignal?: AbortSignal;
@@ -21,7 +23,7 @@ type WorkerInstance = {
   workerId: number;
 };
 
-const DEFAULT_WORKER_COUNT = Math.min(navigator.hardwareConcurrency, 8);
+const DEFAULT_WORKER_COUNT = 3;
 let workerPool: WorkerInstance[] = [];
 let messageId = 0;
 let workerId = 0;
@@ -76,7 +78,7 @@ function handleWorkerMessage(
   }
 
   if (success && e.data.type === "getChunk") {
-    pending.resolve(e.data.chunk);
+    pending.resolve({ data: e.data.data, dataRange: e.data.dataRange });
   } else if (!success) {
     pending.reject(new Error(e.data.error || "Unknown worker error"));
   }
@@ -148,11 +150,12 @@ function getLeastBusyWorker(): WorkerInstance {
   return workerPool.sort((a, b) => a.pendingCount - b.pendingCount)[0];
 }
 
-async function getChunkInWorker(
+async function fetchAndProcessChunkInWorker(
   zarrParams: ZarrArrayParams,
   chunkIndex: number[],
+  sliceSpec: SliceSpec,
   options?: { signal?: AbortSignal }
-): Promise<zarr.Chunk<zarr.DataType>> {
+): Promise<ProcessedChunk> {
   return new Promise((resolve, reject) => {
     const workerInstance = getLeastBusyWorker();
 
@@ -200,6 +203,7 @@ async function getChunkInWorker(
       type: "getChunk",
       arrayParams: zarrParams,
       index: chunkIndex,
+      sliceSpec,
     } as ZarrWorkerRequest);
   });
 }
@@ -227,24 +231,39 @@ function ensureWorkerPool(): void {
   }
 }
 
-export async function getChunk(
+export async function fetchAndProcessChunk(
   array: zarr.Array<zarr.DataType, zarr.Readable>,
   arrayParams: ZarrArrayParams,
   chunkCoords: number[],
+  sliceSpec: SliceSpec,
   options?: { signal?: AbortSignal }
-): Promise<zarr.Chunk<zarr.DataType>> {
+): Promise<ProcessedChunk> {
   ensureWorkerPool();
   try {
-    return await getChunkInWorker(arrayParams, chunkCoords, options);
+    return await fetchAndProcessChunkInWorker(
+      arrayParams,
+      chunkCoords,
+      sliceSpec,
+      options
+    );
   } catch (error) {
     if (error instanceof DOMException && error.name === "AbortError") {
       throw error;
     }
 
     Logger.warn("ZarrWorker", "Falling back to main thread", error);
-    const chunk = await array.getChunk(chunkCoords, options);
-
-    return chunk;
+    const rawChunk = await array.getChunk(chunkCoords, options);
+    if (!isChunkData(rawChunk.data)) {
+      throw new Error(
+        `Unsupported chunk data type: ${rawChunk.data.constructor.name}`
+      );
+    }
+    return processChunk(
+      rawChunk.data,
+      rawChunk.shape,
+      rawChunk.stride,
+      sliceSpec
+    );
   }
 }
 


### PR DESCRIPTION
### Summary
As suggested by @shlomnissan in https://github.com/chanzuckerberg/idetik/pull/638#discussion_r3059530731, this moves the chunk data range calculation off the main thread. I combined it with the fetch/decompress that was already dispatched to a WebWorker just a few lines above.

This also moves chunk slicing/compaction (when necessary) in the same way. This doesn't solve the issue of repeat work when the source is chunked in C and/or T, but it does mitigate some of the performance impact.

### Related Issue
Closes N/A

### Tests & Checks
I used the dev tools to show the work has moved off the main thread
Understanding the performance tab a bit more now, I also reduced the number of workers

#### `main`
note the blocking `processChunk` measurement on the main thread
<img width="2251" height="1131" alt="Screenshot 2026-04-10 at 1 15 25 PM" src="https://github.com/user-attachments/assets/023510a8-e7b5-4efe-afa0-92a81870754e" />

#### this PR
note `processChunk` is handled by multiple workers, and the main thread is not blocked
<img width="2171" height="1334" alt="Screenshot 2026-04-10 at 1 13 44 PM" src="https://github.com/user-attachments/assets/8ed6d5b6-8d35-4832-81a9-7080775ac14f" />
