### PR TITLE
refactor: standardize shader variables for consistency

### DIFF
--- a/src/layers/volume_layer.ts
+++ b/src/layers/volume_layer.ts
@@ -230,10 +230,11 @@ export class VolumeLayer extends Layer implements ChannelsEnabled {
 
   public getUniforms(): Record<string, unknown> {
     return {
-      DebugShowDegenerateRays: Number(this.debugShowDegenerateRays),
-      RelativeStepSize: this.relativeStepSize * this.interactiveStepSizeScale_,
-      OpacityMultiplier: this.opacityMultiplier,
-      EarlyTerminationAlpha: this.earlyTerminationAlpha,
+      u_debugShowDegenerateRays: Number(this.debugShowDegenerateRays),
+      u_relativeStepSize:
+        this.relativeStepSize * this.interactiveStepSizeScale_,
+      u_opacityMultiplier: this.opacityMultiplier,
+      u_earlyTerminationAlpha: this.earlyTerminationAlpha,
     };
   }
 }

--- a/src/objects/renderable/image_renderable.ts
+++ b/src/objects/renderable/image_renderable.ts
@@ -11,12 +11,12 @@ import { vec3 } from "gl-matrix";
 import { Shader } from "../../renderers/shaders";
 
 type UniformValues = {
-  Color: vec3;
-  ImageSampler: number;
+  u_color: vec3;
+  u_imageSampler: number;
   Opacity: number;
-  ValueOffset: number;
-  ValueScale: number;
-  ZTexCoord: number;
+  u_valueOffset: number;
+  u_valueScale: number;
+  u_zTexCoord: number;
 };
 
 export class ImageRenderable extends RenderableObject {
@@ -70,12 +70,12 @@ export class ImageRenderable extends RenderableObject {
       this.channels_[0] ?? validateChannel(texture, {});
 
     return {
-      ImageSampler: 0,
-      Color: color.rgb,
-      ValueOffset: -contrastLimits[0],
-      ValueScale: 1 / (contrastLimits[1] - contrastLimits[0]),
+      u_imageSampler: 0,
+      u_color: color.rgb,
+      u_valueOffset: -contrastLimits[0],
+      u_valueScale: 1 / (contrastLimits[1] - contrastLimits[0]),
       Opacity: opacity,
-      ZTexCoord: this.zTexCoord,
+      u_zTexCoord: this.zTexCoord,
     };
   }
 }

