### PR TITLE
refactor!: make the layer/chunk data path synchronous

### DIFF
--- a/src/core/layer.ts
+++ b/src/core/layer.ts
@@ -61,10 +61,8 @@ export abstract class Layer {
 
   public onEvent(_: EventContext): void {}
 
-  // called when a layer is added to a viewport
   public onAttached(_context: IdetikContext): void {}
 
-  // called when a layer is removed from a viewport
   public onDetached(_context: IdetikContext): void {}
 
   public get objects() {

--- a/src/core/layer.ts
+++ b/src/core/layer.ts
@@ -61,11 +61,11 @@ export abstract class Layer {
 
   public onEvent(_: EventContext): void {}
 
-  // Synchronous attach/detach. The source must be opened before a layer is attached
-  // (see ChunkManager.viewFor) so creating the layer's view needs no async step.
-  public attach(_context: IdetikContext): void {}
+  // called when a layer is added to a viewport
+  public onAttached(_context: IdetikContext): void {}
 
-  public detach(): void {}
+  // called when a layer is removed from a viewport
+  public onDetached(_context: IdetikContext): void {}
 
   public get objects() {
     return this.objects_;

--- a/src/core/layer.ts
+++ b/src/core/layer.ts
@@ -61,13 +61,11 @@ export abstract class Layer {
 
   public onEvent(_: EventContext): void {}
 
-  // TODO: Consider making this an abstract method once chunk manager
-  // integration is finalized. Most layers will likely need access to the chunk
-  // manager, but for now, we allow optional overrides to avoid requiring
-  // placeholder implementations.
-  public async onAttached(_context: IdetikContext) {}
+  // Synchronous attach/detach. The source must be opened before a layer is attached
+  // (see ChunkManager.viewFor) so creating the layer's view needs no async step.
+  public attach(_context: IdetikContext): void {}
 
-  public onDetached(_context: IdetikContext): void {}
+  public detach(): void {}
 
   public get objects() {
     return this.objects_;

--- a/src/core/viewport.ts
+++ b/src/core/viewport.ts
@@ -29,7 +29,7 @@ export class Viewport {
   public readonly events: EventDispatcher;
   public cameraControls?: CameraControls;
 
-  // Carried only to relay to `layer.onAttached` / `layer.onDetached`.
+  // Carried only to relay to `layer.attach` / `layer.detach`.
   // To be removed when the chunk-infrastructure refactor folds chunk management
   // into the source and the attach lifecycle goes away.
   private readonly context_: IdetikContext;
@@ -72,7 +72,7 @@ export class Viewport {
 
   public addLayer(layer: Layer): void {
     this.layers_.push(layer);
-    layer.onAttached(this.context_);
+    layer.attach(this.context_);
   }
 
   public removeLayer(layer: Layer): void {
@@ -81,12 +81,12 @@ export class Viewport {
       throw new Error(`Layer to remove not found: ${layer}`);
     }
     this.layers_.splice(index, 1);
-    layer.onDetached(this.context_);
+    layer.detach();
   }
 
   public removeAllLayers(): void {
     for (const layer of this.layers_) {
-      layer.onDetached(this.context_);
+      layer.detach();
     }
     this.layers_ = [];
   }

--- a/src/core/viewport.ts
+++ b/src/core/viewport.ts
@@ -29,7 +29,7 @@ export class Viewport {
   public readonly events: EventDispatcher;
   public cameraControls?: CameraControls;
 
-  // Carried only to relay to `layer.attach` / `layer.detach`.
+  // Carried only to relay to `layer.onAttached` / `layer.onDetached`.
   // To be removed when the chunk-infrastructure refactor folds chunk management
   // into the source and the attach lifecycle goes away.
   private readonly context_: IdetikContext;
@@ -72,7 +72,7 @@ export class Viewport {
 
   public addLayer(layer: Layer): void {
     this.layers_.push(layer);
-    layer.attach(this.context_);
+    layer.onAttached(this.context_);
   }
 
   public removeLayer(layer: Layer): void {
@@ -81,12 +81,12 @@ export class Viewport {
       throw new Error(`Layer to remove not found: ${layer}`);
     }
     this.layers_.splice(index, 1);
-    layer.detach();
+    layer.onDetached(this.context_);
   }
 
   public removeAllLayers(): void {
     for (const layer of this.layers_) {
-      layer.detach();
+      layer.onDetached(this.context_);
     }
     this.layers_ = [];
   }

--- a/src/data/chunk.ts
+++ b/src/data/chunk.ts
@@ -99,7 +99,8 @@ export type SliceCoordinates = {
 };
 
 export type ChunkSource = {
-  open(): Promise<ChunkLoader>;
+  /** The source's loader. Sources are opened by their factory, so this is synchronous. */
+  getLoader(): ChunkLoader;
 };
 
 export type ChunkLoader = {

--- a/src/data/chunk.ts
+++ b/src/data/chunk.ts
@@ -99,7 +99,6 @@ export type SliceCoordinates = {
 };
 
 export type ChunkSource = {
-  /** The source's loader. Sources are opened by their factory, so this is synchronous. */
   getLoader(): ChunkLoader;
 };
 

--- a/src/data/chunk_manager.ts
+++ b/src/data/chunk_manager.ts
@@ -25,11 +25,8 @@ export class ChunkManager {
     return chunkMemoryStats();
   }
 
-  /**
-   * Creates a view for a source. The source is opened by its factory
-   * (`OmeZarrImageSource.fromHttp(...)` / `fromFileSystem(...)`), so this is synchronous.
-   */
-  public viewFor(
+  /** Adds a view onto `source`'s store, creating the store on first use. */
+  public addView(
     source: ChunkSource,
     policy: ImageSourcePolicy
   ): ChunkStoreView {
@@ -38,7 +35,7 @@ export class ChunkManager {
       store = new ChunkStore(source.getLoader());
       this.stores_.set(source, store);
     }
-    return store.createView(policy);
+    return store.addView(policy);
   }
 
   public update() {

--- a/src/data/chunk_manager.ts
+++ b/src/data/chunk_manager.ts
@@ -25,7 +25,6 @@ export class ChunkManager {
     return chunkMemoryStats();
   }
 
-  /** Adds a view onto `source`'s store, creating the store on first use. */
   public addView(
     source: ChunkSource,
     policy: ImageSourcePolicy

--- a/src/data/chunk_manager.ts
+++ b/src/data/chunk_manager.ts
@@ -9,11 +9,9 @@ export type QueueStats = {
 import { ChunkStore } from "./chunk_store";
 import { ChunkStoreView } from "./chunk_store_view";
 import { ImageSourcePolicy } from "../core/image_source_policy";
-import { Logger } from "../utilities/logger";
 
 export class ChunkManager {
   private readonly stores_ = new Map<ChunkSource, ChunkStore>();
-  private readonly pendingStores_ = new Map<ChunkSource, Promise<ChunkStore>>();
   private readonly queue_ = new ChunkQueue();
 
   public get queueStats(): QueueStats {
@@ -27,47 +25,20 @@ export class ChunkManager {
     return chunkMemoryStats();
   }
 
-  public async addView(
+  /**
+   * Creates a view for a source. The source is opened by its factory
+   * (`OmeZarrImageSource.fromHttp(...)` / `fromFileSystem(...)`), so this is synchronous.
+   */
+  public viewFor(
     source: ChunkSource,
     policy: ImageSourcePolicy
-  ): Promise<ChunkStoreView> {
-    const store = await this.getOrCreateStore(source);
-    const view = store.createView(policy);
-    return view;
-  }
-
-  private async getOrCreateStore(source: ChunkSource): Promise<ChunkStore> {
-    const existing = this.stores_.get(source);
-    if (existing) {
-      return existing;
-    }
-
-    const pending = this.pendingStores_.get(source);
-    if (pending) {
-      return pending;
-    }
-
-    const initializeStore = async () => {
-      const loader = await source.open();
-      return new ChunkStore(loader);
-    };
-
-    const newPending = initializeStore();
-    this.pendingStores_.set(source, newPending);
-
-    try {
-      const store = await newPending;
+  ): ChunkStoreView {
+    let store = this.stores_.get(source);
+    if (!store) {
+      store = new ChunkStore(source.getLoader());
       this.stores_.set(source, store);
-      return store;
-    } catch (error) {
-      Logger.error(
-        "ChunkManager",
-        `Failed to open chunk source: ${String(error)}`
-      );
-      throw error;
-    } finally {
-      this.pendingStores_.delete(source);
     }
+    return store.createView(policy);
   }
 
   public update() {

--- a/src/data/chunk_store.ts
+++ b/src/data/chunk_store.ts
@@ -126,7 +126,7 @@ export class ChunkStore {
     return this.loader_.loadChunkData(chunk, signal);
   }
 
-  public createView(policy: ImageSourcePolicy): ChunkStoreView {
+  public addView(policy: ImageSourcePolicy): ChunkStoreView {
     const view = new ChunkStoreView(this, policy);
     this.views_.push(view);
     this.hasHadViews_ = true;

--- a/src/data/ome_zarr/image_source.ts
+++ b/src/data/ome_zarr/image_source.ts
@@ -16,6 +16,7 @@ import { SourceDimensionMap } from "../chunk";
 type OmeZarrImageSourceProps = {
   location: Location<Readable>;
   version?: OmeZarrVersion;
+  loader: OmeZarrImageLoader;
 };
 
 type HttpOmeZarrImageSourceProps = {
@@ -34,18 +35,28 @@ export class OmeZarrImageSource {
   readonly location: Location<Readable>;
   readonly version?: OmeZarrVersion;
 
-  private loader_?: OmeZarrImageLoader;
+  private readonly loader_: OmeZarrImageLoader;
 
+  /**
+   * Construct only via a static factory (`fromHttp`/`fromFileSystem`). A factory must
+   * fully open the data up front — e.g. via {@link openLoader}, which resolves to a
+   * ready loader or throws — and pass that loader in. The constructor therefore always
+   * receives an opened loader, so a source instance is never in a half-open state
+   * (`getLoader`/`getDimensions` cannot fail). To add a new factory, open the loader
+   * first, then `new OmeZarrImageSource({ location, version, loader })`.
+   */
   private constructor(props: OmeZarrImageSourceProps) {
     this.location = props.location;
     this.version = props.version;
+    this.loader_ = props.loader;
   }
 
-  public async open(): Promise<OmeZarrImageLoader> {
-    if (this.loader_) return this.loader_;
-
-    let zarrVersion = omeZarrToZarrVersion(this.version);
-    const root = await openGroup(this.location, zarrVersion);
+  private static async openLoader(
+    location: Location<Readable>,
+    version?: OmeZarrVersion
+  ): Promise<OmeZarrImageLoader> {
+    let zarrVersion = omeZarrToZarrVersion(version);
+    const root = await openGroup(location, zarrVersion);
     const adaptedOmeImage = parseOmeZarrImage(root.attrs);
     const images = adaptedOmeImage.multiscales;
     if (images.length !== 1) {
@@ -61,7 +72,7 @@ export class OmeZarrImageSource {
       zarrVersion = omeZarrToZarrVersion(adaptedOmeImage.originalVersion);
     }
     const arrayParams = metadata.datasets.map((d) =>
-      createZarrArrayParams(this.location, d.path, zarrVersion)
+      createZarrArrayParams(location, d.path, zarrVersion)
     );
     const arrays = await Promise.all(
       arrayParams.map((params) => openArrayFromParams(params))
@@ -74,22 +85,20 @@ export class OmeZarrImageSource {
         `Mismatch between number of axes (${axes.length}) and array shape (${shape.length})`
       );
     }
-    this.loader_ = new OmeZarrImageLoader({ metadata, arrays, arrayParams });
-    return this.loader_;
+    return new OmeZarrImageLoader({ metadata, arrays, arrayParams });
   }
 
   public getDimensions(): SourceDimensionMap {
-    if (!this.loader_) {
-      throw new Error(
-        "OmeZarrImageSource.getDimensions() requires the source to be opened first; " +
-          "use `await OmeZarrImageSource.fromHttp({ url })` or `await source.open()`."
-      );
-    }
     return this.loader_.getSourceDimensionMap();
   }
 
   public getChannelCount(): number {
     return this.getDimensions().c?.lods[0].size ?? 1;
+  }
+
+  /** The source's loader, for synchronous view creation by the chunk manager. */
+  public getLoader(): OmeZarrImageLoader {
+    return this.loader_;
   }
 
   /**
@@ -101,13 +110,9 @@ export class OmeZarrImageSource {
   public static async fromHttp(
     props: HttpOmeZarrImageSourceProps
   ): Promise<OmeZarrImageSource> {
-    const store = new FetchStore(props.url);
-    const source = new OmeZarrImageSource({
-      location: new Location(store),
-      version: props.version,
-    });
-    await source.open();
-    return source;
+    const location = new Location(new FetchStore(props.url));
+    const loader = await OmeZarrImageSource.openLoader(location, props.version);
+    return new OmeZarrImageSource({ location, version: props.version, loader });
   }
 
   /**
@@ -122,12 +127,11 @@ export class OmeZarrImageSource {
   public static async fromFileSystem(
     props: FileSystemOmeZarrImageSourceProps
   ): Promise<OmeZarrImageSource> {
-    const store = new WebFileSystemStore(props.directory);
-    const source = new OmeZarrImageSource({
-      location: new Location(store, props.path),
-      version: props.version,
-    });
-    await source.open();
-    return source;
+    const location = new Location(
+      new WebFileSystemStore(props.directory),
+      props.path
+    );
+    const loader = await OmeZarrImageSource.openLoader(location, props.version);
+    return new OmeZarrImageSource({ location, version: props.version, loader });
   }
 }

--- a/src/data/ome_zarr/image_source.ts
+++ b/src/data/ome_zarr/image_source.ts
@@ -37,11 +37,6 @@ export class OmeZarrImageSource {
 
   private readonly loader_: OmeZarrImageLoader;
 
-  /**
-   * Private: construct via a static factory (`fromHttp`/`fromFileSystem`). Factories open
-   * the loader up front and pass it in, so a source's loader is non-null.
-   * errors opening a source surface early, and `getLoader`/`getDimensions` always succeed
-   */
   private constructor(props: OmeZarrImageSourceProps) {
     this.location = props.location;
     this.version = props.version;

--- a/src/data/ome_zarr/image_source.ts
+++ b/src/data/ome_zarr/image_source.ts
@@ -38,12 +38,9 @@ export class OmeZarrImageSource {
   private readonly loader_: OmeZarrImageLoader;
 
   /**
-   * Construct only via a static factory (`fromHttp`/`fromFileSystem`). A factory must
-   * fully open the data up front — e.g. via {@link openLoader}, which resolves to a
-   * ready loader or throws — and pass that loader in. The constructor therefore always
-   * receives an opened loader, so a source instance is never in a half-open state
-   * (`getLoader`/`getDimensions` cannot fail). To add a new factory, open the loader
-   * first, then `new OmeZarrImageSource({ location, version, loader })`.
+   * Private: construct via a static factory (`fromHttp`/`fromFileSystem`). Factories open
+   * the loader up front and pass it in, so a source's loader is non-null.
+   * errors opening a source surface early, and `getLoader`/`getDimensions` always succeed
    */
   private constructor(props: OmeZarrImageSourceProps) {
     this.location = props.location;
@@ -96,7 +93,6 @@ export class OmeZarrImageSource {
     return this.getDimensions().c?.lods[0].size ?? 1;
   }
 
-  /** The source's loader, for synchronous view creation by the chunk manager. */
   public getLoader(): OmeZarrImageLoader {
     return this.loader_;
   }

--- a/src/layers/image_layer.ts
+++ b/src/layers/image_layer.ts
@@ -73,7 +73,7 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
     this.onPickValue_ = onPickValue;
   }
 
-  public onAttached(context: IdetikContext): void {
+  public onAttached(context: IdetikContext) {
     if (this.chunkStoreView_) {
       throw new Error(
         "ImageLayer cannot be attached to multiple viewports simultaneously."
@@ -100,7 +100,7 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
     }
   }
 
-  public onDetached(_context: IdetikContext): void {
+  public onDetached(_context: IdetikContext) {
     if (!this.chunkStoreView_) return;
     this.releaseAndRemoveChunks(this.visibleChunks_.keys());
     this.clearObjects();

--- a/src/layers/image_layer.ts
+++ b/src/layers/image_layer.ts
@@ -73,13 +73,13 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
     this.onPickValue_ = onPickValue;
   }
 
-  public attach(context: IdetikContext): void {
+  public onAttached(context: IdetikContext): void {
     if (this.chunkStoreView_) {
       throw new Error(
         "ImageLayer cannot be attached to multiple viewports simultaneously."
       );
     }
-    this.chunkStoreView_ = context.chunkManager.viewFor(
+    this.chunkStoreView_ = context.chunkManager.addView(
       this.source_,
       this.policy_
     );
@@ -100,7 +100,7 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
     }
   }
 
-  public detach(): void {
+  public onDetached(_context: IdetikContext): void {
     if (!this.chunkStoreView_) return;
     this.releaseAndRemoveChunks(this.visibleChunks_.keys());
     this.clearObjects();

--- a/src/layers/image_layer.ts
+++ b/src/layers/image_layer.ts
@@ -73,13 +73,13 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
     this.onPickValue_ = onPickValue;
   }
 
-  public async onAttached(context: IdetikContext) {
+  public attach(context: IdetikContext): void {
     if (this.chunkStoreView_) {
       throw new Error(
-        "ImageLayer cannot be attached to multiple contexts simultaneously."
+        "ImageLayer cannot be attached to multiple viewports simultaneously."
       );
     }
-    this.chunkStoreView_ = await context.chunkManager.addView(
+    this.chunkStoreView_ = context.chunkManager.viewFor(
       this.source_,
       this.policy_
     );
@@ -100,7 +100,7 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
     }
   }
 
-  public onDetached(_context: IdetikContext): void {
+  public detach(): void {
     if (!this.chunkStoreView_) return;
     this.releaseAndRemoveChunks(this.visibleChunks_.keys());
     this.clearObjects();

--- a/src/layers/label_layer.ts
+++ b/src/layers/label_layer.ts
@@ -66,7 +66,7 @@ export class LabelLayer extends Layer {
     this.outlineSelected_ = outlineSelected;
   }
 
-  public onAttached(context: IdetikContext): void {
+  public onAttached(context: IdetikContext) {
     if (this.chunkStoreView_) {
       throw new Error(
         "LabelLayer cannot be attached to multiple viewports simultaneously."
@@ -86,7 +86,7 @@ export class LabelLayer extends Layer {
     }
   }
 
-  public onDetached(_context: IdetikContext): void {
+  public onDetached(_context: IdetikContext) {
     if (!this.chunkStoreView_) return;
     this.releaseAndRemoveChunks(this.visibleChunks_.keys());
     this.clearObjects();

--- a/src/layers/label_layer.ts
+++ b/src/layers/label_layer.ts
@@ -66,13 +66,13 @@ export class LabelLayer extends Layer {
     this.outlineSelected_ = outlineSelected;
   }
 
-  public attach(context: IdetikContext): void {
+  public onAttached(context: IdetikContext): void {
     if (this.chunkStoreView_) {
       throw new Error(
         "LabelLayer cannot be attached to multiple viewports simultaneously."
       );
     }
-    this.chunkStoreView_ = context.chunkManager.viewFor(
+    this.chunkStoreView_ = context.chunkManager.addView(
       this.source_,
       this.policy_
     );
@@ -86,7 +86,7 @@ export class LabelLayer extends Layer {
     }
   }
 
-  public detach(): void {
+  public onDetached(_context: IdetikContext): void {
     if (!this.chunkStoreView_) return;
     this.releaseAndRemoveChunks(this.visibleChunks_.keys());
     this.clearObjects();

--- a/src/layers/label_layer.ts
+++ b/src/layers/label_layer.ts
@@ -66,13 +66,13 @@ export class LabelLayer extends Layer {
     this.outlineSelected_ = outlineSelected;
   }
 
-  public async onAttached(context: IdetikContext) {
+  public attach(context: IdetikContext): void {
     if (this.chunkStoreView_) {
       throw new Error(
-        "LabelLayer cannot be attached to multiple contexts simultaneously."
+        "LabelLayer cannot be attached to multiple viewports simultaneously."
       );
     }
-    this.chunkStoreView_ = await context.chunkManager.addView(
+    this.chunkStoreView_ = context.chunkManager.viewFor(
       this.source_,
       this.policy_
     );
@@ -86,7 +86,7 @@ export class LabelLayer extends Layer {
     }
   }
 
-  public onDetached(_context: IdetikContext): void {
+  public detach(): void {
     if (!this.chunkStoreView_) return;
     this.releaseAndRemoveChunks(this.visibleChunks_.keys());
     this.clearObjects();

--- a/src/layers/volume_layer.ts
+++ b/src/layers/volume_layer.ts
@@ -130,8 +130,13 @@ export class VolumeLayer extends Layer implements ChannelsEnabled {
     return volume;
   }
 
-  public attach(context: IdetikContext): void {
-    this.chunkStoreView_ = context.chunkManager.viewFor(
+  public onAttached(context: IdetikContext): void {
+    if (this.chunkStoreView_) {
+      throw new Error(
+        "VolumeLayer cannot be attached to multiple viewports simultaneously."
+      );
+    }
+    this.chunkStoreView_ = context.chunkManager.addView(
       this.source_,
       this.sourcePolicy_
     );
@@ -142,7 +147,7 @@ export class VolumeLayer extends Layer implements ChannelsEnabled {
     );
   }
 
-  public detach(): void {
+  public onDetached(_context: IdetikContext): void {
     if (!this.chunkStoreView_) return;
     for (const volume of this.currentVolumes_.values()) {
       this.releaseAndRemoveVolume(volume);

--- a/src/layers/volume_layer.ts
+++ b/src/layers/volume_layer.ts
@@ -130,8 +130,8 @@ export class VolumeLayer extends Layer implements ChannelsEnabled {
     return volume;
   }
 
-  public async onAttached(context: IdetikContext) {
-    this.chunkStoreView_ = await context.chunkManager.addView(
+  public attach(context: IdetikContext): void {
+    this.chunkStoreView_ = context.chunkManager.viewFor(
       this.source_,
       this.sourcePolicy_
     );
@@ -142,7 +142,7 @@ export class VolumeLayer extends Layer implements ChannelsEnabled {
     );
   }
 
-  public onDetached(_context: IdetikContext): void {
+  public detach(): void {
     if (!this.chunkStoreView_) return;
     for (const volume of this.currentVolumes_.values()) {
       this.releaseAndRemoveVolume(volume);

--- a/src/layers/volume_layer.ts
+++ b/src/layers/volume_layer.ts
@@ -130,7 +130,7 @@ export class VolumeLayer extends Layer implements ChannelsEnabled {
     return volume;
   }
 
-  public onAttached(context: IdetikContext): void {
+  public onAttached(context: IdetikContext) {
     if (this.chunkStoreView_) {
       throw new Error(
         "VolumeLayer cannot be attached to multiple viewports simultaneously."
@@ -147,7 +147,7 @@ export class VolumeLayer extends Layer implements ChannelsEnabled {
     );
   }
 
-  public onDetached(_context: IdetikContext): void {
+  public onDetached(_context: IdetikContext) {
     if (!this.chunkStoreView_) return;
     for (const volume of this.currentVolumes_.values()) {
       this.releaseAndRemoveVolume(volume);

--- a/test/chunk_store_view.test.ts
+++ b/test/chunk_store_view.test.ts
@@ -9,7 +9,7 @@ describe("ChunkStoreView disposal", () => {
     const loader = createMockLoader();
     const store = new ChunkStore(loader);
     const policy = createNoPrefetchPolicy();
-    const view = store.createView(policy);
+    const view = store.addView(policy);
     const viewport = createTestViewport();
 
     // mark some chunks as visible/needed
@@ -44,8 +44,8 @@ describe("ChunkStoreView disposal", () => {
     const store = new ChunkStore(loader);
     const policy = createNoPrefetchPolicy();
 
-    const view1 = store.createView(policy);
-    const view2 = store.createView(policy);
+    const view1 = store.addView(policy);
+    const view2 = store.addView(policy);
     const viewport = createTestViewport();
 
     // Both views mark same chunks as needed


### PR DESCRIPTION
### Summary
Adding a layer to a `Viewport` (previously `LayerManager`) was hiding async behavior: `addLayer` wasn't async but called the async `onAttached`. In several layers `onAttached` awaited `ChunkManager.addView`, which in turn awaited `source.open()`. That hidden async caused a race — two layers sharing a source could both miss the not-yet-resolved store and each create their own, defeating the whole point of keying stores by source.

This makes the data path synchronous end-to-end:
- Since #681, `OmeZarrImageSource` opens its loader in the `fromHttp`/`fromFileSystem` factories. This PR follows up, removing the lazy `open()` pathway so the loader is now non-null. Opening a source now _always_ happens up front in a factory so failures surface at construction instead of at attach.
- `ChunkManager.addView` is now synchronous: look up or create the store, return a fresh view. The `pendingStores_` promise-cache and its `getOrCreateStore` dance existed only to guard the race the async-ness created, so they're deleted.
- Layer lifecycle hooks `onAttach`/`onDetach` are now synchronous, which is fine for how we use them, especially given the comment in `viewport.ts` that they may go away. I think this is a step in that direction if we want to take it.

BREAKING CHANGE: `ChunkSource.open()` is removed; use `getLoader()` (sources open eagerly via `fromHttp`/`fromFileSystem`).

### Related Issue
Follow-up for #681 
Closes #399 

### Tests & Checks
Existing automated tests pass, manually tested examples