### PR TITLE
feat: eagerly upload chunk textures to the GPU

### DIFF
--- a/src/core/renderable_object.ts
+++ b/src/core/renderable_object.ts
@@ -20,11 +20,17 @@ export abstract class RenderableObject extends Node {
   private cullFaceMode_: CullingMode = "none";
 
   public setTexture(index: number, texture: Texture) {
-    const oldTexture = this.textures_[index];
-    if (oldTexture !== undefined) {
-      this.staleTextures_.push(oldTexture);
-    }
     this.textures_[index] = texture;
+  }
+
+  protected clearTextures() {
+    this.textures_.length = 0;
+  }
+
+  protected markStaleTexture(texture: Texture | undefined) {
+    if (texture !== undefined) {
+      this.staleTextures_.push(texture);
+    }
   }
 
   public popStaleTextures() {

--- a/src/data/chunk.ts
+++ b/src/data/chunk.ts
@@ -1,4 +1,7 @@
-import { TextureUnpackRowAlignment } from "../objects/textures/texture";
+import {
+  type Texture,
+  TextureUnpackRowAlignment,
+} from "../objects/textures/texture";
 import { Logger } from "../utilities/logger";
 
 const chunkDataTypes = [
@@ -34,6 +37,7 @@ export type ChunkViewState = {
 
 export type Chunk = {
   data?: ChunkData;
+  texture?: Texture;
   state: "unloaded" | "queued" | "loading" | "loaded";
   lod: number;
   shape: {

--- a/src/data/chunk_manager.ts
+++ b/src/data/chunk_manager.ts
@@ -1,18 +1,33 @@
-import { ChunkSource } from "./chunk";
-import { ChunkQueue } from "./chunk_queue";
-import { chunkMemoryStats } from "./chunk_memory";
+import { Chunk, ChunkSource } from "./chunk";
+import { ChunkQueue, comparePriority } from "./chunk_queue";
+import { chunkMemoryStats, clearChunkData } from "./chunk_memory";
+import { ChunkStore } from "./chunk_store";
+import { ChunkStoreView } from "./chunk_store_view";
+import { ImageSourcePolicy } from "../core/image_source_policy";
+import { Texture } from "../objects/textures/texture";
+import { Texture3D } from "../objects/textures/texture_3d";
 
 export type QueueStats = {
   pending: number;
   running: number;
 };
-import { ChunkStore } from "./chunk_store";
-import { ChunkStoreView } from "./chunk_store_view";
-import { ImageSourcePolicy } from "../core/image_source_policy";
+
+const MAX_UPLOADS_PER_STORE_PER_UPDATE = 4;
 
 export class ChunkManager {
   private readonly stores_: { source: ChunkSource; store: ChunkStore }[] = [];
   private readonly queue_ = new ChunkQueue();
+
+  private readonly uploadTexture_?: (texture: Texture) => void;
+  private readonly disposeTexture_?: (texture: Texture) => void;
+
+  constructor(
+    uploadTexture?: (texture: Texture) => void,
+    disposeTexture?: (texture: Texture) => void
+  ) {
+    this.uploadTexture_ = uploadTexture;
+    this.disposeTexture_ = disposeTexture;
+  }
 
   public get queueStats(): QueueStats {
     return {
@@ -44,12 +59,16 @@ export class ChunkManager {
       for (const chunk of updatedChunks) {
         if (chunk.priority === null) {
           this.queue_.cancel(chunk);
+          this.disposeChunkTexture(chunk);
+          clearChunkData(chunk);
         } else if (chunk.state === "queued") {
           this.queue_.enqueue(chunk, (signal) =>
             source.loader.loadChunkData(chunk, signal)
           );
         }
       }
+
+      this.uploadLoadedChunks(updatedChunks);
     }
 
     this.queue_.flush();
@@ -59,5 +78,39 @@ export class ChunkManager {
         this.stores_.splice(i, 1);
       }
     }
+  }
+
+  private uploadLoadedChunks(chunks: Set<Chunk>) {
+    if (!this.uploadTexture_) return;
+
+    const pending: Chunk[] = [];
+
+    for (const chunk of chunks) {
+      if (chunk.state === "loaded" && chunk.texture === undefined) {
+        pending.push(chunk);
+      }
+    }
+
+    if (pending.length === 0) return;
+
+    pending.sort(comparePriority);
+
+    const limit = Math.min(pending.length, MAX_UPLOADS_PER_STORE_PER_UPDATE);
+
+    for (let i = 0; i < limit; i++) {
+      const chunk = pending[i];
+      const texture = Texture3D.createWithChunk(chunk);
+      this.uploadTexture_(texture);
+      chunk.texture = texture;
+      clearChunkData(chunk);
+    }
+  }
+
+  private disposeChunkTexture(chunk: Chunk) {
+    if (!this.disposeTexture_) return;
+
+    if (chunk.texture === undefined) return;
+    this.disposeTexture_(chunk.texture);
+    chunk.texture = undefined;
   }
 }

--- a/src/data/chunk_memory.ts
+++ b/src/data/chunk_memory.ts
@@ -26,6 +26,7 @@ export function clearChunkData(chunk: Chunk): void {
     cpuChunkCount -= 1;
   }
   chunk.data = undefined;
+  chunk.texture?.releaseCpuData();
 }
 
 export function chunkMemoryStats() {

--- a/src/data/chunk_queue.ts
+++ b/src/data/chunk_queue.ts
@@ -7,6 +7,20 @@ type LoaderFn = (signal: AbortSignal) => Promise<void>;
 
 type PendingItem = { chunk: Chunk; fn: LoaderFn };
 
+export function comparePriority(a: Chunk, b: Chunk) {
+  const priorityA = a.priority ?? Number.MAX_SAFE_INTEGER;
+  const priorityB = b.priority ?? Number.MAX_SAFE_INTEGER;
+
+  if (priorityA === priorityB) {
+    return (
+      (a.orderKey ?? Number.MAX_SAFE_INTEGER) -
+      (b.orderKey ?? Number.MAX_SAFE_INTEGER)
+    );
+  }
+
+  return priorityA - priorityB;
+}
+
 export class ChunkQueue {
   private readonly maxConcurrent_: number;
   private readonly pending_: PendingItem[] = [];
@@ -61,19 +75,7 @@ export class ChunkQueue {
       return;
     }
 
-    this.pending_.sort((a, b) => {
-      const priorityA = a.chunk.priority ?? Number.MAX_SAFE_INTEGER;
-      const priorityB = b.chunk.priority ?? Number.MAX_SAFE_INTEGER;
-
-      if (priorityA === priorityB) {
-        return (
-          (a.chunk.orderKey ?? Number.MAX_SAFE_INTEGER) -
-          (b.chunk.orderKey ?? Number.MAX_SAFE_INTEGER)
-        );
-      }
-
-      return priorityA - priorityB;
-    });
+    this.pending_.sort((a, b) => comparePriority(a.chunk, b.chunk));
 
     while (
       this.running_.size < this.maxConcurrent_ &&

--- a/src/data/chunk_store.ts
+++ b/src/data/chunk_store.ts
@@ -1,5 +1,4 @@
 import { Chunk, SourceDimensionMap } from "./chunk";
-import { clearChunkData } from "./chunk_memory";
 import { almostEqual } from "../utilities/almost_equal";
 import { Logger } from "../utilities/logger";
 import { ChunkStoreView } from "./chunk_store_view";
@@ -218,7 +217,6 @@ export class ChunkStore {
         );
       }
 
-      clearChunkData(chunk);
       chunk.state = "unloaded";
       chunk.orderKey = null;
       Logger.debug(

--- a/src/data/chunk_store_view.ts
+++ b/src/data/chunk_store_view.ts
@@ -75,7 +75,8 @@ export class ChunkStoreView {
     const lowResChunks: Chunk[] = [];
 
     for (const [chunk, state] of this.chunkViewStates_) {
-      if (!state.visible || chunk.state !== "loaded") continue;
+      if (!state.visible || chunk.state !== "loaded" || !chunk.texture)
+        continue;
       if (chunk.lod === currentLOD) {
         currentLODChunks.push(chunk);
       } else if (chunk.lod === fallbackLOD && currentLOD !== fallbackLOD) {
@@ -113,7 +114,7 @@ export class ChunkStoreView {
         "ChunkStoreView",
         "updateChunkViewStates called with no chunks initialized"
       );
-      this.chunkViewStates_.clear();
+      this.chunkViewStates_.forEach(resetChunkViewState);
       return;
     }
 
@@ -202,7 +203,7 @@ export class ChunkStoreView {
         "ChunkStoreView",
         "updateChunksForVolume called with no chunks initialized"
       );
-      this.chunkViewStates_.clear();
+      this.chunkViewStates_.forEach(resetChunkViewState);
       return;
     }
 

--- a/src/idetik.ts
+++ b/src/idetik.ts
@@ -113,7 +113,10 @@ export class Idetik {
     this.canvas = params.canvas;
 
     this.renderer_ = renderer ?? new WebGLRenderer(this.canvas);
-    this.chunkManager_ = new ChunkManager();
+    this.chunkManager_ = new ChunkManager(
+      (texture) => this.renderer_.uploadTexture(texture),
+      (texture) => this.renderer_.disposeTexture(texture)
+    );
     this.context_ = {
       chunkManager: this.chunkManager_,
     };

--- a/src/layers/image_layer.ts
+++ b/src/layers/image_layer.ts
@@ -11,13 +11,13 @@ import {
   validateChannelPropsCount,
 } from "../core/channel";
 import { ImageRenderable } from "../objects/renderable/image_renderable";
-import { Texture3D } from "../objects/textures/texture_3d";
 import { Color } from "../math/color";
 import { EventContext } from "../core/event_dispatcher";
 import { vec2, vec3 } from "gl-matrix";
 import { handlePointPickingEvent, PointPickingResult } from "./point_picking";
 import { clamp } from "../utilities/clamp";
 import { RenderablePool } from "../utilities/renderable_pool";
+import { Texture } from "../objects/textures/texture";
 
 export type ImageLayerProps = LayerOptions & {
   source: ChunkSource;
@@ -128,8 +128,13 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
     if (!this.chunkStoreView_) return;
     if (this.state !== "ready") this.setState("ready");
 
+    const visibleChunksResident = Array.from(this.visibleChunks_.keys()).every(
+      (chunk) => chunk.texture !== undefined
+    );
+
     if (
       this.visibleChunks_.size > 0 &&
+      visibleChunksResident &&
       !this.chunkStoreView_.allVisibleFallbackLODLoaded() &&
       !this.isPresentationStale()
     ) {
@@ -147,8 +152,7 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
 
     this.clearObjects();
     for (const chunk of orderedByLOD) {
-      if (chunk.state !== "loaded") continue;
-      const image = this.getImageForChunk(chunk);
+      const image = this.getImageForChunk(chunk, chunk.texture!);
       this.visibleChunks_.set(chunk, image);
       this.addObject(image);
     }
@@ -209,23 +213,20 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
     }
   }
 
-  private getImageForChunk(chunk: Chunk) {
+  private getImageForChunk(chunk: Chunk, texture: Texture) {
     const existing = this.visibleChunks_.get(chunk);
     if (existing) return existing;
 
     const pooled = this.pool_.acquire(poolKeyForImageRenderable(chunk));
     if (pooled) {
-      const texture = pooled.textures[0] as Texture3D;
-      texture.updateWithChunk(chunk);
-
+      pooled.setTexture(0, texture);
       pooled.zTexCoord = this.zTexCoordForChunk(chunk);
       pooled.setChannelProps(this.getChannelPropsForChunk(chunk));
       this.updateImageChunk(pooled, chunk);
-
       return pooled;
     }
 
-    return this.createImage(chunk);
+    return this.createImage(chunk, texture);
   }
 
   private getChannelPropsForChunk(chunk: Chunk): ChannelProps[] {
@@ -233,11 +234,11 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
     return [this.channelProps_[chunk.chunkIndex.c] ?? {}];
   }
 
-  private createImage(chunk: Chunk) {
+  private createImage(chunk: Chunk, texture: Texture) {
     const image = new ImageRenderable(
       chunk.shape.x,
       chunk.shape.y,
-      Texture3D.createWithChunk(chunk),
+      texture,
       this.getChannelPropsForChunk(chunk)
     );
     image.zTexCoord = this.zTexCoordForChunk(chunk);

--- a/src/layers/label_layer.ts
+++ b/src/layers/label_layer.ts
@@ -10,7 +10,7 @@ import {
   LabelColorMap,
   LabelColorMapProps,
 } from "../objects/renderable/label_color_map";
-import { Texture3D } from "../objects/textures/texture_3d";
+import { Texture } from "../objects/textures/texture";
 import { EventContext } from "../core/event_dispatcher";
 import { vec2, vec3 } from "gl-matrix";
 import { handlePointPickingEvent, PointPickingResult } from "./point_picking";
@@ -114,8 +114,13 @@ export class LabelLayer extends Layer {
     if (!this.chunkStoreView_) return;
     if (this.state !== "ready") this.setState("ready");
 
+    const visibleChunksResident = Array.from(this.visibleChunks_.keys()).every(
+      (chunk) => chunk.texture !== undefined
+    );
+
     if (
       this.visibleChunks_.size > 0 &&
+      visibleChunksResident &&
       !this.chunkStoreView_.allVisibleFallbackLODLoaded() &&
       !this.isPresentationStale()
     ) {
@@ -133,8 +138,7 @@ export class LabelLayer extends Layer {
 
     this.clearObjects();
     for (const chunk of orderedByLOD) {
-      if (chunk.state !== "loaded") continue;
-      const label = this.getLabelForChunk(chunk);
+      const label = this.getLabelForChunk(chunk, chunk.texture!);
       this.visibleChunks_.set(chunk, label);
       this.addObject(label);
     }
@@ -248,15 +252,13 @@ export class LabelLayer extends Layer {
     return (await label.textures[0].readTexel?.(x, y, z)) ?? null;
   }
 
-  private getLabelForChunk(chunk: Chunk) {
+  private getLabelForChunk(chunk: Chunk, texture: Texture) {
     const existing = this.visibleChunks_.get(chunk);
     if (existing) return existing;
 
     const pooled = this.pool_.acquire(poolKeyForImageRenderable(chunk));
     if (pooled) {
-      const texture = pooled.textures[0] as Texture3D;
-      texture.updateWithChunk(chunk);
-
+      pooled.setTexture(0, texture);
       pooled.zTexCoord = this.zTexCoordForChunk(chunk);
       pooled.setColorMap(this.colorMap_);
       pooled.setSelectedValue(this.selectedValue_);
@@ -265,14 +267,14 @@ export class LabelLayer extends Layer {
       return pooled;
     }
 
-    return this.createLabel(chunk);
+    return this.createLabel(chunk, texture);
   }
 
-  private createLabel(chunk: Chunk) {
+  private createLabel(chunk: Chunk, texture: Texture) {
     const label = new LabelImageRenderable({
       width: chunk.shape.x,
       height: chunk.shape.y,
-      imageData: Texture3D.createWithChunk(chunk),
+      imageData: texture,
       colorMap: this.colorMap_,
       outlineSelected: this.outlineSelected_,
       selectedValue: this.selectedValue_,

--- a/src/layers/volume_layer.ts
+++ b/src/layers/volume_layer.ts
@@ -154,6 +154,7 @@ export class VolumeLayer extends Layer implements ChannelsEnabled {
 
   private updateChunks() {
     if (!this.chunkStoreView_) return;
+    if (this.state !== "ready") this.setState("ready");
 
     const chunksToRender = this.chunkStoreView_.getChunksToRender();
     const currentTime = this.sliceCoords_.t ?? -1;
@@ -182,7 +183,6 @@ export class VolumeLayer extends Layer implements ChannelsEnabled {
 
     this.lastLoadedTime_ = currentTime;
     this.lastNumRenderedChannelChunks_ = chunksToRender.length;
-    if (this.state !== "ready") this.setState("ready");
   }
 
   private updateVolumeTransform(volume: VolumeRenderable, chunk: Chunk) {
@@ -206,7 +206,7 @@ export class VolumeLayer extends Layer implements ChannelsEnabled {
   }
 
   private releaseAndRemoveVolume(volume: VolumeRenderable) {
-    volume.clearLoadedChannels();
+    volume.reset();
     this.pool_.release(this.volumeToPoolKey_.get(volume)!, volume);
     this.volumeToPoolKey_.delete(volume);
   }

--- a/src/objects/renderable/label_image_renderable.ts
+++ b/src/objects/renderable/label_image_renderable.ts
@@ -73,6 +73,8 @@ export class LabelImageRenderable extends RenderableObject {
   }
 
   public setColorMap(colorMap: LabelColorMap) {
+    this.markStaleTexture(this.textures[1]);
+    this.markStaleTexture(this.textures[2]);
     this.setTexture(1, this.makeColorCycleTexture(colorMap.cycle));
     this.setTexture(2, this.makeColorLookupTableTexture(colorMap.lookupTable));
   }

--- a/src/objects/renderable/volume_renderable.ts
+++ b/src/objects/renderable/volume_renderable.ts
@@ -8,7 +8,6 @@ import {
   validateChannel,
   validateChannels,
 } from "../../core/channel";
-import { Texture3D } from "../textures/texture_3d";
 import { vec3 } from "gl-matrix";
 import type { Chunk } from "../../data/chunk";
 
@@ -16,8 +15,9 @@ export class VolumeRenderable extends RenderableObject {
   public voxelScale: vec3 = vec3.fromValues(1, 1, 1);
 
   private channels_: Required<Channel>[];
-  private channelToTextureIndex_: Map<number, number> = new Map();
   private loadedChannels_: Set<number> = new Set();
+
+  private readonly channelToTextureIndex_: Map<number, number> = new Map();
 
   constructor() {
     super();
@@ -32,47 +32,48 @@ export class VolumeRenderable extends RenderableObject {
   }
 
   public updateVolumeWithChunk(chunk: Chunk): void {
+    if (!chunk.texture) return;
+
     const channelIndex = chunk.chunkIndex.c;
 
     const textureIndex = this.channelToTextureIndex_.get(channelIndex);
     if (textureIndex !== undefined) {
-      this.updateChannelTexture(textureIndex, chunk);
+      this.updateChannelTexture(textureIndex, chunk.texture);
     } else {
-      this.addChannelTexture(channelIndex, chunk);
+      this.addChannelTexture(channelIndex, chunk.texture);
     }
 
     this.loadedChannels_.add(channelIndex);
   }
 
-  private addChannelTexture(channelIndex: number, chunk: Chunk): void {
-    const texture = Texture3D.createWithChunk(chunk);
+  private addChannelTexture(channelIndex: number, texture: Texture): void {
     const textureIndex = this.textures.length;
 
     this.setTexture(textureIndex, texture);
     this.channelToTextureIndex_.set(channelIndex, textureIndex);
+
     const newProgramName = dataTypeToVolumeShader(texture.dataType);
     if (this.programName && this.programName !== newProgramName) {
       throw new Error(
         `Volume renderable does not support multiple channels with different data types. Existing program: ${this.programName}, new channel data type: ${texture.dataType} and program: ${newProgramName}`
       );
     }
+
     this.programName = newProgramName;
   }
 
-  private updateChannelTexture(textureIndex: number, chunk: Chunk): void {
-    const texture = this.textures[textureIndex];
-
-    if (!(texture instanceof Texture3D)) {
-      const newTexture = Texture3D.createWithChunk(chunk);
-      this.setTexture(textureIndex, newTexture);
-      return;
-    }
-
-    texture.updateWithChunk(chunk);
+  private updateChannelTexture(textureIndex: number, texture: Texture): void {
+    this.setTexture(textureIndex, texture);
   }
 
   public clearLoadedChannels() {
     this.loadedChannels_ = new Set();
+  }
+
+  public reset() {
+    this.clearTextures();
+    this.channelToTextureIndex_.clear();
+    this.clearLoadedChannels();
   }
 
   public override getUniforms(): Record<string, number[] | number> {

--- a/src/objects/textures/texture.ts
+++ b/src/objects/textures/texture.ts
@@ -117,10 +117,23 @@ export abstract class Texture extends Node {
   // renderer when the texture is uploaded (and cleared on disposal).
   public readTexel?: (x: number, y: number, z: number) => Promise<number>;
 
+  protected data_: DataTextureTypedArray | null = null;
+
+  public get data(): DataTextureTypedArray | null {
+    return this.data_;
+  }
+
+  public set data(data: DataTextureTypedArray) {
+    this.data_ = data;
+    this.needsUpdate = true;
+  }
+
+  public releaseCpuData(): void {
+    this.data_ = null;
+  }
+
   public abstract get width(): number;
   public abstract get height(): number;
-  public abstract get data(): TexImageSource | ArrayBufferView | null;
-  public abstract set data(data: DataTextureTypedArray);
 
   public get type() {
     return "Texture";

--- a/src/objects/textures/texture_2d.ts
+++ b/src/objects/textures/texture_2d.ts
@@ -3,10 +3,8 @@ import {
   Texture,
   bufferToDataType,
 } from "../../objects/textures/texture";
-import { Chunk, ChunkData } from "../../data/chunk";
 
 export class Texture2D extends Texture {
-  private data_: DataTextureTypedArray;
   private readonly width_: number;
   private readonly height_: number;
 
@@ -20,17 +18,8 @@ export class Texture2D extends Texture {
     this.height_ = height;
   }
 
-  public set data(data: DataTextureTypedArray) {
-    this.data_ = data;
-    this.needsUpdate = true;
-  }
-
   public get type() {
     return "Texture2D";
-  }
-
-  public get data() {
-    return this.data_;
   }
 
   public get width() {
@@ -39,39 +28,5 @@ export class Texture2D extends Texture {
 
   public get height() {
     return this.height_;
-  }
-
-  public updateWithChunk(chunk: Chunk, data?: ChunkData) {
-    const source = data ?? chunk.data;
-    if (!source) {
-      throw new Error(
-        "Unable to update texture, chunk data is not initialized."
-      );
-    }
-
-    if (this.data === source) return;
-
-    if (
-      this.width != chunk.shape.x ||
-      this.height != chunk.shape.y ||
-      this.dataType != bufferToDataType(source)
-    ) {
-      throw new Error("Unable to update texture, texture buffer mismatch.");
-    }
-
-    this.data = source;
-  }
-
-  public static createWithChunk(chunk: Chunk, data?: ChunkData) {
-    const source = data ?? chunk.data;
-    if (!source) {
-      throw new Error(
-        "Unable to create texture, chunk data is not initialized."
-      );
-    }
-
-    const texture = new Texture2D(source, chunk.shape.x, chunk.shape.y);
-    texture.unpackAlignment = chunk.rowAlignmentBytes;
-    return texture;
   }
 }

--- a/src/objects/textures/texture_2d_array.ts
+++ b/src/objects/textures/texture_2d_array.ts
@@ -4,9 +4,7 @@ import {
   bufferToDataType,
 } from "../../objects/textures/texture";
 
-import { Chunk, ChunkData } from "../../data/chunk";
 export class Texture2DArray extends Texture {
-  private data_: DataTextureTypedArray;
   private readonly width_: number;
   private readonly height_: number;
   private readonly depth_: number;
@@ -27,15 +25,6 @@ export class Texture2DArray extends Texture {
     return "Texture2DArray";
   }
 
-  public set data(data: DataTextureTypedArray) {
-    this.data_ = data;
-    this.needsUpdate = true;
-  }
-
-  public get data() {
-    return this.data_;
-  }
-
   public get width() {
     return this.width_;
   }
@@ -46,42 +35,5 @@ export class Texture2DArray extends Texture {
 
   public get depth() {
     return this.depth_;
-  }
-
-  public updateWithChunk(chunk: Chunk, data?: ChunkData) {
-    const source = data ?? chunk.data;
-    if (!source) {
-      throw new Error(
-        "Unable to update texture, chunk data is not initialized."
-      );
-    }
-
-    if (this.data === source) return;
-
-    const width = chunk.shape.x;
-    const height = chunk.shape.y;
-    const depth = source.length / (width * height);
-    if (
-      this.width != width ||
-      this.height != height ||
-      this.depth_ != depth ||
-      this.dataType != bufferToDataType(source)
-    ) {
-      throw new Error("Unable to update texture, texture buffer mismatch.");
-    }
-
-    this.data = source;
-  }
-
-  public static createWithChunk(chunk: Chunk, data?: ChunkData) {
-    const source = data ?? chunk.data;
-    if (!source) {
-      throw new Error(
-        "Unable to create texture, chunk data is not initialized."
-      );
-    }
-    const texture = new Texture2DArray(source, chunk.shape.x, chunk.shape.y);
-    texture.unpackAlignment = chunk.rowAlignmentBytes;
-    return texture;
   }
 }

--- a/src/objects/textures/texture_3d.ts
+++ b/src/objects/textures/texture_3d.ts
@@ -2,7 +2,6 @@ import { DataTextureTypedArray, Texture, bufferToDataType } from "./texture";
 import { Chunk } from "../../data/chunk";
 
 export class Texture3D extends Texture {
-  private data_: DataTextureTypedArray;
   private readonly width_: number;
   private readonly height_: number;
   private readonly depth_: number;
@@ -23,17 +22,8 @@ export class Texture3D extends Texture {
     this.depth_ = depth;
   }
 
-  public set data(data: DataTextureTypedArray) {
-    this.data_ = data;
-    this.needsUpdate = true;
-  }
-
   public get type() {
     return "Texture3D";
-  }
-
-  public get data() {
-    return this.data_;
   }
 
   public get width() {
@@ -46,28 +36,6 @@ export class Texture3D extends Texture {
 
   public get depth() {
     return this.depth_;
-  }
-
-  public updateWithChunk(chunk: Chunk) {
-    const source = chunk.data;
-    if (!source) {
-      throw new Error(
-        "Unable to update texture, chunk data is not initialized."
-      );
-    }
-
-    if (this.data === source) return;
-
-    if (
-      this.width != chunk.shape.x ||
-      this.height != chunk.shape.y ||
-      this.depth != chunk.shape.z ||
-      this.dataType != bufferToDataType(source)
-    ) {
-      throw new Error("Unable to update texture, texture buffer mismatch.");
-    }
-
-    this.data = source;
   }
 
   public static createWithChunk(chunk: Chunk) {

--- a/src/renderers/webgl_textures.ts
+++ b/src/renderers/webgl_textures.ts
@@ -135,6 +135,7 @@ export class WebGLTextures {
     this.gl_.bindTexture(textureType, textureId);
     this.configureTextureParameters(texture, textureType);
     this.uploadTextureData(texture, info, textureType);
+    this.currentTexture_ = null;
 
     texture.needsUpdate = false;
   }


### PR DESCRIPTION
### Summary

this pr changes when chunk textures are sent to the gpu. instead of uploading a
chunk lazily the first time it is drawn, each chunk's texture is now uploaded as
soon as its data finishes loading and that gpu texture is owned centrally for
the chunk's whole lifetime rather than by individual layers. once a chunk is on
the gpu its cpu copy is released to save memory, and its texture is freed when
the chunk is no longer needed. the image, label, and volume layers now share
these textures instead of each building and tracking their own.

there's a minor temporary regression: because a chunk's texture is freed the
moment it is no longer needed scrubbing through time can briefly show gaps
where the previous frame used to stay on screen while the next one loaded.
that smoothness returns once eviction is deferred under a budget, keeping
recently used textures resident. this does not affect volume rendering.

this change touches quite a few files but most of the changes are minor.

### Tests & Checks

- all checks have passed
