### PR TITLE
feat: gate chunk uploads with memory budget

### DIFF
--- a/src/data/chunk.ts
+++ b/src/data/chunk.ts
@@ -110,6 +110,8 @@ export type ChunkSource = {
 export type ChunkLoader = {
   getSourceDimensionMap(): SourceDimensionMap;
 
+  getBytesPerElement(): number;
+
   loadChunkData(chunk: Chunk, signal: AbortSignal): Promise<void>;
 };
 

--- a/src/data/chunk_manager.ts
+++ b/src/data/chunk_manager.ts
@@ -20,13 +20,20 @@ export class ChunkManager {
 
   private readonly uploadTexture_?: (texture: Texture) => void;
   private readonly disposeTexture_?: (texture: Texture) => void;
+  private readonly memoryLimitBytes_: number;
 
   constructor(
     uploadTexture?: (texture: Texture) => void,
-    disposeTexture?: (texture: Texture) => void
+    disposeTexture?: (texture: Texture) => void,
+    memoryLimitBytes: number = Infinity
   ) {
     this.uploadTexture_ = uploadTexture;
     this.disposeTexture_ = disposeTexture;
+    this.memoryLimitBytes_ = memoryLimitBytes;
+  }
+
+  public get memoryLimitBytes(): number {
+    return this.memoryLimitBytes_;
   }
 
   public get queueStats(): QueueStats {

--- a/src/data/chunk_manager.ts
+++ b/src/data/chunk_manager.ts
@@ -20,15 +20,18 @@ export class ChunkManager {
 
   private readonly uploadTexture_?: (texture: Texture) => void;
   private readonly disposeTexture_?: (texture: Texture) => void;
+  private readonly getGpuResidentBytes_: () => number;
   private readonly memoryLimitBytes_: number;
 
   constructor(
     uploadTexture?: (texture: Texture) => void,
     disposeTexture?: (texture: Texture) => void,
+    getGpuResidentBytes: () => number = () => 0,
     memoryLimitBytes: number = Infinity
   ) {
     this.uploadTexture_ = uploadTexture;
     this.disposeTexture_ = disposeTexture;
+    this.getGpuResidentBytes_ = getGpuResidentBytes;
     this.memoryLimitBytes_ = memoryLimitBytes;
   }
 
@@ -60,6 +63,8 @@ export class ChunkManager {
   }
 
   public update() {
+    const candidates: { source: ChunkSource; chunk: Chunk }[] = [];
+
     for (const { source, store } of this.stores_) {
       const updatedChunks = store.updateAndCollectChunkChanges();
 
@@ -69,15 +74,14 @@ export class ChunkManager {
           this.disposeChunkTexture(chunk);
           clearChunkData(chunk);
         } else if (chunk.state === "queued") {
-          this.queue_.enqueue(chunk, (signal) =>
-            source.loader.loadChunkData(chunk, signal)
-          );
+          candidates.push({ source, chunk });
         }
       }
 
       this.uploadLoadedChunks(updatedChunks);
     }
 
+    this.enqueueWithinBudget(candidates);
     this.queue_.flush();
 
     for (let i = this.stores_.length - 1; i >= 0; i--) {
@@ -85,6 +89,31 @@ export class ChunkManager {
         this.stores_.splice(i, 1);
       }
     }
+  }
+
+  private enqueueWithinBudget(
+    candidates: { source: ChunkSource; chunk: Chunk }[]
+  ) {
+    if (candidates.length === 0) return;
+
+    candidates.sort((a, b) => comparePriority(a.chunk, b.chunk));
+
+    let committedBytes = this.getGpuResidentBytes_();
+
+    for (const { source, chunk } of candidates) {
+      const bytes = this.chunkBytes(source, chunk);
+      if (committedBytes + bytes > this.memoryLimitBytes_) continue;
+
+      committedBytes += bytes;
+      this.queue_.enqueue(chunk, (signal) =>
+        source.loader.loadChunkData(chunk, signal)
+      );
+    }
+  }
+
+  private chunkBytes(source: ChunkSource, chunk: Chunk): number {
+    const bytesPerElement = source.loader.getBytesPerElement();
+    return chunk.shape.x * chunk.shape.y * chunk.shape.z * bytesPerElement;
   }
 
   private uploadLoadedChunks(chunks: Set<Chunk>) {

--- a/src/data/ome_zarr/image_loader.ts
+++ b/src/data/ome_zarr/image_loader.ts
@@ -107,12 +107,25 @@ export class OmeZarrImageLoader {
   }
 }
 
+const BYTES_PER_ELEMENT: Partial<Record<zarr.DataType, number>> = {
+  int8: 1,
+  uint8: 1,
+  int16: 2,
+  uint16: 2,
+  int32: 4,
+  uint32: 4,
+  float32: 4,
+};
+
 function bytesPerElementForDtype(dtype: zarr.DataType): number {
-  const bits = Number(/\d+/.exec(String(dtype))?.[0]);
-  if (!Number.isFinite(bits) || bits <= 0) {
-    throw new Error(`Cannot determine byte size for zarr dtype "${dtype}"`);
+  const bytes = BYTES_PER_ELEMENT[dtype];
+  if (bytes === undefined) {
+    throw new Error(
+      `Unsupported zarr dtype "${dtype}". ` +
+        `Supported dtypes: ${Object.keys(BYTES_PER_ELEMENT).join(", ")}`
+    );
   }
-  return bits / 8;
+  return bytes;
 }
 
 function inferSourceDimensionMap(

--- a/src/data/ome_zarr/image_loader.ts
+++ b/src/data/ome_zarr/image_loader.ts
@@ -25,16 +25,22 @@ export class OmeZarrImageLoader {
   >;
   private readonly arrayParams_: ReadonlyArray<ZarrArrayParams>;
   private readonly dimensions_: SourceDimensionMap;
+  private readonly bytesPerElement_: number;
 
   constructor(props: OmeZarrImageLoaderProps) {
     this.metadata_ = props.metadata;
     this.arrays_ = props.arrays;
     this.arrayParams_ = props.arrayParams;
     this.dimensions_ = inferSourceDimensionMap(this.metadata_, this.arrays_);
+    this.bytesPerElement_ = bytesPerElementForDtype(this.arrays_[0].dtype);
   }
 
   public getSourceDimensionMap(): SourceDimensionMap {
     return this.dimensions_;
+  }
+
+  public getBytesPerElement(): number {
+    return this.bytesPerElement_;
   }
 
   public async loadChunkData(chunk: Chunk, signal: AbortSignal) {
@@ -99,6 +105,14 @@ export class OmeZarrImageLoader {
     chunk.rowAlignmentBytes = rowAlignment;
     setChunkData(chunk, data);
   }
+}
+
+function bytesPerElementForDtype(dtype: zarr.DataType): number {
+  const bits = Number(/\d+/.exec(String(dtype))?.[0]);
+  if (!Number.isFinite(bits) || bits <= 0) {
+    throw new Error(`Cannot determine byte size for zarr dtype "${dtype}"`);
+  }
+  return bits / 8;
 }
 
 function inferSourceDimensionMap(

--- a/src/idetik.ts
+++ b/src/idetik.ts
@@ -12,6 +12,8 @@ import {
 } from "./core/viewport";
 import { PixelSizeObserver } from "./utilities/pixel_size_observer";
 
+const DEFAULT_MEMORY_LIMIT_MB = 2048;
+
 /** @group Runtime */
 export type Overlay = {
   update(idetik: Idetik): void;
@@ -23,6 +25,7 @@ type IdetikParams = {
   viewports?: ViewportConfig[];
   overlays?: Overlay[];
   showStats?: boolean;
+  memoryLimitMB?: number;
 };
 
 export type IdetikContext = {
@@ -128,9 +131,12 @@ export class Idetik {
     this.canvas = params.canvas;
 
     this.renderer_ = renderer ?? new WebGLRenderer(this.canvas);
+    const memoryLimitMB = params.memoryLimitMB ?? DEFAULT_MEMORY_LIMIT_MB;
+    const memoryLimitBytes = memoryLimitMB * 1024 * 1024;
     this.chunkManager_ = new ChunkManager(
       (texture) => this.renderer_.uploadTexture(texture),
-      (texture) => this.renderer_.disposeTexture(texture)
+      (texture) => this.renderer_.disposeTexture(texture),
+      memoryLimitBytes
     );
     this.context_ = {
       chunkManager: this.chunkManager_,

--- a/src/idetik.ts
+++ b/src/idetik.ts
@@ -136,6 +136,7 @@ export class Idetik {
     this.chunkManager_ = new ChunkManager(
       (texture) => this.renderer_.uploadTexture(texture),
       (texture) => this.renderer_.disposeTexture(texture),
+      () => this.renderer_.gpuTextureBytes,
       memoryLimitBytes
     );
     this.context_ = {

--- a/src/objects/textures/texture.ts
+++ b/src/objects/textures/texture.ts
@@ -84,16 +84,19 @@ export function textureStorageBytes(texture: Texture): number {
     textureChannelCount(texture) * textureBytesPerChannel(texture);
 
   const levels = Math.max(1, texture.mipmapLevels);
-  const depth = Math.max(1, texture.depth);
 
   let width = Math.max(1, texture.width);
   let height = Math.max(1, texture.height);
+  let depth = Math.max(1, texture.depth);
   let total = 0;
 
   for (let i = 0; i < levels; ++i) {
     total += bytesPerTexel * depth * width * height;
     width = Math.max(1, width >> 1);
     height = Math.max(1, height >> 1);
+    if (texture.type === "Texture3D") {
+      depth = Math.max(1, depth >> 1);
+    }
   }
 
   return total;

--- a/src/objects/textures/texture.ts
+++ b/src/objects/textures/texture.ts
@@ -79,6 +79,26 @@ export function textureBytesPerChannel(texture: Texture) {
   }
 }
 
+export function textureStorageBytes(texture: Texture): number {
+  const bytesPerTexel =
+    textureChannelCount(texture) * textureBytesPerChannel(texture);
+
+  const levels = Math.max(1, texture.mipmapLevels);
+  const depth = Math.max(1, texture.depth);
+
+  let width = Math.max(1, texture.width);
+  let height = Math.max(1, texture.height);
+  let total = 0;
+
+  for (let i = 0; i < levels; ++i) {
+    total += bytesPerTexel * depth * width * height;
+    width = Math.max(1, width >> 1);
+    height = Math.max(1, height >> 1);
+  }
+
+  return total;
+}
+
 export function textureDefaultValueRange(texture: Texture): [number, number] {
   if (texture.dataFormat === "rgb" || texture.dataFormat === "rgba") {
     return [0, 1];
@@ -134,6 +154,10 @@ export abstract class Texture extends Node {
 
   public abstract get width(): number;
   public abstract get height(): number;
+
+  public get depth(): number {
+    return 1;
+  }
 
   public get type() {
     return "Texture";

--- a/src/renderers/webgl_textures.ts
+++ b/src/renderers/webgl_textures.ts
@@ -1,10 +1,11 @@
 import { Logger } from "../utilities/logger";
-import type {
-  Texture,
-  TextureFilter,
-  TextureWrapMode,
-  TextureDataType,
-  TextureDataFormat,
+import {
+  textureStorageBytes,
+  type Texture,
+  type TextureFilter,
+  type TextureWrapMode,
+  type TextureDataType,
+  type TextureDataFormat,
 } from "../objects/textures/texture";
 
 import { Texture2D } from "../objects/textures/texture_2d";
@@ -150,8 +151,7 @@ export class WebGLTextures {
         this.currentTexture_ = null;
       }
 
-      const info = this.getDataFormatInfo(texture.dataFormat, texture.dataType);
-      const bytes = this.computeStorageBytes(texture, info);
+      const bytes = textureStorageBytes(texture);
       this.gpuTextureBytes_ = Math.max(0, this.gpuTextureBytes_ - bytes);
       this.textureCount_ = Math.max(0, this.textureCount_ - 1);
     }
@@ -200,7 +200,7 @@ export class WebGLTextures {
       throw new Error(`Unknown texture type ${texture.type}`);
     }
 
-    this.gpuTextureBytes_ += this.computeStorageBytes(texture, info);
+    this.gpuTextureBytes_ += textureStorageBytes(texture);
     this.textureCount_ += 1;
     this.textures_.set(texture, textureId);
     this.gl_.bindTexture(type, null);
@@ -374,50 +374,6 @@ export class WebGLTextures {
       }
     }
     throw new Error(`Unsupported format/type: ${format}/${type}`);
-  }
-
-  private computeStorageBytes(
-    texture: Texture,
-    info: TextureFormatInfo
-  ): number {
-    const bytes = this.bytesPerTexel(info);
-    const levels = Math.max(1, texture.mipmapLevels);
-    const depth = this.isTextureStorage3D(texture)
-      ? Math.max(1, texture.depth)
-      : 1;
-
-    let width = Math.max(1, texture.width);
-    let height = Math.max(1, texture.height);
-    let total = 0;
-    for (let level = 0; level < levels; level++) {
-      total += width * height * depth * bytes;
-      width = Math.max(1, width >> 1);
-      height = Math.max(1, height >> 1);
-    }
-
-    return total;
-  }
-
-  private bytesPerTexel(info: TextureFormatInfo): number {
-    const gl = this.gl_;
-    if (info.format === gl.RGB && info.type === gl.UNSIGNED_BYTE) return 3;
-    if (info.format === gl.RGBA && info.type === gl.UNSIGNED_BYTE) return 4;
-    if (info.format === gl.RED_INTEGER) {
-      switch (info.type) {
-        case gl.BYTE:
-        case gl.UNSIGNED_BYTE:
-          return 1;
-        case gl.SHORT:
-        case gl.UNSIGNED_SHORT:
-          return 2;
-        case gl.INT:
-        case gl.UNSIGNED_INT:
-          return 4;
-      }
-    }
-    if (info.format === gl.RED && info.type === gl.FLOAT) return 4;
-
-    throw new Error("bytesPerTexel: unsupported format/type");
   }
 
   private isTextureStorage3D(

--- a/src/renderers/webgpu/webgpu_renderer.ts
+++ b/src/renderers/webgpu/webgpu_renderer.ts
@@ -451,13 +451,12 @@ class WebGPURenderer extends Renderer {
     );
   }
 
-  // The experimental WebGPU texture pool does not track byte usage yet.
   public get gpuTextureBytes() {
-    return 0;
+    return this.texturePool_.gpuTextureBytes;
   }
 
   public get gpuTextureCount() {
-    return 0;
+    return this.texturePool_.textureCount;
   }
 }
 

--- a/src/renderers/webgpu/webgpu_texture_pool.ts
+++ b/src/renderers/webgpu/webgpu_texture_pool.ts
@@ -3,6 +3,7 @@ import {
   TextureDataType,
   textureBytesPerChannel,
   textureChannelCount,
+  textureStorageBytes,
 } from "@/objects/textures/texture";
 import { Texture3D } from "@/objects/textures/texture_3d";
 
@@ -14,6 +15,9 @@ type WebGPUTexture = {
 export default class WebGPUTexturePool {
   private readonly device_: GPUDevice;
   private readonly textures_: WebGPUTexture[];
+
+  private gpuTextureBytes_ = 0;
+  private textureCount_ = 0;
 
   constructor(device: GPUDevice) {
     this.device_ = device;
@@ -38,8 +42,14 @@ export default class WebGPUTexturePool {
           GPUTextureUsage.COPY_DST |
           GPUTextureUsage.COPY_SRC,
       });
-      this.textures_.push({ entry: entry, texture: texture });
-      cached = this.textures_[this.textures_.length - 1];
+
+      const created = { entry: entry, texture: texture };
+
+      cached = created;
+
+      this.textures_.push(created);
+      this.textureCount_ += 1;
+      this.gpuTextureBytes_ += textureStorageBytes(entry);
     }
 
     this.upload(entry, cached.texture);
@@ -48,6 +58,14 @@ export default class WebGPUTexturePool {
       this.readTexel(cached.texture, entry.dataType, x, y, z);
 
     return cached.texture;
+  }
+
+  public get gpuTextureBytes() {
+    return this.gpuTextureBytes_;
+  }
+
+  public get textureCount() {
+    return this.textureCount_;
   }
 
   private async readTexel(
@@ -103,11 +121,17 @@ export default class WebGPUTexturePool {
     this.textures_[index].texture.destroy();
     this.textures_.splice(index, 1);
     texture.readTexel = undefined;
+
+    const bytes = textureStorageBytes(texture);
+    this.gpuTextureBytes_ = Math.max(0, this.gpuTextureBytes_ - bytes);
+    this.textureCount_ = Math.max(0, this.textureCount_ - 1);
   }
 
   public disposeAll() {
     for (const t of this.textures_) t.texture.destroy();
     this.textures_.length = 0;
+    this.textureCount_ = 0;
+    this.gpuTextureBytes_ = 0;
   }
 }
 


### PR DESCRIPTION
### Summary

this PR gates chunk uploads based on a memory budget. the runtime exposes
a memory budget param with a default value of 2GB. setting to`Infinity` means
no limits (possibly undesirable with deferred eviction). the actual gating is done
by the chunk manager prior to queue handoff.

this change is scoped to gating only. no changes to existing eviction logic.
deferred eviction will be implemented in the next PR.

### Tests & Checks

- all checks have passed
- manual verification (lower memory budget results in partial loading)


https://github.com/user-attachments/assets/c6b726b1-8d9e-4e3e-84fd-59bd8435e3c9

