### PR TITLE
refactor: generalize image slicing to plane/slice axes

### DIFF
--- a/src/data/chunk.ts
+++ b/src/data/chunk.ts
@@ -99,9 +99,25 @@ type SourceDimensionLod = {
 
 /** @group Layer Configuration */
 export type SliceCoordinates = {
+  x?: number;
+  y?: number;
   z?: number;
   c?: number[];
   t?: number;
+};
+
+export type SpatialAxis = "x" | "y" | "z";
+
+export type SliceAxes = {
+  u: SpatialAxis;
+  v: SpatialAxis;
+  w: SpatialAxis;
+};
+
+export const AxisComponent: Record<SpatialAxis, 0 | 1 | 2> = {
+  x: 0,
+  y: 1,
+  z: 2,
 };
 
 export type ChunkSource = {

--- a/src/data/chunk_store_view.ts
+++ b/src/data/chunk_store_view.ts
@@ -1,4 +1,12 @@
-import { Chunk, SliceCoordinates, ChunkViewState, coordToIndex } from "./chunk";
+import {
+  AxisComponent,
+  Chunk,
+  ChunkViewState,
+  coordToIndex,
+  SliceAxes,
+  SliceCoordinates,
+  SpatialAxis,
+} from "./chunk";
 import type { ChunkStore } from "./chunk_store";
 import { ImageSourcePolicy } from "../core/image_source_policy";
 import { ReadonlyVec2, vec2, vec3, mat4 } from "gl-matrix";
@@ -20,13 +28,15 @@ export class ChunkStoreView {
   private policy_: ImageSourcePolicy;
   private policyChanged_ = false;
   private currentLOD_: number = 0;
+  private readonly axes_: SliceAxes = { u: "x", v: "y", w: "z" };
+  private readonly scale0_: number;
   private lastViewBounds2D_: Box2 | null = null;
   private lastViewProjection_: mat4 | null = null;
-  private lastZBounds_?: [number, number];
+  private lastSliceBounds_?: [number, number];
   private lastTCoord_?: number;
   private lastCCoords_?: number[];
 
-  private sourceMaxSquareDistance2D_: number;
+  private readonly sourceMaxSquareDistance2D_: number;
   private readonly chunkViewStates_: Map<Chunk, ChunkViewState> = new Map();
 
   private isDisposed_ = false;
@@ -42,10 +52,20 @@ export class ChunkStoreView {
     );
 
     const dimensions = this.store_.dimensions;
-    const xLod0 = dimensions.x.lods[0];
-    const yLod0 = dimensions.y.lods[0];
+    const uDim = dimensions[this.axes_.u];
+    const vDim = dimensions[this.axes_.v];
+    if (uDim === undefined || vDim === undefined) {
+      throw new Error(
+        `Source is missing dimensions for slice plane axes ` +
+          `"${this.axes_.u}" and "${this.axes_.v}"`
+      );
+    }
+
+    const uLod0 = uDim.lods[0];
+    const vLod0 = vDim.lods[0];
+    this.scale0_ = uLod0.scale;
     this.sourceMaxSquareDistance2D_ = vec2.squaredLength(
-      vec2.fromValues(xLod0.size * xLod0.scale, yLod0.size * yLod0.scale)
+      vec2.fromValues(uLod0.size * uLod0.scale, vLod0.size * vLod0.scale)
     );
   }
 
@@ -98,11 +118,11 @@ export class ChunkStoreView {
 
     this.setLOD(lodFactor);
 
-    const zBounds = this.getZBounds(sliceCoords);
+    const sliceBounds = this.getSliceAxisBounds(sliceCoords);
     const changed =
       this.policyChanged_ ||
       this.viewBounds2DChanged(viewBounds2D) ||
-      this.zBoundsChanged(zBounds) ||
+      this.sliceBoundsChanged(sliceBounds) ||
       this.lastTCoord_ !== sliceCoords.t ||
       this.cCoordsChanged(sliceCoords.c);
 
@@ -121,11 +141,7 @@ export class ChunkStoreView {
     const viewBoundsCenter2D = vec2.create();
     vec2.lerp(viewBoundsCenter2D, viewBounds2D.min, viewBounds2D.max, 0.5);
 
-    const [zMin, zMax] = this.getZBounds(sliceCoords);
-    const viewBounds3D = new Box3(
-      vec3.fromValues(viewBounds2D.min[0], viewBounds2D.min[1], zMin),
-      vec3.fromValues(viewBounds2D.max[0], viewBounds2D.max[1], zMax)
-    );
+    const viewBounds3D = this.makeViewBounds3D(viewBounds2D, sliceBounds);
 
     // reset all existing chunk view states to "not needed" to start
     // logic below will override this for chunks that are actually visible/prefetch
@@ -180,7 +196,7 @@ export class ChunkStoreView {
 
     this.policyChanged_ = false;
     this.lastViewBounds2D_ = viewBounds2D.clone();
-    this.lastZBounds_ = zBounds;
+    this.lastSliceBounds_ = sliceBounds;
     this.lastTCoord_ = sliceCoords.t;
     this.lastCCoords_ = sliceCoords.c ? [...sliceCoords.c] : undefined;
   }
@@ -307,14 +323,11 @@ export class ChunkStoreView {
   }
 
   private setLOD(lodFactor: number): void {
-    // `scale0` is the x pixel size (world units) at LOD 0.
     // With 2x downsampling per LOD, selection happens in log2 space.
-    const dimensions = this.store_.dimensions;
-    const scale0 = dimensions.x.lods[0].scale;
     const bias = this.policy_.lod.bias;
 
     // How many LOD 0 pixels per screen pixel, normalized by source scale and bias.
-    const sourceAdjusted = bias - Math.log2(scale0) - lodFactor;
+    const sourceAdjusted = bias - Math.log2(this.scale0_) - lodFactor;
     const desiredLOD = Math.floor(sourceAdjusted);
 
     const lowestResLOD = this.store_.getLowestResLOD();
@@ -524,35 +537,51 @@ export class ChunkStoreView {
     return coordToIndex(tDim.lods[0], sliceCoords.t);
   }
 
-  private getZBounds(sliceCoords: SliceCoordinates): [number, number] {
-    const zDim = this.store_.dimensions.z;
-    if (zDim === undefined) return [0, 1];
+  private getSliceAxisBounds(sliceCoords: SliceCoordinates): [number, number] {
+    const wDim = this.store_.dimensions[this.axes_.w];
+    if (wDim === undefined) return [0, 1];
 
-    // If z is undefined, return bounds that encompass all z slices (for volume rendering)
-    if (sliceCoords.z === undefined) {
-      const zLod = zDim.lods[this.currentLOD_];
-      return [zLod.translation, zLod.translation + zLod.size * zLod.scale];
+    const wLod = wDim.lods[this.currentLOD_];
+
+    // If slice coordinate is undefined, return bounds that encompass the whole axis (for volume rendering)
+    const sliceValue = sliceCoords[this.axes_.w];
+    if (sliceValue === undefined) {
+      return [wLod.translation, wLod.translation + wLod.size * wLod.scale];
     }
 
-    const zLod = zDim.lods[this.currentLOD_];
-    const zShape = zLod.size;
-    const zScale = zLod.scale;
-    const zTran = zLod.translation;
-    const zPoint = Math.floor((sliceCoords.z - zTran) / zScale);
-    const chunkDepth = zLod.chunkSize;
+    const wShape = wLod.size;
+    const wScale = wLod.scale;
+    const wTran = wLod.translation;
+    const wPoint = Math.floor((sliceValue - wTran) / wScale);
+    const chunkDepth = wLod.chunkSize;
 
-    const zChunk = Math.max(
+    const wChunk = Math.max(
       0,
       Math.min(
-        Math.floor(zPoint / chunkDepth),
-        Math.ceil(zShape / chunkDepth) - 1
+        Math.floor(wPoint / chunkDepth),
+        Math.ceil(wShape / chunkDepth) - 1
       )
     );
 
     return [
-      zTran + zChunk * chunkDepth * zScale,
-      zTran + (zChunk + 1) * chunkDepth * zScale,
+      wTran + wChunk * chunkDepth * wScale,
+      wTran + (wChunk + 1) * chunkDepth * wScale,
     ];
+  }
+
+  private makeViewBounds3D(
+    viewBounds2D: Box2,
+    sliceBounds: [number, number]
+  ): Box3 {
+    const min = vec3.create();
+    const max = vec3.create();
+    min[AxisComponent[this.axes_.u]] = viewBounds2D.min[0];
+    max[AxisComponent[this.axes_.u]] = viewBounds2D.max[0];
+    min[AxisComponent[this.axes_.v]] = viewBounds2D.min[1];
+    max[AxisComponent[this.axes_.v]] = viewBounds2D.max[1];
+    min[AxisComponent[this.axes_.w]] = sliceBounds[0];
+    max[AxisComponent[this.axes_.w]] = sliceBounds[1];
+    return new Box3(min, max);
   }
 
   private viewBounds2DChanged(newBounds: Box2): boolean {
@@ -570,8 +599,10 @@ export class ChunkStoreView {
     );
   }
 
-  private zBoundsChanged(newBounds: [number, number]): boolean {
-    return !this.lastZBounds_ || !vec2.equals(this.lastZBounds_, newBounds);
+  private sliceBoundsChanged(newBounds: [number, number]): boolean {
+    return (
+      !this.lastSliceBounds_ || !vec2.equals(this.lastSliceBounds_, newBounds)
+    );
   }
 
   private cCoordsChanged(newC?: number[]): boolean {
@@ -610,13 +641,15 @@ export class ChunkStoreView {
   }
 
   private squareDistance2D(chunk: Chunk, center: ReadonlyVec2): number {
-    const chunkCenter = {
-      x: chunk.offset.x + 0.5 * chunk.shape.x * chunk.scale.x,
-      y: chunk.offset.y + 0.5 * chunk.shape.y * chunk.scale.y,
-    };
-    const dx = chunkCenter.x - center[0];
-    const dy = chunkCenter.y - center[1];
-    return dx * dx + dy * dy;
+    function axisCenter(axis: SpatialAxis) {
+      return chunk.offset[axis] + 0.5 * chunk.shape[axis] * chunk.scale[axis];
+    }
+
+    const { u, v } = this.axes_;
+    const du = axisCenter(u) - center[0];
+    const dv = axisCenter(v) - center[1];
+
+    return du * du + dv * dv;
   }
 }
 

--- a/src/layers/image_layer.ts
+++ b/src/layers/image_layer.ts
@@ -2,7 +2,7 @@ import { Layer, LayerOptions } from "../core/layer";
 import { Viewport } from "../core/viewport";
 import { OrthographicCamera } from "../objects/cameras/orthographic_camera";
 import type { IdetikContext } from "../idetik";
-import { Chunk, ChunkSource, SliceCoordinates } from "../data/chunk";
+import { Chunk, ChunkSource, SliceAxes, SliceCoordinates } from "../data/chunk";
 import { ChunkStoreView, INTERNAL_POLICY_KEY } from "../data/chunk_store_view";
 import { ImageSourcePolicy } from "../core/image_source_policy";
 import {
@@ -47,6 +47,7 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
 
   private readonly source_: ChunkSource;
   private readonly sliceCoords_: SliceCoordinates;
+  private readonly axes_: SliceAxes = { u: "x", v: "y", w: "z" };
   private readonly onPickValue_?: (info: PointPickingResult) => void;
   private readonly visibleChunks_: Map<Chunk, ImageRenderable> = new Map();
   private readonly pool_ = new RenderablePool<ImageRenderable>();
@@ -135,7 +136,7 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
     this.updateChunks();
 
     for (const [chunk, imageRenderable] of this.visibleChunks_) {
-      imageRenderable.zTexCoord = this.zTexCoordForChunk(chunk);
+      imageRenderable.sliceTexCoord = this.sliceTexCoordForChunk(chunk);
     }
   }
 
@@ -235,7 +236,7 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
     const pooled = this.pool_.acquire(poolKeyForImageRenderable(chunk));
     if (pooled) {
       pooled.setTexture(0, texture);
-      pooled.zTexCoord = this.zTexCoordForChunk(chunk);
+      pooled.sliceTexCoord = this.sliceTexCoordForChunk(chunk);
       pooled.setChannelProps(this.getChannelPropsForChunk(chunk));
       this.updateImageChunk(pooled, chunk);
       return pooled;
@@ -251,25 +252,29 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
 
   private createImage(chunk: Chunk, texture: Texture) {
     const image = new ImageRenderable(
-      chunk.shape.x,
-      chunk.shape.y,
+      chunk.shape[this.axes_.u],
+      chunk.shape[this.axes_.v],
       texture,
       this.getChannelPropsForChunk(chunk)
     );
-    image.zTexCoord = this.zTexCoordForChunk(chunk);
+    image.sliceTexCoord = this.sliceTexCoordForChunk(chunk);
     this.updateImageChunk(image, chunk);
     return image;
   }
 
-  private zSliceIndex(chunk: Chunk): number {
-    const zValue = this.sliceCoords_.z;
-    if (zValue === undefined) return 0;
-    const zLocal = (zValue - chunk.offset.z) / chunk.scale.z;
-    return clamp(Math.round(zLocal), 0, chunk.shape.z - 1);
+  private sliceIndexForChunk(chunk: Chunk): number {
+    const w = this.axes_.w;
+    const sliceValue = this.sliceCoords_[w];
+    if (sliceValue === undefined) {
+      return 0;
+    }
+
+    const local = (sliceValue - chunk.offset[w]) / chunk.scale[w];
+    return clamp(Math.round(local), 0, chunk.shape[w] - 1);
   }
 
-  private zTexCoordForChunk(chunk: Chunk): number {
-    return (this.zSliceIndex(chunk) + 0.5) / chunk.shape.z;
+  private sliceTexCoordForChunk(chunk: Chunk): number {
+    return (this.sliceIndexForChunk(chunk) + 0.5) / chunk.shape[this.axes_.w];
   }
 
   private updateImageChunk(image: ImageRenderable, chunk: Chunk) {
@@ -280,8 +285,9 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
     } else {
       image.wireframeEnabled = false;
     }
-    image.transform.setScale([chunk.scale.x, chunk.scale.y, 1]);
-    image.transform.setTranslation([chunk.offset.x, chunk.offset.y, 0]);
+    const { u, v } = this.axes_;
+    image.transform.setScale([chunk.scale[u], chunk.scale[v], 1]);
+    image.transform.setTranslation([chunk.offset[u], chunk.offset[v], 0]);
   }
 
   public async getValueAtWorld(world: vec3): Promise<number | null> {
@@ -308,15 +314,26 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
       image.transform.inverse
     );
 
-    const x = Math.floor(localPos[0]);
-    const y = Math.floor(localPos[1]);
+    const { u, v, w } = this.axes_;
+    const uIdx = Math.floor(localPos[0]);
+    const vIdx = Math.floor(localPos[1]);
 
-    if (x < 0 || x >= chunk.shape.x || y < 0 || y >= chunk.shape.y) {
+    if (
+      uIdx < 0 ||
+      uIdx >= chunk.shape[u] ||
+      vIdx < 0 ||
+      vIdx >= chunk.shape[v]
+    ) {
       return null;
     }
 
-    const z = this.zSliceIndex(chunk);
-    return (await image.textures[0].readTexel?.(x, y, z)) ?? null;
+    const texel = { x: 0, y: 0, z: 0 };
+    texel[u] = uIdx;
+    texel[v] = vIdx;
+    texel[w] = this.sliceIndexForChunk(chunk);
+    return (
+      (await image.textures[0].readTexel?.(texel.x, texel.y, texel.z)) ?? null
+    );
   }
 
   public get debugMode(): boolean {

--- a/src/layers/label_layer.ts
+++ b/src/layers/label_layer.ts
@@ -2,7 +2,7 @@ import { Layer, LayerOptions } from "../core/layer";
 import { Viewport } from "../core/viewport";
 import { OrthographicCamera } from "../objects/cameras/orthographic_camera";
 import type { IdetikContext } from "../idetik";
-import { Chunk, ChunkSource, SliceCoordinates } from "../data/chunk";
+import { Chunk, ChunkSource, SliceAxes, SliceCoordinates } from "../data/chunk";
 import { ChunkStoreView, INTERNAL_POLICY_KEY } from "../data/chunk_store_view";
 import { ImageSourcePolicy } from "../core/image_source_policy";
 import { LabelImageRenderable } from "../objects/renderable/label_image_renderable";
@@ -33,6 +33,7 @@ export class LabelLayer extends Layer {
 
   private readonly source_: ChunkSource;
   private readonly sliceCoords_: SliceCoordinates;
+  private readonly axes_: SliceAxes = { u: "x", v: "y", w: "z" };
   private readonly onPickValue_?: (info: PointPickingResult) => void;
   private readonly outlineSelected_: boolean;
   private readonly visibleChunks_: Map<Chunk, LabelImageRenderable> = new Map();
@@ -107,7 +108,7 @@ export class LabelLayer extends Layer {
     this.updateChunks();
 
     for (const [chunk, labelRenderable] of this.visibleChunks_) {
-      labelRenderable.zTexCoord = this.zTexCoordForChunk(chunk);
+      labelRenderable.sliceTexCoord = this.sliceTexCoordForChunk(chunk);
     }
   }
 
@@ -242,15 +243,26 @@ export class LabelLayer extends Layer {
       label.transform.inverse
     );
 
-    const x = Math.floor(localPos[0]);
-    const y = Math.floor(localPos[1]);
+    const { u, v, w } = this.axes_;
+    const uIdx = Math.floor(localPos[0]);
+    const vIdx = Math.floor(localPos[1]);
 
-    if (x < 0 || x >= chunk.shape.x || y < 0 || y >= chunk.shape.y) {
+    if (
+      uIdx < 0 ||
+      uIdx >= chunk.shape[u] ||
+      vIdx < 0 ||
+      vIdx >= chunk.shape[v]
+    ) {
       return null;
     }
 
-    const z = this.zSliceIndex(chunk);
-    return (await label.textures[0].readTexel?.(x, y, z)) ?? null;
+    const texel = { x: 0, y: 0, z: 0 };
+    texel[u] = uIdx;
+    texel[v] = vIdx;
+    texel[w] = this.sliceIndexForChunk(chunk);
+    return (
+      (await label.textures[0].readTexel?.(texel.x, texel.y, texel.z)) ?? null
+    );
   }
 
   private getLabelForChunk(chunk: Chunk, texture: Texture) {
@@ -260,7 +272,7 @@ export class LabelLayer extends Layer {
     const pooled = this.pool_.acquire(poolKeyForImageRenderable(chunk));
     if (pooled) {
       pooled.setTexture(0, texture);
-      pooled.zTexCoord = this.zTexCoordForChunk(chunk);
+      pooled.sliceTexCoord = this.sliceTexCoordForChunk(chunk);
       pooled.setColorMap(this.colorMap_);
       pooled.setSelectedValue(this.selectedValue_);
       this.updateLabelChunk(pooled, chunk);
@@ -273,32 +285,37 @@ export class LabelLayer extends Layer {
 
   private createLabel(chunk: Chunk, texture: Texture) {
     const label = new LabelImageRenderable({
-      width: chunk.shape.x,
-      height: chunk.shape.y,
+      width: chunk.shape[this.axes_.u],
+      height: chunk.shape[this.axes_.v],
       imageData: texture,
       colorMap: this.colorMap_,
       outlineSelected: this.outlineSelected_,
       selectedValue: this.selectedValue_,
     });
-    label.zTexCoord = this.zTexCoordForChunk(chunk);
+    label.sliceTexCoord = this.sliceTexCoordForChunk(chunk);
     this.updateLabelChunk(label, chunk);
     return label;
   }
 
-  private zSliceIndex(chunk: Chunk): number {
-    const zValue = this.sliceCoords_.z;
-    if (zValue === undefined) return 0;
-    const zLocal = (zValue - chunk.offset.z) / chunk.scale.z;
-    return clamp(Math.round(zLocal), 0, chunk.shape.z - 1);
+  private sliceIndexForChunk(chunk: Chunk): number {
+    const w = this.axes_.w;
+    const sliceValue = this.sliceCoords_[w];
+    if (sliceValue === undefined) {
+      return 0;
+    }
+
+    const local = (sliceValue - chunk.offset[w]) / chunk.scale[w];
+    return clamp(Math.round(local), 0, chunk.shape[w] - 1);
   }
 
-  private zTexCoordForChunk(chunk: Chunk): number {
-    return (this.zSliceIndex(chunk) + 0.5) / chunk.shape.z;
+  private sliceTexCoordForChunk(chunk: Chunk): number {
+    return (this.sliceIndexForChunk(chunk) + 0.5) / chunk.shape[this.axes_.w];
   }
 
   private updateLabelChunk(label: LabelImageRenderable, chunk: Chunk) {
-    label.transform.setScale([chunk.scale.x, chunk.scale.y, 1]);
-    label.transform.setTranslation([chunk.offset.x, chunk.offset.y, 0]);
+    const { u, v } = this.axes_;
+    label.transform.setScale([chunk.scale[u], chunk.scale[v], 1]);
+    label.transform.setTranslation([chunk.offset[u], chunk.offset[v], 0]);
   }
 
   private releaseAndRemoveChunks(chunks: Iterable<Chunk>): void {

--- a/src/objects/renderable/image_renderable.ts
+++ b/src/objects/renderable/image_renderable.ts
@@ -25,7 +25,7 @@ export class ImageRenderable extends RenderableObject {
 
   // The layer overwrites this per chunk with a texel-centered slice coordinate.
   // 0.5 (the texture's center) is a safe placeholder until it does.
-  public zTexCoord = 0.5;
+  public sliceTexCoord = 0.5;
 
   constructor(
     width: number,
@@ -76,7 +76,8 @@ export class ImageRenderable extends RenderableObject {
       u_valueOffset: -contrastLimits[0],
       u_valueScale: 1 / (contrastLimits[1] - contrastLimits[0]),
       Opacity: opacity,
-      u_zTexCoord: this.zTexCoord,
+      // TODO(shlomnissan): the shader still samples the texture's z-axis
+      u_zTexCoord: this.sliceTexCoord,
     };
   }
 }

--- a/src/objects/renderable/label_image_renderable.ts
+++ b/src/objects/renderable/label_image_renderable.ts
@@ -41,7 +41,7 @@ export class LabelImageRenderable extends RenderableObject {
 
   // The layer overwrites this per chunk with a texel-centered slice coordinate.
   // 0.5 (the texture's center) is a safe placeholder until it does.
-  public zTexCoord = 0.5;
+  public sliceTexCoord = 0.5;
 
   constructor(props: LabelImageRenderableProps) {
     super();
@@ -69,7 +69,8 @@ export class LabelImageRenderable extends RenderableObject {
       u_colorLookupTableSampler: 2,
       u_outlineSelected: this.outlineSelected_ ? 1.0 : 0.0,
       u_selectedValue: this.selectedValue_ ?? -1.0,
-      u_zTexCoord: this.zTexCoord,
+      // TODO(shlomnissan): the shader still samples the texture's z-axis
+      u_zTexCoord: this.sliceTexCoord,
     };
   }
 


### PR DESCRIPTION
### Summary

this PR routes hard-coded XY operations through a `SliceAxes` mapping.
in-plane u/v + a slice normal w. this is fixed on XY for now. no behavior
change. this is the groundwork for selectable slice orientation.

### Tests & Checks

- all checks have passed.