### PR TITLE
feat: add a depth pass to enable occlusion on multi-channel image layer (blending)

### DIFF
--- a/examples/multi_viewport/main.ts
+++ b/examples/multi_viewport/main.ts
@@ -19,29 +19,27 @@ import GUI from "lil-gui";
 const url =
   "https://public.czbiohub.org/royerlab/zebrahub/imaging/multi-view/ZMNS001.ome.zarr/";
 
-// shared source between viewports/layers
 const source = await OmeZarrImageSource.fromHttp({ url });
 
-const lod = 0;
+const baseLod = 0;
 const dims = source.getDimensions();
 const axisRange = (axis: "x" | "y" | "z"): readonly [number, number] => {
-  const d = dims[axis]!.lods[lod];
+  const d = dims[axis]!.lods[baseLod];
   return [d.translation, d.translation + d.size * d.scale] as const;
 };
 const [xMin, xMax] = axisRange("x");
 const [yMin, yMax] = axisRange("y");
 const [zMin, zMax] = axisRange("z");
-const step = (axis: "x" | "y" | "z") => dims[axis]!.lods[lod].scale;
+const step = (axis: "x" | "y" | "z") => dims[axis]!.lods[baseLod].scale;
 
-const timeCount = dims.t?.lods[lod].size ?? 1;
+const timeCount = dims.t?.lods[baseLod].size ?? 1;
 const center = vec3.fromValues(
   (xMin + xMax) / 2,
   (yMin + yMax) / 2,
   (zMin + zMax) / 2
 );
 
