### PR TITLE
refactor: trim public API exports and decouple tests from the barrel

### DIFF
--- a/examples/image_2d/main.ts
+++ b/examples/image_2d/main.ts
@@ -4,15 +4,13 @@ import {
   ImageLayer,
   OmeZarrImageSource,
   OrthographicCamera,
+  PanZoomControls,
   SliceCoordinates,
-} from "@";
-import { PanZoomControls } from "@/objects/cameras/controls";
-import { ScaleBar } from "./scale_bar";
-import { addDimensionSlider } from "../lil_gui_utils";
-import {
   createExplorationPolicy,
   createPlaybackPolicy,
-} from "@/core/image_source_policy";
+} from "@";
+import { ScaleBar } from "./scale_bar";
+import { addDimensionSlider } from "../lil_gui_utils";
 import GUI from "lil-gui";
 
 // A 2D OME-Zarr image viewer with a dataset selector. Pre-populated with

--- a/examples/image_series_labels_overlay/main.ts
+++ b/examples/image_series_labels_overlay/main.ts
@@ -5,10 +5,9 @@ import {
   OmeZarrImageSource,
   OrthographicCamera,
   Color,
-  PointPickingResult,
+  PanZoomControls,
+  createExplorationPolicy,
 } from "@";
-import { PanZoomControls } from "@/objects/cameras/controls";
-import { createExplorationPolicy } from "@/core/image_source_policy";
 
 // These roughly correspond in terms of content and the number of time-points.
 // But the image is smaller in XY than the labels, and has a Z-stack, so it
