### PR TITLE
refactor: use fixed marker atlas in `Points` renderable, remove public `Texture2DArray` export

### DIFF
--- a/examples/points/main.ts
+++ b/examples/points/main.ts
@@ -6,7 +6,6 @@ import {
   Points,
   OrthographicCamera,
   OmeZarrImageSource,
-  Texture2DArray,
   LayerState,
   ImageLayer,
   Color,
@@ -60,8 +59,7 @@ class Particles extends Layer {
   public readonly type = "Particles";
   private readonly points_: vec3[] = [];
   private readonly color_: Color;
-  private readonly markerIndex_: number = 0;
-  private static markerAtlas_: Texture2DArray;
+  private readonly marker_: Marker;
   private needsUpdate_: boolean = true;
   private depth_: number = 0;
 
@@ -70,7 +68,7 @@ class Particles extends Layer {
     this.setState("initialized");
     this.points_ = points;
     this.color_ = Color.from(color);
-    this.markerIndex_ = marker === "circle" ? 0 : marker === "square" ? 1 : 2;
+    this.marker_ = marker;
     this.refreshPointsRenderable();
     this.setState("ready");
   }
@@ -100,80 +98,12 @@ class Particles extends Layer {
         position: p,
         color: Color.from([r / zScale, g / zScale, b / zScale]),
         size: 20.0 / zScale,
-        markerIndex: this.markerIndex_,
+        marker: this.marker_,
       };
     });
-    const pointsRenderable = new Points(scaledPoints, Particles.markerAtlas);
+    const pointsRenderable = new Points(scaledPoints);
     this.objects.length = 0;
     this.addObject(pointsRenderable);
-  }
-
-  private static get markerAtlas() {
-    if (!Particles.markerAtlas_) {
-      Particles.markerAtlas_ = Particles.createMarkerAtlas();
-    }
-    return Particles.markerAtlas_;
-  }
-
-  private static createMarkerAtlas() {
-    const square = (size: number) => {
-      const w = size;
-      const h = size;
-      const data = new Float32Array(w * h);
-      data.fill(1.0);
-      return data;
-    };
-
-    const circle = (size: number) => {
-      const w = size;
-      const h = size;
-      const data = new Float32Array(w * h);
-      for (let i = 0; i < h; i++) {
-        for (let j = 0; j < w; j++) {
-          if ((i - h / 2) ** 2 + (j - w / 2) ** 2 < (w / 2) ** 2) {
-            data[i * w + j] = 1.0;
-          }
-        }
-      }
-      return data;
-    };
-
-    const triangle = (size: number) => {
-      const w = size;
-      const h = size;
-      const data = new Float32Array(w * h);
-      for (let i = 0; i < h; i++) {
-        for (let j = 0; j < w; j++) {
-          if (j >= (w - i) / 2 && j <= (w + i) / 2) {
-            data[i * w + j] = 1.0;
-          }
-        }
-      }
-      return data;
-    };
-
-    const SPRITE_SIZE = 256;
-    const numMarkers = 3;
-    const pixelsPerMarkerSprite = SPRITE_SIZE * SPRITE_SIZE;
-    const data = new Float32Array(numMarkers * pixelsPerMarkerSprite);
-    const squareData = square(SPRITE_SIZE);
-    const circleData = circle(SPRITE_SIZE);
-    const triangleData = triangle(SPRITE_SIZE);
-    for (let i = 0; i < pixelsPerMarkerSprite; i++) {
-      data[i] = circleData[i];
-      data[i + pixelsPerMarkerSprite] = squareData[i];
-      data[i + 2 * pixelsPerMarkerSprite] = triangleData[i];
-    }
-
-    // TODO: this uses f32 values, which are not (by defualt) filterable in WebGL2
-    // to enable this, we can check/add OES_texture_float_linear.
-    // we also don't need the precision of f32 for this so I'd like to use an R8
-    // texture instead, but our Texture class does not yet support it.
-    const texture = new Texture2DArray(data, SPRITE_SIZE, SPRITE_SIZE);
-    texture.wrapR = "clamp_to_edge";
-    texture.wrapS = "clamp_to_edge";
-    texture.wrapT = "clamp_to_edge";
-    return texture;
   }
 }
 const ribosomes = new Particles(ribosomeLocations, Color.RED, "circle");

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,5 @@ export type { LayerState } from "./core/layer";
 export type { Overlay } from "./idetik";
 export type { SliceCoordinates } from "./data/chunk";
 
-export { Texture2DArray } from "./objects/textures/texture_2d_array";
 export { Color } from "./math/color";
 export type { ColorLike } from "./math/color";

--- a/src/objects/renderable/points.ts
+++ b/src/objects/renderable/points.ts
@@ -1,46 +1,45 @@
 import { vec3 } from "gl-matrix";
 
-import { Color } from "../../math/color";
+import { Color, ColorLike } from "../../math/color";
 import { RenderableObject } from "../../core/renderable_object";
 import { Texture2DArray } from "../textures/texture_2d_array";
 import { Geometry } from "../../core/geometry";
 
