### PR TITLE
feat: switch slice orientation at runtime

### DIFF
--- a/src/layers/image_layer.ts
+++ b/src/layers/image_layer.ts
@@ -62,8 +62,9 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
 
   private readonly source_: ChunkSource;
   private readonly sliceCoords_: SliceCoordinates;
-  private readonly axes_: SliceAxes;
-  private readonly planeRotation_: quat;
+  private axes_: SliceAxes;
+  private planeRotation_: quat;
+  private orientation_: SliceOrientation;
   private readonly onPickValue_?: (info: PointPickingResult) => void;
   private readonly visibleChunks_: Map<Chunk, ImageRenderable> = new Map();
   private readonly pool_ = new RenderablePool<ImageRenderable>();
@@ -72,6 +73,7 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
   private policy_: ImageSourcePolicy;
   private channelProps_?: ChannelProps[];
   private chunkStoreView_?: ChunkStoreView;
+  private context_?: IdetikContext;
   private pointerDownPos_: vec2 | null = null;
   private debugMode_ = false;
 
@@ -100,7 +102,8 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
     this.source_ = source;
     this.policy_ = policy;
     this.sliceCoords_ = sliceCoords;
-    this.axes_ = sliceAxesFor(orientation ?? "XY");
+    this.orientation_ = orientation ?? "XY";
+    this.axes_ = sliceAxesFor(this.orientation_);
     this.planeRotation_ = orientationRotation(this.axes_);
     this.channelProps_ = channelProps;
     this.initialChannelProps_ = channelProps;
