### PR TITLE
docs: add a custom header with version badge to the API reference

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -18,6 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-tags: true
       - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'

--- a/.vitepress/api-index.md
+++ b/.vitepress/api-index.md
@@ -1,0 +1,7 @@
+# API Reference <VersionBadge />
+
+This section documents Idetik's public API. It is generated directly from source and reflects the current state of the library.
+
+This reference is not a tutorial. It does not explain workflows or provide step-by-step examples. For that, start with the [guides in the manual](/guide/getting-started). Use the reference when you need exact information: types, functions, parameters, and guarantees.
+
+If you find inconsistencies or missing details, contributions are welcome. Improving comments and documentation in the source directly improves the reference.

--- a/.vitepress/config.mjs
+++ b/.vitepress/config.mjs
@@ -1,5 +1,19 @@
+import { execSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
 import { defineConfig } from 'vitepress'
 import typedocSidebar from '../docs/api/typedoc-sidebar.json' with { type: 'json' }
+
+function getLatestVersion() {
+  try {
+    const tag = execSync("git tag --list 'v*' --sort=-v:refname", { encoding: 'utf-8' })
+      .split('\n')[0]
+      .trim()
+    if (tag) return tag.replace(/^v/, '')
+  } catch {
+    // fall through to package.json
+  }
+  return JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf-8')).version
+}
 
 export default defineConfig({
   title: 'Idetik',
@@ -12,6 +26,9 @@ export default defineConfig({
 
   vite: {
     server: { port: 5174 },
+    define: {
+      __IDETIK_VERSION__: JSON.stringify(getLatestVersion()),
+    },
   },
 
   themeConfig: {
@@ -35,10 +52,7 @@ export default defineConfig({
           ],
         },
       ],
-      '/api/': [
-        { text: 'API Reference', link: '/api/' },
-        ...typedocSidebar,
-      ],
+      '/api/': typedocSidebar,
     },
 
     socialLinks: [

--- a/.vitepress/theme/VersionBadge.vue
+++ b/.vitepress/theme/VersionBadge.vue
@@ -1,0 +1,33 @@
+<template>
+  <span class="api-version-badge">version {{ version }}</span>
+</template>
+
+<script setup>
+const version = __IDETIK_VERSION__
+</script>
+
+<style scoped>
+.api-version-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  vertical-align: 3px;
+  margin-left: 8px;
+  padding: 2px 10px;
+  border: 1px solid var(--vp-button-alt-border);
+  border-radius: 9999px;
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: normal;
+  line-height: 1.6;
+  color: var(--vp-c-text-2);
+}
+
+.api-version-badge::before {
+  content: '';
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background-color: #26bd6c;
+}
+</style>

--- a/.vitepress/theme/index.js
+++ b/.vitepress/theme/index.js
@@ -1,4 +1,10 @@
 import DefaultTheme from 'vitepress/theme'
+import VersionBadge from './VersionBadge.vue'
 import './custom.css'
 
-export default DefaultTheme
+export default {
+  extends: DefaultTheme,
+  enhanceApp({ app }) {
+    app.component('VersionBadge', VersionBadge)
+  },
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,7 @@ hero:
 features:
   - title: Composable by design
     icon: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12.83 2.18a2 2 0 0 0-1.66 0L2.6 6.08a1 1 0 0 0 0 1.83l8.58 3.91a2 2 0 0 0 1.66 0l8.58-3.9a1 1 0 0 0 0-1.83z"/><path d="M2 12a1 1 0 0 0 .58.91l8.6 3.91a2 2 0 0 0 1.65 0l8.58-3.9A1 1 0 0 0 22 12"/><path d="M2 17a1 1 0 0 0 .58.91l8.6 3.91a2 2 0 0 0 1.65 0l8.58-3.9A1 1 0 0 0 22 17"/></svg>'
-    details: Idetik is not a viewer but a toolkit for building viewers. Define viewports with your own cameras, controls, and image, volume, or segmentation layers.
+    details: Idetik is not a viewer but a framework for building viewers. Define viewports with your own cameras, controls, and image, volume, or segmentation layers.
   - title: OME-Zarr native
     icon: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M17.5 19H9a7 7 0 1 1 6.71-9h1.79a4.5 4.5 0 1 1 0 9Z"/></svg>'
     details: Base support for N-dimensional, multi-scale, multi-channel OME-Zarr. Point Idetik at a local or remote store with no conversion step. Version 0.4/0.5 supported.

--- a/typedoc.json
+++ b/typedoc.json
@@ -5,7 +5,8 @@
   "tsconfig": "tsconfig.json",
   "out": "docs/api",
   "docsRoot": "docs",
-  "readme": "none",
+  "readme": ".vitepress/api-index.md",
+  "mergeReadme": true,
   "githubPages": false,
   "navigation": {
     "includeGroups": true


### PR DESCRIPTION
### Summary

this PR adds a dynamic version badge to the API reference index page. it also
adds some context at the top of the page.

### Tests & Checks

- all checks have passed
- visual verification

<img width="1599" height="1192" alt="Screenshot 2026-08-05 at 1 22 54 PM" src="https://github.com/user-attachments/assets/61c7afe4-7f6b-4437-91d0-3d642c4dc8fc" />

