### PR TITLE
ci: fix playwright install hang and add job timeouts

### DIFF
--- a/.github/workflows/lint-test-build.yml
+++ b/.github/workflows/lint-test-build.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   lint-and-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 25
 
     steps:
       - uses: actions/checkout@v4
@@ -45,6 +46,7 @@ jobs:
   build:
     needs: lint-and-test
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     if: ${{ ! contains(github.event.head_commit.message, '[skip ci]') }}
 
     steps:

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "jsdom": "^24.1.1",
         "json-schema-to-zod": "^2.6.1",
         "lil-gui": "^0.20.0",
-        "playwright": "1.56.1",
+        "playwright": "1.60.0",
         "prettier": "^3.3.2",
         "rollup": "^4.59.0",
         "rollup-plugin-dts": "^6.1.1",
@@ -8583,13 +8583,12 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.56.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.56.1.tgz",
-      "integrity": "sha512-aFi5B0WovBHTEvpM3DzXTUaeN6eN0qWnTkKx4NQaH4Wvcmc153PdaY2UBdSYKaGYw+UyWXSVyxDUg5DoPEttjw==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.56.1"
+        "playwright-core": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -8602,11 +8601,10 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.56.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.56.1.tgz",
-      "integrity": "sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
       "dev": true,
-      "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "jsdom": "^24.1.1",
     "json-schema-to-zod": "^2.6.1",
     "lil-gui": "^0.20.0",
-    "playwright": "1.56.1",
+    "playwright": "1.60.0",
     "prettier": "^3.3.2",
     "rollup": "^4.59.0",
     "rollup-plugin-dts": "^6.1.1",


### PR DESCRIPTION
### Summary

node 24.16+ has a yauzl stream regression that hangs playwright's unzip
path on browser install. the runner's latest 24.x crossed that version,
so `npx playwright install chromium` stalled after download
ceiling on every pr. fixed upstream in playwright 1.60.0 ([#40747](https://github.com/microsoft/playwright/issues/40724)).

also adds `timeout-minutes` to the workflow jobs so a future hang fails
in minutes instead of burning a 6-hour runner.

### Tests & Checks

- all checks have passed.