### PR TITLE
refactor: ray-plane intersection for point picking

### DIFF
--- a/src/core/event_dispatcher.ts
+++ b/src/core/event_dispatcher.ts
@@ -1,5 +1,6 @@
 import { vec3 } from "gl-matrix";
 import { Logger } from "../utilities/logger";
+import { Ray } from "../math/ray";
 
 const eventTypes = [
   "pointerdown",
@@ -19,6 +20,7 @@ export class EventContext {
   public readonly type: EventType;
   public readonly event?: Event;
   public worldPos?: vec3;
+  public worldRay?: Ray;
   public clipPos?: vec3;
 
   constructor(type: EventType, event?: Event) {

--- a/src/core/viewport.ts
+++ b/src/core/viewport.ts
@@ -6,6 +6,7 @@ import { vec2, vec3 } from "gl-matrix";
 import { generateID } from "../utilities/id_generator";
 import { Logger } from "../utilities/logger";
 import { EventContext, EventDispatcher } from "./event_dispatcher";
+import { Ray } from "../math/ray";
 import { IdetikContext } from "../idetik";
 
 export interface ViewportConfig {
@@ -53,6 +54,10 @@ export class Viewport {
         const client = vec2.fromValues(clientX, clientY);
         event.clipPos = this.clientToClip(client, 0);
         event.worldPos = this.camera.clipToWorld(event.clipPos);
+
+        const near = this.camera.clipToWorld(this.clientToClip(client, -1));
+        const far = this.camera.clipToWorld(this.clientToClip(client, 1));
+        event.worldRay = new Ray(near, vec3.subtract(vec3.create(), far, near));
       }
       for (const layer of this.layers_) {
         layer.onEvent(event);

--- a/src/layers/image_layer.ts
+++ b/src/layers/image_layer.ts
@@ -19,6 +19,8 @@ import {
 import { ImageRenderable } from "../objects/renderable/image_renderable";
 import { Color } from "../math/color";
 import { EventContext } from "../core/event_dispatcher";
+import { Plane } from "../math/plane";
+import { Ray } from "../math/ray";
 import { vec2, vec3 } from "gl-matrix";
 import { handlePointPickingEvent, PointPickingResult } from "./point_picking";
 import { clamp } from "../utilities/clamp";
@@ -201,9 +203,30 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
     this.pointerDownPos_ = handlePointPickingEvent(
       event,
       this.pointerDownPos_,
-      (world) => this.getValueAtWorld(world),
+      (ray) => this.pickAtRay(ray),
       this.onPickValue_
     );
+  }
+
+  private async pickAtRay(ray: Ray): Promise<PointPickingResult | null> {
+    const firstChunk = this.visibleChunks_.values().next();
+    if (firstChunk.done) return null;
+
+    const transform = firstChunk.value.transform;
+    const planeNormal = vec3.transformQuat(
+      vec3.create(),
+      vec3.fromValues(0, 0, 1),
+      transform.rotation
+    );
+
+    const plane = Plane.fromPointAndNormal(transform.translation, planeNormal);
+    const world = ray.intersectWithPlane(plane);
+    if (!world) return null;
+
+    const value = await this.getValueAtWorld(world);
+    if (value === null) return null;
+
+    return { world, value };
   }
 
   // exposed for use in chunk info overlay

--- a/src/layers/label_layer.ts
+++ b/src/layers/label_layer.ts
@@ -18,6 +18,8 @@ import {
 } from "../objects/renderable/label_color_map";
 import { Texture } from "../objects/textures/texture";
 import { EventContext } from "../core/event_dispatcher";
+import { Plane } from "../math/plane";
+import { Ray } from "../math/ray";
 import { vec2, vec3 } from "gl-matrix";
 import { handlePointPickingEvent, PointPickingResult } from "./point_picking";
 import { clamp } from "../utilities/clamp";
@@ -169,7 +171,7 @@ export class LabelLayer extends Layer {
     this.pointerDownPos_ = handlePointPickingEvent(
       event,
       this.pointerDownPos_,
-      (world) => this.getValueAtWorld(world),
+      (ray) => this.pickAtRay(ray),
       this.outlineSelected_
         ? (info: PointPickingResult) => {
             this.setSelectedValue(info.value);
@@ -177,6 +179,27 @@ export class LabelLayer extends Layer {
           }
         : this.onPickValue_
     );
+  }
+
+  private async pickAtRay(ray: Ray): Promise<PointPickingResult | null> {
+    const firstChunk = this.visibleChunks_.values().next();
+    if (firstChunk.done) return null;
+
+    const transform = firstChunk.value.transform;
+    const planeNormal = vec3.transformQuat(
+      vec3.create(),
+      vec3.fromValues(0, 0, 1),
+      transform.rotation
+    );
+
+    const plane = Plane.fromPointAndNormal(transform.translation, planeNormal);
+    const world = ray.intersectWithPlane(plane);
+    if (!world) return null;
+
+    const value = await this.getValueAtWorld(world);
+    if (value === null) return null;
+
+    return { world, value };
   }
 
   public get colorMap(): LabelColorMap {

--- a/src/layers/point_picking.ts
+++ b/src/layers/point_picking.ts
@@ -1,4 +1,5 @@
 import { EventContext } from "../core/event_dispatcher";
+import { Ray } from "../math/ray";
 import { Logger } from "../utilities/logger";
 import { vec2, vec3 } from "gl-matrix";
 
@@ -10,7 +11,7 @@ export interface PointPickingResult {
 export function handlePointPickingEvent<T>(
   event: EventContext,
   pointerDownPos: vec2 | null,
-  getValueAtWorld: (world: vec3) => Promise<T | null>,
+  pickAtRay: (ray: Ray) => Promise<{ world: vec3; value: T } | null>,
   onPickValue?: (info: { world: vec3; value: T }) => void,
   dragThreshold: number = 3
 ): vec2 | null {
@@ -30,12 +31,12 @@ export function handlePointPickingEvent<T>(
       if (dist < dragThreshold) {
         if (!onPickValue) return null;
 
-        const world = event.worldPos;
-        if (world) {
-          getValueAtWorld(world)
-            .then((value) => {
-              if (value !== null) {
-                onPickValue({ world, value });
+        const ray = event.worldRay;
+        if (ray) {
+          pickAtRay(ray)
+            .then((info) => {
+              if (info !== null) {
+                onPickValue(info);
               }
             })
             .catch((error) => {

--- a/src/math/plane.ts
+++ b/src/math/plane.ts
@@ -9,6 +9,10 @@ export class Plane {
     this.signedDistance = distance;
   }
 
+  public static fromPointAndNormal(point: vec3, normal: vec3): Plane {
+    return new Plane(normal, -vec3.dot(normal, point));
+  }
+
   public set(normal: vec3, distance: number) {
     this.normal = vec3.clone(normal);
     this.signedDistance = distance;

--- a/src/math/ray.ts
+++ b/src/math/ray.ts
@@ -1,0 +1,25 @@
+import { vec3 } from "gl-matrix";
+import { Plane } from "./plane";
+
+// Below this rate the ray is treated as parallel to the plane
+const MIN_APPROACH_RATE = 1e-12;
+
+export class Ray {
+  public readonly origin: vec3;
+  public readonly direction: vec3;
+
+  constructor(origin: vec3, direction: vec3) {
+    this.origin = vec3.clone(origin);
+    this.direction = vec3.normalize(vec3.create(), direction);
+  }
+
+  public intersectWithPlane(plane: Plane): vec3 | null {
+    const approachRate = vec3.dot(this.direction, plane.normal);
+    if (Math.abs(approachRate) < MIN_APPROACH_RATE) {
+      return null;
+    }
+
+    const t = -plane.signedDistanceToPoint(this.origin) / approachRate;
+    return vec3.scaleAndAdd(vec3.create(), this.origin, this.direction, t);
+  }
+}

--- a/test/plane.test.ts
+++ b/test/plane.test.ts
@@ -54,3 +54,25 @@ test("plane with inverted normal flips distance sign", () => {
   expect(planePositiveY.signedDistanceToPoint(point)).toBe(3);
   expect(planeNegativeY.signedDistanceToPoint(point)).toBe(-3);
 });
+
+test("fromPointAndNormal constructs a plane containing the point", () => {
+  const plane = Plane.fromPointAndNormal(
+    vec3.fromValues(10, 20, 300),
+    vec3.fromValues(0, 0, 1)
+  );
+
+  expect(plane.signedDistanceToPoint(vec3.fromValues(10, 20, 300))).toBe(0);
+  expect(plane.signedDistanceToPoint(vec3.fromValues(-5, 7, 300))).toBe(0);
+});
+
+test("fromPointAndNormal handles non-axis-aligned normals", () => {
+  const normal = vec3.normalize(vec3.create(), vec3.fromValues(1, 1, 1));
+  const point = vec3.fromValues(2, 2, 2);
+  const plane = Plane.fromPointAndNormal(point, normal);
+
+  expect(plane.signedDistanceToPoint(point)).toBeCloseTo(0);
+
+  const above = vec3.scaleAndAdd(vec3.create(), point, normal, 1);
+
+  expect(plane.signedDistanceToPoint(above)).toBeCloseTo(1);
+});

--- a/test/ray.test.ts
+++ b/test/ray.test.ts
@@ -1,0 +1,45 @@
+import { expect, test } from "vitest";
+import { vec3 } from "gl-matrix";
+
+import { Plane } from "@/math/plane";
+import { Ray } from "@/math/ray";
+
+test("intersectWithPlane intersects a plane straight on", () => {
+  const ray = new Ray(vec3.fromValues(100, 50, 1e6), vec3.fromValues(0, 0, -1));
+  const plane = Plane.fromPointAndNormal(
+    vec3.fromValues(0, 0, 300),
+    vec3.fromValues(0, 0, 1)
+  );
+
+  const hit = ray.intersectWithPlane(plane)!;
+
+  expect(hit).not.toBeNull();
+  expect(hit[0]).toBeCloseTo(100);
+  expect(hit[1]).toBeCloseTo(50);
+  expect(hit[2]).toBeCloseTo(300);
+});
+
+test("intersectWithPlane intersects a plane at an oblique angle", () => {
+  const ray = new Ray(vec3.fromValues(0, 0, 10), vec3.fromValues(1, 0, -1));
+  const plane = Plane.fromPointAndNormal(
+    vec3.fromValues(0, 0, 0),
+    vec3.fromValues(0, 0, 1)
+  );
+
+  const hit = ray.intersectWithPlane(plane)!;
+
+  expect(hit).not.toBeNull();
+  expect(hit[0]).toBeCloseTo(10);
+  expect(hit[1]).toBeCloseTo(0);
+  expect(hit[2]).toBeCloseTo(0);
+});
+
+test("intersectWithPlane returns null for a ray parallel to the plane", () => {
+  const ray = new Ray(vec3.fromValues(0, 0, 10), vec3.fromValues(1, 0, 0));
+  const plane = Plane.fromPointAndNormal(
+    vec3.fromValues(0, 0, 0),
+    vec3.fromValues(0, 0, 1)
+  );
+
+  expect(ray.intersectWithPlane(plane)).toBeNull();
+});


### PR DESCRIPTION
### Summary

pointer events now carry a world-space ray (near-to-far unprojection)
and both layers pick by intersecting it with their slice plane instead
of unprojecting a single mid-depth point and discarding its z. adds a
ray math primitive and `Plane.fromPointAndNormal`.

picks are unchanged for XY orthographic views, except the reported
world coordinate now lies on the slice plane. The ray path also works
for rotated planes and perspective cameras, unblocking selectable
slice orientation.

### Tests & Checks

- all checks have passed
- manual verification