### PR TITLE
feat: add async `OmeZarrImageSource` API that pre-opens the loader

### DIFF
--- a/examples/image2d_from_omezarr4d_hcs/main.ts
+++ b/examples/image2d_from_omezarr4d_hcs/main.ts
@@ -64,7 +64,7 @@ const onImageChange = async () => {
   viewport.removeAllLayers();
   const imageUrl =
     plateUrl + "/" + wellSelector.value + "/" + imageSelector.value;
-  const source = OmeZarrImageSource.fromHttp({ url: imageUrl });
+  const source = await OmeZarrImageSource.fromHttp({ url: imageUrl });
   const omeroDefaults = await loadOmeroDefaults(source);
   const omeroDefaultZ = omeroDefaults?.defaultZ ?? 0;
   const initZ = (omeroDefaultZ / HIGH_RES_NUM_SLICES) * LOW_RES_Z_SCALE;

--- a/examples/image_2d/main.ts
+++ b/examples/image_2d/main.ts
@@ -93,16 +93,14 @@ const config: DatasetConfig = parsed.preset ?? {
   contrastLimits: [0, 65535],
 };
 
-const source = OmeZarrImageSource.fromHttp({
-  url: config.url,
-  version: config.version,
-});
-
 const datasetInfoDiv = document.querySelector<HTMLDivElement>("#dataset-info")!;
 datasetInfoDiv.textContent = `Loading ${config.label}…\n${config.url}`;
 
-const loader = await source.open();
-const dimensions = loader.getSourceDimensionMap();
+const source = await OmeZarrImageSource.fromHttp({
+  url: config.url,
+  version: config.version,
+});
+const dimensions = source.getDimensions();
 
 const xLod = dimensions.x.lods[0];
 const yLod = dimensions.y.lods[0];
@@ -121,7 +119,7 @@ if (tLod) {
   sliceCoords.t = tLod.translation + midIndex * tLod.scale;
 }
 
-const channelCount = dimensions.c?.lods[0].size ?? 1;
+const channelCount = source.getChannelCount();
 const channelProps: ChannelProps[] = Array.from(
   { length: channelCount },
   (_, idx) =>
@@ -300,7 +298,7 @@ void idetik;
 
 function formatDatasetInfo(
   cfg: DatasetConfig,
-  dims: ReturnType<typeof loader.getSourceDimensionMap>
+  dims: ReturnType<typeof source.getDimensions>
 ): string {
   const xL = dims.x.lods[0];
   const yL = dims.y.lods[0];

--- a/examples/image_series_labels_overlay/main.ts
+++ b/examples/image_series_labels_overlay/main.ts
@@ -17,12 +17,11 @@ const fovName = "B/3/000000";
 const imageUrl = `${baseUrl}/2024_11_07_A549_SEC61_DENV_cropped.zarr/${fovName}`;
 const labelsUrl = `${baseUrl}/2024_11_07_A549_SEC61_DENV_tracking.zarr/${fovName}`;
 
-const imageSource = OmeZarrImageSource.fromHttp({ url: imageUrl });
-const labelsSource = OmeZarrImageSource.fromHttp({ url: labelsUrl });
+const imageSource = await OmeZarrImageSource.fromHttp({ url: imageUrl });
+const labelsSource = await OmeZarrImageSource.fromHttp({ url: labelsUrl });
 
 const lod = 0;
-const loader = await imageSource.open();
-const dimensions = loader.getSourceDimensionMap();
+const dimensions = imageSource.getDimensions();
 
 const tLod = dimensions.t!.lods[lod];
 const tMin = 0;

--- a/examples/multi_viewport/main.ts
+++ b/examples/multi_viewport/main.ts
@@ -33,7 +33,7 @@ const volumeCenter = vec3.fromValues(
 );
 
 // shared source between viewports
-const source = OmeZarrImageSource.fromHttp({ url });
+const source = await OmeZarrImageSource.fromHttp({ url });
 
 // Shared timepoint across all viewports
 const sharedTime = { t: 400 };

--- a/examples/points/main.ts
+++ b/examples/points/main.ts
@@ -117,9 +117,8 @@ ribosomes.setDepth(INITIAL_Z_POSITION);
 ferritin.setDepth(INITIAL_Z_POSITION);
 virusLike.setDepth(INITIAL_Z_POSITION);
 
-const imageSource = OmeZarrImageSource.fromHttp({ url: imageUrl });
-const loader = await imageSource.open();
-const dimensions = loader.getSourceDimensionMap();
+const imageSource = await OmeZarrImageSource.fromHttp({ url: imageUrl });
+const dimensions = imageSource.getDimensions();
 
 const zDimName = "z";
 const zMin = 0;

--- a/examples/volume_rendering/main.ts
+++ b/examples/volume_rendering/main.ts
@@ -12,7 +12,7 @@ import {
 
 const url =
   "https://public.czbiohub.org/organelle_box/datasets/A549/organelle_box_crop_v1.zarr/CLTA/PFA/002000/";
-const source = OmeZarrImageSource.fromHttp({ url });
+const source = await OmeZarrImageSource.fromHttp({ url });
 const sliceCoords = {
   t: 0,
   z: undefined,

--- a/src/data/chunk_manager.ts
+++ b/src/data/chunk_manager.ts
@@ -9,6 +9,7 @@ export type QueueStats = {
 import { ChunkStore } from "./chunk_store";
 import { ChunkStoreView } from "./chunk_store_view";
 import { ImageSourcePolicy } from "../core/image_source_policy";
+import { Logger } from "../utilities/logger";
 
 export class ChunkManager {
   private readonly stores_ = new Map<ChunkSource, ChunkStore>();
@@ -54,11 +55,19 @@ export class ChunkManager {
     const newPending = initializeStore();
     this.pendingStores_.set(source, newPending);
 
-    const store = await newPending;
-    this.stores_.set(source, store);
-    this.pendingStores_.delete(source);
-
-    return store;
+    try {
+      const store = await newPending;
+      this.stores_.set(source, store);
+      return store;
+    } catch (error) {
+      Logger.error(
+        "ChunkManager",
+        `Failed to open chunk source: ${String(error)}`
+      );
+      throw error;
+    } finally {
+      this.pendingStores_.delete(source);
+    }
   }
 
   public update() {

--- a/src/data/ome_zarr/image_source.ts
+++ b/src/data/ome_zarr/image_source.ts
@@ -111,7 +111,7 @@ export class OmeZarrImageSource {
   }
 
   /**
-   * Creates an OmeZarrImageSource from a local filesystem directory.
+   * Creates and opens an OmeZarrImageSource from a local filesystem directory.
    *
    * @param directory return value of `window.showDirectoryPicker()` which gives the browser
    *    permission to access a directory (only works in Chrome/Edge)

--- a/src/data/ome_zarr/image_source.ts
+++ b/src/data/ome_zarr/image_source.ts
@@ -11,6 +11,7 @@ import {
   parseOmeZarrImage,
   Version as OmeZarrVersion,
 } from "./metadata_loaders";
+import { SourceDimensionMap } from "../chunk";
 
 type OmeZarrImageSourceProps = {
   location: Location<Readable>;
@@ -33,12 +34,16 @@ export class OmeZarrImageSource {
   readonly location: Location<Readable>;
   readonly version?: OmeZarrVersion;
 
+  private loader_?: OmeZarrImageLoader;
+
   private constructor(props: OmeZarrImageSourceProps) {
     this.location = props.location;
     this.version = props.version;
   }
 
   public async open(): Promise<OmeZarrImageLoader> {
+    if (this.loader_) return this.loader_;
+
     let zarrVersion = omeZarrToZarrVersion(this.version);
     const root = await openGroup(this.location, zarrVersion);
     const adaptedOmeImage = parseOmeZarrImage(root.attrs);
@@ -69,25 +74,40 @@ export class OmeZarrImageSource {
         `Mismatch between number of axes (${axes.length}) and array shape (${shape.length})`
       );
     }
-    return new OmeZarrImageLoader({
-      metadata,
-      arrays,
-      arrayParams,
-    });
+    this.loader_ = new OmeZarrImageLoader({ metadata, arrays, arrayParams });
+    return this.loader_;
+  }
+
+  public getDimensions(): SourceDimensionMap {
+    if (!this.loader_) {
+      throw new Error(
+        "OmeZarrImageSource.getDimensions() requires the source to be opened first; " +
+          "use `await OmeZarrImageSource.fromHttp({ url })` or `await source.open()`."
+      );
+    }
+    return this.loader_.getSourceDimensionMap();
+  }
+
+  public getChannelCount(): number {
+    return this.getDimensions().c?.lods[0].size ?? 1;
   }
 
   /**
-   * Creates an OmeZarrImageSource from an HTTP(S) URL.
+   * Creates and opens an OmeZarrImageSource from an HTTP(S) URL.
    *
-   * @param url URL of Zarr root
-   * @param version OME-Zarr version
+   * @param props.url URL of the Zarr root
+   * @param props.version OME-Zarr version
    */
-  public static fromHttp(props: HttpOmeZarrImageSourceProps) {
+  public static async fromHttp(
+    props: HttpOmeZarrImageSourceProps
+  ): Promise<OmeZarrImageSource> {
     const store = new FetchStore(props.url);
-    return new OmeZarrImageSource({
+    const source = new OmeZarrImageSource({
       location: new Location(store),
       version: props.version,
     });
+    await source.open();
+    return source;
   }
 
   /**
@@ -99,11 +119,15 @@ export class OmeZarrImageSource {
    * @param path path to image, beginning with "/". This argument allows the application to only
    *    ask the user once for permission to the root directory
    */
-  public static fromFileSystem(props: FileSystemOmeZarrImageSourceProps) {
+  public static async fromFileSystem(
+    props: FileSystemOmeZarrImageSourceProps
+  ): Promise<OmeZarrImageSource> {
     const store = new WebFileSystemStore(props.directory);
-    return new OmeZarrImageSource({
+    const source = new OmeZarrImageSource({
       location: new Location(store, props.path),
       version: props.version,
     });
+    await source.open();
+    return source;
   }
 }


### PR DESCRIPTION
### Summary
Opening a source and getting basic information about it is an unnecessarily clunky process: `OmeZarrImageSource.fromHttp({ url })` (sync), then `source.open()` (async), then get dimensions/channel count out of the returned loader (`loader.getSourceDimensionMap()`).

This PR changes that to make `OmeZarrImageSource.fromHttp` and `OmeZarrImageSource.fromFilesystem` async factories that also open the source. This also adds `getDimensions` and `getChannelCount` on the source, exposing information from the now-opened loader. In the future we can refactor further to possibly consolidate the source/loader, but I think this API should be more ergonomic and doesn't need changes with that potential refactor.

I also added the try/except/finally block to fix #562 since it's somewhat related. If a source failed to open, `ChunkManager` cached the rejected promise forever, so it never retried. A follow-up PR will simplify this code further, but it's worth this quick correctness fix here.

### Related Issue
Closes #562

### Tests & Checks
Tested existing examples, and they all work as expected
