### PR TITLE
refactor: slice images by world-space fragment position

### DIFF
--- a/examples/image_series_labels_overlay/main.ts
+++ b/examples/image_series_labels_overlay/main.ts
@@ -40,10 +40,10 @@ const sliceCoords = {
   z: zMidPoint,
 };
 
-// Labels have unitary C and Z dimensions.
 const labelsSliceCoords = {
   t: tMin * tScale,
   c: [0],
+  z: zMidPoint,
 };
 
 const imageLayer = new ImageLayer({

--- a/src/data/chunk.ts
+++ b/src/data/chunk.ts
@@ -3,6 +3,7 @@ import {
   TextureUnpackRowAlignment,
 } from "../objects/textures/texture";
 import { Logger } from "../utilities/logger";
+import { mat4 } from "gl-matrix";
 
 const chunkDataTypes = [
   Int8Array,
@@ -142,4 +143,16 @@ export function coordToChunkIndex(
 ): number {
   const index = coordToIndex(lod, coord);
   return Math.floor(index / lod.chunkSize);
+}
+
+export function worldToTexCoordForChunk(chunk: Chunk, axes: SliceAxes): mat4 {
+  const m = mat4.create();
+  for (const axis of ["x", "y", "z"] as const) {
+    const scale = 1 / (chunk.scale[axis] * chunk.shape[axis]);
+    const centerShift = axis === axes.w ? 0.5 * chunk.scale[axis] : 0;
+    const component = AxisComponent[axis];
+    m[component * 4 + component] = scale;
+    m[12 + component] = (centerShift - chunk.offset[axis]) * scale;
+  }
+  return m;
 }

--- a/src/data/chunk.ts
+++ b/src/data/chunk.ts
@@ -3,7 +3,7 @@ import {
   TextureUnpackRowAlignment,
 } from "../objects/textures/texture";
 import { Logger } from "../utilities/logger";
-import { mat4 } from "gl-matrix";
+import { mat4, vec3 } from "gl-matrix";
 
 const chunkDataTypes = [
   Int8Array,
@@ -146,13 +146,14 @@ export function coordToChunkIndex(
 }
 
 export function worldToTexCoordForChunk(chunk: Chunk, axes: SliceAxes): mat4 {
-  const m = mat4.create();
+  const scale = vec3.create();
+  const translation = vec3.create();
   for (const axis of ["x", "y", "z"] as const) {
-    const scale = 1 / (chunk.scale[axis] * chunk.shape[axis]);
     const centerShift = axis === axes.w ? 0.5 * chunk.scale[axis] : 0;
     const component = AxisComponent[axis];
-    m[component * 4 + component] = scale;
-    m[12 + component] = (centerShift - chunk.offset[axis]) * scale;
+    scale[component] = 1 / (chunk.scale[axis] * chunk.shape[axis]);
+    translation[component] = centerShift - chunk.offset[axis];
   }
-  return m;
+  const m = mat4.fromScaling(mat4.create(), scale);
+  return mat4.translate(m, m, translation);
 }

--- a/src/layers/image_layer.ts
+++ b/src/layers/image_layer.ts
@@ -271,7 +271,7 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
     image.transform.setTranslation([
       chunk.offset[u],
       chunk.offset[v],
-      chunk.offset[w] + this.sliceIndexForChunk(chunk) * chunk.scale[w],
+      this.sliceCoords_[w] ?? chunk.offset[w],
     ]);
   }
 

--- a/src/layers/image_layer.ts
+++ b/src/layers/image_layer.ts
@@ -2,7 +2,13 @@ import { Layer, LayerOptions } from "../core/layer";
 import { Viewport } from "../core/viewport";
 import { OrthographicCamera } from "../objects/cameras/orthographic_camera";
 import type { IdetikContext } from "../idetik";
-import { Chunk, ChunkSource, SliceAxes, SliceCoordinates } from "../data/chunk";
+import {
+  Chunk,
+  ChunkSource,
+  SliceAxes,
+  SliceCoordinates,
+  worldToTexCoordForChunk,
+} from "../data/chunk";
 import { ChunkStoreView, INTERNAL_POLICY_KEY } from "../data/chunk_store_view";
 import { ImageSourcePolicy } from "../core/image_source_policy";
 import {
@@ -136,7 +142,7 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
     this.updateChunks();
 
     for (const [chunk, imageRenderable] of this.visibleChunks_) {
-      imageRenderable.sliceTexCoord = this.sliceTexCoordForChunk(chunk);
+      this.updateSlicePosition(imageRenderable, chunk);
     }
   }
 
@@ -236,7 +242,6 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
     const pooled = this.pool_.acquire(poolKeyForImageRenderable(chunk));
     if (pooled) {
       pooled.setTexture(0, texture);
-      pooled.sliceTexCoord = this.sliceTexCoordForChunk(chunk);
       pooled.setChannelProps(this.getChannelPropsForChunk(chunk));
       this.updateImageChunk(pooled, chunk);
       return pooled;
@@ -257,24 +262,29 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
       texture,
       this.getChannelPropsForChunk(chunk)
     );
-    image.sliceTexCoord = this.sliceTexCoordForChunk(chunk);
     this.updateImageChunk(image, chunk);
     return image;
+  }
+
+  private updateSlicePosition(image: ImageRenderable, chunk: Chunk) {
+    const { u, v, w } = this.axes_;
+    image.transform.setTranslation([
+      chunk.offset[u],
+      chunk.offset[v],
+      chunk.offset[w] + this.sliceIndexForChunk(chunk) * chunk.scale[w],
+    ]);
   }
 
   private sliceIndexForChunk(chunk: Chunk): number {
     const w = this.axes_.w;
     const sliceValue = this.sliceCoords_[w];
+
     if (sliceValue === undefined) {
       return 0;
     }
 
     const local = (sliceValue - chunk.offset[w]) / chunk.scale[w];
     return clamp(Math.round(local), 0, chunk.shape[w] - 1);
-  }
-
-  private sliceTexCoordForChunk(chunk: Chunk): number {
-    return (this.sliceIndexForChunk(chunk) + 0.5) / chunk.shape[this.axes_.w];
   }
 
   private updateImageChunk(image: ImageRenderable, chunk: Chunk) {
@@ -287,7 +297,8 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
     }
     const { u, v } = this.axes_;
     image.transform.setScale([chunk.scale[u], chunk.scale[v], 1]);
-    image.transform.setTranslation([chunk.offset[u], chunk.offset[v], 0]);
+    this.updateSlicePosition(image, chunk);
+    image.worldToTexCoord = worldToTexCoordForChunk(chunk, this.axes_);
   }
 
   public async getValueAtWorld(world: vec3): Promise<number | null> {

--- a/src/layers/label_layer.ts
+++ b/src/layers/label_layer.ts
@@ -2,7 +2,13 @@ import { Layer, LayerOptions } from "../core/layer";
 import { Viewport } from "../core/viewport";
 import { OrthographicCamera } from "../objects/cameras/orthographic_camera";
 import type { IdetikContext } from "../idetik";
-import { Chunk, ChunkSource, SliceAxes, SliceCoordinates } from "../data/chunk";
+import {
+  Chunk,
+  ChunkSource,
+  SliceAxes,
+  SliceCoordinates,
+  worldToTexCoordForChunk,
+} from "../data/chunk";
 import { ChunkStoreView, INTERNAL_POLICY_KEY } from "../data/chunk_store_view";
 import { ImageSourcePolicy } from "../core/image_source_policy";
 import { LabelImageRenderable } from "../objects/renderable/label_image_renderable";
@@ -108,7 +114,7 @@ export class LabelLayer extends Layer {
     this.updateChunks();
 
     for (const [chunk, labelRenderable] of this.visibleChunks_) {
-      labelRenderable.sliceTexCoord = this.sliceTexCoordForChunk(chunk);
+      this.updateSlicePosition(labelRenderable, chunk);
     }
   }
 
@@ -272,7 +278,6 @@ export class LabelLayer extends Layer {
     const pooled = this.pool_.acquire(poolKeyForImageRenderable(chunk));
     if (pooled) {
       pooled.setTexture(0, texture);
-      pooled.sliceTexCoord = this.sliceTexCoordForChunk(chunk);
       pooled.setColorMap(this.colorMap_);
       pooled.setSelectedValue(this.selectedValue_);
       this.updateLabelChunk(pooled, chunk);
@@ -292,9 +297,17 @@ export class LabelLayer extends Layer {
       outlineSelected: this.outlineSelected_,
       selectedValue: this.selectedValue_,
     });
-    label.sliceTexCoord = this.sliceTexCoordForChunk(chunk);
     this.updateLabelChunk(label, chunk);
     return label;
+  }
+
+  private updateSlicePosition(label: LabelImageRenderable, chunk: Chunk) {
+    const { u, v, w } = this.axes_;
+    label.transform.setTranslation([
+      chunk.offset[u],
+      chunk.offset[v],
+      chunk.offset[w] + this.sliceIndexForChunk(chunk) * chunk.scale[w],
+    ]);
   }
 
   private sliceIndexForChunk(chunk: Chunk): number {
@@ -308,14 +321,11 @@ export class LabelLayer extends Layer {
     return clamp(Math.round(local), 0, chunk.shape[w] - 1);
   }
 
-  private sliceTexCoordForChunk(chunk: Chunk): number {
-    return (this.sliceIndexForChunk(chunk) + 0.5) / chunk.shape[this.axes_.w];
-  }
-
   private updateLabelChunk(label: LabelImageRenderable, chunk: Chunk) {
     const { u, v } = this.axes_;
     label.transform.setScale([chunk.scale[u], chunk.scale[v], 1]);
-    label.transform.setTranslation([chunk.offset[u], chunk.offset[v], 0]);
+    this.updateSlicePosition(label, chunk);
+    label.worldToTexCoord = worldToTexCoordForChunk(chunk, this.axes_);
   }
 
   private releaseAndRemoveChunks(chunks: Iterable<Chunk>): void {

--- a/src/layers/label_layer.ts
+++ b/src/layers/label_layer.ts
@@ -306,7 +306,7 @@ export class LabelLayer extends Layer {
     label.transform.setTranslation([
       chunk.offset[u],
       chunk.offset[v],
-      chunk.offset[w] + this.sliceIndexForChunk(chunk) * chunk.scale[w],
+      this.sliceCoords_[w] ?? chunk.offset[w],
     ]);
   }
 

--- a/src/objects/cameras/orthographic_camera.ts
+++ b/src/objects/cameras/orthographic_camera.ts
@@ -5,6 +5,8 @@ import { Box2 } from "../../math/box2";
 const DEFAULT_ASPECT_RATIO = 1.77; // 16:9
 const DEFAULT_WIDTH = 128;
 const DEFAULT_HEIGHT = 128 / DEFAULT_ASPECT_RATIO;
+const DEFAULT_NEAR = -1e6;
+const DEFAULT_FAR = 1e6;
 
 /**
  * A camera using an orthographic (parallel) projection.
@@ -33,16 +35,16 @@ export class OrthographicCamera extends Camera {
    * @param right - Right edge of the view frame, in world units.
    * @param top - Top edge of the view frame, in world units.
    * @param bottom - Bottom edge of the view frame, in world units.
-   * @param near - Near clipping plane distance. Defaults to `0.0`.
-   * @param far - Far clipping plane distance. Defaults to `100.0`.
+   * @param near - Near clipping plane distance. Defaults to `-1e6`.
+   * @param far - Far clipping plane distance. Defaults to `1e6`.
    */
   constructor(
     left: number,
     right: number,
     top: number,
     bottom: number,
-    near = 0.0,
-    far = 100.0
+    near = DEFAULT_NEAR,
+    far = DEFAULT_FAR
   ) {
     super();
     this.near_ = near;

--- a/src/objects/renderable/image_renderable.ts
+++ b/src/objects/renderable/image_renderable.ts
@@ -7,7 +7,7 @@ import {
   validateChannel,
   validateChannels,
 } from "../../core/channel";
-import { vec3 } from "gl-matrix";
+import { mat4, vec3 } from "gl-matrix";
 import { Shader } from "../../renderers/shaders";
 
 type UniformValues = {
@@ -16,16 +16,14 @@ type UniformValues = {
   Opacity: number;
   u_valueOffset: number;
   u_valueScale: number;
-  u_zTexCoord: number;
+  u_worldToTexCoord: mat4;
 };
 
 /** @group Renderable Objects */
 export class ImageRenderable extends RenderableObject {
   private channels_: Required<Channel>[];
 
-  // The layer overwrites this per chunk with a texel-centered slice coordinate.
-  // 0.5 (the texture's center) is a safe placeholder until it does.
-  public sliceTexCoord = 0.5;
+  public worldToTexCoord: mat4 = mat4.create();
 
   constructor(
     width: number,
@@ -76,8 +74,7 @@ export class ImageRenderable extends RenderableObject {
       u_valueOffset: -contrastLimits[0],
       u_valueScale: 1 / (contrastLimits[1] - contrastLimits[0]),
       Opacity: opacity,
-      // TODO(shlomnissan): the shader still samples the texture's z-axis
-      u_zTexCoord: this.sliceTexCoord,
+      u_worldToTexCoord: this.worldToTexCoord,
     };
   }
 }

--- a/src/objects/renderable/label_color_map.ts
+++ b/src/objects/renderable/label_color_map.ts
@@ -31,7 +31,6 @@ export type LabelColorMapProps = {
   cycle?: ColorLike[];
 };
 
-/** @group Renderable Objects */
 export class LabelColorMap {
   public readonly lookupTable: ReadonlyMap<number, Color>;
   public readonly cycle: ReadonlyArray<Color>;

--- a/src/objects/renderable/label_image_renderable.ts
+++ b/src/objects/renderable/label_image_renderable.ts
@@ -1,5 +1,6 @@
 import { RenderableObject } from "../../core/renderable_object";
 import { PlaneGeometry } from "../../objects/geometry/plane_geometry";
+import { mat4 } from "gl-matrix";
 import { Texture, TextureDataType } from "../../objects/textures/texture";
 import { Color } from "../../math/color";
 import { Texture2D } from "../textures/texture_2d";
@@ -48,12 +49,11 @@ export class LabelImageRenderable extends RenderableObject {
   private outlineSelected_: boolean;
   private selectedValue_: number | null;
 
-  // The layer overwrites this per chunk with a texel-centered slice coordinate.
-  // 0.5 (the texture's center) is a safe placeholder until it does.
-  public sliceTexCoord = 0.5;
+  public worldToTexCoord: mat4 = mat4.create();
 
   constructor(props: LabelImageRenderableProps) {
     super();
+    this.depthTest = false;
     this.geometry = new PlaneGeometry(props.width, props.height, 1, 1);
     this.setTexture(0, validateImageData(props.imageData));
     const colorCycleTexture = this.makeColorCycleTexture(props.colorMap.cycle);
@@ -78,8 +78,7 @@ export class LabelImageRenderable extends RenderableObject {
       u_colorLookupTableSampler: 2,
       u_outlineSelected: this.outlineSelected_ ? 1.0 : 0.0,
       u_selectedValue: this.selectedValue_ ?? -1.0,
-      // TODO(shlomnissan): the shader still samples the texture's z-axis
-      u_zTexCoord: this.sliceTexCoord,
+      u_worldToTexCoord: this.worldToTexCoord,
     };
   }
 

--- a/src/objects/renderable/label_image_renderable.ts
+++ b/src/objects/renderable/label_image_renderable.ts
@@ -53,7 +53,6 @@ export class LabelImageRenderable extends RenderableObject {
 
   constructor(props: LabelImageRenderableProps) {
     super();
-    this.depthTest = false;
     this.geometry = new PlaneGeometry(props.width, props.height, 1, 1);
     this.setTexture(0, validateImageData(props.imageData));
     const colorCycleTexture = this.makeColorCycleTexture(props.colorMap.cycle);

--- a/src/renderers/shaders/label_image_frag.glsl
+++ b/src/renderers/shaders/label_image_frag.glsl
@@ -19,8 +19,6 @@ uniform highp usampler2D u_colorLookupTableSampler;
 uniform float u_opacity;
 uniform float u_outlineSelected; // Note: Using float instead of bool due to framework uniform handling
 uniform float u_selectedValue;
-uniform mat4 u_worldToTexCoord;
-uniform mat4 u_model;
 
 in vec3 v_texCoords;
 
@@ -32,11 +30,7 @@ vec4 unpackRgba(uint packed) {
     return vec4(float(r), float(g), float(b), float(a)) / 255.0;
 }
 
-bool isEdgePixel(DATA_TYPE centerValue, vec3 texCoords) {
-    mat4 modelToTexCoord = u_worldToTexCoord * u_model;
-    vec3 stepX = modelToTexCoord[0].xyz;
-    vec3 stepY = modelToTexCoord[1].xyz;
-
+bool isEdgePixel(DATA_TYPE centerValue, vec3 texCoords, vec3 stepX, vec3 stepY) {
     // Check 8-connected neighbors
     for (int dx = -1; dx <= 1; dx++) {
         for (int dy = -1; dy <= 1; dy++) {
@@ -51,7 +45,7 @@ bool isEdgePixel(DATA_TYPE centerValue, vec3 texCoords) {
                 continue;
             }
 
-            DATA_TYPE neighborValue = texture(u_imageSampler, neighborCoords).r;
+            DATA_TYPE neighborValue = textureLod(u_imageSampler, neighborCoords, 0.0).r;
             if (neighborValue != centerValue) {
                 return true;
             }
@@ -63,12 +57,15 @@ bool isEdgePixel(DATA_TYPE centerValue, vec3 texCoords) {
 void main() {
     DATA_TYPE texel = texture(u_imageSampler, v_texCoords).r;
 
+    vec3 stepX = dFdx(v_texCoords);
+    vec3 stepY = dFdy(v_texCoords);
+
     // Check if this pixel is the selected value
     bool isSelectedValue = u_outlineSelected > 0.5 && u_selectedValue >= 0.0 && float(texel) == u_selectedValue;
 
     // Check if we should outline this selected segment
     if (isSelectedValue) {
-        if (isEdgePixel(texel, v_texCoords)) {
+        if (isEdgePixel(texel, v_texCoords, stepX, stepY)) {
             // Draw outline in bright white with layer opacity
             fragColor = vec4(1.0, 1.0, 1.0, u_opacity);
             return;

--- a/src/renderers/shaders/label_image_frag.glsl
+++ b/src/renderers/shaders/label_image_frag.glsl
@@ -22,7 +22,7 @@ uniform float u_selectedValue;
 uniform mat4 u_worldToTexCoord;
 uniform mat4 u_model;
 
-in vec3 v_positionWorld;
+in vec3 v_texCoords;
 
 vec4 unpackRgba(uint packed) {
     uint r = (packed >> 24u) & 0xFFu;
@@ -61,15 +61,14 @@ bool isEdgePixel(DATA_TYPE centerValue, vec3 texCoords) {
 }
 
 void main() {
-    vec3 texCoords = (u_worldToTexCoord * vec4(v_positionWorld, 1.0)).xyz;
-    DATA_TYPE texel = texture(u_imageSampler, texCoords).r;
+    DATA_TYPE texel = texture(u_imageSampler, v_texCoords).r;
 
     // Check if this pixel is the selected value
     bool isSelectedValue = u_outlineSelected > 0.5 && u_selectedValue >= 0.0 && float(texel) == u_selectedValue;
 
     // Check if we should outline this selected segment
     if (isSelectedValue) {
-        if (isEdgePixel(texel, texCoords)) {
+        if (isEdgePixel(texel, v_texCoords)) {
             // Draw outline in bright white with layer opacity
             fragColor = vec4(1.0, 1.0, 1.0, u_opacity);
             return;

--- a/src/renderers/shaders/label_image_frag.glsl
+++ b/src/renderers/shaders/label_image_frag.glsl
@@ -1,7 +1,7 @@
 #version 300 es
 #pragma inject_defines
 
-precision mediump float;
+precision highp float;
 precision highp int;
 
 layout (location = 0) out vec4 fragColor;
@@ -19,9 +19,10 @@ uniform highp usampler2D u_colorLookupTableSampler;
 uniform float u_opacity;
 uniform float u_outlineSelected; // Note: Using float instead of bool due to framework uniform handling
 uniform float u_selectedValue;
-uniform float u_zTexCoord;
+uniform mat4 u_worldToTexCoord;
+uniform mat4 u_model;
 
-in vec2 v_texCoords;
+in vec3 v_positionWorld;
 
 vec4 unpackRgba(uint packed) {
     uint r = (packed >> 24u) & 0xFFu;
@@ -31,16 +32,18 @@ vec4 unpackRgba(uint packed) {
     return vec4(float(r), float(g), float(b), float(a)) / 255.0;
 }
 
-bool isEdgePixel(DATA_TYPE centerValue) {
-    vec2 texSize = vec2(textureSize(u_imageSampler, 0).xy);
-    vec2 texelSize = 1.0 / texSize;
+bool isEdgePixel(DATA_TYPE centerValue, vec3 texCoords) {
+    mat4 modelToTexCoord = u_worldToTexCoord * u_model;
+    vec3 stepX = modelToTexCoord[0].xyz;
+    vec3 stepY = modelToTexCoord[1].xyz;
 
     // Check 8-connected neighbors
     for (int dx = -1; dx <= 1; dx++) {
         for (int dy = -1; dy <= 1; dy++) {
             if (dx == 0 && dy == 0) continue; // Skip center pixel
 
-            vec2 neighborCoords = v_texCoords + vec2(float(dx), float(dy)) * texelSize;
+            vec3 neighborCoords =
+                texCoords + float(dx) * stepX + float(dy) * stepY;
 
             // Skip if out of bounds
             if (neighborCoords.x < 0.0 || neighborCoords.x > 1.0 ||
@@ -48,7 +51,7 @@ bool isEdgePixel(DATA_TYPE centerValue) {
                 continue;
             }
 
-            DATA_TYPE neighborValue = texture(u_imageSampler, vec3(neighborCoords, u_zTexCoord)).r;
+            DATA_TYPE neighborValue = texture(u_imageSampler, neighborCoords).r;
             if (neighborValue != centerValue) {
                 return true;
             }
@@ -58,14 +61,15 @@ bool isEdgePixel(DATA_TYPE centerValue) {
 }
 
 void main() {
-    DATA_TYPE texel = texture(u_imageSampler, vec3(v_texCoords, u_zTexCoord)).r;
+    vec3 texCoords = (u_worldToTexCoord * vec4(v_positionWorld, 1.0)).xyz;
+    DATA_TYPE texel = texture(u_imageSampler, texCoords).r;
 
     // Check if this pixel is the selected value
     bool isSelectedValue = u_outlineSelected > 0.5 && u_selectedValue >= 0.0 && float(texel) == u_selectedValue;
 
     // Check if we should outline this selected segment
     if (isSelectedValue) {
-        if (isEdgePixel(texel)) {
+        if (isEdgePixel(texel, texCoords)) {
             // Draw outline in bright white with layer opacity
             fragColor = vec4(1.0, 1.0, 1.0, u_opacity);
             return;

--- a/src/renderers/shaders/mesh_vert.glsl
+++ b/src/renderers/shaders/mesh_vert.glsl
@@ -2,14 +2,14 @@
 
 layout (location = 0) in vec3 a_position;
 layout (location = 1) in vec3 a_normal;
-layout (location = 2) in vec2 a_uv;
 
 uniform mat4 u_projection;
 uniform mat4 u_modelView;
+uniform mat4 u_model;
 
-out vec2 v_texCoords;
+out vec3 v_positionWorld;
 
 void main() {
-    v_texCoords = a_uv;
+    v_positionWorld = (u_model * vec4(a_position, 1.0)).xyz;
     gl_Position = u_projection * u_modelView * vec4(a_position, 1.0);
 }

--- a/src/renderers/shaders/mesh_vert.glsl
+++ b/src/renderers/shaders/mesh_vert.glsl
@@ -6,10 +6,11 @@ layout (location = 1) in vec3 a_normal;
 uniform mat4 u_projection;
 uniform mat4 u_modelView;
 uniform mat4 u_model;
+uniform mat4 u_worldToTexCoord;
 
-out vec3 v_positionWorld;
+out vec3 v_texCoords;
 
 void main() {
-    v_positionWorld = (u_model * vec4(a_position, 1.0)).xyz;
+    v_texCoords = (u_worldToTexCoord * u_model * vec4(a_position, 1.0)).xyz;
     gl_Position = u_projection * u_modelView * vec4(a_position, 1.0);
 }

--- a/src/renderers/shaders/scalar_image_frag.glsl
+++ b/src/renderers/shaders/scalar_image_frag.glsl
@@ -1,7 +1,7 @@
 #version 300 es
 #pragma inject_defines
 
-precision mediump float;
+precision highp float;
 
 layout (location = 0) out vec4 fragColor;
 
@@ -17,12 +17,13 @@ uniform vec3 u_color;
 uniform float u_valueOffset;
 uniform float u_valueScale;
 uniform float u_opacity;
-uniform float u_zTexCoord;
+uniform mat4 u_worldToTexCoord;
 
-in vec2 v_texCoords;
+in vec3 v_positionWorld;
 
 void main() {
-    float texel = float(texture(u_imageSampler, vec3(v_texCoords, u_zTexCoord)).r);
+    vec3 texCoords = (u_worldToTexCoord * vec4(v_positionWorld, 1.0)).xyz;
+    float texel = float(texture(u_imageSampler, texCoords).r);
     float value = (texel + u_valueOffset) * u_valueScale;
     fragColor = vec4(value * u_color, u_opacity);
 }

--- a/src/renderers/shaders/scalar_image_frag.glsl
+++ b/src/renderers/shaders/scalar_image_frag.glsl
@@ -17,13 +17,11 @@ uniform vec3 u_color;
 uniform float u_valueOffset;
 uniform float u_valueScale;
 uniform float u_opacity;
-uniform mat4 u_worldToTexCoord;
 
-in vec3 v_positionWorld;
+in vec3 v_texCoords;
 
 void main() {
-    vec3 texCoords = (u_worldToTexCoord * vec4(v_positionWorld, 1.0)).xyz;
-    float texel = float(texture(u_imageSampler, texCoords).r);
+    float texel = float(texture(u_imageSampler, v_texCoords).r);
     float value = (texel + u_valueOffset) * u_valueScale;
     fragColor = vec4(value * u_color, u_opacity);
 }

--- a/src/renderers/webgl_renderer.ts
+++ b/src/renderers/webgl_renderer.ts
@@ -230,6 +230,9 @@ export class WebGLRenderer extends Renderer {
         case "u_modelView":
           program.setUniform(uniformName, modelView);
           break;
+        case "u_model":
+          program.setUniform(uniformName, object.transform.matrix);
+          break;
         case "u_projection":
           program.setUniform(uniformName, projection);
           break;

--- a/src/renderers/webgpu/shaders/image_scalar_f32.wgsl
+++ b/src/renderers/webgpu/shaders/image_scalar_f32.wgsl
@@ -1,16 +1,17 @@
 struct Varyings {
   @builtin(position) position: vec4f,
-  @location(0) texCoords: vec2f,
+  @location(0) positionWorld: vec3f,
 };
 
 struct Uniforms {
   modelView: mat4x4f,
   projection: mat4x4f,
+  model: mat4x4f,
+  worldToTexCoord: mat4x4f,
   color: vec3f,
   opacity: f32,
   valueOffset: f32,
   valueScale: f32,
-  zTexCoord: f32,
 };
 
 @group(0) @binding(0) var<uniform> uniforms: Uniforms;
@@ -20,20 +21,20 @@ struct Uniforms {
 fn vert(
   @location(0) aPos: vec3f,
   // @location(1) is reserved for normals, unused here
-  @location(2) aTexCoords: vec2f,
 ) -> Varyings {
   var out = Varyings();
   out.position = uniforms.projection * uniforms.modelView * vec4f(aPos, 1.0);
-  out.texCoords = aTexCoords;
+  out.positionWorld = (uniforms.model * vec4f(aPos, 1.0)).xyz;
   return out;
 }
 
 @fragment
 fn frag(in: Varyings) -> @location(0) vec4f {
   let dims = textureDimensions(texture);
-  let xy = vec2u(in.texCoords * vec2f(dims.xy));
-  let z = min(u32(uniforms.zTexCoord * f32(dims.z)), dims.z - 1u);
-  let texel = f32(textureLoad(texture, vec3u(xy, z), 0).r);
+  let uvw = (uniforms.worldToTexCoord * vec4f(in.positionWorld, 1.0)).xyz;
+  let scaled = clamp(uvw, vec3f(0.0), vec3f(1.0)) * vec3f(dims);
+  let texelCoords = min(vec3u(scaled), dims - vec3u(1u));
+  let texel = f32(textureLoad(texture, texelCoords, 0).r);
   let value = (texel + uniforms.valueOffset) * uniforms.valueScale;
   return vec4f(value * uniforms.color, uniforms.opacity);
 }

--- a/src/renderers/webgpu/shaders/image_scalar_f32.wgsl
+++ b/src/renderers/webgpu/shaders/image_scalar_f32.wgsl
@@ -1,6 +1,6 @@
 struct Varyings {
   @builtin(position) position: vec4f,
-  @location(0) positionWorld: vec3f,
+  @location(0) texCoords: vec3f,
 };
 
 struct Uniforms {
@@ -24,15 +24,14 @@ fn vert(
 ) -> Varyings {
   var out = Varyings();
   out.position = uniforms.projection * uniforms.modelView * vec4f(aPos, 1.0);
-  out.positionWorld = (uniforms.model * vec4f(aPos, 1.0)).xyz;
+  out.texCoords = (uniforms.worldToTexCoord * uniforms.model * vec4f(aPos, 1.0)).xyz;
   return out;
 }
 
 @fragment
 fn frag(in: Varyings) -> @location(0) vec4f {
   let dims = textureDimensions(texture);
-  let uvw = (uniforms.worldToTexCoord * vec4f(in.positionWorld, 1.0)).xyz;
-  let scaled = clamp(uvw, vec3f(0.0), vec3f(1.0)) * vec3f(dims);
+  let scaled = clamp(in.texCoords, vec3f(0.0), vec3f(1.0)) * vec3f(dims);
   let texelCoords = min(vec3u(scaled), dims - vec3u(1u));
   let texel = f32(textureLoad(texture, texelCoords, 0).r);
   let value = (texel + uniforms.valueOffset) * uniforms.valueScale;

--- a/src/renderers/webgpu/shaders/image_scalar_i32.wgsl
+++ b/src/renderers/webgpu/shaders/image_scalar_i32.wgsl
@@ -1,16 +1,17 @@
 struct Varyings {
   @builtin(position) position: vec4f,
-  @location(0) texCoords: vec2f,
+  @location(0) positionWorld: vec3f,
 };
 
 struct Uniforms {
   modelView: mat4x4f,
   projection: mat4x4f,
+  model: mat4x4f,
+  worldToTexCoord: mat4x4f,
   color: vec3f,
   opacity: f32,
   valueOffset: f32,
   valueScale: f32,
-  zTexCoord: f32,
 };
 
 @group(0) @binding(0) var<uniform> uniforms: Uniforms;
@@ -20,20 +21,20 @@ struct Uniforms {
 fn vert(
   @location(0) aPos: vec3f,
   // @location(1) is reserved for normals, unused here
-  @location(2) aTexCoords: vec2f,
 ) -> Varyings {
   var out = Varyings();
   out.position = uniforms.projection * uniforms.modelView * vec4f(aPos, 1.0);
-  out.texCoords = aTexCoords;
+  out.positionWorld = (uniforms.model * vec4f(aPos, 1.0)).xyz;
   return out;
 }
 
 @fragment
 fn frag(in: Varyings) -> @location(0) vec4f {
   let dims = textureDimensions(texture);
-  let xy = vec2u(in.texCoords * vec2f(dims.xy));
-  let z = min(u32(uniforms.zTexCoord * f32(dims.z)), dims.z - 1u);
-  let texel = f32(textureLoad(texture, vec3u(xy, z), 0).r);
+  let uvw = (uniforms.worldToTexCoord * vec4f(in.positionWorld, 1.0)).xyz;
+  let scaled = clamp(uvw, vec3f(0.0), vec3f(1.0)) * vec3f(dims);
+  let texelCoords = min(vec3u(scaled), dims - vec3u(1u));
+  let texel = f32(textureLoad(texture, texelCoords, 0).r);
   let value = (texel + uniforms.valueOffset) * uniforms.valueScale;
   return vec4f(value * uniforms.color, uniforms.opacity);
 }

--- a/src/renderers/webgpu/shaders/image_scalar_i32.wgsl
+++ b/src/renderers/webgpu/shaders/image_scalar_i32.wgsl
@@ -1,6 +1,6 @@
 struct Varyings {
   @builtin(position) position: vec4f,
-  @location(0) positionWorld: vec3f,
+  @location(0) texCoords: vec3f,
 };
 
 struct Uniforms {
@@ -24,15 +24,14 @@ fn vert(
 ) -> Varyings {
   var out = Varyings();
   out.position = uniforms.projection * uniforms.modelView * vec4f(aPos, 1.0);
-  out.positionWorld = (uniforms.model * vec4f(aPos, 1.0)).xyz;
+  out.texCoords = (uniforms.worldToTexCoord * uniforms.model * vec4f(aPos, 1.0)).xyz;
   return out;
 }
 
 @fragment
 fn frag(in: Varyings) -> @location(0) vec4f {
   let dims = textureDimensions(texture);
-  let uvw = (uniforms.worldToTexCoord * vec4f(in.positionWorld, 1.0)).xyz;
-  let scaled = clamp(uvw, vec3f(0.0), vec3f(1.0)) * vec3f(dims);
+  let scaled = clamp(in.texCoords, vec3f(0.0), vec3f(1.0)) * vec3f(dims);
   let texelCoords = min(vec3u(scaled), dims - vec3u(1u));
   let texel = f32(textureLoad(texture, texelCoords, 0).r);
   let value = (texel + uniforms.valueOffset) * uniforms.valueScale;

--- a/src/renderers/webgpu/shaders/image_scalar_u32.wgsl
+++ b/src/renderers/webgpu/shaders/image_scalar_u32.wgsl
@@ -1,16 +1,17 @@
 struct Varyings {
   @builtin(position) position: vec4f,
-  @location(0) texCoords: vec2f,
+  @location(0) positionWorld: vec3f,
 };
 
 struct Uniforms {
   modelView: mat4x4f,
   projection: mat4x4f,
+  model: mat4x4f,
+  worldToTexCoord: mat4x4f,
   color: vec3f,
   opacity: f32,
   valueOffset: f32,
   valueScale: f32,
-  zTexCoord: f32,
 };
 
 @group(0) @binding(0) var<uniform> uniforms: Uniforms;
@@ -20,20 +21,20 @@ struct Uniforms {
 fn vert(
   @location(0) aPos: vec3f,
   // @location(1) is reserved for normals, unused here
-  @location(2) aTexCoords: vec2f,
 ) -> Varyings {
   var out = Varyings();
   out.position = uniforms.projection * uniforms.modelView * vec4f(aPos, 1.0);
-  out.texCoords = aTexCoords;
+  out.positionWorld = (uniforms.model * vec4f(aPos, 1.0)).xyz;
   return out;
 }
 
 @fragment
 fn frag(in: Varyings) -> @location(0) vec4f {
   let dims = textureDimensions(texture);
-  let xy = vec2u(in.texCoords * vec2f(dims.xy));
-  let z = min(u32(uniforms.zTexCoord * f32(dims.z)), dims.z - 1u);
-  let texel = f32(textureLoad(texture, vec3u(xy, z), 0).r);
+  let uvw = (uniforms.worldToTexCoord * vec4f(in.positionWorld, 1.0)).xyz;
+  let scaled = clamp(uvw, vec3f(0.0), vec3f(1.0)) * vec3f(dims);
+  let texelCoords = min(vec3u(scaled), dims - vec3u(1u));
+  let texel = f32(textureLoad(texture, texelCoords, 0).r);
   let value = (texel + uniforms.valueOffset) * uniforms.valueScale;
   return vec4f(value * uniforms.color, uniforms.opacity);
 }

--- a/src/renderers/webgpu/shaders/image_scalar_u32.wgsl
+++ b/src/renderers/webgpu/shaders/image_scalar_u32.wgsl
@@ -1,6 +1,6 @@
 struct Varyings {
   @builtin(position) position: vec4f,
-  @location(0) positionWorld: vec3f,
+  @location(0) texCoords: vec3f,
 };
 
 struct Uniforms {
@@ -24,15 +24,14 @@ fn vert(
 ) -> Varyings {
   var out = Varyings();
   out.position = uniforms.projection * uniforms.modelView * vec4f(aPos, 1.0);
-  out.positionWorld = (uniforms.model * vec4f(aPos, 1.0)).xyz;
+  out.texCoords = (uniforms.worldToTexCoord * uniforms.model * vec4f(aPos, 1.0)).xyz;
   return out;
 }
 
 @fragment
 fn frag(in: Varyings) -> @location(0) vec4f {
   let dims = textureDimensions(texture);
-  let uvw = (uniforms.worldToTexCoord * vec4f(in.positionWorld, 1.0)).xyz;
-  let scaled = clamp(uvw, vec3f(0.0), vec3f(1.0)) * vec3f(dims);
+  let scaled = clamp(in.texCoords, vec3f(0.0), vec3f(1.0)) * vec3f(dims);
   let texelCoords = min(vec3u(scaled), dims - vec3u(1u));
   let texel = f32(textureLoad(texture, texelCoords, 0).r);
   let value = (texel + uniforms.valueOffset) * uniforms.valueScale;

--- a/src/renderers/webgpu/webgpu_renderer.ts
+++ b/src/renderers/webgpu/webgpu_renderer.ts
@@ -416,11 +416,12 @@ class WebGPURenderer extends Renderer {
     pipeline.uniformsView.set({
       projection: this.currentProjection_,
       modelView: this.currentModelView_,
+      model: object.transform.matrix,
+      worldToTexCoord: uniforms.u_worldToTexCoord,
       color: uniforms.u_color,
       valueOffset: uniforms.u_valueOffset,
       valueScale: uniforms.u_valueScale,
       opacity: this.currentLayerOpacity_ * objectOpacity,
-      zTexCoord: uniforms.u_zTexCoord,
     });
 
     this.bindings_.setUniforms(this.passEncoder_!, pipeline);


### PR DESCRIPTION
### Summary

this PR adds image slicing based on world-space fragment position. planes get placed
at their true world position and fragment shaders derive the 3D texture coordinate from
the fragment's world position. it's another step forward toward selectable slice
orientations.

this approach is based on @aganders3 suggestion:

https://github.com/chanzuckerberg/idetik/pull/707#discussion_r3584072542

### Tests & Checks

- all checks have passed
- visual verification

https://github.com/user-attachments/assets/a993896b-2b86-4315-aceb-daa1c1039d35