### PR TITLE
fix: export memory stats type publicly

### DIFF
--- a/src/idetik.ts
+++ b/src/idetik.ts
@@ -29,7 +29,7 @@ export type IdetikContext = {
 
 // JS heap usage from the non-standard performance.memory API.
 // Chromium only, undefined where the API is unavailable.
-type MemoryStats = {
+export type MemoryStats = {
   cpuChunkBytes: number;
   cpuChunkCount: number;
   gpuTextureBytes: number;

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,7 +37,7 @@ export {
 export type { ChannelProps } from "./core/channel";
 export type { Image as OmeZarrImage } from "./data/ome_zarr/0.4/image";
 export type { LayerState } from "./core/layer";
-export type { Overlay } from "./idetik";
+export type { MemoryStats, Overlay } from "./idetik";
 export type { SliceCoordinates } from "./data/chunk";
 
 export { Color } from "./math/color";


### PR DESCRIPTION
### Summary

this pr exports the `MemoryStats` type for public consumption. 

### Tests & Checks

- all tests have passed.