### PR TITLE
ci: keep breaking changes in the 0.x range (breaking -> minor)

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -17,7 +17,7 @@
           { "type": "build", "release": false },
           { "type": "ci", "release": false },
           { "type": "chore", "release": "patch" },
-          { "breaking": true, "release": "major" }
+          { "breaking": true, "release": "minor" }
         ]
       }
     ],


### PR DESCRIPTION
### Summary
I accidentally released v1.0.0 with #683 - sorry!

This will prevent accidentally bumping the major version again for the time being.

Merging this should also trigger a release with the minor version bumped appropriately.