+type Marker = "circle" | "square" | "triangle";
+
+const MARKER_INDEX: Record<Marker, number> = {
+  circle: 0,
+  square: 1,
+  triangle: 2,
+};
+
 // TODO: add a border (or "secondary") color to improve contrast against background
 type PointProperties = {
   position: vec3;
-  color: Color;
+  color: ColorLike;
   size: number;
-  markerIndex: number;
+  marker: Marker;
 };
 
 export class Points extends RenderableObject {
-  private atlas_: Texture2DArray;
-
-  constructor(points: PointProperties[], markerAtlas: Texture2DArray) {
+  constructor(points: PointProperties[]) {
     super();
     this.programName = "points";
-    this.atlas_ = markerAtlas;
 
-    points.forEach((point) => {
-      const marker = point.markerIndex;
-      if (marker < 0 || marker >= this.atlas_.depth) {
-        throw new Error(
-          `Markers must be in the range [0, ${this.atlas_.depth - 1}] (number of markers in atlas)`
-        );
-      }
+    const vertexData = points.flatMap((point) => {
+      const color = Color.from(point.color);
+      return [
+        point.position[0],
+        point.position[1],
+        point.position[2],
+        color.r,
+        color.g,
+        color.b,
+        color.a,
+        point.size,
+        MARKER_INDEX[point.marker],
+      ];
     });
-
-    const vertexData = points.flatMap((point) => [
-      point.position[0],
-      point.position[1],
-      point.position[2],
-      point.color.r,
-      point.color.g,
-      point.color.b,
-      point.color.a,
-      point.size,
-      point.markerIndex,
-    ]);
     const geometry = new Geometry(vertexData, [], "points");
 
     geometry.addAttribute({
@@ -65,10 +64,80 @@ export class Points extends RenderableObject {
     });
 
     this.geometry = geometry;
-    this.setTexture(0, this.atlas_);
+    this.setTexture(0, getMarkerAtlas());
   }
 
   public get type() {
     return "Points";
   }
+}
+
+let markerAtlas: Texture2DArray | undefined;
+
+// The marker atlas is a fixed set of sprites shared by all Points instances.
+// Each marker in `Marker` maps to a slice in the atlas (see `MARKER_INDEX`).
+function getMarkerAtlas(): Texture2DArray {
+  if (!markerAtlas) {
+    markerAtlas = createMarkerAtlas();
+  }
+  return markerAtlas;
+}
+
+function createMarkerAtlas(): Texture2DArray {
+  const square = (size: number) => {
+    const data = new Float32Array(size * size);
+    data.fill(1.0);
+    return data;
+  };
+
+  const circle = (size: number) => {
+    const data = new Float32Array(size * size);
+    for (let i = 0; i < size; i++) {
+      for (let j = 0; j < size; j++) {
+        if ((i - size / 2) ** 2 + (j - size / 2) ** 2 < (size / 2) ** 2) {
+          data[i * size + j] = 1.0;
+        }
+      }
+    }
+    return data;
+  };
+
+  const triangle = (size: number) => {
+    const data = new Float32Array(size * size);
+    for (let i = 0; i < size; i++) {
+      for (let j = 0; j < size; j++) {
+        if (j >= (size - i) / 2 && j <= (size + i) / 2) {
+          data[i * size + j] = 1.0;
+        }
+      }
+    }
+    return data;
+  };
+
+  const SPRITE_SIZE = 256;
+  const pixelsPerMarkerSprite = SPRITE_SIZE * SPRITE_SIZE;
+  const sprites: Record<Marker, Float32Array> = {
+    circle: circle(SPRITE_SIZE),
+    square: square(SPRITE_SIZE),
+    triangle: triangle(SPRITE_SIZE),
+  };
+
+  const numMarkers = Object.keys(sprites).length;
+  const data = new Float32Array(numMarkers * pixelsPerMarkerSprite);
+  for (const [marker, sprite] of Object.entries(sprites) as [
+    Marker,
+    Float32Array,
+  ][]) {
+    data.set(sprite, MARKER_INDEX[marker] * pixelsPerMarkerSprite);
+  }
+
+  // TODO: this uses f32 values, which are not (by default) filterable in WebGL2
+  // to enable this, we can check/add OES_texture_float_linear.
+  // we also don't need the precision of f32 for this so I'd like to use an R8
+  // texture instead, but our Texture class does not yet support it.
+  const texture = new Texture2DArray(data, SPRITE_SIZE, SPRITE_SIZE);
+  texture.wrapR = "clamp_to_edge";
+  texture.wrapS = "clamp_to_edge";
+  texture.wrapT = "clamp_to_edge";
+  return texture;
 }


### PR DESCRIPTION
### Summary
Points no longer takes a runtime `Texture2DArray` marker atlas. Instead it exposes a fixed set of marker shapes via a `Marker = "circle" | "square" | "triangle"` type, mapped to internal indices and backed by a procedurally generated atlas shared across all instances. This lets us drop `Texture2DArray` from the public API.

Point color now accepts `ColorLike`, matching the rest of the public API.

### Related Issue
Closes N/A

### Tests & Checks
Tested the points example and it looks the same
All other tests pass