### PR TITLE
refactor: decouple chunk store from viewport

### DIFF
--- a/src/core/layer.ts
+++ b/src/core/layer.ts
@@ -24,10 +24,6 @@ export interface LayerOptions {
   blendMode?: BlendMode;
 }
 
-export type RenderContext = {
-  viewport: Viewport;
-};
-
 export abstract class Layer {
   public abstract readonly type: string;
 
@@ -57,7 +53,7 @@ export abstract class Layer {
     this.opacity_ = clamp(value, 0.0, 1.0);
   }
 
-  public abstract update(context?: RenderContext): void;
+  public abstract update(viewport?: Viewport): void;
 
   public onEvent(_: EventContext): void {}
 

--- a/src/core/viewport.ts
+++ b/src/core/viewport.ts
@@ -121,6 +121,15 @@ export class Viewport {
     );
   }
 
+  public getBufferRect(): {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+  } {
+    return this.getBoxRelativeTo(this.element as HTMLCanvasElement).toRect();
+  }
+
   public clientToClip(position: vec2, depth: number = 0): vec3 {
     const [x, y] = position;
     const rect = this.element.getBoundingClientRect();

--- a/src/data/chunk_store_view.ts
+++ b/src/data/chunk_store_view.ts
@@ -1,7 +1,5 @@
 import { Chunk, SliceCoordinates, ChunkViewState, coordToIndex } from "./chunk";
 import type { ChunkStore } from "./chunk_store";
-import { Viewport } from "../core/viewport";
-import { OrthographicCamera } from "../objects/cameras/orthographic_camera";
 import { ImageSourcePolicy } from "../core/image_source_policy";
 import { ReadonlyVec2, vec2, vec3, mat4 } from "gl-matrix";
 import { Box2 } from "../math/box2";
@@ -90,22 +88,11 @@ export class ChunkStoreView {
 
   public updateChunksForImage(
     sliceCoords: SliceCoordinates,
-    viewport: Viewport
+    view: { worldViewRect: Box2; bufferWidthPx: number }
   ): void {
-    const camera = viewport.camera;
-    if (camera.type !== "OrthographicCamera") {
-      throw new Error(
-        "ChunkStoreView currently supports only orthographic cameras. " +
-          "Update the implementation before using a perspective camera."
-      );
-    }
-
-    const orthoCamera = camera as OrthographicCamera;
-    const viewBounds2D = orthoCamera.getWorldViewRect();
+    const viewBounds2D = view.worldViewRect;
     const virtualWidth = Math.abs(viewBounds2D.max[0] - viewBounds2D.min[0]);
-    const canvasElement = viewport.element as HTMLCanvasElement;
-    const bufferWidth = viewport.getBoxRelativeTo(canvasElement).toRect().width;
-    const virtualUnitsPerScreenPixel = virtualWidth / bufferWidth;
+    const virtualUnitsPerScreenPixel = virtualWidth / view.bufferWidthPx;
     const lodFactor = Math.log2(1 / virtualUnitsPerScreenPixel);
 
     this.setLOD(lodFactor);
@@ -199,17 +186,8 @@ export class ChunkStoreView {
 
   public updateChunksForVolume(
     sliceCoords: SliceCoordinates,
-    viewport: Viewport
+    viewProjection: mat4
   ): void {
-    // Each call allocates a new mat4 and computes projection * view.
-    // This is intentional for simplicity. If this ever shows up in profiles
-    // avoid multiply entirely by caching and comparing view/projection separately.
-    const viewProjection = mat4.multiply(
-      mat4.create(),
-      viewport.camera.projectionMatrix,
-      viewport.camera.viewMatrix
-    );
-
     const changed =
       this.policyChanged_ ||
       this.hasViewProjectionChanged(viewProjection) ||

--- a/src/layers/image_layer.ts
+++ b/src/layers/image_layer.ts
@@ -1,4 +1,6 @@
-import { Layer, LayerOptions, RenderContext } from "../core/layer";
+import { Layer, LayerOptions } from "../core/layer";
+import { Viewport } from "../core/viewport";
+import { OrthographicCamera } from "../objects/cameras/orthographic_camera";
 import type { IdetikContext } from "../idetik";
 import { Chunk, ChunkSource, SliceCoordinates } from "../data/chunk";
 import { ChunkStoreView, INTERNAL_POLICY_KEY } from "../data/chunk_store_view";
@@ -105,13 +107,21 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
     this.chunkStoreView_ = undefined;
   }
 
-  public update(context?: RenderContext) {
-    if (!context || !this.chunkStoreView_) return;
+  public update(viewport?: Viewport) {
+    if (!viewport || !this.chunkStoreView_) return;
 
-    this.chunkStoreView_.updateChunksForImage(
-      this.sliceCoords_,
-      context.viewport
-    );
+    const camera = viewport.camera;
+    if (camera.type !== "OrthographicCamera") {
+      throw new Error(
+        "Image rendering currently supports only orthographic cameras. " +
+          "Update the implementation before using a perspective camera."
+      );
+    }
+
+    this.chunkStoreView_.updateChunksForImage(this.sliceCoords_, {
+      worldViewRect: (camera as OrthographicCamera).getWorldViewRect(),
+      bufferWidthPx: viewport.getBufferRect().width,
+    });
 
     this.updateChunks();
 

--- a/src/layers/label_layer.ts
+++ b/src/layers/label_layer.ts
@@ -1,4 +1,6 @@
-import { Layer, LayerOptions, RenderContext } from "../core/layer";
+import { Layer, LayerOptions } from "../core/layer";
+import { Viewport } from "../core/viewport";
+import { OrthographicCamera } from "../objects/cameras/orthographic_camera";
 import type { IdetikContext } from "../idetik";
 import { Chunk, ChunkSource, SliceCoordinates } from "../data/chunk";
 import { ChunkStoreView, INTERNAL_POLICY_KEY } from "../data/chunk_store_view";
@@ -91,13 +93,21 @@ export class LabelLayer extends Layer {
     this.chunkStoreView_ = undefined;
   }
 
-  public update(context?: RenderContext) {
-    if (!context || !this.chunkStoreView_) return;
+  public update(viewport?: Viewport) {
+    if (!viewport || !this.chunkStoreView_) return;
 
-    this.chunkStoreView_.updateChunksForImage(
-      this.sliceCoords_,
-      context.viewport
-    );
+    const camera = viewport.camera;
+    if (camera.type !== "OrthographicCamera") {
+      throw new Error(
+        "Label rendering currently supports only orthographic cameras. " +
+          "Update the implementation before using a perspective camera."
+      );
+    }
+
+    this.chunkStoreView_.updateChunksForImage(this.sliceCoords_, {
+      worldViewRect: (camera as OrthographicCamera).getWorldViewRect(),
+      bufferWidthPx: viewport.getBufferRect().width,
+    });
 
     this.updateChunks();
 

--- a/src/layers/volume_layer.ts
+++ b/src/layers/volume_layer.ts
@@ -1,5 +1,6 @@
 import { Chunk, ChunkSource, SliceCoordinates } from "../data/chunk";
-import { Layer, RenderContext } from "../core/layer";
+import { Layer } from "../core/layer";
+import { Viewport } from "../core/viewport";
 import { VolumeRenderable } from "../objects/renderable/volume_renderable";
 import { IdetikContext } from "../idetik";
 import { ChunkStoreView, INTERNAL_POLICY_KEY } from "../data/chunk_store_view";
@@ -216,26 +217,21 @@ export class VolumeLayer extends Layer implements ChannelsEnabled {
     this.volumeToPoolKey_.delete(volume);
   }
 
-  public update(context?: RenderContext) {
-    if (!this.chunkStoreView_) return;
-    if (context === undefined) {
-      throw new Error(
-        "RenderContext is required for the VolumeLayer update as camera information is used to reorder the chunks."
-      );
-    }
+  public update(viewport?: Viewport) {
+    if (!viewport || !this.chunkStoreView_) return;
 
     this.chunkStoreView_.updateChunksForVolume(
       this.sliceCoords_,
-      context.viewport
+      viewport.camera.getViewProjection()
     );
 
-    const isCameraMoving = context.viewport.cameraControls?.isMoving ?? false;
+    const isCameraMoving = viewport.cameraControls?.isMoving ?? false;
     this.interactiveStepSizeScale_ = isCameraMoving
       ? INTERACTIVE_STEP_SIZE_SCALE
       : 1.0;
 
     this.updateChunks();
-    sortFrontToBack(this.objects, context.viewport.camera);
+    sortFrontToBack(this.objects, viewport.camera);
   }
 
   public getUniforms(): Record<string, unknown> {

--- a/src/objects/cameras/camera.ts
+++ b/src/objects/cameras/camera.ts
@@ -35,10 +35,12 @@ export abstract class Camera extends RenderableObject {
     return vec3.fromValues(m[4], m[5], m[6]);
   }
 
+  public getViewProjection(): mat4 {
+    return mat4.multiply(mat4.create(), this.projectionMatrix, this.viewMatrix);
+  }
+
   get frustum() {
-    return new Frustum(
-      mat4.multiply(mat4.create(), this.projectionMatrix, this.viewMatrix)
-    );
+    return new Frustum(this.getViewProjection());
   }
 
   public abstract setAspectRatio(aspectRatio: number): void;

--- a/src/objects/cameras/orthographic_camera.ts
+++ b/src/objects/cameras/orthographic_camera.ts
@@ -64,13 +64,7 @@ export class OrthographicCamera extends Camera {
     let topLeft = vec4.fromValues(-1.0, -1.0, 0.0, 1.0);
     let bottomRight = vec4.fromValues(1.0, 1.0, 0.0, 1.0);
 
-    const viewProjection = mat4.multiply(
-      mat4.create(),
-      this.projectionMatrix,
-      this.viewMatrix
-    );
-
-    const inv = mat4.invert(mat4.create(), viewProjection)!;
+    const inv = mat4.invert(mat4.create(), this.getViewProjection())!;
     topLeft = vec4.transformMat4(vec4.create(), topLeft, inv);
     bottomRight = vec4.transformMat4(vec4.create(), bottomRight, inv);
 

--- a/src/renderers/webgl_renderer.ts
+++ b/src/renderers/webgl_renderer.ts
@@ -83,7 +83,7 @@ export class WebGLRenderer extends Renderer {
     }
 
     for (const layer of [...opaque, ...transparent]) {
-      layer.update({ viewport });
+      layer.update(viewport);
     }
 
     if (getComputedStyle(viewport.element).visibility === "hidden") return;

--- a/src/renderers/webgpu/webgpu_renderer.ts
+++ b/src/renderers/webgpu/webgpu_renderer.ts
@@ -130,7 +130,7 @@ class WebGPURenderer extends Renderer {
     }
 
     for (const layer of [...opaque, ...transparent]) {
-      layer.update({ viewport });
+      layer.update(viewport);
     }
 
     if (getComputedStyle(viewport.element).visibility === "hidden") return;

--- a/test/chunk_store_view.test.ts
+++ b/test/chunk_store_view.test.ts
@@ -2,7 +2,16 @@ import { describe, expect, test, vi } from "vitest";
 import { ChunkStore } from "@/data/chunk_store";
 import { ChunkLoader, SourceDimensionMap } from "@/data/chunk";
 import { createNoPrefetchPolicy } from "@/core/image_source_policy";
+import { OrthographicCamera } from "@/objects/cameras/orthographic_camera";
+import { Viewport } from "@/core/viewport";
 import { createTestViewport } from "./helpers";
+
+function imageView(viewport: Viewport) {
+  return {
+    worldViewRect: (viewport.camera as OrthographicCamera).getWorldViewRect(),
+    bufferWidthPx: viewport.getBufferRect().width,
+  };
+}
 
 describe("ChunkStoreView disposal", () => {
   test("disposed view's chunks ready for cancellation", () => {
@@ -13,7 +22,7 @@ describe("ChunkStoreView disposal", () => {
     const viewport = createTestViewport();
 
     // mark some chunks as visible/needed
-    view.updateChunksForImage({ z: 0, c: [0], t: 0 }, viewport);
+    view.updateChunksForImage({ z: 0, c: [0], t: 0 }, imageView(viewport));
     expect(view.chunkViewStates.size).toBeGreaterThan(0);
 
     // aggregate states and set priority
@@ -49,8 +58,8 @@ describe("ChunkStoreView disposal", () => {
     const viewport = createTestViewport();
 
     // Both views mark same chunks as needed
-    view1.updateChunksForImage({ z: 0, c: [0], t: 0 }, viewport);
-    view2.updateChunksForImage({ z: 0, c: [0], t: 0 }, viewport);
+    view1.updateChunksForImage({ z: 0, c: [0], t: 0 }, imageView(viewport));
+    view2.updateChunksForImage({ z: 0, c: [0], t: 0 }, imageView(viewport));
 
     store.updateAndCollectChunkChanges();
 


### PR DESCRIPTION
### Summary

the chunk store only ever needed a handful of view values to pick chunks, but
it took the entire viewport which coupled the data layer to the rendering layer.
this PR passes the necessary values instead of the viewport. each value now
comes from a function on its natural owner.

while here i inlined the one-field `RenderContext` wrapper.

### Tests & Checks

- all checks have passed.