-// shared timepoint across all viewports
-const sharedTime = { t: Math.floor((timeCount - 1) / 2) };
+const currentTime = { t: Math.floor((timeCount - 1) / 2) };
 
 const channelProps: ChannelProps[] = [
   { color: Color.CYAN, contrastLimits: [0, 1200] },
@@ -50,7 +48,7 @@ const channelProps: ChannelProps[] = [
 
 const sliceCoords = {
   get t() {
-    return sharedTime.t;
+    return currentTime.t;
   },
   x: center[0],
   y: center[1],
@@ -101,7 +99,6 @@ const camera3D = new PerspectiveCamera({ near: 1.0 });
 
 new Idetik({
   canvas: document.querySelector<HTMLCanvasElement>("#canvas")!,
-  memoryLimitMB: 4096,
   viewports: [
     createSliceViewport("slice-xy", "XY", xRange, yRange),
     {
@@ -130,7 +127,7 @@ const gui = new GUI({ width: 300 });
 
 addDimensionSlider({
   gui,
-  sliceCoords: sharedTime,
+  sliceCoords: currentTime,
   dimensionName: "t",
   minValue: 0,
   maxValue: timeCount - 1,

--- a/examples/multi_viewport/main.ts
+++ b/examples/multi_viewport/main.ts
@@ -97,10 +97,11 @@ const xRange = [xMin, xMax] as const;
 const yRange = [yMin, yMax] as const;
 const zRange = [zMin, zMax] as const;
 
-const camera3D = new PerspectiveCamera();
+const camera3D = new PerspectiveCamera({ near: 1.0 });
 
 new Idetik({
   canvas: document.querySelector<HTMLCanvasElement>("#canvas")!,
+  memoryLimitMB: 4096,
   viewports: [
     createSliceViewport("slice-xy", "XY", xRange, yRange),
     {

--- a/examples/multi_viewport/main.ts
+++ b/examples/multi_viewport/main.ts
@@ -1,4 +1,6 @@
 import {
+  ChannelProps,
+  Color,
   Idetik,
   ImageLayer,
   OmeZarrImageSource,
@@ -16,52 +18,45 @@ import { vec3 } from "gl-matrix";
 import GUI from "lil-gui";
 
 const url =
-  "https://public.czbiohub.org/royerlab/zebrahub/imaging/single-objective/ZSNS001.ome.zarr/";
-const left = 150;
-const right = 950;
-const top = 100;
-const bottom = 900;
+  "https://public.czbiohub.org/royerlab/zebrahub/imaging/multi-view/ZMNS001.ome.zarr/";
 
-// values copied from source
-const z = { translate: 0.0, scale: 1.24, shape: 448 };
-const zMin = z.translate;
-const zMax = z.translate + z.scale * z.shape - z.scale;
+// shared source between viewports/layers
+const source = await OmeZarrImageSource.fromHttp({ url });
 
-const volumeCenter = vec3.fromValues(
-  (right + left) / 2,
-  (top + bottom) / 2,
+const lod = 0;
+const dims = source.getDimensions();
+const axisRange = (axis: "x" | "y" | "z"): readonly [number, number] => {
+  const d = dims[axis]!.lods[lod];
+  return [d.translation, d.translation + d.size * d.scale] as const;
+};
+const [xMin, xMax] = axisRange("x");
+const [yMin, yMax] = axisRange("y");
+const [zMin, zMax] = axisRange("z");
+const step = (axis: "x" | "y" | "z") => dims[axis]!.lods[lod].scale;
+
+const timeCount = dims.t?.lods[lod].size ?? 1;
+const center = vec3.fromValues(
+  (xMin + xMax) / 2,
+  (yMin + yMax) / 2,
   (zMin + zMax) / 2
 );
 
-// shared source between viewports
-const source = await OmeZarrImageSource.fromHttp({ url });
+// shared timepoint across all viewports
+const sharedTime = { t: Math.floor((timeCount - 1) / 2) };
 
-// Shared timepoint across all viewports
-const sharedTime = { t: 400 };
-
-// Volume layer - no z coordinate to render entire volume
-const volumeCoords = {
-  get t() {
-    return sharedTime.t;
-  },
-  c: [0],
-};
-const camera3D = new PerspectiveCamera();
-const volumeLayer = new VolumeLayer({
-  source,
-  sliceCoords: volumeCoords,
-  policy: createPlaybackPolicy({ lod: { min: 2, max: 2 } }),
-  channelProps: [{ contrastLimits: [0, 200] }],
-});
+const channelProps: ChannelProps[] = [
+  { color: Color.CYAN, contrastLimits: [0, 1200] },
+  { color: Color.MAGENTA, contrastLimits: [0, 400] },
+];
 
 const sliceCoords = {
   get t() {
     return sharedTime.t;
   },
-  x: (left + right) / 2,
-  y: (top + bottom) / 2,
-  z: 300,
-  c: [0],
+  x: center[0],
+  y: center[1],
+  z: center[2],
+  c: [0, 1],
 };
 
 function createSliceLayer(orientation: SliceOrientation) {
@@ -69,7 +64,7 @@ function createSliceLayer(orientation: SliceOrientation) {
     source,
     sliceCoords,
     policy: createPlaybackPolicy(),
-    channelProps: [{ contrastLimits: [0, 200] }],
+    channelProps,
     orientation,
   });
 }
@@ -99,9 +94,26 @@ function createSliceViewport(
   };
 }
 
-const xRange = [left, right] as const;
-const yRange = [top, bottom] as const;
+// Volume layer - no z coordinate to render entire volume
+const volumeLod = Math.min(2, dims.x!.lods.length - 1);
+const volumeLayer = new VolumeLayer({
+  source,
+  sliceCoords: {
+    get t() {
+      return sharedTime.t;
+    },
+    c: [0, 1],
+  },
+  policy: createPlaybackPolicy({ lod: { min: volumeLod, max: volumeLod } }),
+  channelProps,
+});
+volumeLayer.opacityMultiplier = 0.01;
+
+const xRange = [xMin, xMax] as const;
+const yRange = [yMin, yMax] as const;
 const zRange = [zMin, zMax] as const;
+
+const camera3D = new PerspectiveCamera();
 
 new Idetik({
   canvas: document.querySelector<HTMLCanvasElement>("#canvas")!,
@@ -112,16 +124,16 @@ new Idetik({
       element: document.querySelector<HTMLDivElement>("#viewport-3d")!,
       camera: camera3D,
       cameraControls: new OrbitControls(camera3D, {
-        radius: 1100,
+        radius: Math.hypot(xMax - xMin, yMax - yMin, zMax - zMin),
         yaw: 0.4,
         pitch: 0.1,
-        target: volumeCenter,
+        target: center,
       }),
       layers: [
-        volumeLayer,
         createSliceLayer("XY"),
         createSliceLayer("XZ"),
         createSliceLayer("YZ"),
+        volumeLayer,
       ],
     },
     createSliceViewport("slice-xz", "XZ", xRange, zRange),
@@ -133,11 +145,11 @@ new Idetik({
 const gui = new GUI({ width: 300 });
 
 addDimensionSlider({
-  gui: gui,
+  gui,
   sliceCoords: sharedTime,
   dimensionName: "t",
   minValue: 0,
-  maxValue: 790,
+  maxValue: timeCount - 1,
   stepValue: 1,
   playback: {
     maxRateHz: 30,
@@ -146,28 +158,28 @@ addDimensionSlider({
 });
 
 addDimensionSlider({
-  gui: gui,
-  sliceCoords: sliceCoords,
+  gui,
+  sliceCoords,
   dimensionName: "x",
-  minValue: left,
-  maxValue: right,
-  stepValue: 1,
+  minValue: xMin,
+  maxValue: xMax,
+  stepValue: step("x"),
 });
 
 addDimensionSlider({
-  gui: gui,
-  sliceCoords: sliceCoords,
+  gui,
+  sliceCoords,
   dimensionName: "y",
-  minValue: top,
-  maxValue: bottom,
-  stepValue: 1,
+  minValue: yMin,
+  maxValue: yMax,
+  stepValue: step("y"),
 });
 
 addDimensionSlider({
-  gui: gui,
-  sliceCoords: sliceCoords,
+  gui,
+  sliceCoords,
   dimensionName: "z",
   minValue: zMin,
   maxValue: zMax,
-  stepValue: z.scale,
+  stepValue: step("z"),
 });

--- a/examples/multi_viewport/main.ts
+++ b/examples/multi_viewport/main.ts
@@ -9,7 +9,6 @@ import {
   PanZoomControls,
   PerspectiveCamera,
   SliceOrientation,
-  VolumeLayer,
   createPlaybackPolicy,
 } from "@";
 import { addDimensionSlider } from "../lil_gui_utils";
@@ -94,21 +93,6 @@ function createSliceViewport(
   };
 }
 
-// Volume layer - no z coordinate to render entire volume
-const volumeLod = Math.min(2, dims.x!.lods.length - 1);
-const volumeLayer = new VolumeLayer({
-  source,
-  sliceCoords: {
-    get t() {
-      return sharedTime.t;
-    },
-    c: [0, 1],
-  },
-  policy: createPlaybackPolicy({ lod: { min: volumeLod, max: volumeLod } }),
-  channelProps,
-});
-volumeLayer.opacityMultiplier = 0.01;
-
 const xRange = [xMin, xMax] as const;
 const yRange = [yMin, yMax] as const;
 const zRange = [zMin, zMax] as const;
@@ -133,7 +117,6 @@ new Idetik({
         createSliceLayer("XY"),
         createSliceLayer("XZ"),
         createSliceLayer("YZ"),
-        volumeLayer,
       ],
     },
     createSliceViewport("slice-xz", "XZ", xRange, zRange),

--- a/src/core/layer.ts
+++ b/src/core/layer.ts
@@ -23,6 +23,15 @@ type StateChangeCallback = (
 export interface LayerProps {
   opacity?: number;
   blendMode?: BlendMode;
+  /**
+   * Whether this layer occludes layers behind it. Occluders write depth in a
+   * pre-pass so that (a) they hide one another correctly in 3D and (b) overlays
+   * drawn afterwards are hidden where a nearer occluder covers them. Layers with
+   * `blendMode: "none"` are always occluders; set this for a layer that blends
+   * internally (e.g. an additive multi-channel image) but should still read as a
+   * solid, opaque plane to other layers.
+   */
+  occludes?: boolean;
 }
 
 /**
@@ -54,10 +63,18 @@ export abstract class Layer {
 
   private opacity_: number;
   public blendMode: BlendMode;
+  public occludes: boolean;
 
-  constructor({ opacity = 1.0, blendMode = "none" }: LayerProps = {}) {
+  constructor({
+    opacity = 1.0,
+    blendMode = "none",
+    occludes = false,
+  }: LayerProps = {}) {
     this.opacity_ = clamp(opacity, 0.0, 1.0);
     this.blendMode = blendMode;
+    // A "none" (opaque) layer inherently occludes; an internally-blended layer
+    // opts in explicitly.
+    this.occludes = occludes || blendMode === "none";
   }
 
   public get opacity() {

--- a/src/core/layer.ts
+++ b/src/core/layer.ts
@@ -23,14 +23,6 @@ type StateChangeCallback = (
 export interface LayerProps {
   opacity?: number;
   blendMode?: BlendMode;
-  /**
-   * Whether this layer occludes layers behind it. Occluders write depth in a
-   * pre-pass so that (a) they hide one another correctly in 3D and (b) overlays
-   * drawn afterwards are hidden where a nearer occluder covers them. Layers with
-   * `blendMode: "none"` are always occluders; set this for a layer that blends
-   * internally (e.g. an additive multi-channel image) but should still read as a
-   * solid, opaque plane to other layers.
-   */
   occludes?: boolean;
 }
 
@@ -68,13 +60,11 @@ export abstract class Layer {
   constructor({
     opacity = 1.0,
     blendMode = "none",
-    occludes = false,
+    occludes,
   }: LayerProps = {}) {
     this.opacity_ = clamp(opacity, 0.0, 1.0);
     this.blendMode = blendMode;
-    // A "none" (opaque) layer inherently occludes; an internally-blended layer
-    // opts in explicitly.
-    this.occludes = occludes || blendMode === "none";
+    this.occludes = occludes ?? blendMode === "none";
   }
 
   public get opacity() {

--- a/src/core/layer.ts
+++ b/src/core/layer.ts
@@ -54,6 +54,7 @@ export abstract class Layer {
   private readonly callbacks_: StateChangeCallback[] = [];
 
   private opacity_: number;
+
   public blendMode: BlendMode;
   public occludes: boolean;
 
@@ -64,6 +65,8 @@ export abstract class Layer {
   }: LayerProps = {}) {
     this.opacity_ = clamp(opacity, 0.0, 1.0);
     this.blendMode = blendMode;
+    // infer from `blendMode` unless explicitly set, but only at construction
+    // re-assigning `blendMode` does not update this value
     this.occludes = occludes ?? blendMode === "none";
   }
 

--- a/src/core/renderable_object.ts
+++ b/src/core/renderable_object.ts
@@ -17,6 +17,7 @@ export abstract class RenderableObject extends Node {
   private geometry_ = new Geometry();
   private wireframeGeometry_: WireframeGeometry | null = null;
   private programName_: Shader | null = null;
+  private depthProgramName_: Shader | null = null;
   private cullFaceMode_: CullingMode = "none";
 
   public setTexture(index: number, texture: Texture) {
@@ -65,6 +66,10 @@ export abstract class RenderableObject extends Node {
     return this.programName_;
   }
 
+  public get depthProgramName(): Shader | null {
+    return this.depthProgramName_;
+  }
+
   public get boundingBox() {
     const box = this.geometry_.boundingBox.clone();
     box.applyTransform(this.transform_.matrix);
@@ -73,6 +78,10 @@ export abstract class RenderableObject extends Node {
 
   protected set programName(programName: Shader) {
     this.programName_ = programName;
+  }
+
+  protected set depthProgramName(programName: Shader) {
+    this.depthProgramName_ = programName;
   }
 
   public get cullFaceMode() {

--- a/src/layers/image_layer.ts
+++ b/src/layers/image_layer.ts
@@ -101,7 +101,7 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
     onPickValue,
     ...layerOptions
   }: ImageLayerProps) {
-    super({ blendMode: "additive", ...layerOptions });
+    super({ blendMode: "additive", occludes: true, ...layerOptions });
     this.setState("initialized");
     this.source_ = source;
     this.policy_ = policy ?? createExplorationPolicy();

--- a/src/objects/renderable/image_renderable.ts
+++ b/src/objects/renderable/image_renderable.ts
@@ -43,6 +43,7 @@ export class ImageRenderable extends RenderableObject {
     this.setTexture(0, texture);
     this.channels_ = validateChannels(texture, channelProps);
     this.programName = textureToShader(texture);
+    this.depthProgramName = "meshDepth";
   }
 
   public get type() {

--- a/src/objects/renderable/label_image_renderable.ts
+++ b/src/objects/renderable/label_image_renderable.ts
@@ -105,6 +105,7 @@ export class LabelImageRenderable extends RenderableObject {
     this.outlineSelected_ = props.outlineSelected ?? false;
     this.selectedValue_ = props.selectedValue ?? null;
     this.programName = labelTextureToShader(props.imageData);
+    this.depthProgramName = "meshDepth";
   }
 
   public get type() {

--- a/src/objects/renderable/points_renderable.ts
+++ b/src/objects/renderable/points_renderable.ts
@@ -26,6 +26,7 @@ export class PointsRenderable extends RenderableObject {
   constructor(points: PointProps[]) {
     super();
     this.programName = "points";
+    this.depthProgramName = "pointsDepth";
 
     const vertexData = points.flatMap((point) => {
       const color = Color.from(point.color);

--- a/src/objects/renderable/projected_line_renderable.ts
+++ b/src/objects/renderable/projected_line_renderable.ts
@@ -19,6 +19,7 @@ export class ProjectedLineRenderable extends RenderableObject {
     this.color_ = Color.from(color);
     this.width_ = width;
     this.programName = "projectedLine";
+    this.depthProgramName = "projectedLineDepth";
   }
 
   public get type() {

--- a/src/renderers/shaders/depth_frag.glsl
+++ b/src/renderers/shaders/depth_frag.glsl
@@ -1,0 +1,5 @@
+#version 300 es
+
+// Depth-only pass: the rasterizer writes depth from the vertex stage, so there
+// is nothing for the fragment stage to do.
+void main() {}

--- a/src/renderers/shaders/depth_frag.glsl
+++ b/src/renderers/shaders/depth_frag.glsl
@@ -1,5 +1,3 @@
 #version 300 es
 
-// Depth-only pass: the rasterizer writes depth from the vertex stage, so there
-// is nothing for the fragment stage to do.
 void main() {}

--- a/src/renderers/shaders/index.ts
+++ b/src/renderers/shaders/index.ts
@@ -9,6 +9,8 @@ import wireframeFragmentShader from "./wireframe_frag.glsl";
 import volumeVertexShader from "./volume_vert.glsl";
 import volumeFragmentShader from "./volume_frag.glsl";
 import labelImage from "./label_image_frag.glsl";
+import depthFragmentShader from "./depth_frag.glsl";
+import pointsDepthFragmentShader from "./points_depth_frag.glsl";
 
 export type Shader =
   | "floatScalarImage"
@@ -28,7 +30,10 @@ type ShaderCode = {
   vertexDefines?: ReadonlyMap<string, string>;
   fragment: string;
   fragmentDefines?: ReadonlyMap<string, string>;
+  depthOnlyFragment?: string;
 };
+
+export const defaultDepthFragment = depthFragmentShader;
 
 export const shaderCode: Record<Shader, ShaderCode> = {
   projectedLine: {
@@ -38,6 +43,7 @@ export const shaderCode: Record<Shader, ShaderCode> = {
   points: {
     vertex: pointsVertexShader,
     fragment: pointsFragmentShader,
+    depthOnlyFragment: pointsDepthFragmentShader,
   },
   wireframe: {
     vertex: wireframeVertexShader,

--- a/src/renderers/shaders/index.ts
+++ b/src/renderers/shaders/index.ts
@@ -23,17 +23,17 @@ export type Shader =
   | "projectedLine"
   | "uintScalarImage"
   | "uintVolume"
-  | "wireframe";
+  | "wireframe"
+  | "meshDepth"
+  | "pointsDepth"
+  | "projectedLineDepth";
 
 type ShaderCode = {
   vertex: string;
   vertexDefines?: ReadonlyMap<string, string>;
   fragment: string;
   fragmentDefines?: ReadonlyMap<string, string>;
-  depthOnlyFragment?: string;
 };
-
-export const defaultDepthFragment = depthFragmentShader;
 
 export const shaderCode: Record<Shader, ShaderCode> = {
   projectedLine: {
@@ -43,7 +43,6 @@ export const shaderCode: Record<Shader, ShaderCode> = {
   points: {
     vertex: pointsVertexShader,
     fragment: pointsFragmentShader,
-    depthOnlyFragment: pointsDepthFragmentShader,
   },
   wireframe: {
     vertex: wireframeVertexShader,
@@ -85,5 +84,17 @@ export const shaderCode: Record<Shader, ShaderCode> = {
     vertex: volumeVertexShader,
     fragment: volumeFragmentShader,
     fragmentDefines: new Map([["TEXTURE_DATA_TYPE_UINT", "1"]]),
+  },
+  meshDepth: {
+    vertex: meshVertexShader,
+    fragment: depthFragmentShader,
+  },
+  pointsDepth: {
+    vertex: pointsVertexShader,
+    fragment: pointsDepthFragmentShader,
+  },
+  projectedLineDepth: {
+    vertex: projectedLineVertexShader,
+    fragment: depthFragmentShader,
   },
 };

--- a/src/renderers/shaders/points_depth_frag.glsl
+++ b/src/renderers/shaders/points_depth_frag.glsl
@@ -1,0 +1,16 @@
+#version 300 es
+
+precision mediump float;
+
+uniform mediump sampler2DArray u_markerAtlas;
+
+flat in uint v_marker;
+
+// Depth-only counterpart to points_frag.glsl. Point sprites are alpha tested
+// against the marker atlas, so the test has to be repeated here or the whole
+// square sprite would occlude.
+void main() {
+    if (texture(u_markerAtlas, vec3(gl_PointCoord, v_marker)).r < 1e-2) {
+        discard;
+    }
+}

--- a/src/renderers/shaders/points_depth_frag.glsl
+++ b/src/renderers/shaders/points_depth_frag.glsl
@@ -6,9 +6,6 @@ uniform mediump sampler2DArray u_markerAtlas;
 
 flat in uint v_marker;
 
-// Depth-only counterpart to points_frag.glsl. Point sprites are alpha tested
-// against the marker atlas, so the test has to be repeated here or the whole
-// square sprite would occlude.
 void main() {
     if (texture(u_markerAtlas, vec3(gl_PointCoord, v_marker)).r < 1e-2) {
         discard;

--- a/src/renderers/webgl_renderer.ts
+++ b/src/renderers/webgl_renderer.ts
@@ -177,8 +177,8 @@ export class WebGLRenderer extends Renderer {
 
   private initStencil() {
     this.gl_.clearStencil(0);
-    this.gl_.stencilMask(0xff);
-    this.gl_.stencilOp(this.gl_.KEEP, this.gl_.KEEP, this.gl_.REPLACE);
+    this.state_.setStencilMask(0xff);
+    this.state_.setStencilOp(this.gl_.KEEP, this.gl_.KEEP, this.gl_.REPLACE);
   }
 
   private setCoverageStencil(coverageGroup: number | null) {

--- a/src/renderers/webgl_renderer.ts
+++ b/src/renderers/webgl_renderer.ts
@@ -62,7 +62,6 @@ export class WebGLRenderer extends Renderer {
     this.bindings_ = new WebGLBuffers(gl);
     this.textures_ = new WebGLTextures(gl);
     this.state_ = new WebGLState(gl);
-    this.initStencil();
     this.resize(this.canvas.width, this.canvas.height);
   }
 
@@ -108,6 +107,7 @@ export class WebGLRenderer extends Renderer {
     }
 
     this.state_.setViewport(viewportBox);
+    this.resetState();
     this.clear();
 
     const viewportRect = viewportBox.toRect();
@@ -116,69 +116,45 @@ export class WebGLRenderer extends Renderer {
     const frustum = viewport.camera.frustum;
 
     const occludingLayers: Layer[] = [];
-    const transparentLayers: Layer[] = [];
+    const nonOccludingLayers: Layer[] = [];
     for (const layer of viewport.layers) {
       if (layer.state !== "ready") continue;
-      (layer.occludes ? occludingLayers : transparentLayers).push(layer);
+      (layer.occludes ? occludingLayers : nonOccludingLayers).push(layer);
     }
-
-    // polygon offset nudges objects slightly *away* to prevent z-fighting when
-    // rendering color in the next passes with depth LEQUAL
-    this.state_.setPolygonOffset({ factor: 1, units: 1 });
-    this.renderDepthOnly(occludingLayers, viewport.camera, frustum);
-    this.state_.setPolygonOffset(null);
+    this.renderDepthPass(occludingLayers, viewport.camera, frustum);
+    this.resetState();
 
     this.state_.setDepthMask(false);
-    this.state_.setDepthFunc(this.gl_.LEQUAL);
-    this.renderLayers(occludingLayers, viewport.camera, frustum);
-
-    // polygon offset nudges objects slightly *towards* so overlays (e.g. labels)
-    // do not z-fight with coplanar occluders
-    this.state_.setPolygonOffset({ factor: -1, units: -1 });
-    this.renderLayers(transparentLayers, viewport.camera, frustum);
-    this.state_.setPolygonOffset(null);
+    for (const layer of [...occludingLayers, ...nonOccludingLayers]) {
+      this.renderLayer(layer, viewport.camera, frustum);
+    }
+    this.resetState();
 
     this.renderedObjects_ = this.renderedObjectsPerFrame_;
   }
 
-  // TODO: this runs the full shader (incl. texture samples) just to
-  // discard it. Replace with depth-only variants that share each
-  // program's vertex shader but use a cheap fragment shader
-  private renderDepthOnly(layers: Layer[], camera: Camera, frustum: Frustum) {
+  private renderDepthPass(layers: Layer[], camera: Camera, frustum: Frustum) {
     this.state_.setColorMask(false);
-    this.state_.setDepthMask(true);
-    this.state_.setDepthTesting(true);
     this.state_.setDepthFunc(this.gl_.LESS);
-    this.state_.setStencilTest(false);
+    // nudge the depth away from the camera, so that the color passes
+    // at the same depth are not rejected
+    this.state_.setPolygonOffset({ factor: 1, units: 1 });
 
     for (const layer of layers) {
-      const objects = [...layer.coverageGroups.values()].flat();
-      for (const object of objects) {
-        if (!object.programName) continue;
-        if (!frustum.intersectsWithBox3(object.boundingBox)) continue;
-        this.state_.setCullFaceMode(object.cullFaceMode);
-        this.bindings_.bindGeometry(object.geometry);
-        object.textures.forEach((texture, index) => {
-          this.textures_.bindTexture(texture, index);
-        });
-        const program = this.programs_.use(object.programName);
-        this.drawGeometry(object.geometry, object, layer, program, camera);
+      for (const members of layer.coverageGroups.values()) {
+        for (const object of members) {
+          if (!object.programName || !object.depthTest) continue;
+          if (!frustum.intersectsWithBox3(object.boundingBox)) continue;
+          this.state_.setCullFaceMode(object.cullFaceMode);
+          this.bindings_.bindGeometry(object.geometry);
+          object.textures.forEach((texture, index) => {
+            this.textures_.bindTexture(texture, index);
+          });
+          const program = this.programs_.useDepthOnly(object.programName);
+          this.drawGeometry(object.geometry, object, layer, program, camera);
+        }
       }
     }
-
-    this.state_.setColorMask(true);
-  }
-
-  private renderLayers(layers: Layer[], camera: Camera, frustum: Frustum) {
-    for (const layer of layers) {
-      this.renderLayer(layer, camera, frustum);
-    }
-  }
-
-  private initStencil() {
-    this.gl_.clearStencil(0);
-    this.state_.setStencilMask(0xff);
-    this.state_.setStencilOp(this.gl_.KEEP, this.gl_.KEEP, this.gl_.REPLACE);
   }
 
   private setCoverageStencil(coverageGroup: number | null) {
@@ -371,15 +347,22 @@ export class WebGLRenderer extends Renderer {
   }
 
   protected clear() {
-    this.state_.setColorMask(true);
-    this.state_.setDepthMask(true);
     this.gl_.clearColor(0, 0, 0, 0);
+    this.gl_.clearStencil(0);
     this.gl_.clear(
       this.gl_.COLOR_BUFFER_BIT |
         this.gl_.DEPTH_BUFFER_BIT |
         this.gl_.STENCIL_BUFFER_BIT
     );
+  }
+
+  private resetState() {
+    this.state_.setColorMask(true);
+    this.state_.setDepthMask(true);
     this.state_.setDepthTesting(true);
     this.state_.setDepthFunc(this.gl_.LEQUAL);
+    this.state_.setPolygonOffset(null);
+    this.state_.setStencilTest(false);
+    this.state_.setBlendingMode("none");
   }
 }

--- a/src/renderers/webgl_renderer.ts
+++ b/src/renderers/webgl_renderer.ts
@@ -143,14 +143,14 @@ export class WebGLRenderer extends Renderer {
     for (const layer of layers) {
       for (const members of layer.coverageGroups.values()) {
         for (const object of members) {
-          if (!object.programName || !object.depthTest) continue;
+          if (!object.depthProgramName || !object.depthTest) continue;
           if (!frustum.intersectsWithBox3(object.boundingBox)) continue;
           this.state_.setCullFaceMode(object.cullFaceMode);
           this.bindings_.bindGeometry(object.geometry);
           object.textures.forEach((texture, index) => {
             this.textures_.bindTexture(texture, index);
           });
-          const program = this.programs_.useDepthOnly(object.programName);
+          const program = this.programs_.use(object.depthProgramName);
           this.drawGeometry(object.geometry, object, layer, program, camera);
         }
       }

--- a/src/renderers/webgl_renderer.ts
+++ b/src/renderers/webgl_renderer.ts
@@ -115,63 +115,45 @@ export class WebGLRenderer extends Renderer {
 
     const frustum = viewport.camera.frustum;
 
-    const opaqueLayers: Layer[] = [];
+    const occludingLayers: Layer[] = [];
     const transparentLayers: Layer[] = [];
     for (const layer of viewport.layers) {
-      (layer.occludes ? opaqueLayers : transparentLayers).push(layer);
+      if (layer.state !== "ready") continue;
+      (layer.occludes ? occludingLayers : transparentLayers).push(layer);
     }
 
-    const readyOccluders = opaqueLayers.filter((l) => l.state === "ready");
-
-    // Pass 1 — coverage: write only depth for every opaque layer, so the depth
-    // buffer ends up holding the nearest occluding surface at each pixel. No
-    // colour is written
-    //
-    // polygon offset nudges objects slightly away to prevent z-fighting when
+    // polygon offset nudges objects slightly *away* to prevent z-fighting when
     // rendering color in the next passes with depth LEQUAL
-    this.state_.setColorMask(false);
-    this.state_.setDepthMask(true);
-    this.state_.setDepthTesting(true);
-    this.state_.setDepthFunc(this.gl_.LESS);
-    this.state_.setStencilTest(false);
     this.state_.setPolygonOffset({ factor: 1, units: 1 });
-    for (const layer of readyOccluders) {
-      this.renderCoverage(layer, viewport.camera, frustum);
-    }
+    this.renderDepthOnly(occludingLayers, viewport.camera, frustum);
     this.state_.setPolygonOffset(null);
-    this.state_.setColorMask(true);
 
-    // Pass 2 — color opaque layers
     this.state_.setDepthMask(false);
     this.state_.setDepthFunc(this.gl_.LEQUAL);
-    for (const layer of readyOccluders) {
-      this.renderLayer(layer, viewport.camera, frustum);
-    }
+    this.renderLayers(occludingLayers, viewport.camera, frustum);
 
-    // Pass 3 — transparent layers: blended on top, depth-tested against opaque
-    // layers so they're hidden by opaque layers, but never occlude
-    //
-    // polygon offset nudges objects slightly closer so overlays (e.g. labels)
-    // do not z-fight with coplanar layers
+    // polygon offset nudges objects slightly *towards* so overlays (e.g. labels)
+    // do not z-fight with coplanar occluders
     this.state_.setPolygonOffset({ factor: -1, units: -1 });
-    for (const layer of transparentLayers) {
-      if (layer.state === "ready") {
-        this.renderLayer(layer, viewport.camera, frustum);
-      }
-    }
+    this.renderLayers(transparentLayers, viewport.camera, frustum);
     this.state_.setPolygonOffset(null);
 
     this.renderedObjects_ = this.renderedObjectsPerFrame_;
   }
 
   // TODO: this runs the full shader (incl. texture samples) just to
-  // discard it. Replace with depth-only program variants that share each
-  // colour program's vertex shader but use an empty fragment shader
-  private renderCoverage(layer: Layer, camera: Camera, frustum: Frustum) {
-    // depth only, so coverage grouping doesn't matter here — every object the
-    // layer offers contributes its depth, and hidden ones aren't offered
-    for (const members of layer.coverageGroups.values()) {
-      for (const object of members) {
+  // discard it. Replace with depth-only variants that share each
+  // program's vertex shader but use a cheap fragment shader
+  private renderDepthOnly(layers: Layer[], camera: Camera, frustum: Frustum) {
+    this.state_.setColorMask(false);
+    this.state_.setDepthMask(true);
+    this.state_.setDepthTesting(true);
+    this.state_.setDepthFunc(this.gl_.LESS);
+    this.state_.setStencilTest(false);
+
+    for (const layer of layers) {
+      const objects = [...layer.coverageGroups.values()].flat();
+      for (const object of objects) {
         if (!object.programName) continue;
         if (!frustum.intersectsWithBox3(object.boundingBox)) continue;
         this.state_.setCullFaceMode(object.cullFaceMode);
@@ -182,6 +164,14 @@ export class WebGLRenderer extends Renderer {
         const program = this.programs_.use(object.programName);
         this.drawGeometry(object.geometry, object, layer, program, camera);
       }
+    }
+
+    this.state_.setColorMask(true);
+  }
+
+  private renderLayers(layers: Layer[], camera: Camera, frustum: Frustum) {
+    for (const layer of layers) {
+      this.renderLayer(layer, camera, frustum);
     }
   }
 

--- a/src/renderers/webgl_renderer.ts
+++ b/src/renderers/webgl_renderer.ts
@@ -138,7 +138,7 @@ export class WebGLRenderer extends Renderer {
     this.state_.setDepthFunc(this.gl_.LESS);
     // nudge the depth away from the camera, so that the color passes
     // at the same depth are not rejected
-    this.state_.setPolygonOffset({ factor: 1, units: 1 });
+    this.state_.setPolygonOffset(true);
 
     for (const layer of layers) {
       for (const members of layer.coverageGroups.values()) {
@@ -361,7 +361,7 @@ export class WebGLRenderer extends Renderer {
     this.state_.setDepthMask(true);
     this.state_.setDepthTesting(true);
     this.state_.setDepthFunc(this.gl_.LEQUAL);
-    this.state_.setPolygonOffset(null);
+    this.state_.setPolygonOffset(false);
     this.state_.setStencilTest(false);
     this.state_.setBlendingMode("none");
   }

--- a/src/renderers/webgl_renderer.ts
+++ b/src/renderers/webgl_renderer.ts
@@ -221,9 +221,6 @@ export class WebGLRenderer extends Renderer {
 
     if (!object.programName) return;
     this.state_.setCullFaceMode(object.cullFaceMode);
-    // Depth *testing* is per-object; depth *writing* follows the per-pass policy
-    // set in `render()`: opaque writes, transparent/blended does not.
-    // Writing depth for blended objects would reject same-depth layers/channels.
     this.state_.setDepthTesting(object.depthTest);
     this.bindings_.bindGeometry(object.geometry);
     object.textures.forEach((texture, index) => {
@@ -374,7 +371,6 @@ export class WebGLRenderer extends Renderer {
   }
 
   protected clear() {
-    // glClear honours the masks, so make sure colour/depth are writable.
     this.state_.setColorMask(true);
     this.state_.setDepthMask(true);
     this.gl_.clearColor(0, 0, 0, 0);

--- a/src/renderers/webgl_renderer.ts
+++ b/src/renderers/webgl_renderer.ts
@@ -79,13 +79,7 @@ export class WebGLRenderer extends Renderer {
     this.renderedObjectsPerFrame_ = 0;
     this.stencilRef_ = 0;
 
-    const opaque: Layer[] = [];
-    const transparent: Layer[] = [];
     for (const layer of viewport.layers) {
-      (layer.blendMode === "none" ? opaque : transparent).push(layer);
-    }
-
-    for (const layer of [...opaque, ...transparent]) {
       layer.update(viewport);
     }
 
@@ -121,21 +115,74 @@ export class WebGLRenderer extends Renderer {
 
     const frustum = viewport.camera.frustum;
 
-    this.state_.setDepthMask(true);
-    for (const layer of opaque) {
-      if (layer.state === "ready") {
-        this.renderLayer(layer, viewport.camera, frustum);
-      }
+    const opaqueLayers: Layer[] = [];
+    const transparentLayers: Layer[] = [];
+    for (const layer of viewport.layers) {
+      (layer.occludes ? opaqueLayers : transparentLayers).push(layer);
     }
 
+    const readyOccluders = opaqueLayers.filter((l) => l.state === "ready");
+
+    // Pass 1 — coverage: write only depth for every opaque layer, so the depth
+    // buffer ends up holding the nearest occluding surface at each pixel. No
+    // colour is written
+    //
+    // polygon offset nudges objects slightly away to prevent z-fighting when
+    // rendering color in the next passes with depth LEQUAL
+    this.state_.setColorMask(false);
+    this.state_.setDepthMask(true);
+    this.state_.setDepthTesting(true);
+    this.state_.setDepthFunc(this.gl_.LESS);
+    this.state_.setStencilTest(false);
+    this.state_.setPolygonOffset({ factor: 1, units: 1 });
+    for (const layer of readyOccluders) {
+      this.renderCoverage(layer, viewport.camera, frustum);
+    }
+    this.state_.setPolygonOffset(null);
+    this.state_.setColorMask(true);
+
+    // Pass 2 — color opaque layers
     this.state_.setDepthMask(false);
-    for (const layer of transparent) {
+    this.state_.setDepthFunc(this.gl_.LEQUAL);
+    for (const layer of readyOccluders) {
+      this.renderLayer(layer, viewport.camera, frustum);
+    }
+
+    // Pass 3 — transparent layers: blended on top, depth-tested against opaque
+    // layers so they're hidden by opaque layers, but never occlude
+    //
+    // polygon offset nudges objects slightly closer so overlays (e.g. labels)
+    // do not z-fight with coplanar layers
+    this.state_.setPolygonOffset({ factor: -1, units: -1 });
+    for (const layer of transparentLayers) {
       if (layer.state === "ready") {
         this.renderLayer(layer, viewport.camera, frustum);
       }
     }
+    this.state_.setPolygonOffset(null);
 
     this.renderedObjects_ = this.renderedObjectsPerFrame_;
+  }
+
+  // TODO: this runs the full shader (incl. texture samples) just to
+  // discard it. Replace with depth-only program variants that share each
+  // colour program's vertex shader but use an empty fragment shader
+  private renderCoverage(layer: Layer, camera: Camera, frustum: Frustum) {
+    // depth only, so coverage grouping doesn't matter here — every object the
+    // layer offers contributes its depth, and hidden ones aren't offered
+    for (const members of layer.coverageGroups.values()) {
+      for (const object of members) {
+        if (!object.programName) continue;
+        if (!frustum.intersectsWithBox3(object.boundingBox)) continue;
+        this.state_.setCullFaceMode(object.cullFaceMode);
+        this.bindings_.bindGeometry(object.geometry);
+        object.textures.forEach((texture, index) => {
+          this.textures_.bindTexture(texture, index);
+        });
+        const program = this.programs_.use(object.programName);
+        this.drawGeometry(object.geometry, object, layer, program, camera);
+      }
+    }
   }
 
   private initStencil() {
@@ -337,6 +384,9 @@ export class WebGLRenderer extends Renderer {
   }
 
   protected clear() {
+    // glClear honours the masks, so make sure colour/depth are writable.
+    this.state_.setColorMask(true);
+    this.state_.setDepthMask(true);
     this.gl_.clearColor(0, 0, 0, 0);
     this.gl_.clear(
       this.gl_.COLOR_BUFFER_BIT |
@@ -344,6 +394,6 @@ export class WebGLRenderer extends Renderer {
         this.gl_.STENCIL_BUFFER_BIT
     );
     this.state_.setDepthTesting(true);
-    this.gl_.depthFunc(this.gl_.LEQUAL);
+    this.state_.setDepthFunc(this.gl_.LEQUAL);
   }
 }

--- a/src/renderers/webgl_shader_programs.ts
+++ b/src/renderers/webgl_shader_programs.ts
@@ -1,4 +1,4 @@
-import { defaultDepthFragment, Shader, shaderCode } from "./shaders";
+import { Shader, shaderCode } from "./shaders";
 import { WebGLShaderProgram } from "./webgl_shader_program";
 
 const pragmaInjectDefines = "#pragma inject_defines";
@@ -6,7 +6,6 @@ const pragmaInjectDefines = "#pragma inject_defines";
 export class WebGLShaderPrograms {
   private gl_: WebGL2RenderingContext;
   private programs_: Map<Shader, WebGLShaderProgram> = new Map();
-  private depthPrograms_: Map<Shader, WebGLShaderProgram> = new Map();
 
   constructor(gl: WebGL2RenderingContext) {
     this.gl_ = gl;
@@ -16,45 +15,27 @@ export class WebGLShaderPrograms {
     let program = this.programs_.get(shader);
     if (program === undefined) {
       const code = shaderCode[shader];
-      program = this.createProgram(
-        replaceSourceDefines(code.vertex, code.vertexDefines),
-        replaceSourceDefines(code.fragment, code.fragmentDefines)
+      const vertexShaderSource = replaceSourceDefines(
+        code.vertex,
+        code.vertexDefines
       );
+      const fragmentShaderSource = replaceSourceDefines(
+        code.fragment,
+        code.fragmentDefines
+      );
+      program = new WebGLShaderProgram(
+        this.gl_,
+        vertexShaderSource,
+        fragmentShaderSource
+      );
+      program.use();
+      const error = this.gl_.getError();
+      if (error !== this.gl_.NO_ERROR) {
+        throw new Error(`Error using WebGL program: ${error}`);
+      }
       this.programs_.set(shader, program);
     } else {
       program.use();
-    }
-    return program;
-  }
-
-  public useDepthOnly(shader: Shader): WebGLShaderProgram {
-    let program = this.depthPrograms_.get(shader);
-    if (program === undefined) {
-      const code = shaderCode[shader];
-      program = this.createProgram(
-        replaceSourceDefines(code.vertex, code.vertexDefines),
-        code.depthOnlyFragment ?? defaultDepthFragment
-      );
-      this.depthPrograms_.set(shader, program);
-    } else {
-      program.use();
-    }
-    return program;
-  }
-
-  private createProgram(
-    vertexShaderSource: string,
-    fragmentShaderSource: string
-  ) {
-    const program = new WebGLShaderProgram(
-      this.gl_,
-      vertexShaderSource,
-      fragmentShaderSource
-    );
-    program.use();
-    const error = this.gl_.getError();
-    if (error !== this.gl_.NO_ERROR) {
-      throw new Error(`Error using WebGL program: ${error}`);
     }
     return program;
   }

--- a/src/renderers/webgl_shader_programs.ts
+++ b/src/renderers/webgl_shader_programs.ts
@@ -1,4 +1,4 @@
-import { Shader, shaderCode } from "./shaders";
+import { defaultDepthFragment, Shader, shaderCode } from "./shaders";
 import { WebGLShaderProgram } from "./webgl_shader_program";
 
 const pragmaInjectDefines = "#pragma inject_defines";
@@ -6,6 +6,7 @@ const pragmaInjectDefines = "#pragma inject_defines";
 export class WebGLShaderPrograms {
   private gl_: WebGL2RenderingContext;
   private programs_: Map<Shader, WebGLShaderProgram> = new Map();
+  private depthPrograms_: Map<Shader, WebGLShaderProgram> = new Map();
 
   constructor(gl: WebGL2RenderingContext) {
     this.gl_ = gl;
@@ -15,27 +16,45 @@ export class WebGLShaderPrograms {
     let program = this.programs_.get(shader);
     if (program === undefined) {
       const code = shaderCode[shader];
-      const vertexShaderSource = replaceSourceDefines(
-        code.vertex,
-        code.vertexDefines
+      program = this.createProgram(
+        replaceSourceDefines(code.vertex, code.vertexDefines),
+        replaceSourceDefines(code.fragment, code.fragmentDefines)
       );
-      const fragmentShaderSource = replaceSourceDefines(
-        code.fragment,
-        code.fragmentDefines
-      );
-      program = new WebGLShaderProgram(
-        this.gl_,
-        vertexShaderSource,
-        fragmentShaderSource
-      );
-      program.use();
-      const error = this.gl_.getError();
-      if (error !== this.gl_.NO_ERROR) {
-        throw new Error(`Error using WebGL program: ${error}`);
-      }
       this.programs_.set(shader, program);
     } else {
       program.use();
+    }
+    return program;
+  }
+
+  public useDepthOnly(shader: Shader): WebGLShaderProgram {
+    let program = this.depthPrograms_.get(shader);
+    if (program === undefined) {
+      const code = shaderCode[shader];
+      program = this.createProgram(
+        replaceSourceDefines(code.vertex, code.vertexDefines),
+        code.depthOnlyFragment ?? defaultDepthFragment
+      );
+      this.depthPrograms_.set(shader, program);
+    } else {
+      program.use();
+    }
+    return program;
+  }
+
+  private createProgram(
+    vertexShaderSource: string,
+    fragmentShaderSource: string
+  ) {
+    const program = new WebGLShaderProgram(
+      this.gl_,
+      vertexShaderSource,
+      fragmentShaderSource
+    );
+    program.use();
+    const error = this.gl_.getError();
+    if (error !== this.gl_.NO_ERROR) {
+      throw new Error(`Error using WebGL program: ${error}`);
     }
     return program;
   }

--- a/src/renderers/webgl_state.ts
+++ b/src/renderers/webgl_state.ts
@@ -26,6 +26,10 @@ export class WebGLState {
   private stencilFunc_: GLenum | null = null;
   private stencilRef_: number | null = null;
   private stencilFuncMask_: number | null = null;
+  private stencilWriteMask_: number | null = null;
+  private stencilFail_: GLenum | null = null;
+  private stencilZFail_: GLenum | null = null;
+  private stencilZPass_: GLenum | null = null;
 
   constructor(gl: WebGL2RenderingContext) {
     this.gl_ = gl;
@@ -210,6 +214,26 @@ export class WebGLState {
       this.enable(this.gl_.STENCIL_TEST);
     } else {
       this.disable(this.gl_.STENCIL_TEST);
+    }
+  }
+
+  public setStencilMask(mask: number) {
+    if (this.stencilWriteMask_ !== mask) {
+      this.gl_.stencilMask(mask);
+      this.stencilWriteMask_ = mask;
+    }
+  }
+
+  public setStencilOp(fail: GLenum, zfail: GLenum, zpass: GLenum) {
+    if (
+      this.stencilFail_ !== fail ||
+      this.stencilZFail_ !== zfail ||
+      this.stencilZPass_ !== zpass
+    ) {
+      this.gl_.stencilOp(fail, zfail, zpass);
+      this.stencilFail_ = fail;
+      this.stencilZFail_ = zfail;
+      this.stencilZPass_ = zpass;
     }
   }
 

--- a/src/renderers/webgl_state.ts
+++ b/src/renderers/webgl_state.ts
@@ -26,8 +26,7 @@ export class WebGLState {
   private stencilFunc_: GLenum | null = null;
   private stencilRef_: number | null = null;
   private stencilFuncMask_: number | null = null;
-  private polygonOffsetFactor_: number | null = null;
-  private polygonOffsetUnits_: number | null = null;
+  private polygonOffsetSet_ = false;
 
   constructor(gl: WebGL2RenderingContext) {
     this.gl_ = gl;
@@ -99,19 +98,15 @@ export class WebGLState {
     }
   }
 
-  public setPolygonOffset(offset: { factor: number; units: number } | null) {
-    if (offset === null) {
+  public setPolygonOffset(enabled: boolean) {
+    if (!enabled) {
       this.disable(this.gl_.POLYGON_OFFSET_FILL);
       return;
     }
     this.enable(this.gl_.POLYGON_OFFSET_FILL);
-    if (
-      this.polygonOffsetFactor_ !== offset.factor ||
-      this.polygonOffsetUnits_ !== offset.units
-    ) {
-      this.gl_.polygonOffset(offset.factor, offset.units);
-      this.polygonOffsetFactor_ = offset.factor;
-      this.polygonOffsetUnits_ = offset.units;
+    if (!this.polygonOffsetSet_) {
+      this.gl_.polygonOffset(1, 1);
+      this.polygonOffsetSet_ = true;
     }
   }
 

--- a/src/renderers/webgl_state.ts
+++ b/src/renderers/webgl_state.ts
@@ -15,6 +15,8 @@ export class WebGLState {
 
   private enabledCapabilities_ = new Map<GLenum, boolean>();
   private depthMaskEnabled_: boolean | null = null;
+  private colorMaskEnabled_: boolean | null = null;
+  private depthFunc_: GLenum | null = null;
   private blendSrcFactor_: GLenum | null = null;
   private blendDstFactor_: GLenum | null = null;
   private currentBlendingMode_: BlendingMode | null = null;
@@ -84,6 +86,29 @@ export class WebGLState {
 
   public get blendingMode(): BlendingMode | null {
     return this.currentBlendingMode_;
+  }
+
+  public setColorMask(enabled: boolean) {
+    if (this.colorMaskEnabled_ !== enabled) {
+      this.gl_.colorMask(enabled, enabled, enabled, enabled);
+      this.colorMaskEnabled_ = enabled;
+    }
+  }
+
+  public setPolygonOffset(offset: { factor: number; units: number } | null) {
+    if (offset === null) {
+      this.disable(this.gl_.POLYGON_OFFSET_FILL);
+      return;
+    }
+    this.enable(this.gl_.POLYGON_OFFSET_FILL);
+    this.gl_.polygonOffset(offset.factor, offset.units);
+  }
+
+  public setDepthFunc(func: GLenum) {
+    if (this.depthFunc_ !== func) {
+      this.gl_.depthFunc(func);
+      this.depthFunc_ = func;
+    }
   }
 
   public setBlendingMode(mode: BlendingMode) {

--- a/src/renderers/webgl_state.ts
+++ b/src/renderers/webgl_state.ts
@@ -26,10 +26,8 @@ export class WebGLState {
   private stencilFunc_: GLenum | null = null;
   private stencilRef_: number | null = null;
   private stencilFuncMask_: number | null = null;
-  private stencilWriteMask_: number | null = null;
-  private stencilFail_: GLenum | null = null;
-  private stencilZFail_: GLenum | null = null;
-  private stencilZPass_: GLenum | null = null;
+  private polygonOffsetFactor_: number | null = null;
+  private polygonOffsetUnits_: number | null = null;
 
   constructor(gl: WebGL2RenderingContext) {
     this.gl_ = gl;
@@ -37,6 +35,8 @@ export class WebGLState {
     // and flips winding order. As such, we need to treat clockwise
     // triangles as front-facing.
     this.gl_.frontFace(this.gl_.CW);
+    this.gl_.stencilMask(0xff);
+    this.gl_.stencilOp(this.gl_.KEEP, this.gl_.KEEP, this.gl_.REPLACE);
   }
 
   private enable(cap: GLenum) {
@@ -105,7 +105,14 @@ export class WebGLState {
       return;
     }
     this.enable(this.gl_.POLYGON_OFFSET_FILL);
-    this.gl_.polygonOffset(offset.factor, offset.units);
+    if (
+      this.polygonOffsetFactor_ !== offset.factor ||
+      this.polygonOffsetUnits_ !== offset.units
+    ) {
+      this.gl_.polygonOffset(offset.factor, offset.units);
+      this.polygonOffsetFactor_ = offset.factor;
+      this.polygonOffsetUnits_ = offset.units;
+    }
   }
 
   public setDepthFunc(func: GLenum) {
@@ -214,26 +221,6 @@ export class WebGLState {
       this.enable(this.gl_.STENCIL_TEST);
     } else {
       this.disable(this.gl_.STENCIL_TEST);
-    }
-  }
-
-  public setStencilMask(mask: number) {
-    if (this.stencilWriteMask_ !== mask) {
-      this.gl_.stencilMask(mask);
-      this.stencilWriteMask_ = mask;
-    }
-  }
-
-  public setStencilOp(fail: GLenum, zfail: GLenum, zpass: GLenum) {
-    if (
-      this.stencilFail_ !== fail ||
-      this.stencilZFail_ !== zfail ||
-      this.stencilZPass_ !== zpass
-    ) {
-      this.gl_.stencilOp(fail, zfail, zpass);
-      this.stencilFail_ = fail;
-      this.stencilZFail_ = zfail;
-      this.stencilZPass_ = zpass;
     }
   }
 


### PR DESCRIPTION
### Summary
In #716 we moved blending for multi-channel images from separate layers into a single layer. However, this means the layer's `blendMode` is now overloaded to control blending of objects _within a layer_ as well as blending _between layers_. We also dropped the explicit `Layer.transparent` attribute in #668, instead deriving it from the `blendMode`.

The main issue this causes is that image layers now appear transparent in some circumstances, because they never write depth.

This PR adds a `Layer.occludes` attribute to disambiguate this. Initially this looks like we're resurrecting the `Layer.transparent` attribute but it's subtly different, hence the different name. `transparent` gated blending and was entirely derivable from `blendMode`. `occludes` gates depth writing, which isn't derivable — an additive multi-channel image blends internally but should still read as solid to other layers.

This also updates the multi-viewport example to use a multi-channel dataset.

Note: in the 3D view a volume layer would now be erased wherever a slice covers it. Previously the example drew the volume first, so it composited into an empty framebuffer; now non-occluding layers (the volume in this example) always draw after occluders (images, in this example) regardless of their order in layers. This is not depth occlusion (the volume layer opts out of depth testing) but a result of the premultiplied blending "under" the already-drawn slices. I plan to fix this in a follow-up PR by: 1) changing the volume layer blending to compositing "over" with back-to-front chunk order, and 2) writing this depth pass into a _texture_ that can later be sampled in the volume shader to terminate rays at the scene depth.

### Tests & Checks
See the multi-viewport example - without this PR the sections in the 3D view would show through each other instead of appearing as three opaque planes.

#### `main`

<img width="730" height="731" alt="Screenshot 2026-08-20 at 11 32 07 AM" src="https://github.com/user-attachments/assets/065b9fb7-5354-4cb2-bfd5-3ad4cc582df6" />

#### with this PR

<img width="730" height="731" alt="Screenshot 2026-08-20 at 11 32 41 AM" src="https://github.com/user-attachments/assets/ac69c8aa-f314-442c-840a-3e3dc946a74e" />