@@ -74,7 +73,7 @@ function createLabelsLayer() {
     opacity: 0.25,
     blendMode: "normal",
     outlineSelected: outlineMode,
-    onPickValue: (info: PointPickingResult) => {
+    onPickValue: (info) => {
       const { world, value } = info;
       pickInfoEl.innerHTML = `
         World: (${world[0].toFixed(1)}, ${world[1].toFixed(1)}, ${world[2].toFixed(1)})<br/>

--- a/examples/lil_gui_utils.ts
+++ b/examples/lil_gui_utils.ts
@@ -1,4 +1,4 @@
-import { SliceCoordinates } from "@/index";
+import { SliceCoordinates } from "@";
 import { Controller, GUI } from "lil-gui";
 
 type DimensionSliderProps = {

--- a/examples/multi_viewport/main.ts
+++ b/examples/multi_viewport/main.ts
@@ -2,14 +2,14 @@ import {
   Idetik,
   ImageLayer,
   OmeZarrImageSource,
+  OrbitControls,
   OrthographicCamera,
+  PanZoomControls,
   PerspectiveCamera,
   VolumeLayer,
+  createPlaybackPolicy,
 } from "@";
-import { PanZoomControls } from "@/objects/cameras/controls";
-import { OrbitControls } from "@/objects/cameras/orbit_controls";
 import { addDimensionSlider } from "../lil_gui_utils";
-import { createPlaybackPolicy } from "@/core/image_source_policy";
 import { vec3 } from "gl-matrix";
 
 import GUI from "lil-gui";

--- a/examples/volume_rendering/main.ts
+++ b/examples/volume_rendering/main.ts
@@ -1,9 +1,14 @@
 import { vec3 } from "gl-matrix";
 import GUI from "lil-gui";
-import { Idetik, OmeZarrImageSource, PerspectiveCamera, VolumeLayer } from "@";
-import { createExplorationPolicy } from "@/core/image_source_policy";
-import { OrbitControls } from "@/objects/cameras/orbit_controls";
-import type { ChannelProps } from "@/core/channel";
+import {
+  ChannelProps,
+  Idetik,
+  OmeZarrImageSource,
+  OrbitControls,
+  PerspectiveCamera,
+  VolumeLayer,
+  createExplorationPolicy,
+} from "@";
 
 const url =
   "https://public.czbiohub.org/organelle_box/datasets/A549/organelle_box_crop_v1.zarr/CLTA/PFA/002000/";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,72 +1,45 @@
 export { Idetik } from "./idetik";
-export type { Overlay } from "./idetik";
 
-export { WebGLRenderer } from "./renderers/webgl_renderer";
-export { OrthographicCamera } from "./objects/cameras/orthographic_camera";
-export { PerspectiveCamera } from "./objects/cameras/perspective_camera";
-export { PanZoomControls } from "./objects/cameras/controls";
-export { OrbitControls } from "./objects/cameras/orbit_controls";
-export type { CameraControls } from "./objects/cameras/controls";
-
-export { Layer } from "./core/layer";
-export type { LayerState } from "./core/layer";
-export { LayerManager } from "./core/layer_manager";
-export type { EventContext } from "./core/event_dispatcher";
-
-export {
-  Viewport,
-  parseViewportConfigs,
-  validateNewViewport,
-} from "./core/viewport";
-export type { ViewportConfig } from "./core/viewport";
-
-export { AxesLayer } from "./layers/axes_layer";
-export { ImageLayer } from "./layers/image_layer";
-export type { ImageLayerProps } from "./layers/image_layer";
-export { VolumeLayer } from "./layers/volume_layer";
-export type { Chunk, ChunkLoader, SliceCoordinates } from "./data/chunk";
-export type { QueueStats } from "./data/chunk_manager";
-export { LabelLayer } from "./layers/label_layer";
-export type { LabelLayerProps } from "./layers/label_layer";
-export type { LabelColorMapProps } from "./objects/renderable/label_color_map";
-export type { PointPickingResult } from "./layers/point_picking";
 export { OmeZarrImageSource } from "./data/ome_zarr/image_source";
 
-export type {
-  PriorityCategory,
-  ImageSourcePolicy,
-  ImageSourcePolicyConfig,
-} from "./core/image_source_policy";
-
-export {
-  createImageSourcePolicy,
-  createExplorationPolicy,
-  createNoPrefetchPolicy,
-  createPlaybackPolicy,
-} from "./core/image_source_policy";
-
-export { Box2 } from "./math/box2";
-export { Box3 } from "./math/box3";
-export { Frustum } from "./math/frustum";
-export { Plane } from "./math/plane";
-export { Spherical } from "./math/spherical";
-
-export type { Image as OmeZarrImage } from "./data/ome_zarr/0.4/image";
 export {
   loadOmeroChannels,
   loadOmeroDefaults,
   loadOmeZarrPlate,
   loadOmeZarrWell,
 } from "./data/ome_zarr/metadata_loaders";
-export type {
-  OmeroMetadata,
-  OmeroChannel,
-} from "./data/ome_zarr/metadata_loaders";
 
+export { Layer } from "./core/layer";
+export { AxesLayer } from "./layers/axes_layer";
+export { ImageLayer } from "./layers/image_layer";
+export { VolumeLayer } from "./layers/volume_layer";
+export { LabelLayer } from "./layers/label_layer";
+
+export { ImageRenderable } from "./objects/renderable/image_renderable";
+export { LabelColorMap } from "./objects/renderable/label_color_map";
+export { LabelImageRenderable } from "./objects/renderable/label_image_renderable";
+export { Points } from "./objects/renderable/points";
+export { ProjectedLine } from "./objects/renderable/projected_line";
+export { VolumeRenderable } from "./objects/renderable/volume_renderable";
+
+export { OrbitControls } from "./objects/cameras/orbit_controls";
+export { OrthographicCamera } from "./objects/cameras/orthographic_camera";
+export { PanZoomControls } from "./objects/cameras/controls";
+export { PerspectiveCamera } from "./objects/cameras/perspective_camera";
+
+export {
+  createExplorationPolicy,
+  createImageSourcePolicy,
+  createNoPrefetchPolicy,
+  createPlaybackPolicy,
+} from "./core/image_source_policy";
+
+export type { ChannelProps } from "./core/channel";
+export type { Image as OmeZarrImage } from "./data/ome_zarr/0.4/image";
+export type { LayerState } from "./core/layer";
+export type { Overlay } from "./idetik";
+export type { SliceCoordinates } from "./data/chunk";
+
+export { Texture2DArray } from "./objects/textures/texture_2d_array";
 export { Color } from "./math/color";
 export type { ColorLike } from "./math/color";
-export type { ChannelProps, ChannelsEnabled } from "./core/channel";
-
-export { Points } from "./objects/renderable/points";
-export { Texture2DArray } from "./objects/textures/texture_2d_array";
-export { Texture3D } from "./objects/textures/texture_3d";

--- a/test/box2.test.ts
+++ b/test/box2.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "vitest";
 import { vec2 } from "gl-matrix";
 
-import { Box2 } from "@";
+import { Box2 } from "@/math/box2";
 
 test("default constructor yields an empty box", () => {
   const b = new Box2();

--- a/test/box3.test.ts
+++ b/test/box3.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "vitest";
 import { mat4, vec3 } from "gl-matrix";
 
-import { Box3 } from "@";
+import { Box3 } from "@/math/box3";
 
 test("default constructor yields an empty box", () => {
   const b = new Box3();

--- a/test/frustum.test.ts
+++ b/test/frustum.test.ts
@@ -1,7 +1,8 @@
 import { expect, test } from "vitest";
 import { mat4, vec3 } from "gl-matrix";
 
-import { Box3, Frustum } from "@";
+import { Box3 } from "@/math/box3";
+import { Frustum } from "@/math/frustum";
 
 function identity(): mat4 {
   return mat4.create();

--- a/test/image_source_policy.test.ts
+++ b/test/image_source_policy.test.ts
@@ -5,7 +5,7 @@ import {
   createExplorationPolicy,
   createNoPrefetchPolicy,
   createPlaybackPolicy,
-} from "@";
+} from "@/core/image_source_policy";
 
 const VALID_PRIORITY_ORDER: PriorityCategory[] = [
   "fallbackVisible",

--- a/test/layer.test.ts
+++ b/test/layer.test.ts
@@ -1,6 +1,6 @@
 import { expect, test, vi } from "vitest";
 
-import { Layer } from "@";
+import { Layer } from "@/core/layer";
 
 class TestLayer extends Layer {
   public readonly type = "TestLayer";

--- a/test/plane.test.ts
+++ b/test/plane.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "vitest";
 import { vec3 } from "gl-matrix";
 
-import { Plane } from "@";
+import { Plane } from "@/math/plane";
 
 test("constructed with default values", () => {
   const plane = new Plane();

--- a/test/sort_by_distance.test.ts
+++ b/test/sort_by_distance.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "vitest";
 import { vec3 } from "gl-matrix";
 import { sortFrontToBack } from "@/math/sort_by_distance";
-import { PerspectiveCamera } from "@/index";
+import { PerspectiveCamera } from "@/objects/cameras/perspective_camera";
 import { RenderableObject } from "@/core/renderable_object";
 import { BoxGeometry } from "@/objects/geometry/box_geometry";
 

--- a/test/spherical.test.ts
+++ b/test/spherical.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "vitest";
 import { vec3 } from "gl-matrix";
 
-import { Spherical } from "@";
+import { Spherical } from "@/math/spherical";
 
 const PI = Math.PI;
 const PI_OVER_2 = PI / 2;

--- a/test/viewport.test.ts
+++ b/test/viewport.test.ts
@@ -1,6 +1,10 @@
 import { expect, test } from "vitest";
 
-import { Viewport, ViewportConfig, parseViewportConfigs } from "@";
+import {
+  Viewport,
+  ViewportConfig,
+  parseViewportConfigs,
+} from "@/core/viewport";
 import {
   createTestElement,
   createTestCamera,

--- a/test/webgl_renderer.test.ts
+++ b/test/webgl_renderer.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "vitest";
 
-import { WebGLRenderer } from "@";
+import { WebGLRenderer } from "@/renderers/webgl_renderer";
 
 test("Instantiate WebGLRenderer", () => {
   document.body.innerHTML = '<canvas id="canvas"></canvas>';


### PR DESCRIPTION
### Summary

this pr trims the public api surface in `index.ts` and decouples usage from
the barrel so tests no longer pin exports we don't want consumers to see.

- `index.ts` removed unused public exports
- `tests` import internals via deep paths instead of the barrel
- `examples` import only from the public barrel

### Tests & Checks

- all checks have passed
