### PR TITLE
feat: per-channel opacity

### DIFF
--- a/examples/volume_rendering/main.ts
+++ b/examples/volume_rendering/main.ts
@@ -90,6 +90,7 @@ function createChannelControls(
   // Local version of the channel config to avoid mutating the original when adjusting contrast limits, e.g. if setting the max below the min
   const guiConfig: ChannelProps = {
     ...config,
+    opacity: config.opacity ?? 1,
     contrastLimits: config.contrastLimits
       ? [config.contrastLimits[0], config.contrastLimits[1]]
       : undefined,
@@ -107,6 +108,13 @@ function createChannelControls(
     .name("Color")
     .onChange((hex: string) => {
       updateChannelProperty(index, "color", hex);
+    });
+
+  channelFolder
+    .add(guiConfig, "opacity", 0, 1, 0.01)
+    .name("Opacity")
+    .onChange((opacity: number) => {
+      updateChannelProperty(index, "opacity", opacity);
     });
 
   if (guiConfig.contrastLimits) {

--- a/src/core/layer.ts
+++ b/src/core/layer.ts
@@ -39,12 +39,6 @@ export abstract class Layer {
   public blendMode: BlendMode;
 
   constructor({ opacity = 1.0, blendMode = "none" }: LayerOptions = {}) {
-    if (opacity < 0 || opacity > 1) {
-      Logger.warn(
-        "Layer",
-        `Layer opacity out of bounds: ${opacity} — clamping to [0.0, 1.0]`
-      );
-    }
     this.opacity_ = clamp(opacity, 0.0, 1.0);
     this.blendMode = blendMode;
   }

--- a/src/objects/renderable/image_renderable.ts
+++ b/src/objects/renderable/image_renderable.ts
@@ -11,8 +11,9 @@ import { vec3 } from "gl-matrix";
 import { Shader } from "../../renderers/shaders";
 
 type UniformValues = {
-  ImageSampler: number;
   Color: vec3;
+  ImageSampler: number;
+  Opacity: number;
   ValueOffset: number;
   ValueScale: number;
 };
@@ -60,13 +61,15 @@ export class ImageRenderable extends RenderableObject {
       throw new Error("No texture set");
     }
 
-    const { color, contrastLimits } =
+    const { color, contrastLimits, opacity } =
       this.channels_[0] ?? validateChannel(texture, {});
+
     return {
       ImageSampler: 0,
       Color: color.rgb,
       ValueOffset: -contrastLimits[0],
       ValueScale: 1 / (contrastLimits[1] - contrastLimits[0]),
+      Opacity: opacity,
     };
   }
 }

--- a/src/objects/renderable/volume_renderable.ts
+++ b/src/objects/renderable/volume_renderable.ts
@@ -86,6 +86,7 @@ export class VolumeRenderable extends RenderableObject {
     ]
     const valueOffset = [0, 0, 0, 0];
     const valueScale = [1, 1, 1, 1];
+    const channelOpacity = [1, 1, 1, 1];
     const samplerUniforms: number[] = [];
 
     // Allow to render without channel props specified
@@ -112,6 +113,8 @@ export class VolumeRenderable extends RenderableObject {
       valueScale[k] =
         1 / (channel.contrastLimits[1] - channel.contrastLimits[0]);
       loadedAndVisibleTextures[k] = 1;
+
+      channelOpacity[k] = channel.opacity;
     }
 
     return samplerUniforms.reduce<Record<string, number[] | number>>(
@@ -124,6 +127,7 @@ export class VolumeRenderable extends RenderableObject {
         "Color[0]": colors,
         ValueOffset: valueOffset,
         ValueScale: valueScale,
+        ChannelOpacity: channelOpacity,
         VoxelScale: [
           this.voxelScale[0],
           this.voxelScale[1],

--- a/src/objects/textures/channel.ts
+++ b/src/objects/textures/channel.ts
@@ -6,17 +6,20 @@ import {
 } from "../../objects/textures/texture";
 import { MAX_CHANNELS } from "../../core/constants";
 import { Logger } from "../../utilities/logger";
+import { clamp } from "../../utilities/clamp";
 
 export type Channel = {
   visible: boolean;
   color: Color;
   contrastLimits: [number, number];
+  opacity: number;
 };
 
 export type ChannelProps = {
   visible?: boolean;
   color?: ColorLike;
   contrastLimits?: [number, number];
+  opacity?: number;
 };
 
 /** Layer that exposes channel controls. */
@@ -30,16 +33,11 @@ export interface ChannelsEnabled {
 
 export function validateChannel(
   texture: Texture | null,
-  { visible, color, contrastLimits }: ChannelProps
+  { visible, color, contrastLimits, opacity }: ChannelProps
 ): Channel {
-  if (visible === undefined) {
-    visible = true;
-  }
-  if (color === undefined) {
-    color = Color.WHITE;
-  } else {
-    color = Color.from(color);
-  }
+  visible ??= true;
+  color = color === undefined ? Color.WHITE : Color.from(color);
+  opacity = opacity === undefined ? 1 : clamp(opacity, 0, 1);
 
   if (texture !== null) {
     contrastLimits = validateContrastLimits(contrastLimits, texture);
@@ -50,10 +48,12 @@ export function validateChannel(
     );
     contrastLimits = [0, 1];
   }
+
   return {
     visible,
     color,
     contrastLimits,
+    opacity,
   };
 }
 

--- a/src/renderers/shaders/volume_frag.glsl
+++ b/src/renderers/shaders/volume_frag.glsl
@@ -43,6 +43,7 @@ uniform float EarlyTerminationAlpha;
 uniform vec4 Visible;
 uniform vec4 ValueOffset;
 uniform vec4 ValueScale;
+uniform vec4 ChannelOpacity;
 uniform vec3 Color[4];
 
 vec2 findBoxIntersectionsAlongRay(vec3 rayOrigin, vec3 rayDir, vec3 boxMin, vec3 boxMax) {
@@ -132,7 +133,7 @@ void main() {
         for (int ch = 0; ch < 4; ch++) {
             if (!bool(Visible[ch]) || sampleValues[ch] == 0.0) continue;
             sampleColor = Color[ch];
-            sampleAlpha = clamp(sampleValues[ch] * intensityScale, 0.0, 1.0);
+            sampleAlpha = clamp(sampleValues[ch] * intensityScale * ChannelOpacity[ch], 0.0, 1.0);
             blendedSampleAlpha = (1.0 - accumulatedColor.a) * sampleAlpha;
 
             // Front-to-back compositing

--- a/src/renderers/webgl_renderer.ts
+++ b/src/renderers/webgl_renderer.ts
@@ -220,7 +220,11 @@ export class WebGLRenderer extends Renderer {
           program.setUniform(uniformName, resolution);
           break;
         case "u_opacity":
-          program.setUniform(uniformName, layer.opacity);
+          program.setUniform(
+            uniformName,
+            layer.opacity *
+              ((objectUniforms.Opacity as number | undefined) ?? 1)
+          );
           break;
         case "CameraPositionModel": {
           const inverseModelView = mat4.invert(mat4.create(), modelView)!;

--- a/src/renderers/webgpu/webgpu_renderer.ts
+++ b/src/renderers/webgpu/webgpu_renderer.ts
@@ -72,7 +72,7 @@ class WebGPURenderer extends Renderer {
   private currentDepthWrite_ = true;
   private currentStencil_ = false;
   private currentBlendMode_: BlendMode = "none";
-  private currentOpacity_ = 1.0;
+  private currentLayerOpacity_ = 1.0;
 
   constructor(canvas: HTMLCanvasElement, device: GPUDevice) {
     super(canvas);
@@ -214,7 +214,7 @@ class WebGPURenderer extends Renderer {
     }
 
     this.currentBlendMode_ = layer.blendMode;
-    this.currentOpacity_ = layer.opacity;
+    this.currentLayerOpacity_ = layer.opacity;
 
     layer.objects.forEach((object, i) => {
       if (frustum.intersectsWithBox3(object.boundingBox)) {
@@ -315,7 +315,7 @@ class WebGPURenderer extends Renderer {
       projection: this.currentProjection_,
       modelView: this.currentModelView_,
       color: object.wireframeColor.rgb,
-      opacity: this.currentOpacity_,
+      opacity: this.currentLayerOpacity_,
     });
 
     this.bindings_.setUniforms(renderPass, pipeline);
@@ -398,6 +398,7 @@ class WebGPURenderer extends Renderer {
     );
 
     const uniforms = object.getUniforms();
+    const objectOpacity = (uniforms.Opacity as number | undefined) ?? 1;
 
     pipeline.uniformsView.set({
       projection: this.currentProjection_,
@@ -405,7 +406,7 @@ class WebGPURenderer extends Renderer {
       color: uniforms.Color,
       valueOffset: uniforms.ValueOffset,
       valueScale: uniforms.ValueScale,
-      opacity: this.currentOpacity_,
+      opacity: this.currentLayerOpacity_ * objectOpacity,
     });
 
     this.bindings_.setUniforms(this.passEncoder_!, pipeline);


### PR DESCRIPTION
### Summary

This PR adds an optional opacity field to `ChannelProps` so each channel
can be attenuated independently. Primarily motivated by 3D volume
rendering, where one `VolumeLayer` composites multiple channels in a
single shader and previously had no per-channel opacity control.
For 2D the channel opacity multiplies with `layer.opacity` via the existing
`u_opacity` uniform.

### Tests & Checks

- All checks have passed

https://github.com/user-attachments/assets/90cc6f5e-8f0a-45e0-a247-7d7772bee1ba

