### PR TITLE
refactor: decouple chunk store from chunk loader

### DIFF
--- a/src/data/chunk.ts
+++ b/src/data/chunk.ts
@@ -99,7 +99,7 @@ export type SliceCoordinates = {
 };
 
 export type ChunkSource = {
-  getLoader(): ChunkLoader;
+  get loader(): ChunkLoader;
 };
 
 export type ChunkLoader = {

--- a/src/data/chunk_manager.ts
+++ b/src/data/chunk_manager.ts
@@ -11,7 +11,7 @@ import { ChunkStoreView } from "./chunk_store_view";
 import { ImageSourcePolicy } from "../core/image_source_policy";
 
 export class ChunkManager {
-  private readonly stores_ = new Map<ChunkSource, ChunkStore>();
+  private readonly stores_: { source: ChunkSource; store: ChunkStore }[] = [];
   private readonly queue_ = new ChunkQueue();
 
   public get queueStats(): QueueStats {
@@ -29,16 +29,16 @@ export class ChunkManager {
     source: ChunkSource,
     policy: ImageSourcePolicy
   ): ChunkStoreView {
-    let store = this.stores_.get(source);
+    let store = this.stores_.find((s) => s.source === source)?.store;
     if (!store) {
-      store = new ChunkStore(source.getLoader());
-      this.stores_.set(source, store);
+      store = new ChunkStore(source.loader.getSourceDimensionMap());
+      this.stores_.push({ source, store });
     }
     return store.addView(policy);
   }
 
   public update() {
-    for (const [_, store] of this.stores_) {
+    for (const { source, store } of this.stores_) {
       const updatedChunks = store.updateAndCollectChunkChanges();
 
       for (const chunk of updatedChunks) {
@@ -46,7 +46,7 @@ export class ChunkManager {
           this.queue_.cancel(chunk);
         } else if (chunk.state === "queued") {
           this.queue_.enqueue(chunk, (signal) =>
-            store.loadChunkData(chunk, signal)
+            source.loader.loadChunkData(chunk, signal)
           );
         }
       }
@@ -54,9 +54,9 @@ export class ChunkManager {
 
     this.queue_.flush();
 
-    for (const [source, store] of this.stores_) {
-      if (store.canDispose()) {
-        this.stores_.delete(source);
+    for (let i = this.stores_.length - 1; i >= 0; i--) {
+      if (this.stores_[i].store.canDispose()) {
+        this.stores_.splice(i, 1);
       }
     }
   }

--- a/src/data/chunk_store.ts
+++ b/src/data/chunk_store.ts
@@ -1,4 +1,4 @@
-import { Chunk, SourceDimensionMap, ChunkLoader } from "./chunk";
+import { Chunk, SourceDimensionMap } from "./chunk";
 import { clearChunkData } from "./chunk_memory";
 import { almostEqual } from "../utilities/almost_equal";
 import { Logger } from "../utilities/logger";
@@ -8,15 +8,13 @@ import { ImageSourcePolicy } from "../core/image_source_policy";
 export class ChunkStore {
   // Chunks indexed as chunks_[lod][t][c][z][y][x].
   private readonly chunks_: Chunk[][][][][][];
-  private readonly loader_: ChunkLoader;
   private readonly lowestResLOD_: number;
   private readonly dimensions_: SourceDimensionMap;
   private readonly views_: ChunkStoreView[] = [];
   private hasHadViews_ = false;
 
-  constructor(loader: ChunkLoader) {
-    this.loader_ = loader;
-    this.dimensions_ = this.loader_.getSourceDimensionMap();
+  constructor(dimensions: SourceDimensionMap) {
+    this.dimensions_ = dimensions;
     this.lowestResLOD_ = this.dimensions_.numLods - 1;
 
     this.validateXYScaleRatios();
@@ -120,10 +118,6 @@ export class ChunkStore {
 
   public getLowestResLOD(): number {
     return this.lowestResLOD_;
-  }
-
-  public loadChunkData(chunk: Chunk, signal: AbortSignal) {
-    return this.loader_.loadChunkData(chunk, signal);
   }
 
   public addView(policy: ImageSourcePolicy): ChunkStoreView {

--- a/src/data/ome_zarr/image_source.ts
+++ b/src/data/ome_zarr/image_source.ts
@@ -88,7 +88,7 @@ export class OmeZarrImageSource {
     return this.getDimensions().c?.lods[0].size ?? 1;
   }
 
-  public getLoader(): OmeZarrImageLoader {
+  public get loader(): OmeZarrImageLoader {
     return this.loader_;
   }
 

--- a/test/chunk_store_view.test.ts
+++ b/test/chunk_store_view.test.ts
@@ -1,13 +1,12 @@
-import { describe, expect, test, vi } from "vitest";
+import { describe, expect, test } from "vitest";
 import { ChunkStore } from "@/data/chunk_store";
-import { ChunkLoader, SourceDimensionMap } from "@/data/chunk";
+import { SourceDimensionMap } from "@/data/chunk";
 import { createNoPrefetchPolicy } from "@/core/image_source_policy";
 import { createTestViewport } from "./helpers";
 
 describe("ChunkStoreView disposal", () => {
   test("disposed view's chunks ready for cancellation", () => {
-    const loader = createMockLoader();
-    const store = new ChunkStore(loader);
+    const store = new ChunkStore(createSimpleDimensions());
     const policy = createNoPrefetchPolicy();
     const view = store.addView(policy);
     const viewport = createTestViewport();
@@ -40,8 +39,7 @@ describe("ChunkStoreView disposal", () => {
   });
 
   test("disposed view's chunks needed by another view", () => {
-    const loader = createMockLoader();
-    const store = new ChunkStore(loader);
+    const store = new ChunkStore(createSimpleDimensions());
     const policy = createNoPrefetchPolicy();
 
     const view1 = store.addView(policy);
@@ -65,13 +63,6 @@ describe("ChunkStoreView disposal", () => {
     }
   });
 });
-
-function createMockLoader(): ChunkLoader {
-  return {
-    getSourceDimensionMap: createSimpleDimensions,
-    loadChunkData: vi.fn(),
-  };
-}
 
 function createSimpleDimensions(): SourceDimensionMap {
   return {


### PR DESCRIPTION
### Summary

the chunk store now takes a source dimension map instead of a chunk loader,
and load orchestration moves entirely to the chunk manager via the source
loader getter. drops the redundant load-data pass-through on the store and
swaps the chunk manager store registry from a map to a small array lookup.
the chunk store view test now passes dimensions instead of a mock loader.

### Tests & Checks

- all checks have passed.