### PR TITLE
feat: allow updating memory limit and overlays at runtime

### DIFF
--- a/src/data/chunk_manager.ts
+++ b/src/data/chunk_manager.ts
@@ -22,7 +22,7 @@ export class ChunkManager {
   private readonly uploadTexture_?: (texture: Texture) => void;
   private readonly disposeTexture_?: (texture: Texture) => void;
   private readonly getGpuResidentBytes_: () => number;
-  private readonly memoryLimitBytes_: number;
+  private memoryLimitBytes_: number;
   private readonly maxGpuUploadsPerUpdate_: number;
 
   private readonly resident_ = new Set<Chunk>();
@@ -45,6 +45,10 @@ export class ChunkManager {
 
   public get memoryLimitBytes(): number {
     return this.memoryLimitBytes_;
+  }
+
+  public set memoryLimitBytes(value: number) {
+    this.memoryLimitBytes_ = value;
   }
 
   public get queueStats(): QueueStats {

--- a/src/idetik.ts
+++ b/src/idetik.ts
@@ -153,7 +153,7 @@ export class Idetik {
       this.context_
     );
 
-    this.overlays = params.overlays ?? [];
+    this.overlays = [...(params.overlays ?? [])];
 
     if (params.showStats) this.stats_ = createStats();
 
@@ -259,6 +259,25 @@ export class Idetik {
     this.viewports_.splice(index, 1);
     Logger.info("Idetik", `Removed viewport "${viewport.id}"`);
     return true;
+  }
+
+  public addOverlay(overlay: Overlay): void {
+    this.overlays.push(overlay);
+  }
+
+  public removeOverlay(overlay: Overlay): boolean {
+    const index = this.overlays.indexOf(overlay);
+    if (index === -1) {
+      Logger.warn("Idetik", "Overlay not found, nothing to remove");
+      return false;
+    }
+
+    this.overlays.splice(index, 1);
+    return true;
+  }
+
+  public setMemoryLimitMB(memoryLimitMB: number): void {
+    this.chunkManager_.memoryLimitBytes = memoryLimitMB * 1024 * 1024;
   }
 
   public start() {


### PR DESCRIPTION
### Summary

this PR make idetik runtime params a construction-time snapshot with runtime
setters. it adds runtime mutators for memory limits and overlays.

https://github.com/chanzuckerberg/idetik/pull/702#issuecomment-4906222994

i decided to skip mutators for `maxConcurrentRequests` and `maxGpuUploadsPerUpdate`. trivial to implement but i'm not sure we need to adjust these values at runtime.

### Tests & Checks

- all checks have passed
