### PR TITLE
feat: add frame timing stats and on-screen overlay

### DIFF
--- a/src/core/renderer.ts
+++ b/src/core/renderer.ts
@@ -58,6 +58,11 @@ export abstract class Renderer {
     return this.renderedObjects_;
   }
 
+  /** GPU execution time in ms. Override in subclasses that support GPU timing. */
+  public get gpuFrameTimeMs(): number {
+    return 0;
+  }
+
   public set backgroundColor(color: ColorLike) {
     this.backgroundColor_ = Color.from(color);
   }

--- a/src/core/renderer.ts
+++ b/src/core/renderer.ts
@@ -58,6 +58,11 @@ export abstract class Renderer {
     return this.renderedObjects_;
   }
 
+  /** Display name of the renderer. Override in subclasses. */
+  public get name(): string {
+    return "Unknown";
+  }
+
   /** GPU execution time in ms. Override in subclasses that support GPU timing. */
   public get gpuFrameTimeMs(): number {
     return 0;

--- a/src/idetik.ts
+++ b/src/idetik.ts
@@ -10,6 +10,7 @@ import {
   ViewportConfig,
 } from "./core/viewport";
 import { PixelSizeObserver } from "./utilities/pixel_size_observer";
+import { FrameTimer, type FrameTimingStats } from "./utilities/frame_timer";
 
 export type Overlay = {
   update(idetik: Idetik): void;
@@ -34,6 +35,7 @@ export class Idetik {
   public readonly canvas: HTMLCanvasElement;
   public readonly overlays: Overlay[];
   private readonly stats_?: Stats;
+  private readonly frameTimer_ = new FrameTimer();
   private readonly sizeObserver_: PixelSizeObserver;
   private lastAnimationId_?: number;
 
@@ -123,6 +125,10 @@ export class Idetik {
 
   public get chunkQueueStats() {
     return this.chunkManager_.queueStats;
+  }
+
+  public get frameTimingStats(): FrameTimingStats {
+    return this.frameTimer_.stats;
   }
 
   public get renderedObjects() {
@@ -219,10 +225,14 @@ export class Idetik {
 
     this.lastTimestamp_ = timestamp;
 
+    const renderStart = performance.now();
+
     for (const viewport of this.viewports_) {
       viewport.cameraControls?.onUpdate(dt);
       this.renderer_.render(viewport);
     }
+
+    this.frameTimer_.recordFrame(performance.now() - renderStart);
 
     this.chunkManager_.update();
 

--- a/src/idetik.ts
+++ b/src/idetik.ts
@@ -11,6 +11,10 @@ import {
 } from "./core/viewport";
 import { PixelSizeObserver } from "./utilities/pixel_size_observer";
 import { FrameTimer, type FrameTimingStats } from "./utilities/frame_timer";
+import {
+  createFrameTimingOverlay,
+  updateFrameTimingOverlay,
+} from "./utilities/frame_timing_overlay";
 
 export type Overlay = {
   update(idetik: Idetik): void;
@@ -21,6 +25,7 @@ type IdetikParams = {
   viewports?: ViewportConfig[];
   overlays?: Overlay[];
   showStats?: boolean;
+  showFrameTiming?: boolean;
 };
 
 export type IdetikContext = {
@@ -36,6 +41,7 @@ export class Idetik {
   public readonly overlays: Overlay[];
   private readonly stats_?: Stats;
   private readonly frameTimer_ = new FrameTimer();
+  private readonly frameTimingOverlay_?: HTMLElement;
   private readonly sizeObserver_: PixelSizeObserver;
   private lastAnimationId_?: number;
 
@@ -107,6 +113,9 @@ export class Idetik {
     this.overlays = params.overlays ?? [];
 
     if (params.showStats) this.stats_ = createStats();
+    if (params.showFrameTiming) {
+      this.frameTimingOverlay_ = createFrameTimingOverlay();
+    }
 
     const sizeDependents: HTMLElement[] = [this.canvas];
     for (const viewport of this.viewports_) {
@@ -223,6 +232,7 @@ export class Idetik {
     // cap dt to prevent large time-step jumps when resuming from background tabs
     const dt = Math.min(timestamp - this.lastTimestamp_, 100) / 1000;
 
+    const frameDeltaMs = timestamp - this.lastTimestamp_;
     this.lastTimestamp_ = timestamp;
 
     const renderStart = performance.now();
@@ -232,7 +242,21 @@ export class Idetik {
       this.renderer_.render(viewport);
     }
 
-    this.frameTimer_.recordFrame(performance.now() - renderStart);
+    const renderSubmitMs = performance.now() - renderStart;
+
+    this.frameTimer_.recordFrame({
+      frameDeltaMs,
+      renderSubmitMs,
+      gpuTimeMs: this.renderer_.gpuFrameTimeMs,
+    });
+
+    if (this.frameTimingOverlay_) {
+      updateFrameTimingOverlay(
+        this.frameTimingOverlay_,
+        this.frameTimer_,
+        this.renderer_.renderedObjects
+      );
+    }
 
     this.chunkManager_.update();
 

--- a/src/idetik.ts
+++ b/src/idetik.ts
@@ -140,6 +140,10 @@ export class Idetik {
     return this.frameTimer_.stats;
   }
 
+  public get rendererName(): string {
+    return this.renderer_.name;
+  }
+
   public get renderedObjects() {
     return this.renderer_.renderedObjects;
   }
@@ -254,7 +258,8 @@ export class Idetik {
       updateFrameTimingOverlay(
         this.frameTimingOverlay_,
         this.frameTimer_,
-        this.renderer_.renderedObjects
+        this.renderer_.renderedObjects,
+        this.renderer_.name
       );
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export { Idetik } from "./idetik";
 export type { Overlay } from "./idetik";
+export type { FrameTimingStats } from "./utilities/frame_timer";
 
 export { WebGLRenderer } from "./renderers/webgl_renderer";
 export { OrthographicCamera } from "./objects/cameras/orthographic_camera";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 export { Idetik } from "./idetik";
 export type { Overlay } from "./idetik";
-export type { FrameTimingStats } from "./utilities/frame_timer";
+export type { FrameSample, FrameTimingStats } from "./utilities/frame_timer";
 
 export { WebGLRenderer } from "./renderers/webgl_renderer";
 export { OrthographicCamera } from "./objects/cameras/orthographic_camera";

--- a/src/renderers/webgl_renderer.ts
+++ b/src/renderers/webgl_renderer.ts
@@ -28,6 +28,10 @@ import { Frustum } from "../math/frustum";
 const axisDirection = mat4.fromScaling(mat4.create(), [1, -1, 1]);
 
 export class WebGLRenderer extends Renderer {
+  public override get name() {
+    return "WebGL2";
+  }
+
   private readonly gl_: WebGL2RenderingContext;
   private readonly programs_: WebGLShaderPrograms;
   private readonly bindings_: WebGLBuffers;

--- a/src/utilities/frame_timer.ts
+++ b/src/utilities/frame_timer.ts
@@ -1,0 +1,79 @@
+const DEFAULT_WINDOW_SIZE = 60;
+
+export type FrameTimingStats = {
+  /** Last frame's render time in milliseconds */
+  frameTimeMs: number;
+  /** Rolling average render time in milliseconds */
+  averageFrameTimeMs: number;
+  /** Frames per second based on rolling average */
+  fps: number;
+  /** Minimum frame time in the rolling window */
+  minFrameTimeMs: number;
+  /** Maximum frame time in the rolling window */
+  maxFrameTimeMs: number;
+  /** Number of frames sampled so far */
+  frameCount: number;
+};
+
+export class FrameTimer {
+  private readonly samples_: Float64Array;
+  private readonly windowSize_: number;
+  private cursor_ = 0;
+  private frameCount_ = 0;
+  private lastFrameTimeMs_ = 0;
+
+  constructor(windowSize: number = DEFAULT_WINDOW_SIZE) {
+    this.windowSize_ = windowSize;
+    this.samples_ = new Float64Array(windowSize);
+  }
+
+  public recordFrame(renderTimeMs: number) {
+    this.lastFrameTimeMs_ = renderTimeMs;
+    this.samples_[this.cursor_] = renderTimeMs;
+    this.cursor_ = (this.cursor_ + 1) % this.windowSize_;
+    this.frameCount_++;
+  }
+
+  public get stats(): FrameTimingStats {
+    const count = Math.min(this.frameCount_, this.windowSize_);
+    if (count === 0) {
+      return {
+        frameTimeMs: 0,
+        averageFrameTimeMs: 0,
+        fps: 0,
+        minFrameTimeMs: 0,
+        maxFrameTimeMs: 0,
+        frameCount: 0,
+      };
+    }
+
+    let sum = 0;
+    let min = Infinity;
+    let max = -Infinity;
+
+    for (let i = 0; i < count; i++) {
+      const t = this.samples_[i];
+      sum += t;
+      if (t < min) min = t;
+      if (t > max) max = t;
+    }
+
+    const avg = sum / count;
+
+    return {
+      frameTimeMs: this.lastFrameTimeMs_,
+      averageFrameTimeMs: avg,
+      fps: avg > 0 ? 1000 / avg : 0,
+      minFrameTimeMs: min,
+      maxFrameTimeMs: max,
+      frameCount: this.frameCount_,
+    };
+  }
+
+  public reset() {
+    this.samples_.fill(0);
+    this.cursor_ = 0;
+    this.frameCount_ = 0;
+    this.lastFrameTimeMs_ = 0;
+  }
+}

--- a/src/utilities/frame_timer.ts
+++ b/src/utilities/frame_timer.ts
@@ -1,79 +1,118 @@
 const DEFAULT_WINDOW_SIZE = 60;
 
+export type FrameSample = {
+  /** Wall-clock time between frames (rAF delta). Includes GPU work + vsync. */
+  frameDeltaMs: number;
+  /** CPU time spent submitting render commands. */
+  renderSubmitMs: number;
+  /** GPU execution time. 0 until GPU timestamp queries are implemented. */
+  gpuTimeMs: number;
+};
+
 export type FrameTimingStats = {
-  /** Last frame's render time in milliseconds */
-  frameTimeMs: number;
-  /** Rolling average render time in milliseconds */
-  averageFrameTimeMs: number;
-  /** Frames per second based on rolling average */
+  /** Latest sample */
+  current: FrameSample;
+  /** Rolling averages over the window */
+  average: FrameSample;
+  /** Rolling minimums over the window */
+  min: FrameSample;
+  /** Rolling maximums over the window */
+  max: FrameSample;
+  /** FPS derived from average frame delta */
   fps: number;
-  /** Minimum frame time in the rolling window */
-  minFrameTimeMs: number;
-  /** Maximum frame time in the rolling window */
-  maxFrameTimeMs: number;
   /** Number of frames sampled so far */
   frameCount: number;
 };
 
+const ZERO_SAMPLE: FrameSample = {
+  frameDeltaMs: 0,
+  renderSubmitMs: 0,
+  gpuTimeMs: 0,
+};
+
+const KEYS: (keyof FrameSample)[] = [
+  "frameDeltaMs",
+  "renderSubmitMs",
+  "gpuTimeMs",
+];
+
 export class FrameTimer {
-  private readonly samples_: Float64Array;
   private readonly windowSize_: number;
+  private readonly samples_: FrameSample[];
   private cursor_ = 0;
   private frameCount_ = 0;
-  private lastFrameTimeMs_ = 0;
+  private current_: FrameSample = { ...ZERO_SAMPLE };
 
   constructor(windowSize: number = DEFAULT_WINDOW_SIZE) {
     this.windowSize_ = windowSize;
-    this.samples_ = new Float64Array(windowSize);
+    this.samples_ = [];
   }
 
-  public recordFrame(renderTimeMs: number) {
-    this.lastFrameTimeMs_ = renderTimeMs;
-    this.samples_[this.cursor_] = renderTimeMs;
+  public recordFrame(sample: FrameSample) {
+    this.current_ = sample;
+
+    if (this.samples_.length < this.windowSize_) {
+      this.samples_.push(sample);
+    } else {
+      this.samples_[this.cursor_] = sample;
+    }
+
     this.cursor_ = (this.cursor_ + 1) % this.windowSize_;
     this.frameCount_++;
   }
 
   public get stats(): FrameTimingStats {
-    const count = Math.min(this.frameCount_, this.windowSize_);
+    const count = this.samples_.length;
     if (count === 0) {
       return {
-        frameTimeMs: 0,
-        averageFrameTimeMs: 0,
+        current: { ...ZERO_SAMPLE },
+        average: { ...ZERO_SAMPLE },
+        min: { ...ZERO_SAMPLE },
+        max: { ...ZERO_SAMPLE },
         fps: 0,
-        minFrameTimeMs: 0,
-        maxFrameTimeMs: 0,
         frameCount: 0,
       };
     }
 
-    let sum = 0;
-    let min = Infinity;
-    let max = -Infinity;
+    const avg: FrameSample = { ...ZERO_SAMPLE };
+    const min: FrameSample = {
+      frameDeltaMs: Infinity,
+      renderSubmitMs: Infinity,
+      gpuTimeMs: Infinity,
+    };
+    const max: FrameSample = {
+      frameDeltaMs: -Infinity,
+      renderSubmitMs: -Infinity,
+      gpuTimeMs: -Infinity,
+    };
 
     for (let i = 0; i < count; i++) {
-      const t = this.samples_[i];
-      sum += t;
-      if (t < min) min = t;
-      if (t > max) max = t;
+      const s = this.samples_[i];
+      for (const k of KEYS) {
+        avg[k] += s[k];
+        if (s[k] < min[k]) min[k] = s[k];
+        if (s[k] > max[k]) max[k] = s[k];
+      }
     }
 
-    const avg = sum / count;
+    for (const k of KEYS) {
+      avg[k] /= count;
+    }
 
     return {
-      frameTimeMs: this.lastFrameTimeMs_,
-      averageFrameTimeMs: avg,
-      fps: avg > 0 ? 1000 / avg : 0,
-      minFrameTimeMs: min,
-      maxFrameTimeMs: max,
+      current: { ...this.current_ },
+      average: avg,
+      min,
+      max,
+      fps: avg.frameDeltaMs > 0 ? 1000 / avg.frameDeltaMs : 0,
       frameCount: this.frameCount_,
     };
   }
 
   public reset() {
-    this.samples_.fill(0);
+    this.samples_.length = 0;
     this.cursor_ = 0;
     this.frameCount_ = 0;
-    this.lastFrameTimeMs_ = 0;
+    this.current_ = { ...ZERO_SAMPLE };
   }
 }

--- a/src/utilities/frame_timing_overlay.ts
+++ b/src/utilities/frame_timing_overlay.ts
@@ -27,12 +27,14 @@ function fmt(ms: number): string {
 export function updateFrameTimingOverlay(
   el: HTMLElement,
   frameTimer: FrameTimer,
-  renderedObjects: number
+  renderedObjects: number,
+  rendererName: string
 ) {
   const s = frameTimer.stats;
   if (s.frameCount === 0) return;
 
   const lines = [
+    `renderer  ${rendererName}`,
     `         avg      last     min      max`,
     `frame ${fmt(s.average.frameDeltaMs)} ${fmt(s.current.frameDeltaMs)} ${fmt(s.min.frameDeltaMs)} ${fmt(s.max.frameDeltaMs)} ms`,
     `cpu   ${fmt(s.average.renderSubmitMs)} ${fmt(s.current.renderSubmitMs)} ${fmt(s.min.renderSubmitMs)} ${fmt(s.max.renderSubmitMs)} ms`,

--- a/src/utilities/frame_timing_overlay.ts
+++ b/src/utilities/frame_timing_overlay.ts
@@ -46,7 +46,9 @@ export function updateFrameTimingOverlay(
     lines.push(`gpu        ---`);
   }
 
-  lines.push(`fps   ${s.fps.toFixed(0).padStart(7)}    objects ${renderedObjects}`);
+  lines.push(
+    `fps   ${s.fps.toFixed(0).padStart(7)}    objects ${renderedObjects}`
+  );
 
   el.textContent = lines.join("\n");
 }

--- a/src/utilities/frame_timing_overlay.ts
+++ b/src/utilities/frame_timing_overlay.ts
@@ -1,0 +1,52 @@
+import type { FrameTimer } from "./frame_timer";
+
+export function createFrameTimingOverlay(): HTMLElement {
+  const el = document.createElement("div");
+  el.style.cssText = [
+    "position: fixed",
+    "bottom: 8px",
+    "left: 8px",
+    "background: rgba(0, 0, 0, 0.75)",
+    "color: #0f0",
+    "font: 12px/1.4 monospace",
+    "padding: 6px 10px",
+    "border-radius: 4px",
+    "pointer-events: none",
+    "z-index: 10000",
+    "white-space: pre",
+  ].join(";");
+
+  document.body.appendChild(el);
+  return el;
+}
+
+function fmt(ms: number): string {
+  return ms.toFixed(2).padStart(7);
+}
+
+export function updateFrameTimingOverlay(
+  el: HTMLElement,
+  frameTimer: FrameTimer,
+  renderedObjects: number
+) {
+  const s = frameTimer.stats;
+  if (s.frameCount === 0) return;
+
+  const lines = [
+    `         avg      last     min      max`,
+    `frame ${fmt(s.average.frameDeltaMs)} ${fmt(s.current.frameDeltaMs)} ${fmt(s.min.frameDeltaMs)} ${fmt(s.max.frameDeltaMs)} ms`,
+    `cpu   ${fmt(s.average.renderSubmitMs)} ${fmt(s.current.renderSubmitMs)} ${fmt(s.min.renderSubmitMs)} ${fmt(s.max.renderSubmitMs)} ms`,
+  ];
+
+  if (s.current.gpuTimeMs > 0) {
+    lines.push(
+      `gpu   ${fmt(s.average.gpuTimeMs)} ${fmt(s.current.gpuTimeMs)} ${fmt(s.min.gpuTimeMs)} ${fmt(s.max.gpuTimeMs)} ms`
+    );
+  } else {
+    lines.push(`gpu        ---`);
+  }
+
+  lines.push(`fps   ${s.fps.toFixed(0).padStart(7)}    objects ${renderedObjects}`);
+
+  el.textContent = lines.join("\n");
+}


### PR DESCRIPTION
## Summary

- Adds `showFrameTiming: true` option to display a live performance overlay
- Exposes `idetik.frameTimingStats` for programmatic access
- Adds `Renderer.gpuFrameTimeMs` hook for future GPU timestamp queries

## How it works

The overlay measures three independent timing sources per frame:

| Row | What it measures | How | Why it matters |
|-----|-----------------|-----|----------------|
| **frame** | Wall-clock time between frames | rAF timestamp delta | Total cost including GPU + vsync. Tells you actual framerate. |
| **cpu** | Time spent submitting render commands | `performance.now()` around `renderer.render()` | How much work the CPU is doing per frame. |
| **gpu** | GPU execution time | `Renderer.gpuFrameTimeMs` (defaults to 0) | Placeholder — override in WebGPU renderer with `writeTimestamp()` to get real GPU timing. |

Each row shows **avg / last / min / max** over a rolling 60-frame window.

### Reading the numbers

- `frame >> cpu` → **GPU-bound**. CPU submits fast, waits for GPU.
- `frame ≈ cpu` → **CPU-bound**. Render submission is the bottleneck.
- `frame ≈ 16.7ms` → vsync-locked at 60fps. Both CPU and GPU are fast enough.

### Usage

```typescript
const idetik = new Idetik({
  canvas,
  viewports: [{ camera, layers }],
  showFrameTiming: true,
});
```

### Programmatic access

```typescript
const stats = idetik.frameTimingStats;
console.log(`avg render: ${stats.average.renderSubmitMs.toFixed(2)}ms`);
```

### Adding GPU timing (future)

Override `gpuFrameTimeMs` in a renderer subclass — the overlay picks it up automatically:
```typescript
public override get gpuFrameTimeMs(): number {
  return this.lastGpuTimeMs_;
}
```

## Test plan

- [ ] Add `showFrameTiming: true` to any example, verify overlay renders
- [ ] Verify values update when interacting (pan/zoom/rotate)
- [ ] Confirm no impact when flag is not set

🤖 Generated with [Claude Code](https://claude.com/claude-code)