### PR TITLE
feat: add base-class guard for multiple layer attachment

### DIFF
--- a/src/core/layer.ts
+++ b/src/core/layer.ts
@@ -33,6 +33,7 @@ export abstract class Layer {
 
   private objects_: RenderableObject[] = [];
   private state_: LayerState = "initialized";
+  private attached_ = false;
   private readonly callbacks_: StateChangeCallback[] = [];
 
   private opacity_: number;
@@ -61,9 +62,25 @@ export abstract class Layer {
 
   public onEvent(_: EventContext): void {}
 
-  public onAttached(_context: IdetikContext): void {}
+  public onAttached(context: IdetikContext): void {
+    if (this.attached_) {
+      throw new Error(
+        `${this.type} cannot be attached to multiple viewports simultaneously.`
+      );
+    }
+    this.attach(context);
+    this.attached_ = true;
+  }
 
-  public onDetached(_context: IdetikContext): void {}
+  public onDetached(context: IdetikContext): void {
+    if (!this.attached_) return;
+    this.detach(context);
+    this.attached_ = false;
+  }
+
+  protected attach(_context: IdetikContext): void {}
+
+  protected detach(_context: IdetikContext): void {}
 
   public get objects() {
     return this.objects_;

--- a/src/core/viewport.ts
+++ b/src/core/viewport.ts
@@ -71,8 +71,8 @@ export class Viewport {
   }
 
   public addLayer(layer: Layer): void {
-    this.layers_.push(layer);
     layer.onAttached(this.context_);
+    this.layers_.push(layer);
   }
 
   public removeLayer(layer: Layer): void {

--- a/src/layers/image_layer.ts
+++ b/src/layers/image_layer.ts
@@ -73,12 +73,7 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
     this.onPickValue_ = onPickValue;
   }
 
-  public onAttached(context: IdetikContext) {
-    if (this.chunkStoreView_) {
-      throw new Error(
-        "ImageLayer cannot be attached to multiple viewports simultaneously."
-      );
-    }
+  protected attach(context: IdetikContext) {
     this.chunkStoreView_ = context.chunkManager.addView(
       this.source_,
       this.policy_
@@ -100,11 +95,10 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
     }
   }
 
-  public onDetached(_context: IdetikContext) {
-    if (!this.chunkStoreView_) return;
+  protected detach(_context: IdetikContext) {
     this.releaseAndRemoveChunks(this.visibleChunks_.keys());
     this.clearObjects();
-    this.chunkStoreView_.dispose();
+    this.chunkStoreView_?.dispose();
     this.chunkStoreView_ = undefined;
   }
 

--- a/src/layers/label_layer.ts
+++ b/src/layers/label_layer.ts
@@ -66,12 +66,7 @@ export class LabelLayer extends Layer {
     this.outlineSelected_ = outlineSelected;
   }
 
-  public onAttached(context: IdetikContext) {
-    if (this.chunkStoreView_) {
-      throw new Error(
-        "LabelLayer cannot be attached to multiple viewports simultaneously."
-      );
-    }
+  protected attach(context: IdetikContext) {
     this.chunkStoreView_ = context.chunkManager.addView(
       this.source_,
       this.policy_
@@ -86,11 +81,10 @@ export class LabelLayer extends Layer {
     }
   }
 
-  public onDetached(_context: IdetikContext) {
-    if (!this.chunkStoreView_) return;
+  protected detach(_context: IdetikContext) {
     this.releaseAndRemoveChunks(this.visibleChunks_.keys());
     this.clearObjects();
-    this.chunkStoreView_.dispose();
+    this.chunkStoreView_?.dispose();
     this.chunkStoreView_ = undefined;
   }
 

--- a/src/layers/volume_layer.ts
+++ b/src/layers/volume_layer.ts
@@ -130,12 +130,7 @@ export class VolumeLayer extends Layer implements ChannelsEnabled {
     return volume;
   }
 
-  public onAttached(context: IdetikContext) {
-    if (this.chunkStoreView_) {
-      throw new Error(
-        "VolumeLayer cannot be attached to multiple viewports simultaneously."
-      );
-    }
+  protected attach(context: IdetikContext) {
     this.chunkStoreView_ = context.chunkManager.addView(
       this.source_,
       this.sourcePolicy_
@@ -147,13 +142,12 @@ export class VolumeLayer extends Layer implements ChannelsEnabled {
     );
   }
 
-  public onDetached(_context: IdetikContext) {
-    if (!this.chunkStoreView_) return;
+  protected detach(_context: IdetikContext) {
     for (const volume of this.currentVolumes_.values()) {
       this.releaseAndRemoveVolume(volume);
     }
     this.clearObjects();
-    this.chunkStoreView_.dispose();
+    this.chunkStoreView_?.dispose();
     this.chunkStoreView_ = undefined;
   }
 

--- a/test/layer.test.ts
+++ b/test/layer.test.ts
@@ -1,16 +1,32 @@
 import { expect, test, vi } from "vitest";
 
 import { Layer } from "@/core/layer";
+import { IdetikContext } from "@/idetik";
 
 class TestLayer extends Layer {
   public readonly type = "TestLayer";
+
+  public attachCount = 0;
+  public detachCount = 0;
+  public throwOnAttach = false;
 
   public update() {}
 
   public setStateReady() {
     this.setState("ready");
   }
+
+  protected attach() {
+    if (this.throwOnAttach) throw new Error("attach failed");
+    this.attachCount++;
+  }
+
+  protected detach() {
+    this.detachCount++;
+  }
 }
+
+const context = {} as IdetikContext;
 
 test("Default layer state is 'initialized'", () => {
   const layer = new TestLayer();
@@ -35,4 +51,40 @@ test("Remove state change callback", () => {
   layer.setStateReady();
 
   expect(callback).toHaveBeenCalledTimes(0);
+});
+
+test("Attaching to a second viewport while attached throws", () => {
+  const layer = new TestLayer();
+  layer.onAttached(context);
+
+  expect(() => layer.onAttached(context)).toThrow(
+    "TestLayer cannot be attached to multiple viewports simultaneously."
+  );
+  expect(layer.attachCount).toBe(1);
+});
+
+test("onDetached is a no-op when not attached", () => {
+  const layer = new TestLayer();
+  layer.onDetached(context);
+
+  expect(layer.detachCount).toBe(0);
+});
+
+test("Re-attaching after detach is allowed", () => {
+  const layer = new TestLayer();
+  layer.onAttached(context);
+  layer.onDetached(context);
+
+  expect(() => layer.onAttached(context)).not.toThrow();
+  expect(layer.attachCount).toBe(2);
+});
+
+test("A failed attach does not mark the layer as attached", () => {
+  const layer = new TestLayer();
+  layer.throwOnAttach = true;
+  expect(() => layer.onAttached(context)).toThrow("attach failed");
+
+  // onDetached must be a no-op — the layer was never fully attached.
+  layer.onDetached(context);
+  expect(layer.detachCount).toBe(0);
 });


### PR DESCRIPTION
### Summary
The "a layer can't be attached to two viewports at once" check was duplicated across `ImageLayer`, `LabelLayer`, and `VolumeLayer` and relied on the presence of `layer.chunkStoreView_` as a proxy for attachment. It's an attachment-lifecycle invariant, so this moves it into the `Layer` base class. This removes any distinction between layers that _can_ be attached to multiple viewports, and layers that _can't_.

Two notes:
1. `Viewport.addLayer` now calls `onAttached` _before_ registering the layer, so a layer that fails to attach isn't left in `viewport.layers_`.
2. `attached_` is set only after `attach()` succeeds, so a failed attach leaves the layer unattached.

An alternative; we could instead have layers keep track of _which_ viewport they're attached to (if any) instead of having "attached_" and then needing to also pass in the viewport on `update`. Moving from one viewport to another would then be like a reparenting operation.

Note that there can be a resource leak if a layer ends up partially initialized but throws during `onAttached`. For example the layers that use the chunk store now can throw on channel validation _after_ getting a `ChunkStoreView`. For now I think this will just be up to the layer to clean up (that is: make `attach()` atomic). This is pre-existing behavior, so I can address in a follow-up.

### Related Issue
Closes #687
Follow-up from https://github.com/chanzuckerberg/idetik/pull/683#discussion_r3437275176.

### Tests & Checks
All examples still work, no changes needed
Existing tests pass
A few new tests added to check the behavior