--- a/src/objects/renderable/label_image_renderable.ts
+++ b/src/objects/renderable/label_image_renderable.ts
@@ -63,12 +63,12 @@ export class LabelImageRenderable extends RenderableObject {
 
   public getUniforms() {
     return {
-      ImageSampler: 0,
-      ColorCycleSampler: 1,
-      ColorLookupTableSampler: 2,
+      u_imageSampler: 0,
+      u_colorCycleSampler: 1,
+      u_colorLookupTableSampler: 2,
       u_outlineSelected: this.outlineSelected_ ? 1.0 : 0.0,
       u_selectedValue: this.selectedValue_ ?? -1.0,
-      ZTexCoord: this.zTexCoord,
+      u_zTexCoord: this.zTexCoord,
     };
   }
 

--- a/src/objects/renderable/projected_line.ts
+++ b/src/objects/renderable/projected_line.ts
@@ -42,8 +42,8 @@ export class ProjectedLine extends RenderableObject {
 
   public override getUniforms() {
     return {
-      LineColor: this.color.rgb,
-      LineWidth: this.width,
+      u_lineColor: this.color.rgb,
+      u_lineWidth: this.width,
     };
   }
 }

--- a/src/objects/renderable/volume_renderable.ts
+++ b/src/objects/renderable/volume_renderable.ts
@@ -119,16 +119,16 @@ export class VolumeRenderable extends RenderableObject {
 
     return samplerUniforms.reduce<Record<string, number[] | number>>(
       (uniforms, textureIndex, i) => {
-        uniforms[`Channel${i}Sampler`] = textureIndex;
+        uniforms[`u_channel${i}Sampler`] = textureIndex;
         return uniforms;
       },
       {
-        Visible: loadedAndVisibleTextures,
-        "Color[0]": colors,
-        ValueOffset: valueOffset,
-        ValueScale: valueScale,
-        ChannelOpacity: channelOpacity,
-        VoxelScale: [
+        u_visible: loadedAndVisibleTextures,
+        "u_color[0]": colors,
+        u_valueOffset: valueOffset,
+        u_valueScale: valueScale,
+        u_channelOpacity: channelOpacity,
+        u_voxelScale: [
           this.voxelScale[0],
           this.voxelScale[1],
           this.voxelScale[2],

--- a/src/renderers/shaders/label_image_frag.glsl
+++ b/src/renderers/shaders/label_image_frag.glsl
@@ -5,16 +5,16 @@ precision highp int;
 
 layout (location = 0) out vec4 fragColor;
 
-uniform highp usampler3D ImageSampler;
-uniform mediump sampler2D ColorCycleSampler;
-uniform highp usampler2D ColorLookupTableSampler;
+uniform highp usampler3D u_imageSampler;
+uniform mediump sampler2D u_colorCycleSampler;
+uniform highp usampler2D u_colorLookupTableSampler;
 
 uniform float u_opacity;
 uniform float u_outlineSelected; // Note: Using float instead of bool due to framework uniform handling
 uniform float u_selectedValue;
-uniform float ZTexCoord;
+uniform float u_zTexCoord;
 
-in vec2 TexCoords;
+in vec2 v_texCoords;
 
 vec4 unpackRgba(uint packed) {
     uint r = (packed >> 24u) & 0xFFu;
@@ -25,23 +25,23 @@ vec4 unpackRgba(uint packed) {
 }
 
 bool isEdgePixel(uint centerValue) {
-    vec2 texSize = vec2(textureSize(ImageSampler, 0).xy);
+    vec2 texSize = vec2(textureSize(u_imageSampler, 0).xy);
     vec2 texelSize = 1.0 / texSize;
-    
+
     // Check 8-connected neighbors
     for (int dx = -1; dx <= 1; dx++) {
         for (int dy = -1; dy <= 1; dy++) {
             if (dx == 0 && dy == 0) continue; // Skip center pixel
-            
-            vec2 neighborCoords = TexCoords + vec2(float(dx), float(dy)) * texelSize;
-            
+
+            vec2 neighborCoords = v_texCoords + vec2(float(dx), float(dy)) * texelSize;
+
             // Skip if out of bounds
-            if (neighborCoords.x < 0.0 || neighborCoords.x > 1.0 || 
+            if (neighborCoords.x < 0.0 || neighborCoords.x > 1.0 ||
                 neighborCoords.y < 0.0 || neighborCoords.y > 1.0) {
                 continue;
             }
-            
-            uint neighborValue = texture(ImageSampler, vec3(neighborCoords, ZTexCoord)).r;
+
+            uint neighborValue = texture(u_imageSampler, vec3(neighborCoords, u_zTexCoord)).r;
             if (neighborValue != centerValue) {
                 return true;
             }
@@ -51,11 +51,11 @@ bool isEdgePixel(uint centerValue) {
 }
 
 void main() {
-    uint texel = texture(ImageSampler, vec3(TexCoords, ZTexCoord)).r;
-    
+    uint texel = texture(u_imageSampler, vec3(v_texCoords, u_zTexCoord)).r;
+
     // Check if this pixel is the selected value
     bool isSelectedValue = u_outlineSelected > 0.5 && u_selectedValue >= 0.0 && float(texel) == u_selectedValue;
-    
+
     // Check if we should outline this selected segment
     if (isSelectedValue) {
         if (isEdgePixel(texel)) {
@@ -65,27 +65,27 @@ void main() {
         }
     }
 
-    uint mapLength = uint(textureSize(ColorLookupTableSampler, 0).x);
+    uint mapLength = uint(textureSize(u_colorLookupTableSampler, 0).x);
     for (uint i = 0u; i < mapLength; ++i) {
-        uint key = texelFetch(ColorLookupTableSampler, ivec2(i, 0), 0).r;
+        uint key = texelFetch(u_colorLookupTableSampler, ivec2(i, 0), 0).r;
         if (texel == key) {
-            uint value = texelFetch(ColorLookupTableSampler, ivec2(i, 1), 0).r;
+            uint value = texelFetch(u_colorLookupTableSampler, ivec2(i, 1), 0).r;
             vec4 color = unpackRgba(value);
-            
+
             // If this is the selected segment and outlining is enabled, make it slightly transparent
             float alpha = isSelectedValue ? u_opacity * color.a * 0.9 : u_opacity * color.a;
-            
+
             fragColor = vec4(color.rgb, alpha);
             return;
         }
     }
 
-    uint cycleLength = uint(textureSize(ColorCycleSampler, 0).x);
+    uint cycleLength = uint(textureSize(u_colorCycleSampler, 0).x);
     uint index = uint(texel - 1u) % cycleLength;
-    vec4 color = texelFetch(ColorCycleSampler, ivec2(index, 0), 0);
-    
+    vec4 color = texelFetch(u_colorCycleSampler, ivec2(index, 0), 0);
+
     // If this is the selected segment and outlining is enabled, make it slightly transparent
     float alpha = isSelectedValue ? u_opacity * color.a * 0.9 : u_opacity * color.a;
-    
+
     fragColor = vec4(color.rgb, alpha);
 }

--- a/src/renderers/shaders/mesh_frag.glsl
+++ b/src/renderers/shaders/mesh_frag.glsl
@@ -4,10 +4,10 @@ precision mediump float;
 
 layout (location = 0) out vec4 fragColor;
 
-uniform sampler2D ImageSampler;
+uniform sampler2D u_imageSampler;
 
-in vec2 TexCoords;
+in vec2 v_texCoords;
 
 void main() {
-    fragColor = vec4(texture(ImageSampler, TexCoords).rgb, 1.0);
+    fragColor = vec4(texture(u_imageSampler, v_texCoords).rgb, 1.0);
 }

--- a/src/renderers/shaders/mesh_vert.glsl
+++ b/src/renderers/shaders/mesh_vert.glsl
@@ -1,15 +1,15 @@
 #version 300 es
 
-layout (location = 0) in vec3 inPosition;
-layout (location = 1) in vec3 inNormal;
-layout (location = 2) in vec2 inUV;
+layout (location = 0) in vec3 a_position;
+layout (location = 1) in vec3 a_normal;
+layout (location = 2) in vec2 a_uv;
 
-uniform mat4 Projection;
-uniform mat4 ModelView;
+uniform mat4 u_projection;
+uniform mat4 u_modelView;
 
-out vec2 TexCoords;
+out vec2 v_texCoords;
 
 void main() {
-    TexCoords = inUV;
-    gl_Position = Projection * ModelView * vec4(inPosition, 1.0);
+    v_texCoords = a_uv;
+    gl_Position = u_projection * u_modelView * vec4(a_position, 1.0);
 }

--- a/src/renderers/shaders/points_frag.glsl
+++ b/src/renderers/shaders/points_frag.glsl
@@ -4,20 +4,20 @@ precision mediump float;
 
 layout (location = 0) out vec4 fragColor;
 
-uniform mediump sampler2DArray markerAtlas;
+uniform mediump sampler2DArray u_markerAtlas;
 
-in vec4 color;
-flat in uint marker;
+in vec4 v_color;
+flat in uint v_marker;
 
 uniform float u_opacity;
 
 
 void main() {
-    float alpha = texture(markerAtlas, vec3(gl_PointCoord, marker)).r;
+    float alpha = texture(u_markerAtlas, vec3(gl_PointCoord, v_marker)).r;
     float alpha_threshold = 1e-2;
     if (alpha < alpha_threshold) {
         discard;
     }
-    fragColor = vec4(color.rgb, u_opacity * alpha * color.a);
+    fragColor = vec4(v_color.rgb, u_opacity * alpha * v_color.a);
 }
 

--- a/src/renderers/shaders/points_vert.glsl
+++ b/src/renderers/shaders/points_vert.glsl
@@ -2,22 +2,22 @@
 
 precision mediump float;
 
-layout (location = 0) in vec3 inPosition;
-layout (location = 6) in vec4 inColor;
-layout (location = 7) in float inSize;
-layout (location = 8) in float inMarker;
+layout (location = 0) in vec3 a_position;
+layout (location = 6) in vec4 a_color;
+layout (location = 7) in float a_size;
+layout (location = 8) in float a_marker;
 
-uniform mat4 Projection;
-uniform mat4 ModelView;
+uniform mat4 u_projection;
+uniform mat4 u_modelView;
 
-out vec4 color;
-flat out uint marker;
+out vec4 v_color;
+flat out uint v_marker;
 
 
 void main() {
-    gl_Position = Projection * ModelView * vec4(inPosition, 1.0);
-    gl_PointSize = inSize;
-    color = inColor;
-    marker = uint(inMarker);
+    gl_Position = u_projection * u_modelView * vec4(a_position, 1.0);
+    gl_PointSize = a_size;
+    v_color = a_color;
+    v_marker = uint(a_marker);
 }
 

--- a/src/renderers/shaders/projected_line_frag.glsl
+++ b/src/renderers/shaders/projected_line_frag.glsl
@@ -4,9 +4,9 @@ precision mediump float;
 
 layout (location = 0) out vec4 fragColor;
 
-uniform vec3 LineColor;
+uniform vec3 u_lineColor;
 uniform float u_opacity;
 
 void main() {
-    fragColor = vec4(LineColor, u_opacity);
+    fragColor = vec4(u_lineColor, u_opacity);
 }

--- a/src/renderers/shaders/projected_line_vert.glsl
+++ b/src/renderers/shaders/projected_line_vert.glsl
@@ -1,30 +1,30 @@
 #version 300 es
 
-layout (location = 0) in vec3 inPosition;
-layout (location = 3) in vec3 inPrevPosition;
-layout (location = 4) in vec3 inNextPosition;
-layout (location = 5) in float direction;
+layout (location = 0) in vec3 a_position;
+layout (location = 3) in vec3 a_prevPosition;
+layout (location = 4) in vec3 a_nextPosition;
+layout (location = 5) in float a_direction;
 
-uniform mat4 Projection;
-uniform mat4 ModelView;
-uniform vec2 Resolution;
-uniform float LineWidth;
+uniform mat4 u_projection;
+uniform mat4 u_modelView;
+uniform vec2 u_resolution;
+uniform float u_lineWidth;
 
 // adapted from https://github.com/mattdesl/webgl-lines
 void main() {
-    mat4 projModelView = Projection * ModelView;
+    mat4 projModelView = u_projection * u_modelView;
 
-    vec4 prevPos = projModelView * vec4(inPrevPosition, 1.0);
-    vec4 currPos = projModelView * vec4(inPosition, 1.0);
-    vec4 nextPos = projModelView * vec4(inNextPosition, 1.0);
+    vec4 prevPos = projModelView * vec4(a_prevPosition, 1.0);
+    vec4 currPos = projModelView * vec4(a_position, 1.0);
+    vec4 nextPos = projModelView * vec4(a_nextPosition, 1.0);
 
-    vec2 aspectVec = vec2(Resolution.x / Resolution.y, 1.0);
+    vec2 aspectVec = vec2(u_resolution.x / u_resolution.y, 1.0);
     vec2 prevScreen = (prevPos.xy / prevPos.w) * aspectVec;
     vec2 currScreen = (currPos.xy / currPos.w) * aspectVec;
     vec2 nextScreen = (nextPos.xy / nextPos.w) * aspectVec;
 
-    // direction is + or -; which way to project the vertex away from the path
-    float d = sign(direction);
+    // a_direction is + or -; which way to project the vertex away from the path
+    float d = sign(a_direction);
 
     // `normal` points perpendicular to the path in screen space
     vec2 normal;
@@ -49,9 +49,9 @@ void main() {
         miterLength = 1.0 / max(dot(normal, perpPrev), 0.1);
     }
 
-    // `normal * LineWidth / Resolution` means LineWidth is in pixels
+    // `normal * u_lineWidth / u_resolution` means u_lineWidth is in pixels
     vec4 offset = vec4(
-        (normal * LineWidth / Resolution) * miterLength * d,
+        (normal * u_lineWidth / u_resolution) * miterLength * d,
         0.0,
         0.0
     );

--- a/src/renderers/shaders/scalar_image_frag.glsl
+++ b/src/renderers/shaders/scalar_image_frag.glsl
@@ -6,23 +6,23 @@ precision mediump float;
 layout (location = 0) out vec4 fragColor;
 
 #if defined TEXTURE_DATA_TYPE_INT
-uniform mediump isampler3D ImageSampler;
+uniform mediump isampler3D u_imageSampler;
 #elif defined TEXTURE_DATA_TYPE_UINT
-uniform mediump usampler3D ImageSampler;
+uniform mediump usampler3D u_imageSampler;
 #else
-uniform mediump sampler3D ImageSampler;
+uniform mediump sampler3D u_imageSampler;
 #endif
 
-uniform vec3 Color;
-uniform float ValueOffset;
-uniform float ValueScale;
+uniform vec3 u_color;
+uniform float u_valueOffset;
+uniform float u_valueScale;
 uniform float u_opacity;
-uniform float ZTexCoord;
+uniform float u_zTexCoord;
 
-in vec2 TexCoords;
+in vec2 v_texCoords;
 
 void main() {
-    float texel = float(texture(ImageSampler, vec3(TexCoords, ZTexCoord)).r);
-    float value = (texel + ValueOffset) * ValueScale;
-    fragColor = vec4(value * Color, u_opacity);
+    float texel = float(texture(u_imageSampler, vec3(v_texCoords, u_zTexCoord)).r);
+    float value = (texel + u_valueOffset) * u_valueScale;
+    fragColor = vec4(value * u_color, u_opacity);
 }

--- a/src/renderers/shaders/volume_frag.glsl
+++ b/src/renderers/shaders/volume_frag.glsl
@@ -7,44 +7,44 @@ layout (location = 0) out vec4 fragColor;
 // This shader could be optimised by creating four separate shader variants
 #if defined TEXTURE_DATA_TYPE_INT
 precision mediump isampler3D;
-uniform isampler3D Channel0Sampler;
-uniform isampler3D Channel1Sampler;
-uniform isampler3D Channel2Sampler;
-uniform isampler3D Channel3Sampler;
+uniform isampler3D u_channel0Sampler;
+uniform isampler3D u_channel1Sampler;
+uniform isampler3D u_channel2Sampler;
+uniform isampler3D u_channel3Sampler;
 #elif defined TEXTURE_DATA_TYPE_UINT
 precision mediump usampler3D;
-uniform usampler3D Channel0Sampler;
-uniform usampler3D Channel1Sampler;
-uniform usampler3D Channel2Sampler;
-uniform usampler3D Channel3Sampler;
+uniform usampler3D u_channel0Sampler;
+uniform usampler3D u_channel1Sampler;
+uniform usampler3D u_channel2Sampler;
+uniform usampler3D u_channel3Sampler;
 #else
 precision mediump sampler3D;
-uniform sampler3D Channel0Sampler;
-uniform sampler3D Channel1Sampler;
-uniform sampler3D Channel2Sampler;
-uniform sampler3D Channel3Sampler;
+uniform sampler3D u_channel0Sampler;
+uniform sampler3D u_channel1Sampler;
+uniform sampler3D u_channel2Sampler;
+uniform sampler3D u_channel3Sampler;
 #endif
 
-uniform highp vec3 CameraPositionModel;
-uniform vec3 VoxelScale;
-in highp vec3 PositionModel;
+uniform highp vec3 u_cameraPositionModel;
+uniform vec3 u_voxelScale;
+in highp vec3 v_positionModel;
 
 // The bounding box in model space is normalized to -0.5 to 0.5
 vec3 boundingboxMin = vec3(-0.50);
 vec3 boundingboxMax = vec3(0.50);
 
 // Volume rendering parameters
-uniform bool DebugShowDegenerateRays;
-uniform float RelativeStepSize;
-uniform float OpacityMultiplier;
-uniform float EarlyTerminationAlpha;
+uniform bool u_debugShowDegenerateRays;
+uniform float u_relativeStepSize;
+uniform float u_opacityMultiplier;
+uniform float u_earlyTerminationAlpha;
 
 // Multi-channel support (max 4 channels, could support more with arrays if needed)
-uniform vec4 Visible;
-uniform vec4 ValueOffset;
-uniform vec4 ValueScale;
-uniform vec4 ChannelOpacity;
-uniform vec3 Color[4];
+uniform vec4 u_visible;
+uniform vec4 u_valueOffset;
+uniform vec4 u_valueScale;
+uniform vec4 u_channelOpacity;
+uniform vec3 u_color[4];
 
 vec2 findBoxIntersectionsAlongRay(vec3 rayOrigin, vec3 rayDir, vec3 boxMin, vec3 boxMax) {
     vec3 reciprocalRayDir = 1.0 / rayDir;
@@ -66,19 +66,19 @@ vec2 findBoxIntersectionsAlongRay(vec3 rayOrigin, vec3 rayDir, vec3 boxMin, vec3
 vec4 sampleChannels(vec3 uvw) {
   vec4 c = vec4(0.0);
 
-  if (bool(Visible.x)) c.x = float(texture(Channel0Sampler, uvw).r);
-  if (bool(Visible.y)) c.y = float(texture(Channel1Sampler, uvw).r);
-  if (bool(Visible.z)) c.z = float(texture(Channel2Sampler, uvw).r);
-  if (bool(Visible.w)) c.w = float(texture(Channel3Sampler, uvw).r);
+  if (bool(u_visible.x)) c.x = float(texture(u_channel0Sampler, uvw).r);
+  if (bool(u_visible.y)) c.y = float(texture(u_channel1Sampler, uvw).r);
+  if (bool(u_visible.z)) c.z = float(texture(u_channel2Sampler, uvw).r);
+  if (bool(u_visible.w)) c.w = float(texture(u_channel3Sampler, uvw).r);
 
-  return (c + ValueOffset) * ValueScale;
+  return (c + u_valueOffset) * u_valueScale;
 }
 
 vec3 getTextureSize() {
-    if (bool(Visible.x)) return vec3(textureSize(Channel0Sampler, 0));
-    else if (bool(Visible.y)) return vec3(textureSize(Channel1Sampler, 0));
-    else if (bool(Visible.z)) return vec3(textureSize(Channel2Sampler, 0));
-    else if (bool(Visible.w)) return vec3(textureSize(Channel3Sampler, 0));
+    if (bool(u_visible.x)) return vec3(textureSize(u_channel0Sampler, 0));
+    else if (bool(u_visible.y)) return vec3(textureSize(u_channel1Sampler, 0));
+    else if (bool(u_visible.z)) return vec3(textureSize(u_channel2Sampler, 0));
+    else if (bool(u_visible.w)) return vec3(textureSize(u_channel3Sampler, 0));
     return vec3(1.0); // Ideally at least one channel should be visible
 }
 
@@ -86,20 +86,20 @@ void main() {
     // Step 1 - calculate where the ray enters and exits the volume
 
     // The ray in model space goes from the camera to the point on the back face
-    vec3 RayDirModel = normalize(PositionModel - CameraPositionModel);
+    vec3 RayDirModel = normalize(v_positionModel - u_cameraPositionModel);
 
-    vec2 rayIntersections = findBoxIntersectionsAlongRay(CameraPositionModel, RayDirModel, boundingboxMin, boundingboxMax);
+    vec2 rayIntersections = findBoxIntersectionsAlongRay(u_cameraPositionModel, RayDirModel, boundingboxMin, boundingboxMax);
     float tEnter = rayIntersections.x;
     float tExit = rayIntersections.y;
 
-    if (DebugShowDegenerateRays && (tExit == tEnter)) {
+    if (u_debugShowDegenerateRays && (tExit == tEnter)) {
         fragColor = vec4(1.0, 0.0, 0.0, 1.0);
         return;
     }
 
-    vec3 entryPoint = CameraPositionModel + RayDirModel * tEnter;
+    vec3 entryPoint = u_cameraPositionModel + RayDirModel * tEnter;
     entryPoint = clamp(entryPoint + 0.5, 0.0, 1.0);
-    vec3 exitPoint = CameraPositionModel + RayDirModel * tExit;
+    vec3 exitPoint = u_cameraPositionModel + RayDirModel * tExit;
     exitPoint = clamp(exitPoint + 0.5, 0.0, 1.0);
 
     // Step 2 - calculate the number of samples based on the length of the ray
@@ -109,16 +109,16 @@ void main() {
     vec3 textureSize = getTextureSize();
     vec3 rayInVoxels = rayWithinModel * textureSize;
     float rayLengthInVoxels = length(rayInVoxels);
-    int numSamples = max(int(ceil(rayLengthInVoxels / RelativeStepSize)), 1);
+    int numSamples = max(int(ceil(rayLengthInVoxels / u_relativeStepSize)), 1);
     vec3 stepIncrement = rayWithinModel / float(numSamples);
 
     // Calculate actual world-space step size for opacity correction.
     // This accounts for anisotropic voxels so brightness stays constant regardless
     // of viewing angle. For anisotropic voxels (e.g., 1x1x3 microns), rays along
     // different axes traverse different amounts of material per step.
-    vec3 stepInWorldSpace = stepIncrement * textureSize * VoxelScale;
+    vec3 stepInWorldSpace = stepIncrement * textureSize * u_voxelScale;
     float worldSpaceStepSize = length(stepInWorldSpace);
-    float intensityScale = OpacityMultiplier * worldSpaceStepSize;
+    float intensityScale = u_opacityMultiplier * worldSpaceStepSize;
 
     // Step 3 - perform the ray marching and compositing in front to back order
     vec3 position = entryPoint;
@@ -126,14 +126,14 @@ void main() {
 
     vec3 sampleColor = vec3(0.0);
     float sampleAlpha, blendedSampleAlpha;
-    for (int i = 0; i < numSamples && accumulatedColor.a < EarlyTerminationAlpha; i++) {
+    for (int i = 0; i < numSamples && accumulatedColor.a < u_earlyTerminationAlpha; i++) {
 
         vec4 sampleValues = sampleChannels(position);
         // Combine color per channel
         for (int ch = 0; ch < 4; ch++) {
-            if (!bool(Visible[ch]) || sampleValues[ch] == 0.0) continue;
-            sampleColor = Color[ch];
-            sampleAlpha = clamp(sampleValues[ch] * intensityScale * ChannelOpacity[ch], 0.0, 1.0);
+            if (!bool(u_visible[ch]) || sampleValues[ch] == 0.0) continue;
+            sampleColor = u_color[ch];
+            sampleAlpha = clamp(sampleValues[ch] * intensityScale * u_channelOpacity[ch], 0.0, 1.0);
             blendedSampleAlpha = (1.0 - accumulatedColor.a) * sampleAlpha;
 
             // Front-to-back compositing

--- a/src/renderers/shaders/volume_vert.glsl
+++ b/src/renderers/shaders/volume_vert.glsl
@@ -2,13 +2,13 @@
 
 precision highp float;
 
-layout (location = 0) in vec3 inPosition;
+layout (location = 0) in vec3 a_position;
 
-uniform mat4 Projection;
-uniform mat4 ModelView;
-out highp vec3 PositionModel;
+uniform mat4 u_projection;
+uniform mat4 u_modelView;
+out highp vec3 v_positionModel;
 
 void main() {
-    PositionModel = inPosition;
-    gl_Position = Projection * ModelView * vec4(inPosition, 1.0);
+    v_positionModel = a_position;
+    gl_Position = u_projection * u_modelView * vec4(a_position, 1.0);
 }

--- a/src/renderers/shaders/wireframe_vert.glsl
+++ b/src/renderers/shaders/wireframe_vert.glsl
@@ -1,11 +1,11 @@
 #version 300 es
 
-layout (location = 0) in vec3 inPosition;
-layout (location = 1) in vec3 inNormal;
+layout (location = 0) in vec3 a_position;
+layout (location = 1) in vec3 a_normal;
 
-uniform mat4 Projection;
-uniform mat4 ModelView;
+uniform mat4 u_projection;
+uniform mat4 u_modelView;
 
 void main() {
-    gl_Position = Projection * ModelView * vec4(inPosition, 1.0);
+    gl_Position = u_projection * u_modelView * vec4(a_position, 1.0);
 }

--- a/src/renderers/webgl_renderer.ts
+++ b/src/renderers/webgl_renderer.ts
@@ -227,13 +227,13 @@ export class WebGLRenderer extends Renderer {
 
     for (const uniformName of program.uniformNames) {
       switch (uniformName) {
-        case "ModelView":
+        case "u_modelView":
           program.setUniform(uniformName, modelView);
           break;
-        case "Projection":
+        case "u_projection":
           program.setUniform(uniformName, projection);
           break;
-        case "Resolution":
+        case "u_resolution":
           program.setUniform(uniformName, resolution);
           break;
         case "u_opacity":
@@ -243,7 +243,7 @@ export class WebGLRenderer extends Renderer {
               ((objectUniforms.Opacity as number | undefined) ?? 1)
           );
           break;
-        case "CameraPositionModel": {
+        case "u_cameraPositionModel": {
           const inverseModelView = mat4.invert(mat4.create(), modelView)!;
           const cameraPositionView = vec4.fromValues(0, 0, 0, 1);
           const cameraPositionModel = vec4.transformMat4(

--- a/src/renderers/webgpu/webgpu_renderer.ts
+++ b/src/renderers/webgpu/webgpu_renderer.ts
@@ -416,11 +416,11 @@ class WebGPURenderer extends Renderer {
     pipeline.uniformsView.set({
       projection: this.currentProjection_,
       modelView: this.currentModelView_,
-      color: uniforms.Color,
-      valueOffset: uniforms.ValueOffset,
-      valueScale: uniforms.ValueScale,
+      color: uniforms.u_color,
+      valueOffset: uniforms.u_valueOffset,
+      valueScale: uniforms.u_valueScale,
       opacity: this.currentLayerOpacity_ * objectOpacity,
-      zTexCoord: uniforms.ZTexCoord,
+      zTexCoord: uniforms.u_zTexCoord,
     });
 
     this.bindings_.setUniforms(this.passEncoder_!, pipeline);


### PR DESCRIPTION
### Summary

this PR standardize all shader variable names for consistency using
a prefix for each type `u_` for uniforms, `a_` for vertex attribute
and `v_` for varying.

### Tests & Checks

- all checks have passed.
