### PR TITLE
feat: add bidirectional temporal prefetch

### DIFF
--- a/examples/image_2d/main.ts
+++ b/examples/image_2d/main.ts
@@ -106,6 +106,26 @@ const xLod = dimensions.x.lods[0];
 const yLod = dimensions.y.lods[0];
 const zLod = dimensions.z?.lods[0];
 const tLod = dimensions.t?.lods[0];
+const maxTemporalPrefetch = Math.min(Math.max((tLod?.size ?? 1) - 1, 0), 25);
+const temporalPrefetchState = {
+  backward: 0,
+  forward: Math.min(20, maxTemporalPrefetch),
+};
+let playbackRateHz = 0;
+
+function createCurrentImageSourcePolicy() {
+  const temporalPrefetch = [
+    temporalPrefetchState.backward,
+    temporalPrefetchState.forward,
+  ] as const;
+  return playbackRateHz > 0
+    ? createPlaybackPolicy({
+        prefetch: { x: 0, y: 0, z: 0, t: temporalPrefetch },
+      })
+    : createExplorationPolicy({
+        prefetch: { x: 1, y: 1, z: 1, t: temporalPrefetch },
+      });
+}
 
 const sliceCoords: SliceCoordinates = {
   c: [config.channel],
@@ -135,9 +155,13 @@ const channelProps: ChannelProps[] = Array.from(
 const imageLayer = new ImageLayer({
   source,
   sliceCoords,
-  policy: createExplorationPolicy(),
+  policy: createCurrentImageSourcePolicy(),
   channelProps,
 });
+
+function updateImageSourcePolicy() {
+  imageLayer.imageSourcePolicy = createCurrentImageSourcePolicy();
+}
 
 const camera = new OrthographicCamera(
   xLod.translation,
@@ -244,11 +268,21 @@ if (tLod && tLod.size > 1) {
     stepValue: tLod.scale,
     playback: {
       onRateChange: (rateHz: number) => {
-        imageLayer.imageSourcePolicy =
-          rateHz > 0 ? createPlaybackPolicy() : createExplorationPolicy();
+        playbackRateHz = rateHz;
+        updateImageSourcePolicy();
       },
     },
   });
+
+  const temporalPrefetchFolder = gui.addFolder("Temporal Prefetch");
+  temporalPrefetchFolder
+    .add(temporalPrefetchState, "backward", 0, maxTemporalPrefetch, 1)
+    .name("Backward timepoints")
+    .onChange(updateImageSourcePolicy);
+  temporalPrefetchFolder
+    .add(temporalPrefetchState, "forward", 0, maxTemporalPrefetch, 1)
+    .name("Forward timepoints")
+    .onChange(updateImageSourcePolicy);
 }
 
 const channelFolder = gui.addFolder("Channel");
@@ -293,8 +327,84 @@ debugFolder
   .add(debugState, "showWireframes")
   .name("Show tile wireframes")
   .onChange((show: boolean) => (imageLayer.debugMode = show));
+if (tLod && tLod.size > 1) {
+  debugFolder
+    .add({ logTemporalChunkStates }, "logTemporalChunkStates")
+    .name("Log temporal chunk states");
+}
 
 void idetik;
+
+type TemporalChunkStateSummary = {
+  timeIndex: number;
+  direction: "backward" | "current" | "forward" | "equidistant";
+  distance: number;
+  chunks: number;
+  visible: number;
+  prefetch: number;
+  queued: number;
+  loading: number;
+  decoded: number;
+  residentTexture: number;
+  pendingRelease: number;
+};
+
+function logTemporalChunkStates() {
+  const view = imageLayer.chunkStoreView;
+  if (!view || !tLod || sliceCoords.t === undefined) {
+    console.info("No temporal chunk states available.");
+    return;
+  }
+
+  const currentTimeIndex = Math.round(
+    (sliceCoords.t - tLod.translation) / tLod.scale
+  );
+  const summariesByTimeIndex = new Map<number, TemporalChunkStateSummary>();
+
+  for (const [chunk, state] of view.chunkViewStates) {
+    const timeIndex = chunk.chunkIndex.t;
+    const forwardOffset =
+      (timeIndex - currentTimeIndex + tLod.size) % tLod.size;
+    const backwardOffset =
+      (currentTimeIndex - timeIndex + tLod.size) % tLod.size;
+    const summary = summariesByTimeIndex.get(timeIndex) ?? {
+      timeIndex,
+      direction:
+        forwardOffset === 0
+          ? "current"
+          : backwardOffset < forwardOffset
+            ? "backward"
+            : forwardOffset < backwardOffset
+              ? "forward"
+              : "equidistant",
+      distance: Math.min(forwardOffset, backwardOffset),
+      chunks: 0,
+      visible: 0,
+      prefetch: 0,
+      queued: 0,
+      loading: 0,
+      decoded: 0,
+      residentTexture: 0,
+      pendingRelease: 0,
+    };
+
+    ++summary.chunks;
+    summary.visible += Number(state.visible);
+    summary.prefetch += Number(state.prefetch);
+    summary.queued += Number(chunk.state === "queued");
+    summary.loading += Number(chunk.state === "loading");
+    summary.decoded += Number(chunk.data !== undefined);
+    summary.residentTexture += Number(chunk.texture !== undefined);
+    summary.pendingRelease += Number(
+      chunk.texture !== undefined && chunk.releasedAt !== undefined
+    );
+    summariesByTimeIndex.set(timeIndex, summary);
+  }
+
+  console.table(
+    [...summariesByTimeIndex.values()].sort((a, b) => a.timeIndex - b.timeIndex)
+  );
+}
 
 function formatDatasetInfo(
   cfg: DatasetConfig,

--- a/src/core/image_source_policy.ts
+++ b/src/core/image_source_policy.ts
@@ -8,15 +8,20 @@ const ALL_CATEGORIES = [
 
 export type PriorityCategory = (typeof ALL_CATEGORIES)[number];
 
-export type ImageSourcePolicyConfig = {
+type TemporalPrefetchTuple = readonly [backward: number, forward: number];
+type TemporalPrefetch = number | TemporalPrefetchTuple;
+
+export type ImageSourcePolicyConfig<
+  T extends TemporalPrefetch = TemporalPrefetch,
+> = {
   profile?: string;
   prefetch: {
     x: number;
     y: number;
     z?: number;
-    t?: number;
+    t?: T;
   };
-  priorityOrder: PriorityCategory[];
+  priorityOrder: readonly PriorityCategory[];
   lod?: {
     min?: number;
     max?: number;
@@ -24,34 +29,52 @@ export type ImageSourcePolicyConfig = {
   };
 };
 
-export type ImageSourcePolicy = Readonly<{
-  profile: string;
-  prefetch: {
-    x: number;
-    y: number;
-    z: number;
-    t: number;
-  };
-  priorityOrder: readonly PriorityCategory[];
-  priorityMap: Readonly<Record<PriorityCategory, number>>;
-  lod: {
-    min: number;
-    max: number;
-    bias: number;
-  };
-}>;
+export type ImageSourcePolicy<T extends TemporalPrefetch = TemporalPrefetch> =
+  Readonly<{
+    profile: string;
+    prefetch: {
+      x: number;
+      y: number;
+      z: number;
+      t: T;
+    };
+    priorityOrder: readonly PriorityCategory[];
+    priorityMap: Readonly<Record<PriorityCategory, number>>;
+    lod: {
+      min: number;
+      max: number;
+      bias: number;
+    };
+  }>;
+
+type TemporalPrefetchFrom<C> = C extends {
+  prefetch: { t: TemporalPrefetchTuple };
+}
+  ? TemporalPrefetchTuple
+  : C extends { prefetch?: { t?: infer T } }
+    ? number | Extract<T, TemporalPrefetchTuple>
+    : number;
+
+type PresetPolicyArgs<O> = undefined extends O
+  ? [overrides?: O]
+  : [overrides: O];
 
 /** @group Layer Configuration */
-export function createImageSourcePolicy(
-  config: ImageSourcePolicyConfig
-): ImageSourcePolicy {
+export function createImageSourcePolicy<
+  const C extends ImageSourcePolicyConfig,
+>(config: C): ImageSourcePolicy<TemporalPrefetchFrom<C>> {
   validatePolicyConfig(config);
 
+  const temporalPrefetch = config.prefetch.t ?? 0;
+  const resolvedTemporalPrefetch =
+    typeof temporalPrefetch === "number"
+      ? temporalPrefetch
+      : Object.freeze([temporalPrefetch[0], temporalPrefetch[1]] as const);
   const prefetch = {
     x: config.prefetch.x,
     y: config.prefetch.y,
     z: config.prefetch.z ?? 0,
-    t: config.prefetch.t ?? 0,
+    t: resolvedTemporalPrefetch,
   };
 
   const priorityMap: Readonly<Record<PriorityCategory, number>> = Object.freeze(
@@ -79,13 +102,15 @@ export function createImageSourcePolicy(
     lod,
   };
 
-  return Object.freeze(resolved);
+  return Object.freeze(resolved) as ImageSourcePolicy<TemporalPrefetchFrom<C>>;
 }
 
 /** @group Layer Configuration */
-export function createExplorationPolicy(
-  overrides: Partial<ImageSourcePolicyConfig> = {}
-): ImageSourcePolicy {
+export function createExplorationPolicy<
+  const O extends Partial<ImageSourcePolicyConfig> | undefined = undefined,
+>(
+  ...[overrides]: PresetPolicyArgs<O>
+): ImageSourcePolicy<TemporalPrefetchFrom<O>> {
   const base: ImageSourcePolicyConfig = {
     profile: "exploration",
     prefetch: { x: 1, y: 1, z: 1, t: 0 },
@@ -97,13 +122,17 @@ export function createExplorationPolicy(
       "fallbackBackground",
     ],
   };
-  return createImageSourcePolicy(mergeConfig(base, overrides));
+  return createImageSourcePolicy(
+    mergeConfig(base, overrides)
+  ) as ImageSourcePolicy<TemporalPrefetchFrom<O>>;
 }
 
 /** @group Layer Configuration */
-export function createPlaybackPolicy(
-  overrides: Partial<ImageSourcePolicyConfig> = {}
-): ImageSourcePolicy {
+export function createPlaybackPolicy<
+  const O extends Partial<ImageSourcePolicyConfig> | undefined = undefined,
+>(
+  ...[overrides]: PresetPolicyArgs<O>
+): ImageSourcePolicy<TemporalPrefetchFrom<O>> {
   const base: ImageSourcePolicyConfig = {
     profile: "playback",
     prefetch: { x: 0, y: 0, z: 0, t: 20 },
@@ -115,13 +144,17 @@ export function createPlaybackPolicy(
       "prefetchSpace",
     ],
   };
-  return createImageSourcePolicy(mergeConfig(base, overrides));
+  return createImageSourcePolicy(
+    mergeConfig(base, overrides)
+  ) as ImageSourcePolicy<TemporalPrefetchFrom<O>>;
 }
 
 /** @group Layer Configuration */
-export function createNoPrefetchPolicy(
-  overrides: Partial<ImageSourcePolicyConfig> = {}
-): ImageSourcePolicy {
+export function createNoPrefetchPolicy<
+  const O extends Partial<ImageSourcePolicyConfig> | undefined = undefined,
+>(
+  ...[overrides]: PresetPolicyArgs<O>
+): ImageSourcePolicy<TemporalPrefetchFrom<O>> {
   const base: ImageSourcePolicyConfig = {
     profile: "no-prefetch",
     prefetch: { x: 0, y: 0, z: 0, t: 0 },
@@ -133,14 +166,33 @@ export function createNoPrefetchPolicy(
       "prefetchTime",
     ],
   };
-  return createImageSourcePolicy(mergeConfig(base, overrides));
+  return createImageSourcePolicy(
+    mergeConfig(base, overrides)
+  ) as ImageSourcePolicy<TemporalPrefetchFrom<O>>;
 }
 
-function validatePolicyConfig(config: ImageSourcePolicyConfig) {
-  for (const [k, v] of Object.entries(config.prefetch)) {
-    if (v === undefined) continue; // z/t may be omitted
-    if (v < 0) {
-      throw new Error(`prefetch.${k} must be a non-negative number`);
+function validatePolicyConfig(config: ImageSourcePolicyConfig): void {
+  for (const [dimension, value] of Object.entries(config.prefetch)) {
+    if (value === undefined) continue; // z/t may be omitted
+
+    if (typeof value === "number") {
+      if (value < 0) {
+        throw new Error(`prefetch.${dimension} must be a non-negative number`);
+      }
+      continue;
+    }
+
+    if (dimension !== "t" || value.length !== 2) {
+      throw new Error("prefetch.t must be a [backward, forward] tuple");
+    }
+    for (let i = 0; i < value.length; ++i) {
+      if (
+        typeof value[i] !== "number" ||
+        Number.isNaN(value[i]) ||
+        value[i] < 0
+      ) {
+        throw new Error(`prefetch.t[${i}] must be a non-negative number`);
+      }
     }
   }
 

--- a/src/data/chunk_store_view.ts
+++ b/src/data/chunk_store_view.ts
@@ -340,63 +340,100 @@ export class ChunkStoreView {
     viewBounds3D: Box3,
     viewBoundsCenter2D: ReadonlyVec2
   ): void {
-    const numTimePoints = this.store_.dimensions.t?.lods[0].size ?? 1;
-    const windowSize = Math.min(this.policy_.prefetch.t, numTimePoints - 1);
     const fallbackLOD = this.fallbackLOD();
     const priority = this.policy_.priorityMap["prefetchTime"];
     const channels = this.channelsOfInterest(sliceCoords);
 
-    for (let i = 1; i <= windowSize; ++i) {
-      const t = (currentTimeIndex + i) % numTimePoints;
-      this.iterateChunksInBox(
-        t,
-        fallbackLOD,
-        channels,
-        viewBounds3D,
-        (chunk) => {
-          const squareDistance = this.squareDistance2D(
-            chunk,
-            viewBoundsCenter2D
-          );
-          const normalizedDistance = clamp(
-            squareDistance / this.sourceMaxSquareDistance2D_,
-            0,
-            1 - Number.EPSILON
-          );
-          const orderKey = i + normalizedDistance;
+    this.forEachPrefetchTimeIndex(
+      currentTimeIndex,
+      (timeIndex, temporalDistance) => {
+        this.iterateChunksInBox(
+          timeIndex,
+          fallbackLOD,
+          channels,
+          viewBounds3D,
+          (chunk) => {
+            const squareDistance = this.squareDistance2D(
+              chunk,
+              viewBoundsCenter2D
+            );
+            const normalizedDistance = clamp(
+              squareDistance / this.sourceMaxSquareDistance2D_,
+              0,
+              1 - Number.EPSILON
+            );
+            const orderKey = temporalDistance + normalizedDistance;
 
-          this.chunkViewStates_.set(chunk, {
-            visible: false,
-            prefetch: true,
-            priority,
-            orderKey,
-          });
-        }
-      );
-    }
+            this.chunkViewStates_.set(chunk, {
+              visible: false,
+              prefetch: true,
+              priority,
+              orderKey,
+            });
+          }
+        );
+      }
+    );
   }
 
   private markTimeChunksForPrefetchVolume(
     currentTimeIndex: number,
     sliceCoords: SliceCoordinates
-  ) {
-    const numTimePoints = this.store_.dimensions.t?.lods[0].size ?? 1;
-    const windowSize = Math.min(this.policy_.prefetch.t, numTimePoints - 1);
+  ): void {
     const fallbackLOD = this.fallbackLOD();
     const priority = this.policy_.priorityMap["prefetchTime"];
     const channels = this.channelsOfInterest(sliceCoords);
 
-    for (let i = 1; i <= windowSize; ++i) {
-      const t = (currentTimeIndex + i) % numTimePoints;
-      this.iterateAllChunksAtLod(t, fallbackLOD, channels, (chunk) => {
-        const orderKey = i; // nearer along the playback loop first
-        this.chunkViewStates_.set(chunk, {
-          visible: false,
-          prefetch: true,
-          priority,
-          orderKey,
-        });
-      });
+    this.forEachPrefetchTimeIndex(
+      currentTimeIndex,
+      (timeIndex, temporalDistance) => {
+        this.iterateAllChunksAtLod(
+          timeIndex,
+          fallbackLOD,
+          channels,
+          (chunk) => {
+            this.chunkViewStates_.set(chunk, {
+              visible: false,
+              prefetch: true,
+              priority,
+              orderKey: temporalDistance,
+            });
+          }
+        );
+      }
+    );
+  }
+
+  private forEachPrefetchTimeIndex(
+    currentTimeIndex: number,
+    callback: (timeIndex: number, temporalDistance: number) => void
+  ): void {
+    const timePointCount = this.store_.dimensions.t?.lods[0].size ?? 1;
+    const temporalPrefetch = this.policy_.prefetch.t;
+    const isScalar = typeof temporalPrefetch === "number";
+    const backward = isScalar ? 0 : temporalPrefetch[0];
+    const forward = isScalar ? temporalPrefetch : temporalPrefetch[1];
+
+    const maxWindow = timePointCount - 1;
+    const backwardWindow = Math.min(Math.floor(backward), maxWindow);
+    const forwardWindow = Math.min(Math.floor(forward), maxWindow);
+
+    for (let distance = 1; distance <= forwardWindow; ++distance) {
+      const backwardDistance = timePointCount - distance;
+      const nearestDistance =
+        backwardDistance <= backwardWindow
+          ? Math.min(distance, backwardDistance)
+          : distance;
+      const timeIndex = (currentTimeIndex + distance) % timePointCount;
+      callback(timeIndex, nearestDistance);
+    }
+
+    for (let distance = 1; distance <= backwardWindow; ++distance) {
+      const forwardDistance = timePointCount - distance;
+      if (forwardDistance <= forwardWindow) continue;
+      const timeIndex =
+        (currentTimeIndex - distance + timePointCount) % timePointCount;
+      callback(timeIndex, distance);
     }
   }
 

--- a/test/chunk_store_view.test.ts
+++ b/test/chunk_store_view.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, test } from "vitest";
+import { mat4 } from "gl-matrix";
 import { ChunkStore } from "@/data/chunk_store";
+import { ChunkStoreView } from "@/data/chunk_store_view";
 import { SourceDimensionMap } from "@/data/chunk";
-import { createNoPrefetchPolicy } from "@/core/image_source_policy";
+import {
+  createNoPrefetchPolicy,
+  createPlaybackPolicy,
+} from "@/core/image_source_policy";
 import { OrthographicCamera } from "@/objects/cameras/orthographic_camera";
 import { Viewport } from "@/core/viewport";
 import { createTestViewport } from "./helpers";
@@ -72,6 +77,188 @@ describe("ChunkStoreView disposal", () => {
     }
   });
 });
+
+describe("ChunkStoreView temporal prefetch", () => {
+  test("keeps scalar temporal prefetch forward-only and circular", () => {
+    const { view } = createTemporalView(5, 2);
+
+    view.updateChunksForImage(
+      { z: 0, c: [0], t: 4 },
+      imageView(createTestViewport())
+    );
+
+    expect(prefetchedTimeIndices(view)).toEqual([0, 1]);
+  });
+
+  test.each([
+    {
+      label: "scalar",
+      temporalPrefetch: 99,
+      expectedOrderKeys: [
+        [0, 3],
+        [1, 4],
+        [3, 1],
+        [4, 2],
+      ] as const,
+    },
+    {
+      label: "tuple",
+      temporalPrefetch: [99, 99] as const,
+      expectedOrderKeys: [
+        [0, 2],
+        [1, 1],
+        [3, 1],
+        [4, 2],
+      ] as const,
+    },
+  ])(
+    "caps oversized $label windows without overwriting chunk states",
+    ({ temporalPrefetch, expectedOrderKeys }) => {
+      const { view } = createTemporalView(5, temporalPrefetch);
+
+      view.updateChunksForVolume({ c: [0], t: 2 }, mat4.create());
+
+      expect(prefetchedTimeIndices(view)).toEqual([0, 1, 3, 4]);
+      expectCurrentTimeVisible(view, 2);
+      expectPrefetchOrderKeys(view, expectedOrderKeys);
+    }
+  );
+
+  test("uses tuple temporal prefetch as [backward, forward]", () => {
+    const { policy, view } = createTemporalView(7, [2, 1]);
+
+    view.updateChunksForImage(
+      { z: 0, c: [0], t: 3 },
+      imageView(createTestViewport())
+    );
+
+    expect(prefetchedTimeIndices(view)).toEqual([1, 2, 4]);
+    for (const [chunk, state] of view.chunkViewStates) {
+      if (!state.prefetch) continue;
+      const temporalDistance = Math.abs(chunk.chunkIndex.t - 3);
+      expect(state.priority).toBe(policy.priorityMap.prefetchTime);
+      expect(state.orderKey).toBeGreaterThanOrEqual(temporalDistance);
+      expect(state.orderKey).toBeLessThan(temporalDistance + 1);
+    }
+  });
+
+  test("wraps tuple temporal prefetch in both directions for volumes", () => {
+    const { policy, view } = createTemporalView(5, [1, 1]);
+
+    view.updateChunksForVolume({ c: [0], t: 0 }, mat4.create());
+
+    expect(prefetchedTimeIndices(view)).toEqual([1, 4]);
+    for (const [, state] of view.chunkViewStates) {
+      if (!state.prefetch) continue;
+      expect(state.priority).toBe(policy.priorityMap.prefetchTime);
+      expect(state.orderKey).toBe(1);
+    }
+  });
+
+  test.each([
+    {
+      direction: "forward",
+      temporalPrefetch: [0, 2] as const,
+      expectedTimeIndices: [1, 2],
+    },
+    {
+      direction: "backward",
+      temporalPrefetch: [2, 0] as const,
+      expectedTimeIndices: [3, 4],
+    },
+  ])(
+    "selects only the $direction tuple direction near a wrap boundary",
+    ({ temporalPrefetch, expectedTimeIndices }) => {
+      const { view } = createTemporalView(5, temporalPrefetch);
+
+      view.updateChunksForVolume({ c: [0], t: 0 }, mat4.create());
+
+      expect(prefetchedTimeIndices(view)).toEqual(expectedTimeIndices);
+    }
+  );
+
+  test("deduplicates overlapping ranges using nearest ring distance", () => {
+    const { view } = createTemporalView(5, [3, 3]);
+
+    view.updateChunksForVolume({ c: [0], t: 0 }, mat4.create());
+
+    expect(prefetchedTimeIndices(view)).toEqual([1, 2, 3, 4]);
+    expectPrefetchOrderKeys(view, [
+      [1, 1],
+      [2, 2],
+      [3, 2],
+      [4, 1],
+    ]);
+  });
+});
+
+function createTemporalView(
+  timePointCount: number,
+  temporalPrefetch: number | readonly [backward: number, forward: number]
+) {
+  const policy = createPlaybackPolicy({
+    prefetch: { x: 0, y: 0, z: 0, t: temporalPrefetch },
+  });
+  const store = new ChunkStore(createTemporalDimensions(timePointCount));
+  return { policy, view: store.addView(policy) };
+}
+
+function prefetchedTimeIndices(view: ChunkStoreView): number[] {
+  const timeIndices = new Set<number>();
+  for (const [chunk, state] of view.chunkViewStates) {
+    if (!state.prefetch) continue;
+    timeIndices.add(chunk.chunkIndex.t);
+  }
+  return [...timeIndices].sort((a, b) => a - b);
+}
+
+function expectCurrentTimeVisible(
+  view: ChunkStoreView,
+  currentTimeIndex: number
+): void {
+  const currentStates = [...view.chunkViewStates].filter(
+    ([chunk]) => chunk.chunkIndex.t === currentTimeIndex
+  );
+  expect(currentStates.length).toBeGreaterThan(0);
+  for (const [, state] of currentStates) {
+    expect(state.visible).toBe(true);
+    expect(state.prefetch).toBe(false);
+  }
+}
+
+function expectPrefetchOrderKeys(
+  view: ChunkStoreView,
+  expected: ReadonlyArray<readonly [timeIndex: number, orderKey: number]>
+): void {
+  for (const [timeIndex, orderKey] of expected) {
+    const states = [...view.chunkViewStates].filter(
+      ([chunk]) => chunk.chunkIndex.t === timeIndex
+    );
+    expect(states.length).toBeGreaterThan(0);
+    for (const [, state] of states) {
+      expect(state.prefetch).toBe(true);
+      expect(state.orderKey).toBe(orderKey);
+    }
+  }
+}
+
+function createTemporalDimensions(timePointCount: number): SourceDimensionMap {
+  return {
+    ...createSimpleDimensions(),
+    t: {
+      name: "t",
+      index: 3,
+      lods: [
+        {
+          size: timePointCount,
+          scale: 1,
+          chunkSize: 1,
+          translation: 0,
+        },
+      ],
+    },
+  };
+}
 
 function createSimpleDimensions(): SourceDimensionMap {
   return {

--- a/test/image_source_policy.test.ts
+++ b/test/image_source_policy.test.ts
@@ -1,5 +1,6 @@
-import { expect, test } from "vitest";
+import { expect, expectTypeOf, test } from "vitest";
 import {
+  type ImageSourcePolicy,
   PriorityCategory,
   createImageSourcePolicy,
   createExplorationPolicy,
@@ -23,6 +24,7 @@ test("createImageSourcePolicy fills defaults for optional fields", () => {
 
   expect(p.profile).toBe("custom");
   expect(p.prefetch).toEqual({ x: 1, y: 2, z: 0, t: 0 });
+  expectTypeOf(p.prefetch.t).toEqualTypeOf<number>();
   expect(p.lod).toEqual({ min: 0, max: Number.MAX_SAFE_INTEGER, bias: 0.5 });
   expect(Object.keys(p.priorityMap)).toHaveLength(5);
   expect(Object.isFrozen(p.priorityMap)).toBe(true);
@@ -73,6 +75,41 @@ test("createPlaybackPolicy sets playback defaults", () => {
   });
 });
 
+test("infers scalar and tuple temporal prefetch readback types", () => {
+  type TemporalTuple = readonly [number, number];
+  const tupleOverrides = {
+    prefetch: { x: 0, y: 0, z: 0, t: [2, 1] as TemporalTuple },
+  };
+  const createPolicyWithOptionalTuple = (overrides: {
+    prefetch?: typeof tupleOverrides.prefetch;
+  }) => createPlaybackPolicy(overrides);
+
+  expectTypeOf(createPlaybackPolicy().prefetch.t).toEqualTypeOf<number>();
+  expectTypeOf(
+    createPlaybackPolicy(tupleOverrides).prefetch.t
+  ).toEqualTypeOf<TemporalTuple>();
+  expectTypeOf(
+    createPolicyWithOptionalTuple
+  ).returns.toEqualTypeOf<ImageSourcePolicy>();
+
+  // @ts-expect-error Explicit non-undefined overrides require an argument.
+  createPlaybackPolicy<typeof tupleOverrides>();
+});
+
+test("copies and freezes temporal prefetch tuples", () => {
+  const temporalPrefetch: [number, number] = [2, 1];
+  const p = createImageSourcePolicy({
+    prefetch: { x: 0, y: 0, t: temporalPrefetch },
+    priorityOrder: [...VALID_PRIORITY_ORDER] as const,
+  });
+
+  temporalPrefetch[0] = 10;
+
+  expectTypeOf(p.prefetch.t).toEqualTypeOf<readonly [number, number]>();
+  expect(p.prefetch.t).toEqual([2, 1]);
+  expect(Object.isFrozen(p.prefetch.t)).toBe(true);
+});
+
 test("throws on negative prefetch values", () => {
   expect(() =>
     createImageSourcePolicy({
@@ -80,6 +117,38 @@ test("throws on negative prefetch values", () => {
       priorityOrder: VALID_PRIORITY_ORDER,
     })
   ).toThrow("prefetch.x must be a non-negative number");
+});
+
+test("throws on negative temporal tuple values", () => {
+  expect(() =>
+    createImageSourcePolicy({
+      prefetch: { x: 0, y: 0, t: [-1, 0] },
+      priorityOrder: VALID_PRIORITY_ORDER,
+    })
+  ).toThrow("prefetch.t[0] must be a non-negative number");
+
+  expect(() =>
+    createImageSourcePolicy({
+      prefetch: { x: 0, y: 0, t: [0, -1] },
+      priorityOrder: VALID_PRIORITY_ORDER,
+    })
+  ).toThrow("prefetch.t[1] must be a non-negative number");
+});
+
+test("throws on NaN temporal tuple values", () => {
+  expect(() =>
+    createImageSourcePolicy({
+      prefetch: { x: 0, y: 0, t: [NaN, 0] },
+      priorityOrder: VALID_PRIORITY_ORDER,
+    })
+  ).toThrow("prefetch.t[0] must be a non-negative number");
+
+  expect(() =>
+    createImageSourcePolicy({
+      prefetch: { x: 0, y: 0, t: [0, NaN] },
+      priorityOrder: VALID_PRIORITY_ORDER,
+    })
+  ).toThrow("prefetch.t[1] must be a non-negative number");
 });
 
 test("throws when lod.min > lod.max", () => {


### PR DESCRIPTION
### Summary
<!---
  Please try to cover the following questions in your summary:
  1. Describe the product (or technical) problem you are solving.
  2. Explain the engineering solution you have chosen.
  3. Discuss the implementation choices/tradeoffs you have made.
-->

You can now prefetch back in `t` which allows for a slightly smoother experience with scrubbing back and forth.

`prefetch.t` now accepts a tuple of numbers `[backward, forward]`. You can still pass in a scalar value for `t` and that'll default to just forward. I originally thought about converting a scalar that gets passed into `t` into a tuple of `[0, forward]` but saw that would break things in downstream packages.  

Made sure it worked with circular prefetching.

### Related Issue
Closes #701

### Tests & Checks
<!---
  How did you validate that your changes were implemented correctly?
  
  Please think about the following prompts:
  1. I wrote automated tests.
  2. I manually tested my changes, and here's what I 


did:
-->
Tested by allowing you to adjust forward and backward t prefetch range in the image2d example. Not sure if the changes to the example should be kept.

https://github.com/user-attachments/assets/28486dfa-1d27-40b9-b096-20c7d4e376a0
