### PR TITLE
fix: Fix viewport dimensions

### DIFF
--- a/src/renderers/webgl_renderer.ts
+++ b/src/renderers/webgl_renderer.ts
@@ -93,6 +93,7 @@ export class WebGLRenderer extends Renderer {
       return;
     }
 
+    this.state_.setViewport(viewportBox);
     this.clear();
 
     const frustum = viewport.camera.frustum;


### PR DESCRIPTION
### Summary

This PR ensures set viewport is called in the WebGL context to resolve dimension
issues in multi-viewport configuration.

This issue was introduced by #653 

### Tests & Checks

- All checks have passed.