@@ -108,6 +111,7 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
   }
 
   protected attach(context: IdetikContext) {
+    this.context_ = context;
     this.chunkStoreView_ = context.chunkManager.addView(
       this.source_,
       this.policy_,
@@ -135,6 +139,7 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
     this.clearObjects();
     this.chunkStoreView_?.dispose();
     this.chunkStoreView_ = undefined;
+    this.context_ = undefined;
   }
 
   public update(viewport?: Viewport) {
@@ -160,6 +165,39 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
     for (const [chunk, imageRenderable] of this.visibleChunks_) {
       this.updateSlicePosition(imageRenderable, chunk);
     }
+  }
+
+  public get orientation(): SliceOrientation {
+    return this.orientation_;
+  }
+
+  /**
+   * Changes the slice orientation at runtime. Visible renderables are rebuilt
+   * for the new plane, chunks already resident in the shared cache are reused.
+   */
+  public setOrientation(orientation: SliceOrientation) {
+    if (orientation === this.orientation_) {
+      return;
+    }
+
+    this.releaseAndRemoveChunks(this.visibleChunks_.keys());
+    this.clearObjects();
+    this.chunkStoreView_?.dispose();
+    this.lastPresentationTimeStamp_ = undefined;
+    this.lastPresentationTimeCoord_ = undefined;
+    this.orientation_ = orientation;
+    this.axes_ = sliceAxesFor(orientation);
+    this.planeRotation_ = orientationRotation(this.axes_);
+
+    if (!this.context_) {
+      return;
+    }
+
+    this.chunkStoreView_ = this.context_.chunkManager.addView(
+      this.source_,
+      this.policy_,
+      this.axes_
+    );
   }
 
   private updateChunks() {

--- a/src/layers/label_layer.ts
+++ b/src/layers/label_layer.ts
@@ -48,8 +48,9 @@ export class LabelLayer extends Layer {
 
   private readonly source_: ChunkSource;
   private readonly sliceCoords_: SliceCoordinates;
-  private readonly axes_: SliceAxes;
-  private readonly planeRotation_: quat;
+  private axes_: SliceAxes;
+  private planeRotation_: quat;
+  private orientation_: SliceOrientation;
   private readonly onPickValue_?: (info: PointPickingResult) => void;
   private readonly outlineSelected_: boolean;
   private readonly visibleChunks_: Map<Chunk, LabelImageRenderable> = new Map();
@@ -58,6 +59,7 @@ export class LabelLayer extends Layer {
   private selectedValue_: number | null = null;
   private policy_: ImageSourcePolicy;
   private chunkStoreView_?: ChunkStoreView;
+  private context_?: IdetikContext;
   private pointerDownPos_: vec2 | null = null;
 
   private static readonly STALE_PRESENTATION_MS_ = 1000;
@@ -79,7 +81,8 @@ export class LabelLayer extends Layer {
     this.source_ = source;
     this.policy_ = policy;
     this.sliceCoords_ = sliceCoords;
-    this.axes_ = sliceAxesFor(orientation ?? "XY");
+    this.orientation_ = orientation ?? "XY";
+    this.axes_ = sliceAxesFor(this.orientation_);
     this.planeRotation_ = orientationRotation(this.axes_);
     this.colorMap_ = new LabelColorMap(colorMap);
     this.onPickValue_ = onPickValue;
@@ -87,6 +90,7 @@ export class LabelLayer extends Layer {
   }
 
   protected attach(context: IdetikContext) {
+    this.context_ = context;
     this.chunkStoreView_ = context.chunkManager.addView(
       this.source_,
       this.policy_,
@@ -107,6 +111,7 @@ export class LabelLayer extends Layer {
     this.clearObjects();
     this.chunkStoreView_?.dispose();
     this.chunkStoreView_ = undefined;
+    this.context_ = undefined;
   }
 
   public update(viewport?: Viewport) {
@@ -132,6 +137,39 @@ export class LabelLayer extends Layer {
     for (const [chunk, labelRenderable] of this.visibleChunks_) {
       this.updateSlicePosition(labelRenderable, chunk);
     }
+  }
+
+  public get orientation(): SliceOrientation {
+    return this.orientation_;
+  }
+
+  /**
+   * Changes the slice orientation at runtime. Visible renderables are rebuilt
+   * for the new plane, chunks already resident in the shared cache are reused.
+   */
+  public setOrientation(orientation: SliceOrientation) {
+    if (orientation === this.orientation_) {
+      return;
+    }
+
+    this.releaseAndRemoveChunks(this.visibleChunks_.keys());
+    this.clearObjects();
+    this.chunkStoreView_?.dispose();
+    this.lastPresentationTimeStamp_ = undefined;
+    this.lastPresentationTimeCoord_ = undefined;
+    this.orientation_ = orientation;
+    this.axes_ = sliceAxesFor(orientation);
+    this.planeRotation_ = orientationRotation(this.axes_);
+
+    if (!this.context_) {
+      return;
+    }
+
+    this.chunkStoreView_ = this.context_.chunkManager.addView(
+      this.source_,
+      this.policy_,
+      this.axes_
+    );
   }
 
   private updateChunks() {

--- a/src/objects/cameras/orthographic_camera.ts
+++ b/src/objects/cameras/orthographic_camera.ts
@@ -40,8 +40,9 @@ export class OrthographicCamera extends Camera {
   private height_: number = DEFAULT_HEIGHT;
   private viewportAspectRatio_: number = DEFAULT_ASPECT_RATIO;
   private viewportSize_: [number, number] = [DEFAULT_WIDTH, DEFAULT_HEIGHT];
-  private readonly axes_: SliceAxes;
-  private readonly rotation_: quat;
+  private axes_: SliceAxes;
+  private rotation_: quat;
+  private orientation_: SliceOrientation;
 
   /**
    * Creates an orthographic camera framing the given world-space rectangle.
@@ -63,7 +64,8 @@ export class OrthographicCamera extends Camera {
     super();
     this.near_ = options.near ?? DEFAULT_NEAR;
     this.far_ = options.far ?? DEFAULT_FAR;
-    this.axes_ = sliceAxesFor(options.orientation ?? "XY");
+    this.orientation_ = options.orientation ?? "XY";
+    this.axes_ = sliceAxesFor(this.orientation_);
     this.rotation_ = orientationRotation(this.axes_);
     this.setFrame(left, right, bottom, top);
     this.updateProjectionMatrix();
@@ -92,6 +94,35 @@ export class OrthographicCamera extends Camera {
 
   public get type(): CameraType {
     return "OrthographicCamera";
+  }
+
+  public get orientation(): SliceOrientation {
+    return this.orientation_;
+  }
+
+  /**
+   * Changes the slice orientation the camera faces. The current frame and
+   * zoom carry over numerically to the new plane axes. Call {@link setFrame}
+   * to reframe the view for the new plane.
+   */
+  public setOrientation(orientation: SliceOrientation) {
+    if (orientation === this.orientation_) {
+      return;
+    }
+
+    const u = this.transform.translation[AxisComponent[this.axes_.u]];
+    const v = this.transform.translation[AxisComponent[this.axes_.v]];
+
+    this.orientation_ = orientation;
+    this.axes_ = sliceAxesFor(orientation);
+    this.rotation_ = orientationRotation(this.axes_);
+
+    const translation = vec3.create();
+    translation[AxisComponent[this.axes_.u]] = u;
+    translation[AxisComponent[this.axes_.v]] = v;
+
+    this.transform.setTranslation(translation);
+    this.transform.setRotation(this.rotation_);
   }
 
   public zoom(factor: number) {


### PR DESCRIPTION
### Summary

this PR adds runtime orientation switching to the orthographic camera and
the image and label layers at runtime. this lets downstream users change
orientation without having to manage multiple sets of camera/layer per
slice orientation.

### Tests & Checks

- all checks have passed.
- shape verified by copick integration (in progress).
