### PR TITLE
feat: add slice orientation to the orthographic camera

### DIFF
--- a/examples/points/main.ts
+++ b/examples/points/main.ts
@@ -143,7 +143,10 @@ const imageLayer = new ImageLayer({
   channelProps: [{ color: Color.WHITE, contrastLimits: [-0.00001, 0.00001] }],
 });
 
-const camera = new OrthographicCamera(0, xExtent, 0, yExtent, -10000, 10000);
+const camera = new OrthographicCamera(0, xExtent, 0, yExtent, {
+  near: -10000,
+  far: 10000,
+});
 const app = new Idetik({
   canvas: document.querySelector<HTMLCanvasElement>("canvas")!,
   viewports: [

--- a/src/data/chunk.ts
+++ b/src/data/chunk.ts
@@ -4,6 +4,7 @@ import {
 } from "../objects/textures/texture";
 import { Logger } from "../utilities/logger";
 import { mat4, vec3 } from "gl-matrix";
+import { AxisComponent, SliceAxes } from "../math/axes";
 
 const chunkDataTypes = [
   Int8Array,
@@ -105,20 +106,6 @@ export type SliceCoordinates = {
   z?: number;
   c?: number[];
   t?: number;
-};
-
-export type SpatialAxis = "x" | "y" | "z";
-
-export type SliceAxes = {
-  u: SpatialAxis;
-  v: SpatialAxis;
-  w: SpatialAxis;
-};
-
-export const AxisComponent: Record<SpatialAxis, 0 | 1 | 2> = {
-  x: 0,
-  y: 1,
-  z: 2,
 };
 
 export type ChunkSource = {

--- a/src/data/chunk_store_view.ts
+++ b/src/data/chunk_store_view.ts
@@ -1,12 +1,5 @@
-import {
-  AxisComponent,
-  Chunk,
-  ChunkViewState,
-  coordToIndex,
-  SliceAxes,
-  SliceCoordinates,
-  SpatialAxis,
-} from "./chunk";
+import { Chunk, ChunkViewState, coordToIndex, SliceCoordinates } from "./chunk";
+import { AxisComponent, SliceAxes, SpatialAxis } from "../math/axes";
 import type { ChunkStore } from "./chunk_store";
 import { ImageSourcePolicy } from "../core/image_source_policy";
 import { ReadonlyVec2, vec2, vec3, mat4 } from "gl-matrix";

--- a/src/layers/image_layer.ts
+++ b/src/layers/image_layer.ts
@@ -5,10 +5,10 @@ import type { IdetikContext } from "../idetik";
 import {
   Chunk,
   ChunkSource,
-  SliceAxes,
   SliceCoordinates,
   worldToTexCoordForChunk,
 } from "../data/chunk";
+import { SliceAxes } from "../math/axes";
 import { ChunkStoreView, INTERNAL_POLICY_KEY } from "../data/chunk_store_view";
 import { ImageSourcePolicy } from "../core/image_source_policy";
 import {

--- a/src/layers/label_layer.ts
+++ b/src/layers/label_layer.ts
@@ -5,10 +5,10 @@ import type { IdetikContext } from "../idetik";
 import {
   Chunk,
   ChunkSource,
-  SliceAxes,
   SliceCoordinates,
   worldToTexCoordForChunk,
 } from "../data/chunk";
+import { SliceAxes } from "../math/axes";
 import { ChunkStoreView, INTERNAL_POLICY_KEY } from "../data/chunk_store_view";
 import { ImageSourcePolicy } from "../core/image_source_policy";
 import { LabelImageRenderable } from "../objects/renderable/label_image_renderable";

--- a/src/math/axes.ts
+++ b/src/math/axes.ts
@@ -1,0 +1,49 @@
+import { mat3, quat, vec3 } from "gl-matrix";
+
+export type SpatialAxis = "x" | "y" | "z";
+
+export type SliceAxes = {
+  u: SpatialAxis;
+  v: SpatialAxis;
+  w: SpatialAxis;
+};
+
+export const AxisComponent: Record<SpatialAxis, 0 | 1 | 2> = {
+  x: 0,
+  y: 1,
+  z: 2,
+};
+
+export type SliceOrientation = "XY" | "XZ" | "YZ";
+
+export function sliceAxesFor(orientation: SliceOrientation): SliceAxes {
+  switch (orientation) {
+    case "XY":
+      return { u: "x", v: "y", w: "z" };
+    case "XZ":
+      return { u: "x", v: "z", w: "y" };
+    case "YZ":
+      return { u: "y", v: "z", w: "x" };
+  }
+}
+
+export function orientationRotation(axes: SliceAxes): quat {
+  const u = vec3.create();
+  const v = vec3.create();
+
+  u[AxisComponent[axes.u]] = 1;
+  v[AxisComponent[axes.v]] = 1;
+
+  const forward = vec3.cross(vec3.create(), u, v);
+
+  // prettier-ignore
+  const basis = mat3.fromValues(
+    u[0], u[1], u[2],
+    v[0], v[1], v[2],
+    forward[0], forward[1], forward[2]
+  );
+
+  const rotation = quat.fromMat3(quat.create(), basis);
+
+  return quat.normalize(rotation, rotation);
+}

--- a/src/objects/cameras/orthographic_camera.ts
+++ b/src/objects/cameras/orthographic_camera.ts
@@ -1,12 +1,25 @@
 import { Camera, CameraType } from "./camera";
-import { vec2, vec4, mat4 } from "gl-matrix";
+import { quat, vec2, vec3, vec4, mat4 } from "gl-matrix";
 import { Box2 } from "../../math/box2";
+import {
+  AxisComponent,
+  SliceAxes,
+  SliceOrientation,
+  orientationRotation,
+  sliceAxesFor,
+} from "../../math/axes";
 
 const DEFAULT_ASPECT_RATIO = 1.77; // 16:9
 const DEFAULT_WIDTH = 128;
 const DEFAULT_HEIGHT = 128 / DEFAULT_ASPECT_RATIO;
 const DEFAULT_NEAR = -1e6;
 const DEFAULT_FAR = 1e6;
+
+type OrthographicCameraOptions = {
+  near?: number;
+  far?: number;
+  orientation?: SliceOrientation;
+};
 
 /**
  * A camera using an orthographic (parallel) projection.
@@ -27,6 +40,8 @@ export class OrthographicCamera extends Camera {
   private height_: number = DEFAULT_HEIGHT;
   private viewportAspectRatio_: number = DEFAULT_ASPECT_RATIO;
   private viewportSize_: [number, number] = [DEFAULT_WIDTH, DEFAULT_HEIGHT];
+  private readonly axes_: SliceAxes;
+  private readonly rotation_: quat;
 
   /**
    * Creates an orthographic camera framing the given world-space rectangle.
@@ -35,20 +50,21 @@ export class OrthographicCamera extends Camera {
    * @param right - Right edge of the view frame, in world units.
    * @param top - Top edge of the view frame, in world units.
    * @param bottom - Bottom edge of the view frame, in world units.
-   * @param near - Near clipping plane distance. Defaults to `-1e6`.
-   * @param far - Far clipping plane distance. Defaults to `1e6`.
+   * @param options - Near/far clipping plane distances (default `-1e6` and
+   *   `1e6`) and the slice orientation the camera faces (default `"XY"`).
    */
   constructor(
     left: number,
     right: number,
     top: number,
     bottom: number,
-    near = DEFAULT_NEAR,
-    far = DEFAULT_FAR
+    options: OrthographicCameraOptions = {}
   ) {
     super();
-    this.near_ = near;
-    this.far_ = far;
+    this.near_ = options.near ?? DEFAULT_NEAR;
+    this.far_ = options.far ?? DEFAULT_FAR;
+    this.axes_ = sliceAxesFor(options.orientation ?? "XY");
+    this.rotation_ = orientationRotation(this.axes_);
     this.setFrame(left, right, bottom, top);
     this.updateProjectionMatrix();
   }
@@ -66,11 +82,12 @@ export class OrthographicCamera extends Camera {
     this.width_ = Math.abs(right - left);
     this.height_ = Math.abs(top - bottom);
     this.updateProjectionMatrix();
-    const centerX = 0.5 * (left + right);
-    const centerY = 0.5 * (bottom + top);
-    this.transform.setTranslation([centerX, centerY, 0]);
+    const translation = vec3.create();
+    translation[AxisComponent[this.axes_.u]] = 0.5 * (left + right);
+    translation[AxisComponent[this.axes_.v]] = 0.5 * (bottom + top);
+    this.transform.setTranslation(translation);
     this.transform.setScale([1, 1, 1]);
-    this.transform.setRotation([0, 0, 0, 1]);
+    this.transform.setRotation(this.rotation_);
   }
 
   public get type(): CameraType {
@@ -93,9 +110,11 @@ export class OrthographicCamera extends Camera {
     topLeft = vec4.transformMat4(vec4.create(), topLeft, inv);
     bottomRight = vec4.transformMat4(vec4.create(), bottomRight, inv);
 
+    const u = AxisComponent[this.axes_.u];
+    const v = AxisComponent[this.axes_.v];
     return new Box2(
-      vec2.fromValues(topLeft[0], topLeft[1]),
-      vec2.fromValues(bottomRight[0], bottomRight[1])
+      vec2.fromValues(topLeft[u], topLeft[v]),
+      vec2.fromValues(bottomRight[u], bottomRight[v])
     );
   }
 


### PR DESCRIPTION
### Summary

this PR adds an orientation option to orthographic camera. the
constructor takes an options object with an orientation param
(`XY` | `XZ` | `YZ`, defaults to `XY`. `setFrame` applies the
matching rotation and places the frame center on the plane's axes
instead of assuming world `XY`.

Notes:

- this change breaks the constructor's positional near/far parameters.
- default XY behavior remain unchanged.
- layers don't consume non-XY orientations yet. next PR.

### Tests & Checks

- all checks have passed.
- manual verification.