### PR TITLE
fix: remove background color property from runtime

### DIFF
--- a/examples/multi_viewport/index.html
+++ b/examples/multi_viewport/index.html
@@ -9,7 +9,7 @@
         margin: 0;
         padding: 0;
         overflow: hidden;
-        background-color: black;
+        background-color: #333333;
         font-family: sans-serif;
       }
 

--- a/examples/multi_viewport/main.ts
+++ b/examples/multi_viewport/main.ts
@@ -105,7 +105,6 @@ const zRange = [zMin, zMax] as const;
 
 new Idetik({
   canvas: document.querySelector<HTMLCanvasElement>("#canvas")!,
-  backgroundColor: "#333333",
   viewports: [
     createSliceViewport("slice-xy", "XY", xRange, yRange),
     {

--- a/src/core/renderer.ts
+++ b/src/core/renderer.ts
@@ -1,5 +1,4 @@
 import { Camera } from "../objects/cameras/camera";
-import { Color, ColorLike } from "../math/color";
 import { Layer } from "./layer";
 import { Viewport } from "./viewport";
 import { Texture } from "../objects/textures/texture";
@@ -8,7 +7,6 @@ export abstract class Renderer {
   private readonly canvas_: HTMLCanvasElement | null;
   private width_ = 0;
   private height_ = 0;
-  private backgroundColor_: Color = new Color(0, 0, 0, 0);
 
   protected renderedObjects_ = 0;
   protected abstract resize(width: number, height: number): void;
@@ -53,10 +51,6 @@ export abstract class Renderer {
     return this.height_;
   }
 
-  public get backgroundColor(): Color {
-    return this.backgroundColor_;
-  }
-
   public get renderedObjects() {
     return this.renderedObjects_;
   }
@@ -68,8 +62,4 @@ export abstract class Renderer {
   public abstract uploadTexture(texture: Texture): void;
 
   public abstract disposeTexture(texture: Texture): void;
-
-  public set backgroundColor(color: ColorLike) {
-    this.backgroundColor_ = Color.from(color);
-  }
 }

--- a/src/idetik.ts
+++ b/src/idetik.ts
@@ -1,6 +1,5 @@
 import { WebGLRenderer } from "./renderers/webgl_renderer";
 import { createWebGPURenderer } from "./renderers/webgpu/webgpu_renderer";
-import { ColorLike } from "./math/color";
 import { Logger } from "./utilities/logger";
 import { ChunkManager } from "./data/chunk_manager";
 import { Renderer } from "./core/renderer";
@@ -29,7 +28,6 @@ type IdetikParams = {
   memoryLimitMB?: number;
   maxConcurrentRequests?: number;
   maxGpuUploadsPerUpdate?: number;
-  backgroundColor?: ColorLike;
 };
 
 export type IdetikContext = {
@@ -135,9 +133,6 @@ export class Idetik {
     this.canvas = params.canvas;
 
     this.renderer_ = renderer ?? new WebGLRenderer(this.canvas);
-    if (params.backgroundColor !== undefined) {
-      this.renderer_.backgroundColor = params.backgroundColor;
-    }
     const memoryLimitMB = params.memoryLimitMB ?? DEFAULT_MEMORY_LIMIT_MB;
     const memoryLimitBytes = memoryLimitMB * 1024 * 1024;
     this.chunkManager_ = new ChunkManager(

--- a/src/renderers/webgl_renderer.ts
+++ b/src/renderers/webgl_renderer.ts
@@ -312,7 +312,7 @@ export class WebGLRenderer extends Renderer {
   }
 
   protected clear() {
-    this.gl_.clearColor(...this.backgroundColor.rgba);
+    this.gl_.clearColor(0, 0, 0, 0);
     this.gl_.clear(this.gl_.COLOR_BUFFER_BIT | this.gl_.DEPTH_BUFFER_BIT);
     this.state_.setDepthTesting(true);
     this.gl_.depthFunc(this.gl_.LEQUAL);

--- a/src/renderers/webgpu/webgpu_renderer.ts
+++ b/src/renderers/webgpu/webgpu_renderer.ts
@@ -366,12 +366,7 @@ class WebGPURenderer extends Renderer {
           resolveTarget: this.context_.getCurrentTexture().createView(),
           loadOp,
           storeOp: "store",
-          clearValue: {
-            r: this.backgroundColor.r,
-            g: this.backgroundColor.g,
-            b: this.backgroundColor.b,
-            a: this.backgroundColor.a,
-          },
+          clearValue: { r: 0, g: 0, b: 0, a: 0 },
         },
       ],
       depthStencilAttachment: {


### PR DESCRIPTION
### Summary

this PR removes the `backgroundColor` parameter from runtime object
initialization. this property causes blending issues when coupled with volume
rendering since using `premultiplied` requires framebuffer to start with alpha = 0.
the background color can be set by the application HTML/CSS since webgl2 context
is initialized with alpha: false. 

### Tests & Checks

- all checks have passed
- visual verification, viewport background is correct

<img width="1539" height="1037" alt="Screenshot 2026-08-05 at 10 35 23 AM" src="https://github.com/user-attachments/assets/9558760d-a25d-4e1c-b655-26083bccb13d" />

