### PR TITLE
refactor: support signed data types for labels

### DIFF
--- a/src/objects/renderable/label_image_renderable.ts
+++ b/src/objects/renderable/label_image_renderable.ts
@@ -3,6 +3,7 @@ import { PlaneGeometry } from "../../objects/geometry/plane_geometry";
 import { Texture, TextureDataType } from "../../objects/textures/texture";
 import { Color } from "../../math/color";
 import { Texture2D } from "../textures/texture_2d";
+import { Shader } from "../../renderers/shaders";
 import { LabelColorMap } from "./label_color_map";
 
 type LabelImageRenderableProps = {
@@ -14,7 +15,8 @@ type LabelImageRenderableProps = {
   selectedValue?: number | null;
 };
 
-const supportedDataTypes = new Set<TextureDataType>([
+const signedDataTypes = new Set<TextureDataType>(["byte", "short", "int"]);
+const unsignedDataTypes = new Set<TextureDataType>([
   "unsigned_byte",
   "unsigned_short",
   "unsigned_int",
@@ -26,12 +28,19 @@ function validateImageData(imageData: Texture) {
       `Image data format must be scalar, instead found: ${imageData.dataFormat}`
     );
   }
-  if (!supportedDataTypes.has(imageData.dataType)) {
+  if (
+    !signedDataTypes.has(imageData.dataType) &&
+    !unsignedDataTypes.has(imageData.dataType)
+  ) {
     throw new Error(
-      `Image data type must be unsigned, instead found: ${imageData.dataType}`
+      `Image data type must be an integer, instead found: ${imageData.dataType}`
     );
   }
   return imageData;
+}
+
+function labelTextureToShader(texture: Texture): Shader {
+  return signedDataTypes.has(texture.dataType) ? "intLabelImage" : "labelImage";
 }
 
 /** @group Renderable Objects */
@@ -55,7 +64,7 @@ export class LabelImageRenderable extends RenderableObject {
     this.setTexture(2, colorLookupTableTexture);
     this.outlineSelected_ = props.outlineSelected ?? false;
     this.selectedValue_ = props.selectedValue ?? null;
-    this.programName = "labelImage";
+    this.programName = labelTextureToShader(props.imageData);
   }
 
   public get type() {

--- a/src/renderers/shaders/index.ts
+++ b/src/renderers/shaders/index.ts
@@ -13,6 +13,7 @@ import labelImage from "./label_image_frag.glsl";
 export type Shader =
   | "floatScalarImage"
   | "floatVolume"
+  | "intLabelImage"
   | "intScalarImage"
   | "intVolume"
   | "labelImage"
@@ -59,6 +60,11 @@ export const shaderCode: Record<Shader, ShaderCode> = {
   labelImage: {
     vertex: meshVertexShader,
     fragment: labelImage,
+  },
+  intLabelImage: {
+    vertex: meshVertexShader,
+    fragment: labelImage,
+    fragmentDefines: new Map([["TEXTURE_DATA_TYPE_INT", "1"]]),
   },
   floatVolume: {
     vertex: volumeVertexShader,

--- a/src/renderers/shaders/label_image_frag.glsl
+++ b/src/renderers/shaders/label_image_frag.glsl
@@ -1,11 +1,18 @@
 #version 300 es
+#pragma inject_defines
 
 precision mediump float;
 precision highp int;
 
 layout (location = 0) out vec4 fragColor;
 
+#if defined TEXTURE_DATA_TYPE_INT
+uniform highp isampler3D u_imageSampler;
+#define DATA_TYPE int
+#else
 uniform highp usampler3D u_imageSampler;
+#define DATA_TYPE uint
+#endif
 uniform mediump sampler2D u_colorCycleSampler;
 uniform highp usampler2D u_colorLookupTableSampler;
 
@@ -24,7 +31,7 @@ vec4 unpackRgba(uint packed) {
     return vec4(float(r), float(g), float(b), float(a)) / 255.0;
 }
 
-bool isEdgePixel(uint centerValue) {
+bool isEdgePixel(DATA_TYPE centerValue) {
     vec2 texSize = vec2(textureSize(u_imageSampler, 0).xy);
     vec2 texelSize = 1.0 / texSize;
 
@@ -41,7 +48,7 @@ bool isEdgePixel(uint centerValue) {
                 continue;
             }
 
-            uint neighborValue = texture(u_imageSampler, vec3(neighborCoords, u_zTexCoord)).r;
+            DATA_TYPE neighborValue = texture(u_imageSampler, vec3(neighborCoords, u_zTexCoord)).r;
             if (neighborValue != centerValue) {
                 return true;
             }
@@ -51,7 +58,7 @@ bool isEdgePixel(uint centerValue) {
 }
 
 void main() {
-    uint texel = texture(u_imageSampler, vec3(v_texCoords, u_zTexCoord)).r;
+    DATA_TYPE texel = texture(u_imageSampler, vec3(v_texCoords, u_zTexCoord)).r;
 
     // Check if this pixel is the selected value
     bool isSelectedValue = u_outlineSelected > 0.5 && u_selectedValue >= 0.0 && float(texel) == u_selectedValue;
@@ -68,7 +75,8 @@ void main() {
     uint mapLength = uint(textureSize(u_colorLookupTableSampler, 0).x);
     for (uint i = 0u; i < mapLength; ++i) {
         uint key = texelFetch(u_colorLookupTableSampler, ivec2(i, 0), 0).r;
-        if (texel == key) {
+        // int(key) round-trips negative labels via two's complement.
+        if (texel == DATA_TYPE(key)) {
             uint value = texelFetch(u_colorLookupTableSampler, ivec2(i, 1), 0).r;
             vec4 color = unpackRgba(value);
 
@@ -81,7 +89,7 @@ void main() {
     }
 
     uint cycleLength = uint(textureSize(u_colorCycleSampler, 0).x);
-    uint index = uint(texel - 1u) % cycleLength;
+    uint index = uint(texel - DATA_TYPE(1)) % cycleLength;
     vec4 color = texelFetch(u_colorCycleSampler, ivec2(index, 0), 0);
 
     // If this is the selected segment and outlining is enabled, make it slightly transparent


### PR DESCRIPTION
### Summary

this PR adds support for signed data types in label image renderables. this
change solved the issue i was having with rendering segmentation data
in copick. it turns out that some of the data was signed even though the
values themselves are exclusively positive.

if there's a correctness concern around this change i can transform the data
on the copick server as an alternative.

### Tests & Checks

- all checks have passed.
- verified copick segmentation layer is working locally via npm link.

<img width="1517" height="1015" alt="Screenshot 2026-07-20 at 3 00 09 PM" src="https://github.com/user-attachments/assets/2388b122-7ee4-4ec6-a78a-75dc61183554" />
