### PR TITLE
feat: add deferred eviction by priority

### DIFF
--- a/src/data/chunk.ts
+++ b/src/data/chunk.ts
@@ -38,6 +38,7 @@ export type ChunkViewState = {
 export type Chunk = {
   data?: ChunkData;
   texture?: Texture;
+  releasedAt?: DOMHighResTimeStamp;
   state: "unloaded" | "queued" | "loading" | "loaded";
   lod: number;
   shape: {

--- a/src/data/chunk_manager.ts
+++ b/src/data/chunk_manager.ts
@@ -4,7 +4,7 @@ import { chunkMemoryStats, clearChunkData } from "./chunk_memory";
 import { ChunkStore } from "./chunk_store";
 import { ChunkStoreView } from "./chunk_store_view";
 import { ImageSourcePolicy } from "../core/image_source_policy";
-import { Texture } from "../objects/textures/texture";
+import { Texture, textureStorageBytes } from "../objects/textures/texture";
 import { Texture3D } from "../objects/textures/texture_3d";
 
 export type QueueStats = {
@@ -24,6 +24,8 @@ export class ChunkManager {
   private readonly getGpuResidentBytes_: () => number;
   private readonly memoryLimitBytes_: number;
   private readonly maxGpuUploadsPerUpdate_: number;
+
+  private readonly resident_ = new Set<Chunk>();
 
   constructor(
     uploadTexture?: (texture: Texture) => void,
@@ -76,11 +78,12 @@ export class ChunkManager {
 
       for (const chunk of updatedChunks) {
         if (chunk.priority === null) {
-          this.queue_.cancel(chunk);
-          this.disposeChunkTexture(chunk);
-          clearChunkData(chunk);
-        } else if (chunk.state === "queued") {
-          candidates.push({ source, chunk });
+          this.releaseChunk(chunk);
+        } else {
+          chunk.releasedAt = undefined;
+          if (chunk.state === "queued") {
+            candidates.push({ source, chunk });
+          }
         }
       }
 
@@ -97,6 +100,18 @@ export class ChunkManager {
     }
   }
 
+  private releaseChunk(chunk: Chunk) {
+    this.queue_.cancel(chunk);
+
+    if (chunk.texture !== undefined) {
+      chunk.releasedAt ??= performance.now();
+      return;
+    }
+
+    clearChunkData(chunk);
+    if (chunk.state === "loaded") chunk.state = "unloaded";
+  }
+
   private enqueueWithinBudget(
     candidates: { source: ChunkSource; chunk: Chunk }[]
   ) {
@@ -105,9 +120,25 @@ export class ChunkManager {
     candidates.sort((a, b) => comparePriority(a.chunk, b.chunk));
 
     let committedBytes = this.getGpuResidentBytes_();
+    let victims: Chunk[] | null = null;
 
     for (const { source, chunk } of candidates) {
       const bytes = this.chunkBytes(source, chunk);
+
+      // A chunk that can never fit must not trigger eviction. It would drain
+      // the entire cache and still be skipped.
+      if (bytes > this.memoryLimitBytes_) continue;
+
+      if (committedBytes + bytes > this.memoryLimitBytes_) {
+        victims ??= this.evictionCandidates();
+        committedBytes = this.evictWorseChunks(
+          committedBytes,
+          bytes,
+          chunk,
+          victims
+        );
+      }
+
       if (committedBytes + bytes > this.memoryLimitBytes_) continue;
 
       committedBytes += bytes;
@@ -115,6 +146,44 @@ export class ChunkManager {
         source.loader.loadChunkData(chunk, signal)
       );
     }
+  }
+
+  private evictionCandidates(): Chunk[] {
+    const victims: Chunk[] = [];
+
+    for (const chunk of this.resident_) {
+      if (chunk.visible) continue;
+      victims.push(chunk);
+    }
+
+    return victims.sort((a, b) => {
+      const byRankDescending = -comparePriority(a, b);
+      if (byRankDescending !== 0) return byRankDescending;
+      return (a.releasedAt ?? 0) - (b.releasedAt ?? 0);
+    });
+  }
+
+  private evictWorseChunks(
+    committedBytes: number,
+    pendingBytes: number,
+    candidate: Chunk,
+    victims: Chunk[]
+  ): number {
+    while (
+      committedBytes + pendingBytes > this.memoryLimitBytes_ &&
+      victims.length > 0 &&
+      comparePriority(victims[0], candidate) > 0
+    ) {
+      const victim = victims.shift()!;
+      if (victim.texture === undefined) continue;
+
+      committedBytes -= textureStorageBytes(victim.texture);
+      this.disposeChunkTexture(victim);
+      victim.state = "unloaded";
+      victim.releasedAt = undefined;
+    }
+
+    return committedBytes;
   }
 
   private chunkBytes(source: ChunkSource, chunk: Chunk): number {
@@ -144,6 +213,7 @@ export class ChunkManager {
       const texture = Texture3D.createWithChunk(chunk);
       this.uploadTexture_(texture);
       chunk.texture = texture;
+      this.resident_.add(chunk);
       clearChunkData(chunk);
     }
   }
@@ -154,5 +224,6 @@ export class ChunkManager {
     if (chunk.texture === undefined) return;
     this.disposeTexture_(chunk.texture);
     chunk.texture = undefined;
+    this.resident_.delete(chunk);
   }
 }

--- a/src/data/chunk_store.ts
+++ b/src/data/chunk_store.ts
@@ -204,25 +204,6 @@ export class ChunkStore {
       chunk.priority === null && chunk.state === "queued";
     if (shouldCancelQueuedChunk) {
       chunk.state = "unloaded";
-      return;
-    }
-
-    const shouldDisposeChunk =
-      chunk.state === "loaded" && chunk.priority === null;
-    if (shouldDisposeChunk) {
-      if (chunk.visible || chunk.prefetch) {
-        throw new Error(
-          `Chunk state inconsistency detected: priority is null but visible=${chunk.visible} or prefetch=${chunk.prefetch} ` +
-            `for chunk ${JSON.stringify(chunk.chunkIndex)} in LOD ${chunk.lod}`
-        );
-      }
-
-      chunk.state = "unloaded";
-      chunk.orderKey = null;
-      Logger.debug(
-        "ChunkStore",
-        `Disposing chunk ${JSON.stringify(chunk.chunkIndex)} in LOD ${chunk.lod}`
-      );
     }
   }
 

--- a/src/data/chunk_store_view.ts
+++ b/src/data/chunk_store_view.ts
@@ -264,7 +264,7 @@ export class ChunkStoreView {
     for (const [chunk, state] of this.chunkViewStates_) {
       if (!state.visible || chunk.lod !== fallbackLOD) continue;
       foundAny = true;
-      if (chunk.state !== "loaded") return false;
+      if (chunk.texture === undefined) return false;
     }
     return foundAny;
   }


### PR DESCRIPTION
### Summary

this pr adds deferred eviction by priority. chunks are evicted only under
memory pressure based on `memoryLimitMB`.

the stale frame regression introduced by #698 is resolved but still not
applied to volumes. i will add a fix for it in a subsequent pr.

@srivarra i'm going to post another pr after this one for circular
prefetching so it's probably better for range prefetching to come after that.


### Tests & Checks

- all checks have passed
- manual verification (video shows chunks of previous frames are not evicted by default)


https://github.com/user-attachments/assets/92e5de01-0fba-44f0-8a60-9a52025528ba

