### PR TITLE
feat: add slice orientation to image and label layers

### DIFF
--- a/examples/lil_gui_utils.ts
+++ b/examples/lil_gui_utils.ts
@@ -4,7 +4,7 @@ import { Controller, GUI } from "lil-gui";
 type DimensionSliderProps = {
   gui: GUI;
   sliceCoords: SliceCoordinates;
-  dimensionName: "z" | "t";
+  dimensionName: "x" | "y" | "z" | "t";
   minValue: number;
   maxValue: number;
   stepValue: number;

--- a/examples/multi_viewport/index.html
+++ b/examples/multi_viewport/index.html
@@ -14,18 +14,51 @@
       }
 
       #container {
-        display: flex;
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        grid-template-rows: 1fr 1fr;
         width: 100vw;
         height: 100vh;
       }
 
       .viewport {
-        flex: 1;
-        border: 3px solid black;
+        position: relative;
+        border: 1px solid #555;
+      }
+
+      .viewport:nth-child(2n) {
+        margin-left: -1px;
+      }
+      .viewport:nth-child(n + 3) {
+        margin-top: -1px;
       }
 
       .viewport.active {
-        border: 3px solid #aaaa00;
+        border-color: #ffee66;
+        z-index: 1;
+      }
+
+      .viewport-label {
+        position: absolute;
+        top: 10px;
+        left: 10px;
+        font-weight: bold;
+        font-size: 12px;
+        letter-spacing: 2px;
+        user-select: none;
+        pointer-events: none;
+      }
+
+      .axis-x {
+        color: #ff0000;
+      }
+
+      .axis-y {
+        color: #00ff00;
+      }
+
+      .axis-z {
+        color: #0000ff;
       }
 
       canvas {
@@ -40,8 +73,22 @@
   </head>
   <body>
     <div id="container">
-      <div class="viewport" id="viewport-left"></div>
-      <div class="viewport" id="viewport-right"></div>
+      <div class="viewport" id="viewport-slice-xy">
+        <span class="viewport-label">
+          <span class="axis-x">X</span><span class="axis-y">Y</span>
+        </span>
+      </div>
+      <div class="viewport" id="viewport-3d"></div>
+      <div class="viewport" id="viewport-slice-xz">
+        <span class="viewport-label">
+          <span class="axis-x">X</span><span class="axis-z">Z</span>
+        </span>
+      </div>
+      <div class="viewport" id="viewport-slice-yz">
+        <span class="viewport-label">
+          <span class="axis-y">Y</span><span class="axis-z">Z</span>
+        </span>
+      </div>
     </div>
     <canvas id="canvas"></canvas>
     <script type="module" src="./main.ts"></script>

--- a/examples/multi_viewport/main.ts
+++ b/examples/multi_viewport/main.ts
@@ -6,6 +6,7 @@ import {
   OrthographicCamera,
   PanZoomControls,
   PerspectiveCamera,
+  SliceOrientation,
   VolumeLayer,
   createPlaybackPolicy,
 } from "@";
@@ -53,48 +54,85 @@ const volumeLayer = new VolumeLayer({
   channelProps: [{ contrastLimits: [0, 200] }],
 });
 
-const camera2D = new OrthographicCamera(left, right, top, bottom);
 const sliceCoords = {
   get t() {
     return sharedTime.t;
   },
+  x: (left + right) / 2,
+  y: (top + bottom) / 2,
   z: 300,
   c: [0],
 };
-const imageLayer = new ImageLayer({
-  source,
-  sliceCoords: sliceCoords,
-  policy: createPlaybackPolicy(),
-  channelProps: [{ contrastLimits: [0, 200] }],
-});
+
+function createSliceLayer(orientation: SliceOrientation) {
+  return new ImageLayer({
+    source,
+    sliceCoords,
+    policy: createPlaybackPolicy(),
+    channelProps: [{ contrastLimits: [0, 200] }],
+    orientation,
+  });
+}
+
+function createSliceViewport(
+  id: string,
+  orientation: SliceOrientation,
+  [uMin, uMax]: readonly [number, number],
+  [vMin, vMax]: readonly [number, number]
+) {
+  const uPad = 0.2 * (uMax - uMin);
+  const vPad = 0.2 * (vMax - vMin);
+  const camera = new OrthographicCamera(
+    uMin - uPad,
+    uMax + uPad,
+    vMin - vPad,
+    vMax + vPad,
+    { orientation }
+  );
+
+  return {
+    id,
+    element: document.querySelector<HTMLDivElement>(`#viewport-${id}`)!,
+    camera,
+    cameraControls: new PanZoomControls(camera),
+    layers: [createSliceLayer(orientation)],
+  };
+}
+
+const xRange = [left, right] as const;
+const yRange = [top, bottom] as const;
+const zRange = [zMin, zMax] as const;
 
 new Idetik({
   canvas: document.querySelector<HTMLCanvasElement>("#canvas")!,
+  backgroundColor: "#333333",
   viewports: [
+    createSliceViewport("slice-xy", "XY", xRange, yRange),
     {
-      id: "volume",
-      element: document.querySelector<HTMLDivElement>("#viewport-left")!,
+      id: "3d",
+      element: document.querySelector<HTMLDivElement>("#viewport-3d")!,
       camera: camera3D,
       cameraControls: new OrbitControls(camera3D, {
-        radius: 750,
+        radius: 1100,
+        yaw: 0.4,
+        pitch: 0.1,
         target: volumeCenter,
       }),
-      layers: [volumeLayer],
+      layers: [
+        volumeLayer,
+        createSliceLayer("XY"),
+        createSliceLayer("XZ"),
+        createSliceLayer("YZ"),
+      ],
     },
-    {
-      id: "slice",
-      element: document.querySelector<HTMLDivElement>("#viewport-right")!,
-      camera: camera2D,
-      cameraControls: new PanZoomControls(camera2D),
-      layers: [imageLayer],
-    },
+    createSliceViewport("slice-xz", "XZ", xRange, zRange),
+    createSliceViewport("slice-yz", "YZ", yRange, zRange),
   ],
-  showStats: true,
+  showStats: false,
 }).start();
 
 const gui = new GUI({ width: 300 });
 
-// Shared time slider for all viewports with playback controls
 addDimensionSlider({
   gui: gui,
   sliceCoords: sharedTime,
@@ -108,12 +146,29 @@ addDimensionSlider({
   },
 });
 
-const zRange = { min: zMin, max: zMax };
+addDimensionSlider({
+  gui: gui,
+  sliceCoords: sliceCoords,
+  dimensionName: "x",
+  minValue: left,
+  maxValue: right,
+  stepValue: 1,
+});
+
+addDimensionSlider({
+  gui: gui,
+  sliceCoords: sliceCoords,
+  dimensionName: "y",
+  minValue: top,
+  maxValue: bottom,
+  stepValue: 1,
+});
+
 addDimensionSlider({
   gui: gui,
   sliceCoords: sliceCoords,
   dimensionName: "z",
-  minValue: zRange.min,
-  maxValue: zRange.max,
+  minValue: zMin,
+  maxValue: zMax,
   stepValue: z.scale,
 });

--- a/src/data/chunk_manager.ts
+++ b/src/data/chunk_manager.ts
@@ -1,4 +1,5 @@
 import { Chunk, ChunkSource } from "./chunk";
+import { SliceAxes } from "../math/axes";
 import { ChunkQueue, comparePriority } from "./chunk_queue";
 import { chunkMemoryStats, clearChunkData } from "./chunk_memory";
 import { ChunkStore } from "./chunk_store";
@@ -64,14 +65,15 @@ export class ChunkManager {
 
   public addView(
     source: ChunkSource,
-    policy: ImageSourcePolicy
+    policy: ImageSourcePolicy,
+    axes?: SliceAxes
   ): ChunkStoreView {
     let store = this.stores_.find((s) => s.source === source)?.store;
     if (!store) {
       store = new ChunkStore(source.loader.getSourceDimensionMap());
       this.stores_.push({ source, store });
     }
-    return store.addView(policy);
+    return store.addView(policy, axes);
   }
 
   public update() {

--- a/src/data/chunk_store.ts
+++ b/src/data/chunk_store.ts
@@ -1,4 +1,5 @@
 import { Chunk, SourceDimensionMap } from "./chunk";
+import { SliceAxes } from "../math/axes";
 import { almostEqual } from "../utilities/almost_equal";
 import { Logger } from "../utilities/logger";
 import { ChunkStoreView } from "./chunk_store_view";
@@ -119,8 +120,8 @@ export class ChunkStore {
     return this.lowestResLOD_;
   }
 
-  public addView(policy: ImageSourcePolicy): ChunkStoreView {
-    const view = new ChunkStoreView(this, policy);
+  public addView(policy: ImageSourcePolicy, axes?: SliceAxes): ChunkStoreView {
+    const view = new ChunkStoreView(this, policy, axes);
     this.views_.push(view);
     this.hasHadViews_ = true;
     return view;

--- a/src/data/chunk_store_view.ts
+++ b/src/data/chunk_store_view.ts
@@ -21,7 +21,7 @@ export class ChunkStoreView {
   private policy_: ImageSourcePolicy;
   private policyChanged_ = false;
   private currentLOD_: number = 0;
-  private readonly axes_: SliceAxes = { u: "x", v: "y", w: "z" };
+  private readonly axes_: SliceAxes;
   private readonly scale0_: number;
   private lastViewBounds2D_: Box2 | null = null;
   private lastViewProjection_: mat4 | null = null;
@@ -34,9 +34,14 @@ export class ChunkStoreView {
 
   private isDisposed_ = false;
 
-  constructor(store: ChunkStore, policy: ImageSourcePolicy) {
+  constructor(
+    store: ChunkStore,
+    policy: ImageSourcePolicy,
+    axes: SliceAxes = { u: "x", v: "y", w: "z" }
+  ) {
     this.store_ = store;
     this.policy_ = policy;
+    this.axes_ = axes;
 
     Logger.info(
       "ChunkStoreView",
@@ -78,6 +83,20 @@ export class ChunkStoreView {
     return this.store_.channelCount;
   }
 
+  public getWholePlaneRect(): Box2 {
+    const dimensions = this.store_.dimensions;
+    const uLod0 = dimensions[this.axes_.u]!.lods[0];
+    const vLod0 = dimensions[this.axes_.v]!.lods[0];
+
+    return new Box2(
+      vec2.fromValues(uLod0.translation, vLod0.translation),
+      vec2.fromValues(
+        uLod0.translation + uLod0.size * uLod0.scale,
+        vLod0.translation + vLod0.size * vLod0.scale
+      )
+    );
+  }
+
   public getChunksToRender(): Chunk[] {
     // Iterates `chunkViewStates_` (only chunks touched by the most recent
     // updateChunks*ForRegion) instead of every chunk at the time index, so the
@@ -109,11 +128,12 @@ export class ChunkStoreView {
     const virtualUnitsPerScreenPixel = virtualWidth / view.bufferWidthPx;
     const lodFactor = Math.log2(1 / virtualUnitsPerScreenPixel);
 
-    this.setLOD(lodFactor);
+    const lodChanged = this.setLOD(lodFactor);
 
     const sliceBounds = this.getSliceAxisBounds(sliceCoords);
     const changed =
       this.policyChanged_ ||
+      lodChanged ||
       this.viewBounds2DChanged(viewBounds2D) ||
       this.sliceBoundsChanged(sliceBounds) ||
       this.lastTCoord_ !== sliceCoords.t ||
@@ -315,7 +335,7 @@ export class ChunkStoreView {
     }
   }
 
-  private setLOD(lodFactor: number): void {
+  private setLOD(lodFactor: number): boolean {
     // With 2x downsampling per LOD, selection happens in log2 space.
     const bias = this.policy_.lod.bias;
 
@@ -335,9 +355,9 @@ export class ChunkStoreView {
     );
 
     const target = clamp(desiredLOD, minPolicyLOD, maxPolicyLOD);
-    if (target !== this.currentLOD_) {
-      this.currentLOD_ = target;
-    }
+    if (target === this.currentLOD_) return false;
+    this.currentLOD_ = target;
+    return true;
   }
 
   private markTimeChunksForPrefetchImage(
@@ -606,30 +626,25 @@ export class ChunkStoreView {
   }
 
   private getPaddedBounds(bounds: Box3): Box3 {
+    const { u, v, w } = this.axes_;
     const dimensions = this.store_.dimensions;
-    const xLod = dimensions.x.lods[this.currentLOD_];
-    const yLod = dimensions.y.lods[this.currentLOD_];
-    const zLod = dimensions.z?.lods[this.currentLOD_];
+    const uLod = dimensions[u]!.lods[this.currentLOD_];
+    const vLod = dimensions[v]!.lods[this.currentLOD_];
+    const wLod = dimensions[w]?.lods[this.currentLOD_];
 
-    const padX = xLod.chunkSize * xLod.scale * this.policy_.prefetch.x;
-    const padY = yLod.chunkSize * yLod.scale * this.policy_.prefetch.y;
-
-    let padZ = 0;
-    if (zLod) {
-      padZ = zLod.chunkSize * zLod.scale * this.policy_.prefetch.z;
+    const pad = vec3.create();
+    pad[AxisComponent[u]] =
+      uLod.chunkSize * uLod.scale * this.policy_.prefetch.x;
+    pad[AxisComponent[v]] =
+      vLod.chunkSize * vLod.scale * this.policy_.prefetch.y;
+    if (wLod) {
+      pad[AxisComponent[w]] =
+        wLod.chunkSize * wLod.scale * this.policy_.prefetch.z;
     }
 
     return new Box3(
-      vec3.fromValues(
-        bounds.min[0] - padX,
-        bounds.min[1] - padY,
-        bounds.min[2] - padZ
-      ),
-      vec3.fromValues(
-        bounds.max[0] + padX,
-        bounds.max[1] + padY,
-        bounds.max[2] + padZ
-      )
+      vec3.subtract(vec3.create(), bounds.min, pad),
+      vec3.add(vec3.create(), bounds.max, pad)
     );
   }
 

--- a/src/idetik.ts
+++ b/src/idetik.ts
@@ -1,5 +1,6 @@
 import { WebGLRenderer } from "./renderers/webgl_renderer";
 import { createWebGPURenderer } from "./renderers/webgpu/webgpu_renderer";
+import { ColorLike } from "./math/color";
 import { Logger } from "./utilities/logger";
 import { ChunkManager } from "./data/chunk_manager";
 import { Renderer } from "./core/renderer";
@@ -28,6 +29,7 @@ type IdetikParams = {
   memoryLimitMB?: number;
   maxConcurrentRequests?: number;
   maxGpuUploadsPerUpdate?: number;
+  backgroundColor?: ColorLike;
 };
 
 export type IdetikContext = {
@@ -133,6 +135,9 @@ export class Idetik {
     this.canvas = params.canvas;
 
     this.renderer_ = renderer ?? new WebGLRenderer(this.canvas);
+    if (params.backgroundColor !== undefined) {
+      this.renderer_.backgroundColor = params.backgroundColor;
+    }
     const memoryLimitMB = params.memoryLimitMB ?? DEFAULT_MEMORY_LIMIT_MB;
     const memoryLimitBytes = memoryLimitMB * 1024 * 1024;
     this.chunkManager_ = new ChunkManager(

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,7 @@ export type OmeZarrImage = Image;
 export type { LayerState } from "./core/layer";
 export type { MemoryStats, Overlay } from "./idetik";
 export type { SliceCoordinates } from "./data/chunk";
+export type { SliceOrientation } from "./math/axes";
 
 export { Color } from "./math/color";
 export type { ColorLike } from "./math/color";

--- a/src/layers/image_layer.ts
+++ b/src/layers/image_layer.ts
@@ -8,7 +8,13 @@ import {
   SliceCoordinates,
   worldToTexCoordForChunk,
 } from "../data/chunk";
-import { SliceAxes } from "../math/axes";
+import {
+  AxisComponent,
+  SliceAxes,
+  SliceOrientation,
+  orientationRotation,
+  sliceAxesFor,
+} from "../math/axes";
 import { ChunkStoreView, INTERNAL_POLICY_KEY } from "../data/chunk_store_view";
 import { ImageSourcePolicy } from "../core/image_source_policy";
 import {
@@ -21,7 +27,7 @@ import { Color } from "../math/color";
 import { EventContext } from "../core/event_dispatcher";
 import { Plane } from "../math/plane";
 import { Ray } from "../math/ray";
-import { vec2, vec3 } from "gl-matrix";
+import { quat, vec2, vec3 } from "gl-matrix";
 import { handlePointPickingEvent, PointPickingResult } from "./point_picking";
 import { clamp } from "../utilities/clamp";
 import { RenderablePool } from "../utilities/renderable_pool";
@@ -32,6 +38,7 @@ export type ImageLayerProps = LayerOptions & {
   source: ChunkSource;
   sliceCoords: SliceCoordinates;
   policy: ImageSourcePolicy;
+  orientation?: SliceOrientation;
   channelProps?: ChannelProps[];
   onPickValue?: (info: PointPickingResult) => void;
 };
@@ -55,7 +62,8 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
 
   private readonly source_: ChunkSource;
   private readonly sliceCoords_: SliceCoordinates;
-  private readonly axes_: SliceAxes = { u: "x", v: "y", w: "z" };
+  private readonly axes_: SliceAxes;
+  private readonly planeRotation_: quat;
   private readonly onPickValue_?: (info: PointPickingResult) => void;
   private readonly visibleChunks_: Map<Chunk, ImageRenderable> = new Map();
   private readonly pool_ = new RenderablePool<ImageRenderable>();
@@ -82,6 +90,7 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
     source,
     sliceCoords,
     policy,
+    orientation,
     channelProps,
     onPickValue,
     ...layerOptions
@@ -91,6 +100,8 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
     this.source_ = source;
     this.policy_ = policy;
     this.sliceCoords_ = sliceCoords;
+    this.axes_ = sliceAxesFor(orientation ?? "XY");
+    this.planeRotation_ = orientationRotation(this.axes_);
     this.channelProps_ = channelProps;
     this.initialChannelProps_ = channelProps;
     this.onPickValue_ = onPickValue;
@@ -99,7 +110,8 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
   protected attach(context: IdetikContext) {
     this.chunkStoreView_ = context.chunkManager.addView(
       this.source_,
-      this.policy_
+      this.policy_,
+      this.axes_
     );
 
     const channelCount = this.chunkStoreView_.channelCount;
@@ -129,15 +141,17 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
     if (!viewport || !this.chunkStoreView_) return;
 
     const camera = viewport.camera;
-    if (camera.type !== "OrthographicCamera") {
-      throw new Error(
-        "Image rendering currently supports only orthographic cameras. " +
-          "Update the implementation before using a perspective camera."
-      );
-    }
+
+    // non-orthographic viewports have no world-space view rect, so we load the
+    // whole slice plane and pick LOD as if it spanned the viewport. stopgap
+    // until view-dependent LOD selection and culling work under perspective.
+    const worldViewRect =
+      camera.type === "OrthographicCamera"
+        ? (camera as OrthographicCamera).getWorldViewRect()
+        : this.chunkStoreView_.getWholePlaneRect();
 
     this.chunkStoreView_.updateChunksForImage(this.sliceCoords_, {
-      worldViewRect: (camera as OrthographicCamera).getWorldViewRect(),
+      worldViewRect,
       bufferWidthPx: viewport.getBufferRect().width,
     });
 
@@ -262,7 +276,9 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
     const existing = this.visibleChunks_.get(chunk);
     if (existing) return existing;
 
-    const pooled = this.pool_.acquire(poolKeyForImageRenderable(chunk));
+    const pooled = this.pool_.acquire(
+      poolKeyForImageRenderable(chunk, this.axes_)
+    );
     if (pooled) {
       pooled.setTexture(0, texture);
       pooled.setChannelProps(this.getChannelPropsForChunk(chunk));
@@ -291,11 +307,11 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
 
   private updateSlicePosition(image: ImageRenderable, chunk: Chunk) {
     const { u, v, w } = this.axes_;
-    image.transform.setTranslation([
-      chunk.offset[u],
-      chunk.offset[v],
-      this.sliceCoords_[w] ?? chunk.offset[w],
-    ]);
+    const translation = vec3.create();
+    translation[AxisComponent[u]] = chunk.offset[u];
+    translation[AxisComponent[v]] = chunk.offset[v];
+    translation[AxisComponent[w]] = this.sliceCoords_[w] ?? chunk.offset[w];
+    image.transform.setTranslation(translation);
   }
 
   private sliceIndexForChunk(chunk: Chunk): number {
@@ -320,6 +336,7 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
     }
     const { u, v } = this.axes_;
     image.transform.setScale([chunk.scale[u], chunk.scale[v], 1]);
+    image.transform.setRotation(this.planeRotation_);
     this.updateSlicePosition(image, chunk);
     image.worldToTexCoord = worldToTexCoordForChunk(chunk, this.axes_);
   }
@@ -421,15 +438,16 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
     for (const chunk of chunks) {
       const image = this.visibleChunks_.get(chunk);
       if (image) {
-        this.pool_.release(poolKeyForImageRenderable(chunk), image);
+        this.pool_.release(poolKeyForImageRenderable(chunk, this.axes_), image);
         this.visibleChunks_.delete(chunk);
       }
     }
   }
 }
 
-export function poolKeyForImageRenderable(chunk: Chunk) {
+export function poolKeyForImageRenderable(chunk: Chunk, axes: SliceAxes) {
   return [
+    `plane${axes.u}${axes.v}`,
     `lod${chunk.lod}`,
     `shape${chunk.shape.x}x${chunk.shape.y}x${chunk.shape.z}`,
     `align${chunk.rowAlignmentBytes}`,

--- a/src/layers/label_layer.ts
+++ b/src/layers/label_layer.ts
@@ -8,7 +8,13 @@ import {
   SliceCoordinates,
   worldToTexCoordForChunk,
 } from "../data/chunk";
-import { SliceAxes } from "../math/axes";
+import {
+  AxisComponent,
+  SliceAxes,
+  SliceOrientation,
+  orientationRotation,
+  sliceAxesFor,
+} from "../math/axes";
 import { ChunkStoreView, INTERNAL_POLICY_KEY } from "../data/chunk_store_view";
 import { ImageSourcePolicy } from "../core/image_source_policy";
 import { LabelImageRenderable } from "../objects/renderable/label_image_renderable";
@@ -20,7 +26,7 @@ import { Texture } from "../objects/textures/texture";
 import { EventContext } from "../core/event_dispatcher";
 import { Plane } from "../math/plane";
 import { Ray } from "../math/ray";
-import { vec2, vec3 } from "gl-matrix";
+import { quat, vec2, vec3 } from "gl-matrix";
 import { handlePointPickingEvent, PointPickingResult } from "./point_picking";
 import { clamp } from "../utilities/clamp";
 import { RenderablePool } from "../utilities/renderable_pool";
@@ -30,6 +36,7 @@ export type LabelLayerProps = LayerOptions & {
   source: ChunkSource;
   sliceCoords: SliceCoordinates;
   policy: ImageSourcePolicy;
+  orientation?: SliceOrientation;
   colorMap?: LabelColorMapProps;
   onPickValue?: (info: PointPickingResult) => void;
   outlineSelected?: boolean;
@@ -41,7 +48,8 @@ export class LabelLayer extends Layer {
 
   private readonly source_: ChunkSource;
   private readonly sliceCoords_: SliceCoordinates;
-  private readonly axes_: SliceAxes = { u: "x", v: "y", w: "z" };
+  private readonly axes_: SliceAxes;
+  private readonly planeRotation_: quat;
   private readonly onPickValue_?: (info: PointPickingResult) => void;
   private readonly outlineSelected_: boolean;
   private readonly visibleChunks_: Map<Chunk, LabelImageRenderable> = new Map();
@@ -60,6 +68,7 @@ export class LabelLayer extends Layer {
     source,
     sliceCoords,
     policy,
+    orientation,
     colorMap = {},
     onPickValue,
     outlineSelected = false,
@@ -70,6 +79,8 @@ export class LabelLayer extends Layer {
     this.source_ = source;
     this.policy_ = policy;
     this.sliceCoords_ = sliceCoords;
+    this.axes_ = sliceAxesFor(orientation ?? "XY");
+    this.planeRotation_ = orientationRotation(this.axes_);
     this.colorMap_ = new LabelColorMap(colorMap);
     this.onPickValue_ = onPickValue;
     this.outlineSelected_ = outlineSelected;
@@ -78,7 +89,8 @@ export class LabelLayer extends Layer {
   protected attach(context: IdetikContext) {
     this.chunkStoreView_ = context.chunkManager.addView(
       this.source_,
-      this.policy_
+      this.policy_,
+      this.axes_
     );
 
     if (this.chunkStoreView_.channelCount > 1) {
@@ -101,15 +113,17 @@ export class LabelLayer extends Layer {
     if (!viewport || !this.chunkStoreView_) return;
 
     const camera = viewport.camera;
-    if (camera.type !== "OrthographicCamera") {
-      throw new Error(
-        "Label rendering currently supports only orthographic cameras. " +
-          "Update the implementation before using a perspective camera."
-      );
-    }
+
+    // non-orthographic viewports have no world-space view rect, so we load the
+    // whole slice plane and pick LOD as if it spanned the viewport. stopgap
+    // until view-dependent LOD selection and culling work under perspective.
+    const worldViewRect =
+      camera.type === "OrthographicCamera"
+        ? (camera as OrthographicCamera).getWorldViewRect()
+        : this.chunkStoreView_.getWholePlaneRect();
 
     this.chunkStoreView_.updateChunksForImage(this.sliceCoords_, {
-      worldViewRect: (camera as OrthographicCamera).getWorldViewRect(),
+      worldViewRect,
       bufferWidthPx: viewport.getBufferRect().width,
     });
 
@@ -303,7 +317,9 @@ export class LabelLayer extends Layer {
     const existing = this.visibleChunks_.get(chunk);
     if (existing) return existing;
 
-    const pooled = this.pool_.acquire(poolKeyForImageRenderable(chunk));
+    const pooled = this.pool_.acquire(
+      poolKeyForImageRenderable(chunk, this.axes_)
+    );
     if (pooled) {
       pooled.setTexture(0, texture);
       pooled.setColorMap(this.colorMap_);
@@ -331,11 +347,11 @@ export class LabelLayer extends Layer {
 
   private updateSlicePosition(label: LabelImageRenderable, chunk: Chunk) {
     const { u, v, w } = this.axes_;
-    label.transform.setTranslation([
-      chunk.offset[u],
-      chunk.offset[v],
-      this.sliceCoords_[w] ?? chunk.offset[w],
-    ]);
+    const translation = vec3.create();
+    translation[AxisComponent[u]] = chunk.offset[u];
+    translation[AxisComponent[v]] = chunk.offset[v];
+    translation[AxisComponent[w]] = this.sliceCoords_[w] ?? chunk.offset[w];
+    label.transform.setTranslation(translation);
   }
 
   private sliceIndexForChunk(chunk: Chunk): number {
@@ -352,6 +368,7 @@ export class LabelLayer extends Layer {
   private updateLabelChunk(label: LabelImageRenderable, chunk: Chunk) {
     const { u, v } = this.axes_;
     label.transform.setScale([chunk.scale[u], chunk.scale[v], 1]);
+    label.transform.setRotation(this.planeRotation_);
     this.updateSlicePosition(label, chunk);
     label.worldToTexCoord = worldToTexCoordForChunk(chunk, this.axes_);
   }
@@ -360,7 +377,7 @@ export class LabelLayer extends Layer {
     for (const chunk of chunks) {
       const label = this.visibleChunks_.get(chunk);
       if (label) {
-        this.pool_.release(poolKeyForImageRenderable(chunk), label);
+        this.pool_.release(poolKeyForImageRenderable(chunk, this.axes_), label);
         this.visibleChunks_.delete(chunk);
       }
     }

--- a/test/renderable_pool.test.ts
+++ b/test/renderable_pool.test.ts
@@ -73,9 +73,10 @@ describe("poolKeyForImageRenderable", () => {
         lod: 2,
         shape: { x: 256, y: 128, z: 32 },
         rowAlignmentBytes: 4,
-      })
+      }),
+      { u: "x", v: "y", w: "z" }
     );
 
-    expect(key).toBe("lod2:shape256x128x32:align4");
+    expect(key).toBe("planexy:lod2:shape256x128x32:align4");
   });
 });


### PR DESCRIPTION
### Summary

this PR completes the selectable slice orientation work. image and label
layers now accept an orientation prop (`XY` | `XZ` | `YZ`, default `XY`).
the slice axes are threaded to the chunk store view which drives culling,
LOD selection, and prefetch in plane axes, and the slice plane transform
is rotated to match. 

one stopgap worth noting: dynamic LOD selection requires an orthographic camera (LOD is derived from the world-space view rect, which only ortho cameras provide). both image and label layers used to throw on a perspective camera. to support orthoslices in a 3D view i removed that and instead treat the whole slice plane as visible with LOD chosen as if the plane spanned the viewport. so in 3D the full slice loads and zooming won't increase LOD. making view-dependent LOD work under perspective is doable but out of scope here.


### Tests & Checks

- all checks have passed
- visual verification (modified the multiple viewport example)


<img width="1623" height="1225" alt="Screenshot 2026-07-28 at 10 56 20 AM" src="https://github.com/user-attachments/assets/4e01d4cd-c596-40f7-93a0-481787447a83" />
