### PR TITLE
docs: add TypeDoc API reference skeleton

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -20,9 +20,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version-file: '.nvmrc'
           cache: npm
       - run: npm ci
+      - run: npm run docs:api
       - run: npx vitepress build --base /idetik/
       - uses: actions/configure-pages@v4
       - uses: actions/upload-pages-artifact@v3

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ dist-ssr
 
 # Docs
 .vitepress/cache
+docs/api
 
 # Generated manifests
 examples/examples-manifest.json

--- a/.vitepress/config.mjs
+++ b/.vitepress/config.mjs
@@ -1,4 +1,5 @@
 import { defineConfig } from 'vitepress'
+import typedocSidebar from '../docs/api/typedoc-sidebar.json' with { type: 'json' }
 
 export default defineConfig({
   title: 'Idetik',
@@ -13,16 +14,23 @@ export default defineConfig({
   themeConfig: {
     nav: [
       { text: 'Guide', link: '/guide/getting-started' },
+      { text: 'API', link: '/api/' },
     ],
 
-    sidebar: [
-      {
-        text: 'Guide',
-        items: [
-          { text: 'Getting Started', link: '/guide/getting-started' },
-        ],
-      },
-    ],
+    sidebar: {
+      '/guide/': [
+        {
+          text: 'Guide',
+          items: [
+            { text: 'Getting Started', link: '/guide/getting-started' },
+          ],
+        },
+      ],
+      '/api/': [
+        { text: 'API Reference', link: '/api/' },
+        ...typedocSidebar,
+      ],
+    },
 
     socialLinks: [
       { icon: 'github', link: 'https://github.com/chanzuckerberg/idetik' },

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Project
+# Idetik
 
-A layer-based library for interactive visualization of large datasets.
+A layer-based library for interactive visualization of large bioimaging data, with first-class support for OME-Zarr.
 
 ## Project Status
 
@@ -31,7 +31,8 @@ If you believe you have found a security issue, please responsibly disclose via 
 
    `npm run examples`
 
-   This will start a server on <http://localhost:5173>.
+   This will start a server on <http://localhost:5173>. The examples under [examples/](examples/)
+   are for local development and testing only; they are not deployed.
 
 4. To run the unit test suite (headless Chrome using playwright), run:
 
@@ -41,7 +42,29 @@ If you believe you have found a security issue, please responsibly disclose via 
    automatically, so you can leave it running while you work. To run the tests once and exit, use
    `npm run test -- --run`.
 
-5. See [package.json](package.json) for other available commands.
+5. To build the library for publishing:
+
+   `npm run build`
+
+   This bundles the library and emits type declarations to `dist/`. Use `npm run compile` to
+   type-check and emit declarations only (no bundle).
+
+6. To build the examples as a static site (e.g. to verify the production build):
+
+   `npm run build:examples`
+
+   Output is written to `examples/dist/`.
+
+7. To work on the documentation site:
+
+   - `npm run docs:dev` — start the VitePress dev server on <http://localhost:5174>
+   - `npm run docs:build` — build the static docs site to `.vitepress/dist/` (also generates the
+     API reference from TypeScript/JSDoc via TypeDoc)
+   - `npm run docs:preview` — build, then locally serve the production docs
+
+   The docs site is deployed to GitHub Pages automatically on push to `main`.
+
+8. See [package.json](package.json) for other available commands.
 
 ## Release
 
@@ -54,11 +77,13 @@ We use [semantic-release](https://github.com/semantic-release/semantic-release) 
 #### How It Works
 
 1. **Use Conventional Commits**: When creating PRs, ensure your PR title follows the [Conventional Commits](https://www.conventionalcommits.org/) format:
-   - `feat: add new feature` → triggers a **minor** version bump (e.g., 7.0.0 → 7.1.0)
-   - `fix: resolve bug` → triggers a **patch** version bump (e.g., 7.0.0 → 7.0.1)
-   - `feat!: breaking change` or `BREAKING CHANGE:` in commit footer → triggers a **major** version bump (e.g., 7.0.0 → 8.0.0)
-   - `refactor:`, `perf:`, `chore:` → triggers a **patch** version bump
+   - `feat: add new feature` → triggers a **minor** version bump (e.g., 0.1.0 → 0.2.0)
+   - `fix: resolve bug` → triggers a **patch** version bump (e.g., 0.1.0 → 0.1.1)
+   - `feat!: breaking change` or `BREAKING CHANGE:` in commit footer → triggers a **minor** version bump while in `0.x` (e.g., 0.1.0 → 0.2.0)
+   - `refactor:`, `perf:`, `chore:`, `revert:` → triggers a **patch** version bump
    - `docs:`, `style:`, `test:`, `ci:`, `build:` → no release
+
+   While the project is in `0.x`, breaking changes bump the **minor** version (see [.releaserc.json](.releaserc.json)); `1.0.0` will be cut deliberately.
 
 2. **PR Title Validation**: Our CI automatically validates PR titles to ensure they follow the conventional commit format.
 
@@ -69,7 +94,7 @@ We use [semantic-release](https://github.com/semantic-release/semantic-release) 
    - Generates/updates `CHANGELOG.md`
    - Publishes to npm as `@idetik/core`
    - Creates a GitHub release with release notes
-   - Tags the release (e.g., `v7.1.0`)
+   - Tags the release (e.g., `v0.2.0`)
 
 4. **No Manual Intervention Required**: The entire process is automatic once merged to `main`.
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -8,34 +8,49 @@ npm install @idetik/core
 
 ## Basic Usage
 
+Render a volume from a remote OME-Zarr source:
+
 ```typescript
 import {
   Idetik,
-  OrthographicCamera,
-  PanZoomControls,
-  ChunkedImageLayer,
+  PerspectiveCamera,
+  OrbitControls,
+  VolumeLayer,
   OmeZarrImageSource,
-  createExplorationPolicy
+  createExplorationPolicy,
 } from '@idetik/core'
 
-const source = OmeZarrImageSource.fromHttp({
-  url: 'https://public.czbiohub.org/royerlab/zebrahub/imaging/single-objective/ZSNS001.ome.zarr/'
+const source = await OmeZarrImageSource.fromHttp({
+  url: 'https://public.czbiohub.org/royerlab/zebrahub/imaging/multi-view/ZMNS001.ome.zarr/',
 })
 
-const camera = new OrthographicCamera(100, 900, 100, 900)
-const layer = new ChunkedImageLayer({
+const camera = new PerspectiveCamera()
+
+const layer = new VolumeLayer({
   source,
-  sliceCoords: { t: 0, c: 0, z: 0 },
-  policy: createExplorationPolicy(),
-  channelProps: [{ contrastLimits: [0, 150], visible: true }],
+  sliceCoords: { t: 0, z: undefined, c: undefined }, // show all channels
+  // The volume layer renders a single LOD, so pin one in the policy.
+  policy: createExplorationPolicy({ lod: { min: 2, max: 2 } }),
+  channelProps: [
+    { visible: true, color: '#00ffff', contrastLimits: [300, 1500] }, // h2afva
+    { visible: true, color: '#ff00ff', contrastLimits: [75, 500] }, // mezzo
+  ],
 })
+
+// Frame the camera using the source's physical dimensions: aim at the
+// volume center and back off to ~120% of its largest extent.
+const dims = source.getDimensions()
+const span = (d: typeof dims.x) => d.lods[0].size * d.lods[0].scale
+const center = (d: typeof dims.x) => d.lods[0].translation + span(d) / 2
+const target: [number, number, number] = [center(dims.x), center(dims.y), center(dims.z!)]
+const radius = 1.2 * Math.max(span(dims.x), span(dims.y), span(dims.z!))
 
 const idetik = new Idetik({
-  canvas: document.querySelector('canvas'),
+  canvas: document.querySelector<HTMLCanvasElement>('canvas')!,
   viewports: [{
     camera,
     layers: [layer],
-    cameraControls: new PanZoomControls(camera),
+    cameraControls: new OrbitControls(camera, { radius, target }),
   }],
 })
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -40,5 +40,5 @@ export default [
       'no-console': process.env.NODE_ENV === 'production' ? 'error' : 'warn'
     }
   },
-  { ignores: ["node_modules", "**/coverage", "**/dist"] },
+  { ignores: ["node_modules", "**/coverage", "**/dist", ".vitepress/cache", "docs/api"] },
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,9 @@
         "rollup-plugin-dts": "^6.1.1",
         "semantic-release": "^25.0.2",
         "tslib": "^2.8.1",
+        "typedoc": "^0.28.19",
+        "typedoc-plugin-markdown": "^4.12.0",
+        "typedoc-vitepress-theme": "^1.1.3",
         "typescript": "^5.2.2",
         "typescript-eslint": "^8.1.0",
         "vite": "^6.4.2",
@@ -1496,6 +1499,62 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@gerrit0/mini-shiki": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.23.0.tgz",
+      "integrity": "sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/engine-oniguruma": "^3.23.0",
+        "@shikijs/langs": "^3.23.0",
+        "@shikijs/themes": "^3.23.0",
+        "@shikijs/types": "^3.23.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
+    "node_modules/@gerrit0/mini-shiki/node_modules/@shikijs/engine-oniguruma": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.23.0.tgz",
+      "integrity": "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
+    "node_modules/@gerrit0/mini-shiki/node_modules/@shikijs/langs": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.23.0.tgz",
+      "integrity": "sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0"
+      }
+    },
+    "node_modules/@gerrit0/mini-shiki/node_modules/@shikijs/themes": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.23.0.tgz",
+      "integrity": "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0"
+      }
+    },
+    "node_modules/@gerrit0/mini-shiki/node_modules/@shikijs/types": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.23.0.tgz",
+      "integrity": "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
       }
     },
     "node_modules/@humanfs/core": {
@@ -6341,6 +6400,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/linkify-it": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
+      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
     "node_modules/load-json-file": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
@@ -6446,6 +6525,13 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -6521,6 +6607,47 @@
       "integrity": "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/markdown-it": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.2.0.tgz",
+      "integrity": "sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.1",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/markdown-it/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/marked": {
       "version": "15.0.12",
@@ -6601,6 +6728,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/meow": {
       "version": "13.2.0",
@@ -9530,6 +9664,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/querystringify": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
@@ -10762,6 +10906,53 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/typedoc": {
+      "version": "0.28.19",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.19.tgz",
+      "integrity": "sha512-wKh+lhdmMFivMlc6vRRcMGXeGEHGU2g8a2CkPTJjJlwRf1iXbimWIPcFolCqe4E0d/FRtGszpIrsp3WLpDB8Pw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@gerrit0/mini-shiki": "^3.23.0",
+        "lunr": "^2.3.9",
+        "markdown-it": "^14.1.1",
+        "minimatch": "^10.2.5",
+        "yaml": "^2.8.3"
+      },
+      "bin": {
+        "typedoc": "bin/typedoc"
+      },
+      "engines": {
+        "node": ">= 18",
+        "pnpm": ">= 10"
+      },
+      "peerDependencies": {
+        "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x || 6.0.x"
+      }
+    },
+    "node_modules/typedoc-plugin-markdown": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-4.12.0.tgz",
+      "integrity": "sha512-eJDEMAfxCmede22c/Jw7d0FA13ggAQv+KkwQYKYCdqI02cin6Rc9QRwbG/7XvvHWinuFejySnZVUWDtvGk3Vbg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "typedoc": "0.28.x"
+      }
+    },
+    "node_modules/typedoc-vitepress-theme": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/typedoc-vitepress-theme/-/typedoc-vitepress-theme-1.1.3.tgz",
+      "integrity": "sha512-EK9iV7e3+R8lFNigdc0rIPWMxqfmDku0uGac3qYUu9tS4Qf1rhWZnyZJ4zu4G3iXrP5mqNPkv2wpODzRlA7jLw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "typedoc-plugin-markdown": ">=4.11.0"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -10799,6 +10990,13 @@
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/uglify-js": {
       "version": "3.19.3",
@@ -12172,6 +12370,22 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yargs": {
       "version": "18.0.0",

--- a/package.json
+++ b/package.json
@@ -43,14 +43,15 @@
     "format-check": "prettier --check './**/*.{ts,tsx,html,json}'",
     "lint": "eslint .",
     "pub": "npm run build; npm publish --access=public",
-    "docs:dev": "vitepress dev",
-    "docs:build": "vitepress build",
+    "docs:api": "typedoc",
+    "docs:dev": "npm run docs:api && vitepress dev",
+    "docs:build": "npm run docs:api && vitepress build",
     "docs:preview": "npm run docs:build && vitepress preview"
   },
   "dependencies": {
     "gl-matrix": "^3.4.3",
-    "zarrita": "^0.7.1",
     "webgpu-utils": "^2.1.0",
+    "zarrita": "^0.7.1",
     "zod": "^3.24.1"
   },
   "devDependencies": {
@@ -75,6 +76,9 @@
     "rollup-plugin-dts": "^6.1.1",
     "semantic-release": "^25.0.2",
     "tslib": "^2.8.1",
+    "typedoc": "^0.28.19",
+    "typedoc-plugin-markdown": "^4.12.0",
+    "typedoc-vitepress-theme": "^1.1.3",
     "typescript": "^5.2.2",
     "typescript-eslint": "^8.1.0",
     "vite": "^6.4.2",

--- a/src/core/channel.ts
+++ b/src/core/channel.ts
@@ -12,6 +12,7 @@ export type Channel = {
   opacity: number;
 };
 
+/** @group Layer Configuration */
 export type ChannelProps = {
   visible?: boolean;
   color?: ColorLike;

--- a/src/core/image_source_policy.ts
+++ b/src/core/image_source_policy.ts
@@ -41,6 +41,7 @@ export type ImageSourcePolicy = Readonly<{
   };
 }>;
 
+/** @group Layer Configuration */
 export function createImageSourcePolicy(
   config: ImageSourcePolicyConfig
 ): ImageSourcePolicy {
@@ -81,6 +82,7 @@ export function createImageSourcePolicy(
   return Object.freeze(resolved);
 }
 
+/** @group Layer Configuration */
 export function createExplorationPolicy(
   overrides: Partial<ImageSourcePolicyConfig> = {}
 ): ImageSourcePolicy {
@@ -98,6 +100,7 @@ export function createExplorationPolicy(
   return createImageSourcePolicy(mergeConfig(base, overrides));
 }
 
+/** @group Layer Configuration */
 export function createPlaybackPolicy(
   overrides: Partial<ImageSourcePolicyConfig> = {}
 ): ImageSourcePolicy {
@@ -115,6 +118,7 @@ export function createPlaybackPolicy(
   return createImageSourcePolicy(mergeConfig(base, overrides));
 }
 
+/** @group Layer Configuration */
 export function createNoPrefetchPolicy(
   overrides: Partial<ImageSourcePolicyConfig> = {}
 ): ImageSourcePolicy {

--- a/src/core/layer.ts
+++ b/src/core/layer.ts
@@ -5,6 +5,7 @@ import { Logger } from "../utilities/logger";
 import { EventContext } from "./event_dispatcher";
 import { Viewport } from "./viewport";
 
+/** @group Layers */
 export type LayerState = "initialized" | "loading" | "ready";
 export type BlendMode =
   | "none"
@@ -24,6 +25,22 @@ export interface LayerOptions {
   blendMode?: BlendMode;
 }
 
+/**
+ * Abstract base class for everything that can be added to a viewport.
+ *
+ * A `Layer` owns a set of renderable objects and contributes them to the scene
+ * each frame. Subclasses (e.g. {@link ImageLayer}, {@link VolumeLayer},
+ * {@link LabelLayer}) implement {@link Layer.update} to build or refresh those
+ * objects for the current view, and may override the `attach`/`detach` hooks to
+ * acquire and release resources when the layer joins or leaves a viewport.
+ *
+ * Layers carry shared presentation state — {@link Layer.opacity} and blend mode —
+ * and expose a lifecycle {@link LayerState} (`initialized` → `loading` → `ready`)
+ * that observers can subscribe to. A layer instance may be attached to only one
+ * viewport at a time.
+ *
+ * @group Layers
+ */
 export abstract class Layer {
   public abstract readonly type: string;
 

--- a/src/data/chunk.ts
+++ b/src/data/chunk.ts
@@ -96,6 +96,7 @@ type SourceDimensionLod = {
   translation: number;
 };
 
+/** @group Layer Configuration */
 export type SliceCoordinates = {
   z?: number;
   c?: number[];

--- a/src/data/ome_zarr/image_source.ts
+++ b/src/data/ome_zarr/image_source.ts
@@ -30,7 +30,11 @@ type FileSystemOmeZarrImageSourceProps = {
   path?: `/${string}`;
 };
 
-/** Opens an OME-Zarr multiscale image Zarr group from either a URL or local directory. */
+/**
+ * Opens an OME-Zarr multiscale image Zarr group from either a URL or local directory.
+ *
+ * @group Data Loading
+ */
 export class OmeZarrImageSource {
   readonly location: Location<Readable>;
   readonly version?: OmeZarrVersion;

--- a/src/data/ome_zarr/metadata_loaders.ts
+++ b/src/data/ome_zarr/metadata_loaders.ts
@@ -53,6 +53,7 @@ function removeProperty<O, P extends keyof O>(obj: O, prop: P): Omit<O, P> {
   return objCopy;
 }
 
+/** @group Data Loading */
 export async function loadOmeZarrPlate(
   url: string,
   version?: Version
@@ -128,6 +129,7 @@ function parseWell(attrs: Record<string, unknown>): AdaptedOme<Well["ome"]> {
   }
 }
 
+/** @group Data Loading */
 export async function loadOmeZarrWell(
   url: string,
   path: string,
@@ -150,6 +152,7 @@ export async function loadOmeZarrWell(
 export type OmeroMetadata = NonNullable<Image["ome"]["omero"]>;
 export type OmeroChannel = OmeroMetadata["channels"][number];
 
+/** @group Data Loading */
 export async function loadOmeroChannels(
   source: OmeZarrImageSource
 ): Promise<OmeroChannel[]> {
@@ -159,6 +162,7 @@ export async function loadOmeroChannels(
   return image.omero?.channels ?? [];
 }
 
+/** @group Data Loading */
 export async function loadOmeroDefaults(
   source: OmeZarrImageSource
 ): Promise<OmeroMetadata["rdefs"]> {

--- a/src/idetik.ts
+++ b/src/idetik.ts
@@ -12,10 +12,12 @@ import {
 } from "./core/viewport";
 import { PixelSizeObserver } from "./utilities/pixel_size_observer";
 
+/** @group Runtime */
 export type Overlay = {
   update(idetik: Idetik): void;
 };
 
+/** @inline */
 type IdetikParams = {
   canvas: HTMLCanvasElement;
   viewports?: ViewportConfig[];
@@ -29,6 +31,7 @@ export type IdetikContext = {
 
 // JS heap usage from the non-standard performance.memory API.
 // Chromium only, undefined where the API is unavailable.
+/** @group Runtime */
 export type MemoryStats = {
   cpuChunkBytes: number;
   cpuChunkCount: number;
@@ -38,6 +41,18 @@ export type MemoryStats = {
   jsHeapLimitBytes?: number;
 };
 
+/**
+ * The top-level entry point for an Idetik visualization.
+ *
+ * An `Idetik` instance owns the renderer, the shared chunk manager, and one or
+ * more viewports. Each viewport pairs a camera, its controls, and a stack of
+ * layers and draws into a region of the canvas. Call {@link Idetik.start} to
+ * begin the render loop and {@link Idetik.stop} to halt it.
+ *
+ * @see {@link Layer} for the data layers rendered within a viewport.
+ *
+ * @group Runtime
+ */
 export class Idetik {
   private readonly chunkManager_: ChunkManager;
   private readonly context_: IdetikContext;

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,8 +34,15 @@ export {
   createPlaybackPolicy,
 } from "./core/image_source_policy";
 
+import type { Image } from "./data/ome_zarr/0.4/image";
+
 export type { ChannelProps } from "./core/channel";
-export type { Image as OmeZarrImage } from "./data/ome_zarr/0.4/image";
+/**
+ * Parsed OME-Zarr (OME-NGFF 0.4) image metadata.
+ *
+ * @group Data Loading
+ */
+export type OmeZarrImage = Image;
 export type { LayerState } from "./core/layer";
 export type { MemoryStats, Overlay } from "./idetik";
 export type { SliceCoordinates } from "./data/chunk";

--- a/src/layers/axes_layer.ts
+++ b/src/layers/axes_layer.ts
@@ -2,6 +2,7 @@ import { Layer } from "../core/layer";
 import { ProjectedLineGeometry } from "../objects/geometry/projected_line_geometry";
 import { ProjectedLine } from "../objects/renderable/projected_line";
 
+/** @group Layers */
 export class AxesLayer extends Layer {
   public readonly type = "AxesLayer";
 

--- a/src/layers/image_layer.ts
+++ b/src/layers/image_layer.ts
@@ -19,6 +19,7 @@ import { clamp } from "../utilities/clamp";
 import { RenderablePool } from "../utilities/renderable_pool";
 import { Texture } from "../objects/textures/texture";
 
+/** @inline */
 export type ImageLayerProps = LayerOptions & {
   source: ChunkSource;
   sliceCoords: SliceCoordinates;
@@ -27,6 +28,20 @@ export type ImageLayerProps = LayerOptions & {
   onPickValue?: (info: PointPickingResult) => void;
 };
 
+/**
+ * A layer that renders a 2D slice of a chunked, multi-channel image source.
+ *
+ * `ImageLayer` streams chunks from a `ChunkSource` (e.g.
+ * {@link OmeZarrImageSource}) according to the supplied `ImageSourcePolicy`,
+ * which decides which resolution levels and chunks to load for the current
+ * view. Per-channel appearance (contrast limits,
+ * color, visibility) is controlled via {@link ChannelProps}, and the visible
+ * slice is selected with {@link SliceCoordinates}.
+ *
+ * @see {@link VolumeLayer} for 3D volume rendering of the same data.
+ *
+ * @group Layers
+ */
 export class ImageLayer extends Layer implements ChannelsEnabled {
   public readonly type = "ImageLayer";
 

--- a/src/layers/label_layer.ts
+++ b/src/layers/label_layer.ts
@@ -27,6 +27,7 @@ export type LabelLayerProps = LayerOptions & {
   outlineSelected?: boolean;
 };
 
+/** @group Layers */
 export class LabelLayer extends Layer {
   public readonly type = "LabelLayer";
 

--- a/src/layers/volume_layer.ts
+++ b/src/layers/volume_layer.ts
@@ -23,6 +23,7 @@ export type VolumeLayerProps = {
 
 const INTERACTIVE_STEP_SIZE_SCALE = 2.0;
 
+/** @group Layers */
 export class VolumeLayer extends Layer implements ChannelsEnabled {
   public readonly type = "VolumeLayer";
 

--- a/src/math/color.ts
+++ b/src/math/color.ts
@@ -1,7 +1,9 @@
 import { vec3, vec4 } from "gl-matrix";
 
+/** @group Layer Configuration */
 export type ColorLike = Color | vec3 | vec4 | string;
 
+/** @group Layer Configuration */
 export class Color {
   public static readonly RED: Color = new Color(1.0, 0.0, 0.0);
   public static readonly GREEN: Color = new Color(0.0, 1.0, 0.0);

--- a/src/objects/cameras/controls.ts
+++ b/src/objects/cameras/controls.ts
@@ -10,6 +10,7 @@ export interface CameraControls {
   onEvent(event: EventContext): void;
 }
 
+/** @group Cameras & Controls */
 export class PanZoomControls implements CameraControls {
   private readonly camera_: OrthographicCamera;
   private dragActive_ = false;

--- a/src/objects/cameras/orbit_controls.ts
+++ b/src/objects/cameras/orbit_controls.ts
@@ -24,6 +24,7 @@ type OrbitParams = {
   dampingFactor?: number;
 };
 
+/** @group Cameras & Controls */
 export class OrbitControls implements CameraControls {
   private readonly camera_: PerspectiveCamera;
 

--- a/src/objects/cameras/orthographic_camera.ts
+++ b/src/objects/cameras/orthographic_camera.ts
@@ -6,6 +6,19 @@ const DEFAULT_ASPECT_RATIO = 1.77; // 16:9
 const DEFAULT_WIDTH = 128;
 const DEFAULT_HEIGHT = 128 / DEFAULT_ASPECT_RATIO;
 
+/**
+ * A camera using an orthographic (parallel) projection.
+ *
+ * Orthographic projection has no perspective foreshortening, so object size is
+ * independent of distance from the camera. This is the camera to use for 2D
+ * image viewing, where it pairs naturally with {@link PanZoomControls}. The
+ * initial frame is given in world coordinates; zoom and pan are applied as
+ * scale and translation on top of that frame.
+ *
+ * @see {@link PerspectiveCamera} for 3D scenes with perspective projection.
+ *
+ * @group Cameras & Controls
+ */
 export class OrthographicCamera extends Camera {
   // width_ and height_ should always be defined by constructor (see setFrame)
   private width_: number = DEFAULT_WIDTH;
@@ -13,6 +26,16 @@ export class OrthographicCamera extends Camera {
   private viewportAspectRatio_: number = DEFAULT_ASPECT_RATIO;
   private viewportSize_: [number, number] = [DEFAULT_WIDTH, DEFAULT_HEIGHT];
 
+  /**
+   * Creates an orthographic camera framing the given world-space rectangle.
+   *
+   * @param left - Left edge of the view frame, in world units.
+   * @param right - Right edge of the view frame, in world units.
+   * @param top - Top edge of the view frame, in world units.
+   * @param bottom - Bottom edge of the view frame, in world units.
+   * @param near - Near clipping plane distance. Defaults to `0.0`.
+   * @param far - Far clipping plane distance. Defaults to `100.0`.
+   */
   constructor(
     left: number,
     right: number,

--- a/src/objects/cameras/perspective_camera.ts
+++ b/src/objects/cameras/perspective_camera.ts
@@ -14,6 +14,7 @@ type PerspectiveCameraOptions = {
   position?: vec3;
 };
 
+/** @group Cameras & Controls */
 export class PerspectiveCamera extends Camera {
   private fov_: number;
   private aspectRatio_: number;

--- a/src/objects/renderable/image_renderable.ts
+++ b/src/objects/renderable/image_renderable.ts
@@ -19,6 +19,7 @@ type UniformValues = {
   u_zTexCoord: number;
 };
 
+/** @group Renderable Objects */
 export class ImageRenderable extends RenderableObject {
   private channels_: Required<Channel>[];
 

--- a/src/objects/renderable/label_color_map.ts
+++ b/src/objects/renderable/label_color_map.ts
@@ -31,6 +31,7 @@ export type LabelColorMapProps = {
   cycle?: ColorLike[];
 };
 
+/** @group Renderable Objects */
 export class LabelColorMap {
   public readonly lookupTable: ReadonlyMap<number, Color>;
   public readonly cycle: ReadonlyArray<Color>;

--- a/src/objects/renderable/label_image_renderable.ts
+++ b/src/objects/renderable/label_image_renderable.ts
@@ -34,6 +34,7 @@ function validateImageData(imageData: Texture) {
   return imageData;
 }
 
+/** @group Renderable Objects */
 export class LabelImageRenderable extends RenderableObject {
   private outlineSelected_: boolean;
   private selectedValue_: number | null;

--- a/src/objects/renderable/points.ts
+++ b/src/objects/renderable/points.ts
@@ -21,6 +21,7 @@ type PointProperties = {
   marker: Marker;
 };
 
+/** @group Renderable Objects */
 export class Points extends RenderableObject {
   constructor(points: PointProperties[]) {
     super();

--- a/src/objects/renderable/projected_line.ts
+++ b/src/objects/renderable/projected_line.ts
@@ -8,6 +8,7 @@ type LineParameters = {
   width: number;
 };
 
+/** @group Renderable Objects */
 export class ProjectedLine extends RenderableObject {
   private color_: Color;
   private width_: number;

--- a/src/objects/renderable/volume_renderable.ts
+++ b/src/objects/renderable/volume_renderable.ts
@@ -11,6 +11,7 @@ import {
 import { vec3 } from "gl-matrix";
 import type { Chunk } from "../../data/chunk";
 
+/** @group Renderable Objects */
 export class VolumeRenderable extends RenderableObject {
   public voxelScale: vec3 = vec3.fromValues(1, 1, 1);
 

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://typedoc.org/schema.json",
+  "plugin": ["typedoc-plugin-markdown", "typedoc-vitepress-theme"],
+  "entryPoints": ["src/index.ts"],
+  "tsconfig": "tsconfig.json",
+  "out": "docs/api",
+  "docsRoot": "docs",
+  "readme": "none",
+  "githubPages": false,
+  "navigation": {
+    "includeGroups": true
+  },
+  "groupOrder": [
+    "Runtime",
+    "Data Loading",
+    "Layers",
+    "Layer Configuration",
+    "Renderable Objects",
+    "Cameras & Controls",
+    "*"
+  ],
+  "hidePageHeader": true,
+  "useCodeBlocks": true,
+  "expandObjects": true,
+  "parametersFormat": "table",
+  "sidebar": {
+    "autoConfiguration": true,
+    "pretty": true
+  }
+}


### PR DESCRIPTION
### Summary
This uses TypeDoc to create an API reference. Most items remain undocumented, but the public API is given "groups" using JSDoc like `/** @group Layer Configuration */`. I don't know much about TypeDoc so config was all set up using Claude.

Currently these groups are:
* Runtime
* Data Loading
* Layers
* Layer Configuration
* Renderable Objects
* Cameras & Controls

I'm happy to iterate on these, but here's what it looks like:
<img width="1442" height="1242" alt="Screenshot 2026-06-26 at 9 08 05 PM" src="https://github.com/user-attachments/assets/fefde145-39a3-4a98-97d5-c533aea26885" />

### Tests & Checks
no changes to the code, examples still work, etc.

note: this builds on #660 so the target branch is that to help see the diff