### PR TITLE
perf: restore increased worker count, and remove `getVisibleDataRange`

### DIFF
--- a/src/data/chunk.ts
+++ b/src/data/chunk.ts
@@ -32,14 +32,8 @@ export type ChunkViewState = {
   orderKey: number | null;
 };
 
-export type ChunkDataRange = {
-  min: number;
-  max: number;
-};
-
 export type Chunk = {
   data?: ChunkData;
-  dataRange?: ChunkDataRange;
   state: "unloaded" | "queued" | "loading" | "loaded";
   lod: number;
   shape: {
@@ -113,37 +107,6 @@ export type ChunkLoader = {
 
   loadChunkData(chunk: Chunk, signal: AbortSignal): Promise<void>;
 };
-
-export function computeChunkDataRange(data: ChunkData): ChunkDataRange {
-  let min = Infinity;
-  let max = -Infinity;
-  for (let i = 0; i < data.length; i++) {
-    const v = data[i];
-    if (v < min) min = v;
-    if (v > max) max = v;
-  }
-  return { min, max };
-}
-
-type ChannelDataRange = Record<number, ChunkDataRange>;
-
-export function computeChannelDataRange(
-  chunks: Iterable<Chunk>
-): ChannelDataRange {
-  const result: ChannelDataRange = {};
-  for (const chunk of chunks) {
-    if (!chunk.dataRange) continue;
-    const c = chunk.chunkIndex.c;
-    const existing = result[c];
-    if (!existing) {
-      result[c] = { min: chunk.dataRange.min, max: chunk.dataRange.max };
-    } else {
-      existing.min = Math.min(existing.min, chunk.dataRange.min);
-      existing.max = Math.max(existing.max, chunk.dataRange.max);
-    }
-  }
-  return result;
-}
 
 export function coordToIndex(lod: SourceDimensionLod, coord: number): number {
   return Math.round((coord - lod.translation) / lod.scale);

--- a/src/data/ome_zarr/chunk_processing.ts
+++ b/src/data/ome_zarr/chunk_processing.ts
@@ -1,9 +1,4 @@
-import {
-  ChunkData,
-  ChunkDataConstructor,
-  ChunkDataRange,
-  computeChunkDataRange,
-} from "../chunk";
+import { ChunkData, ChunkDataConstructor, ChunkDataRange } from "../chunk";
 
 export type SliceSpec = {
   targetShape: { x: number; y: number; z: number };
@@ -15,7 +10,7 @@ export type SliceSpec = {
 
 export type ProcessedChunk = {
   data: ChunkData;
-  dataRange: ChunkDataRange;
+  dataRange: Promise<ChunkDataRange>;
 };
 
 export function processChunk(
@@ -23,15 +18,8 @@ export function processChunk(
   receivedShape: number[],
   receivedStride: number[],
   spec: SliceSpec
-): ProcessedChunk {
-  const data = sliceReceivedChunk(
-    receivedData,
-    receivedShape,
-    receivedStride,
-    spec
-  );
-  const dataRange = computeChunkDataRange(data);
-  return { data, dataRange };
+): ChunkData {
+  return sliceReceivedChunk(receivedData, receivedShape, receivedStride, spec);
 }
 
 function sliceReceivedChunk(

--- a/src/data/ome_zarr/chunk_processing.ts
+++ b/src/data/ome_zarr/chunk_processing.ts
@@ -1,4 +1,4 @@
-import { ChunkData, ChunkDataConstructor, ChunkDataRange } from "../chunk";
+import { ChunkData, ChunkDataConstructor } from "../chunk";
 
 export type SliceSpec = {
   targetShape: { x: number; y: number; z: number };
@@ -6,11 +6,6 @@ export type SliceSpec = {
   dimIndices: { x: number; y: number; z?: number; c?: number; t?: number };
   cChunkSize?: number;
   tChunkSize?: number;
-};
-
-export type ProcessedChunk = {
-  data: ChunkData;
-  dataRange: Promise<ChunkDataRange>;
 };
 
 export function processChunk(

--- a/src/data/ome_zarr/image_loader.ts
+++ b/src/data/ome_zarr/image_loader.ts
@@ -101,7 +101,7 @@ export class OmeZarrImageLoader {
 
     // NOTE: if source chunks have multiple channels/timepoints
     // this results in duplicate fetching and decompression
-    const { data, dataRange } = await fetchAndProcessChunk(
+    const data = await fetchAndProcessChunk(
       array,
       arrayParams,
       chunkCoords,
@@ -117,9 +117,6 @@ export class OmeZarrImageLoader {
     }
     chunk.rowAlignmentBytes = rowAlignment;
     chunk.data = data;
-    dataRange.then((range) => {
-      chunk.dataRange = range;
-    });
   }
 }
 

--- a/src/data/ome_zarr/image_loader.ts
+++ b/src/data/ome_zarr/image_loader.ts
@@ -117,7 +117,9 @@ export class OmeZarrImageLoader {
     }
     chunk.rowAlignmentBytes = rowAlignment;
     chunk.data = data;
-    chunk.dataRange = dataRange;
+    dataRange.then((range) => {
+      chunk.dataRange = range;
+    });
   }
 }
 

--- a/src/data/ome_zarr/worker_kernel.ts
+++ b/src/data/ome_zarr/worker_kernel.ts
@@ -2,7 +2,7 @@
 
 import * as zarr from "zarrita";
 import { openArrayFromParams, ZarrArrayParams } from "../zarr/open";
-import { isChunkData, ChunkData, ChunkDataRange } from "../chunk";
+import { isChunkData, ChunkData, ChunkDataRange, computeChunkDataRange } from "../chunk";
 import { SliceSpec, processChunk } from "./chunk_processing";
 
 type ZarrWorkerMessageType = "getChunk" | "cancel";
@@ -28,6 +28,9 @@ export type ZarrWorkerResponse = {
       success: true;
       type: "getChunk";
       data: ChunkData;
+    }
+  | {
+      type: "dataRange";
       dataRange: ChunkDataRange;
     }
   | {
@@ -81,6 +84,7 @@ async function handleGetChunkMessage(
 
   const array = await getOrOpenArray(arrayParams);
 
+  const fetchStart = performance.now();
   let chunk;
   try {
     chunk = await array.getChunk(index, { signal: abortController.signal });
@@ -94,6 +98,7 @@ async function handleGetChunkMessage(
   } finally {
     activeRequests.delete(id);
   }
+  performance.measure("zarrFetch", { start: fetchStart });
 
   if (!isChunkData(chunk.data)) {
     throw new Error(
@@ -101,17 +106,17 @@ async function handleGetChunkMessage(
     );
   }
 
-  const processStart = performance.now();
-  const { data, dataRange } = processChunk(
-    chunk.data,
-    chunk.shape,
-    chunk.stride,
-    sliceSpec
-  );
-  performance.measure("processChunk", { start: processStart });
+  const sliceStart = performance.now();
+  const data = processChunk(chunk.data, chunk.shape, chunk.stride, sliceSpec);
+  performance.measure("processChunk", { start: sliceStart });
+
+  const copyStart = performance.now();
+  // Copy before transfer so range computation can run after the data is sent.
+  const dataCopy = data.slice();
+  performance.measure("copyChunk", { start: copyStart });
 
   try {
-    self.postMessage({ id, success: true, type: "getChunk", data, dataRange }, [
+    self.postMessage({ id, success: true, type: "getChunk", data }, [
       data.buffer,
     ]);
   } catch (postError) {
@@ -119,6 +124,11 @@ async function handleGetChunkMessage(
       `Failed to send result: ${postError instanceof Error ? postError.message : String(postError)}`
     );
   }
+
+  const rangeStart = performance.now();
+  const dataRange = computeChunkDataRange(dataCopy);
+  performance.measure("computeChunkDataRange", { start: rangeStart });
+  self.postMessage({ id, type: "dataRange", dataRange });
 }
 
 // we need to open arrays in each worker since we can't transfer them

--- a/src/data/ome_zarr/worker_kernel.ts
+++ b/src/data/ome_zarr/worker_kernel.ts
@@ -2,7 +2,7 @@
 
 import * as zarr from "zarrita";
 import { openArrayFromParams, ZarrArrayParams } from "../zarr/open";
-import { isChunkData, ChunkData, ChunkDataRange, computeChunkDataRange } from "../chunk";
+import { isChunkData, ChunkData } from "../chunk";
 import { SliceSpec, processChunk } from "./chunk_processing";
 
 type ZarrWorkerMessageType = "getChunk" | "cancel";
@@ -28,10 +28,6 @@ export type ZarrWorkerResponse = {
       success: true;
       type: "getChunk";
       data: ChunkData;
-    }
-  | {
-      type: "dataRange";
-      dataRange: ChunkDataRange;
     }
   | {
       success: false;
@@ -110,11 +106,6 @@ async function handleGetChunkMessage(
   const data = processChunk(chunk.data, chunk.shape, chunk.stride, sliceSpec);
   performance.measure("processChunk", { start: sliceStart });
 
-  const copyStart = performance.now();
-  // Copy before transfer so range computation can run after the data is sent.
-  const dataCopy = data.slice();
-  performance.measure("copyChunk", { start: copyStart });
-
   try {
     self.postMessage({ id, success: true, type: "getChunk", data }, [
       data.buffer,
@@ -124,11 +115,6 @@ async function handleGetChunkMessage(
       `Failed to send result: ${postError instanceof Error ? postError.message : String(postError)}`
     );
   }
-
-  const rangeStart = performance.now();
-  const dataRange = computeChunkDataRange(dataCopy);
-  performance.measure("computeChunkDataRange", { start: rangeStart });
-  self.postMessage({ id, type: "dataRange", dataRange });
 }
 
 // we need to open arrays in each worker since we can't transfer them

--- a/src/data/ome_zarr/worker_pool.ts
+++ b/src/data/ome_zarr/worker_pool.ts
@@ -1,7 +1,7 @@
 import * as zarr from "zarrita";
 import { Logger } from "../../utilities/logger";
 import { ZarrArrayParams } from "../zarr/open";
-import { isChunkData } from "../chunk";
+import { isChunkData, ChunkDataRange, computeChunkDataRange } from "../chunk";
 import { ZarrWorkerRequest, ZarrWorkerResponse } from "./worker_kernel";
 import { SliceSpec, ProcessedChunk, processChunk } from "./chunk_processing";
 // "inline" import to ensure worker code works in dependent projects
@@ -23,12 +23,14 @@ type WorkerInstance = {
   workerId: number;
 };
 
-const DEFAULT_WORKER_COUNT = 3;
+// leave 2 cores for the main thread and the OS/other tabs
+const DEFAULT_WORKER_COUNT = Math.max(1, navigator.hardwareConcurrency - 2);
 let workerPool: WorkerInstance[] = [];
 let messageId = 0;
 let workerId = 0;
 const pendingMessages = new Map<number, PendingGetChunkRequest>();
 const canceledMessages = new Set<number>();
+const pendingDataRanges = new Map<number, (range: ChunkDataRange) => void>();
 
 function getWorkerInstance(worker: Worker): WorkerInstance | undefined {
   const instance = workerPool.find((w) => w.worker === worker);
@@ -45,7 +47,18 @@ function handleWorkerMessage(
   e: MessageEvent<ZarrWorkerResponse>,
   worker: Worker
 ): void {
-  const { id, success } = e.data;
+  const { id } = e.data;
+
+  if (e.data.type === "dataRange") {
+    const resolveRange = pendingDataRanges.get(id);
+    if (resolveRange) {
+      resolveRange(e.data.dataRange);
+      pendingDataRanges.delete(id);
+    }
+    return;
+  }
+
+  const { success } = e.data;
   const pending = pendingMessages.get(id);
 
   if (!pending) {
@@ -78,7 +91,10 @@ function handleWorkerMessage(
   }
 
   if (success && e.data.type === "getChunk") {
-    pending.resolve({ data: e.data.data, dataRange: e.data.dataRange });
+    const dataRange = new Promise<ChunkDataRange>((resolve) => {
+      pendingDataRanges.set(id, resolve);
+    });
+    pending.resolve({ data: e.data.data, dataRange });
   } else if (!success) {
     pending.reject(new Error(e.data.error || "Unknown worker error"));
   }
@@ -258,12 +274,13 @@ export async function fetchAndProcessChunk(
         `Unsupported chunk data type: ${rawChunk.data.constructor.name}`
       );
     }
-    return processChunk(
+    const data = processChunk(
       rawChunk.data,
       rawChunk.shape,
       rawChunk.stride,
       sliceSpec
     );
+    return { data, dataRange: Promise.resolve(computeChunkDataRange(data)) };
   }
 }
 
@@ -273,4 +290,5 @@ export function terminateWorkerPool(): void {
   }
   workerPool = [];
   pendingMessages.clear();
+  pendingDataRanges.clear();
 }

--- a/src/data/ome_zarr/worker_pool.ts
+++ b/src/data/ome_zarr/worker_pool.ts
@@ -1,16 +1,16 @@
 import * as zarr from "zarrita";
 import { Logger } from "../../utilities/logger";
 import { ZarrArrayParams } from "../zarr/open";
-import { isChunkData, ChunkDataRange, computeChunkDataRange } from "../chunk";
+import { isChunkData, ChunkData } from "../chunk";
 import { ZarrWorkerRequest, ZarrWorkerResponse } from "./worker_kernel";
-import { SliceSpec, ProcessedChunk, processChunk } from "./chunk_processing";
+import { SliceSpec, processChunk } from "./chunk_processing";
 // "inline" import to ensure worker code works in dependent projects
 // this is a workaround for a vite limitation when building a library
 // see https://github.com/vitejs/vite/issues/11672
 import WorkerKernel from "./worker_kernel.ts?worker&inline";
 
 type PendingGetChunkRequest = {
-  resolve: (value: ProcessedChunk) => void;
+  resolve: (value: ChunkData) => void;
   reject: (error: Error) => void;
   abortListener?: () => void;
   abortSignal?: AbortSignal;
@@ -30,7 +30,6 @@ let messageId = 0;
 let workerId = 0;
 const pendingMessages = new Map<number, PendingGetChunkRequest>();
 const canceledMessages = new Set<number>();
-const pendingDataRanges = new Map<number, (range: ChunkDataRange) => void>();
 
 function getWorkerInstance(worker: Worker): WorkerInstance | undefined {
   const instance = workerPool.find((w) => w.worker === worker);
@@ -47,18 +46,7 @@ function handleWorkerMessage(
   e: MessageEvent<ZarrWorkerResponse>,
   worker: Worker
 ): void {
-  const { id } = e.data;
-
-  if (e.data.type === "dataRange") {
-    const resolveRange = pendingDataRanges.get(id);
-    if (resolveRange) {
-      resolveRange(e.data.dataRange);
-      pendingDataRanges.delete(id);
-    }
-    return;
-  }
-
-  const { success } = e.data;
+  const { id, success } = e.data;
   const pending = pendingMessages.get(id);
 
   if (!pending) {
@@ -91,10 +79,7 @@ function handleWorkerMessage(
   }
 
   if (success && e.data.type === "getChunk") {
-    const dataRange = new Promise<ChunkDataRange>((resolve) => {
-      pendingDataRanges.set(id, resolve);
-    });
-    pending.resolve({ data: e.data.data, dataRange });
+    pending.resolve(e.data.data);
   } else if (!success) {
     pending.reject(new Error(e.data.error || "Unknown worker error"));
   }
@@ -171,7 +156,7 @@ async function fetchAndProcessChunkInWorker(
   chunkIndex: number[],
   sliceSpec: SliceSpec,
   options?: { signal?: AbortSignal }
-): Promise<ProcessedChunk> {
+): Promise<ChunkData> {
   return new Promise((resolve, reject) => {
     const workerInstance = getLeastBusyWorker();
 
@@ -253,7 +238,7 @@ export async function fetchAndProcessChunk(
   chunkCoords: number[],
   sliceSpec: SliceSpec,
   options?: { signal?: AbortSignal }
-): Promise<ProcessedChunk> {
+): Promise<ChunkData> {
   ensureWorkerPool();
   try {
     return await fetchAndProcessChunkInWorker(
@@ -274,13 +259,12 @@ export async function fetchAndProcessChunk(
         `Unsupported chunk data type: ${rawChunk.data.constructor.name}`
       );
     }
-    const data = processChunk(
+    return processChunk(
       rawChunk.data,
       rawChunk.shape,
       rawChunk.stride,
       sliceSpec
     );
-    return { data, dataRange: Promise.resolve(computeChunkDataRange(data)) };
   }
 }
 
@@ -290,5 +274,4 @@ export function terminateWorkerPool(): void {
   }
   workerPool = [];
   pendingMessages.clear();
-  pendingDataRanges.clear();
 }

--- a/src/layers/image_layer.ts
+++ b/src/layers/image_layer.ts
@@ -1,11 +1,6 @@
 import { Layer, LayerOptions, RenderContext } from "../core/layer";
 import type { IdetikContext } from "../idetik";
-import {
-  Chunk,
-  ChunkSource,
-  SliceCoordinates,
-  computeChannelDataRange,
-} from "../data/chunk";
+import { Chunk, ChunkSource, SliceCoordinates } from "../data/chunk";
 import { ChunkStoreView, INTERNAL_POLICY_KEY } from "../core/chunk_store_view";
 import { ImageSourcePolicy } from "../core/image_source_policy";
 import {
@@ -399,10 +394,6 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
       throw new Error(`Callback to remove could not be found: ${callback}`);
     }
     this.channelChangeCallbacks_.splice(index, 1);
-  }
-
-  public getVisibleDataRange() {
-    return computeChannelDataRange(this.visibleChunks_.keys());
   }
 
   private releaseAndRemoveChunks(chunks: Iterable<Chunk>): void {

--- a/src/layers/volume_layer.ts
+++ b/src/layers/volume_layer.ts
@@ -1,9 +1,4 @@
-import {
-  Chunk,
-  ChunkSource,
-  SliceCoordinates,
-  computeChannelDataRange,
-} from "../data/chunk";
+import { Chunk, ChunkSource, SliceCoordinates } from "../data/chunk";
 import { Layer, RenderContext } from "../core/layer";
 import { VolumeRenderable } from "../objects/renderable/volume_renderable";
 import { IdetikContext } from "../idetik";
@@ -41,7 +36,6 @@ export class VolumeLayer extends Layer implements ChannelsEnabled {
   private chunkStoreView_?: ChunkStoreView;
   private channelProps_?: ChannelProps[];
 
-  private visibleChunks_: Chunk[] = [];
   private lastLoadedTime_: number | undefined = undefined;
   private lastNumRenderedChannelChunks_: number | undefined = undefined;
   private interactiveStepSizeScale_ = 1.0;
@@ -109,10 +103,6 @@ export class VolumeLayer extends Layer implements ChannelsEnabled {
     this.channelChangeCallbacks_.splice(index, 1);
   }
 
-  public getVisibleDataRange() {
-    return computeChannelDataRange(this.visibleChunks_);
-  }
-
   constructor({ source, sliceCoords, policy, channelProps }: VolumeLayerProps) {
     super({ transparent: true, blendMode: "premultiplied" });
     this.source_ = source;
@@ -168,7 +158,6 @@ export class VolumeLayer extends Layer implements ChannelsEnabled {
     const chunksToRender = this.chunkStoreView_.getChunksToRender(
       this.sliceCoords_
     );
-    this.visibleChunks_ = chunksToRender;
     const currentTime = this.sliceCoords_.t ?? -1;
     const groupedChunks = groupBySpatialIndex(chunksToRender);
 


### PR DESCRIPTION
### Summary
In idetik-remote, chunks were being cancelled before they could finish loading, producing a mostly-black volume with occasional flashes. Two regressions were stacking: PR #647 cut the worker count from up to 8 down to 3, and PR #638 added a full min/max scan (`computeChunkDataRange`) to the chunk-load critical path. Each chunk's worker time roughly doubled at the same time as the worker pool was cut. This is generally fine for local rendering where the network is the bottleneck, but it's very bad for server-side rendering. Oops!

This PR effectively reverts #647 and #638. We lose `getVisibleDataRange` which was intended for use in an auto-contrast feature for [idetik-dca-viewer](https://github.com/chanzuckerberg/idetik-dca-viewer), but that has not been merged anyway.

### Related Issue
N/A

### Tests & Checks
manually tested this branch with idetik-remote to compare against the baseline performance (v0.14.0)