### PR TITLE
fix: prioritize current frame for single-LOD case (typical volume rendering case)

### DIFF
--- a/src/core/chunk_store_view.ts
+++ b/src/core/chunk_store_view.ts
@@ -242,11 +242,7 @@ export class ChunkStoreView {
 
     const channels = this.channelsOfInterest(sliceCoords);
     const fallbackLOD = this.fallbackLOD();
-    // Derive isFallbackLOD/isCurrentLOD from the chunk's own LOD so that
-    // when currentLOD === fallbackLOD both flags are true on the same
-    // chunk — `computePriority` then returns `fallbackVisible` (priority 0)
-    // instead of `visibleCurrent`. Without this, in playback the current
-    // frame waits behind the entire `prefetchTime` queue.
+
     const markVolumeChunkVisible = (chunk: Chunk) => {
       const isFallbackLOD = chunk.lod === fallbackLOD;
       const isCurrentLOD = chunk.lod === this.currentLOD_;

--- a/src/core/chunk_store_view.ts
+++ b/src/core/chunk_store_view.ts
@@ -242,10 +242,17 @@ export class ChunkStoreView {
 
     const channels = this.channelsOfInterest(sliceCoords);
     const fallbackLOD = this.fallbackLOD();
-    const markVolumeChunkVisible = (chunk: Chunk, isFallbackLOD: boolean) => {
+    // Derive isFallbackLOD/isCurrentLOD from the chunk's own LOD so that
+    // when currentLOD === fallbackLOD both flags are true on the same
+    // chunk — `computePriority` then returns `fallbackVisible` (priority 0)
+    // instead of `visibleCurrent`. Without this, in playback the current
+    // frame waits behind the entire `prefetchTime` queue.
+    const markVolumeChunkVisible = (chunk: Chunk) => {
+      const isFallbackLOD = chunk.lod === fallbackLOD;
+      const isCurrentLOD = chunk.lod === this.currentLOD_;
       const priority = this.computePriority(
         isFallbackLOD,
-        !isFallbackLOD,
+        isCurrentLOD,
         true,
         false,
         true
@@ -262,14 +269,14 @@ export class ChunkStoreView {
       currentTimeIndex,
       this.currentLOD_,
       channels,
-      (chunk) => markVolumeChunkVisible(chunk, false)
+      markVolumeChunkVisible
     );
     if (this.currentLOD_ !== fallbackLOD) {
       this.iterateAllChunksAtLod(
         currentTimeIndex,
         fallbackLOD,
         channels,
-        (chunk) => markVolumeChunkVisible(chunk, true)
+        markVolumeChunkVisible
       );
     }
 


### PR DESCRIPTION
### Summary

When working with remote rendering, I noticed a bug I introduced in #665 that results in the volume layer stalling until the entire prefetch queue drains.

That PR rewrote `updateChunksForVolume` and replaced the per-chunk `isCurrentLOD = chunk.lod === currentLOD_` derivation with a `markVolumeChunkVisible(chunk, isFallbackLOD)` helper that computes `isCurrentLOD = !isFallbackLOD`. When `currentLOD === fallbackLOD`, only the current-LOD pass runs, so every chunk is marked with `isFallbackLOD=false, isCurrentLOD=true`. `computePriority` then returns `visibleCurrent` (priority 2 under `createPlaybackPolicy`) instead of `fallbackVisible` (priority 0) — and since `prefetchTime` is priority 1 in the same policy, the current frame's chunks land in the queue *behind* the entire prefetch backlog.

This restores previous behavior by getting both `isFallbackLOD` and `isCurrentLOD` from the chunk's own `chunk.lod` inside `markVolumeChunkVisible`, so for single LOD (we configure this typically by setting min LOD === max LOD in the policy) both flags are true and `computePriority` returns `fallbackVisible` as it did before #665.

### Tests & Checks
I confirmed this fix restores the expected (previous) behavior in a reef idetik-remote session.