### PR TITLE
refactor: standardize constructors on a single props object

### DIFF
--- a/examples/image2d_from_omezarr4d_hcs/main.ts
+++ b/examples/image2d_from_omezarr4d_hcs/main.ts
@@ -41,7 +41,12 @@ wellPaths.forEach((path) => {
 
 const policy = createNoPrefetchPolicy();
 
-const camera = new OrthographicCamera(0, xSize * xScale, 0, ySize * yScale);
+const camera = new OrthographicCamera({
+  left: 0,
+  right: xSize * xScale,
+  top: 0,
+  bottom: ySize * yScale,
+});
 
 const idetik = new Idetik({
   canvas: document.querySelector<HTMLCanvasElement>("canvas")!,

--- a/examples/image_2d/main.ts
+++ b/examples/image_2d/main.ts
@@ -139,12 +139,12 @@ const imageLayer = new ImageLayer({
   channelProps,
 });
 
-const camera = new OrthographicCamera(
-  xLod.translation,
-  xLod.translation + xLod.scale * xLod.size,
-  yLod.translation,
-  yLod.translation + yLod.scale * yLod.size
-);
+const camera = new OrthographicCamera({
+  left: xLod.translation,
+  right: xLod.translation + xLod.scale * xLod.size,
+  top: yLod.translation,
+  bottom: yLod.translation + yLod.scale * yLod.size,
+});
 
 const timePointDiv = document.querySelector<HTMLDivElement>("#time-point")!;
 if (!tLod) timePointDiv.style.display = "none";

--- a/examples/image_2d/main.ts
+++ b/examples/image_2d/main.ts
@@ -135,7 +135,6 @@ const channelProps: ChannelProps[] = Array.from(
 const imageLayer = new ImageLayer({
   source,
   sliceCoords,
-  policy: createExplorationPolicy(),
   channelProps,
 });
 

--- a/examples/labels_overlay/main.ts
+++ b/examples/labels_overlay/main.ts
@@ -112,7 +112,12 @@ zSlider.addEventListener("input", (event) => {
   }, 20);
 });
 
-const camera = new OrthographicCamera(0, xStopPoint, 0, yStopPoint);
+const camera = new OrthographicCamera({
+  left: 0,
+  right: xStopPoint,
+  top: 0,
+  bottom: yStopPoint,
+});
 const idetik = new Idetik({
   canvas: document.querySelector<HTMLCanvasElement>("canvas")!,
   viewports: [

--- a/examples/labels_overlay/main.ts
+++ b/examples/labels_overlay/main.ts
@@ -6,7 +6,6 @@ import {
   OrthographicCamera,
   Color,
   PanZoomControls,
-  createExplorationPolicy,
 } from "@";
 
 // A 3D (z-stack) OME-Zarr image with a matching label segmentation overlaid on
@@ -46,7 +45,6 @@ const labelsSliceCoords = {
 const imageLayer = new ImageLayer({
   source: imageSource,
   sliceCoords,
-  policy: createExplorationPolicy(),
   channelProps: [
     {
       visible: true,
@@ -68,8 +66,7 @@ function createLabelsLayer() {
   return new LabelLayer({
     source: labelsSource,
     sliceCoords: labelsSliceCoords,
-    policy: createExplorationPolicy(),
-    opacity: 0.75,
+    opacity: 0.55,
     blendMode: "normal",
     outlineSelected: outlineMode,
     onPickValue: (info) => {

--- a/examples/multi_viewport/main.ts
+++ b/examples/multi_viewport/main.ts
@@ -82,13 +82,13 @@ function createSliceViewport(
 ) {
   const uPad = 0.2 * (uMax - uMin);
   const vPad = 0.2 * (vMax - vMin);
-  const camera = new OrthographicCamera(
-    uMin - uPad,
-    uMax + uPad,
-    vMin - vPad,
-    vMax + vPad,
-    { orientation }
-  );
+  const camera = new OrthographicCamera({
+    left: uMin - uPad,
+    right: uMax + uPad,
+    top: vMin - vPad,
+    bottom: vMax + vPad,
+    orientation,
+  });
 
   return {
     id,

--- a/examples/points/main.ts
+++ b/examples/points/main.ts
@@ -143,7 +143,11 @@ const imageLayer = new ImageLayer({
   channelProps: [{ color: Color.WHITE, contrastLimits: [-0.00001, 0.00001] }],
 });
 
-const camera = new OrthographicCamera(0, xExtent, 0, yExtent, {
+const camera = new OrthographicCamera({
+  left: 0,
+  right: xExtent,
+  top: 0,
+  bottom: yExtent,
   near: -10000,
   far: 10000,
 });

--- a/src/idetik.ts
+++ b/src/idetik.ts
@@ -27,7 +27,6 @@ type IdetikProps = {
   memoryLimitMB?: number;
   maxConcurrentRequests?: number;
   maxGpuUploadsPerUpdate?: number;
-  renderer?: Renderer;
 };
 
 export type IdetikContext = {
@@ -84,7 +83,6 @@ export class Idetik {
    *   The `id` property is optional but useful for referencing specific viewports later.
    * @param params.overlays - Optional array of overlay objects that update each frame (e.g., for HUD elements)
    * @param params.showStats - Optional flag to display performance statistics
-   * @param params.renderer - Optional renderer instance; defaults to a WebGL renderer bound to the canvas
    *
    * @example
    * // Single viewport (element defaults to canvas)
@@ -123,7 +121,7 @@ export class Idetik {
   constructor(params: IdetikProps) {
     this.canvas = params.canvas;
 
-    this.renderer_ = params.renderer ?? new WebGLRenderer(this.canvas);
+    this.renderer_ = new WebGLRenderer(this.canvas);
     const memoryLimitMB = params.memoryLimitMB ?? DEFAULT_MEMORY_LIMIT_MB;
     const memoryLimitBytes = memoryLimitMB * 1024 * 1024;
     this.chunkManager_ = new ChunkManager(

--- a/src/idetik.ts
+++ b/src/idetik.ts
@@ -27,6 +27,7 @@ type IdetikProps = {
   memoryLimitMB?: number;
   maxConcurrentRequests?: number;
   maxGpuUploadsPerUpdate?: number;
+  renderer?: Renderer;
 };
 
 export type IdetikContext = {
@@ -83,10 +84,11 @@ export class Idetik {
    *   The `id` property is optional but useful for referencing specific viewports later.
    * @param params.overlays - Optional array of overlay objects that update each frame (e.g., for HUD elements)
    * @param params.showStats - Optional flag to display performance statistics
+   * @param params.renderer - Optional renderer instance; defaults to a WebGL renderer bound to the canvas
    *
    * @example
    * // Single viewport (element defaults to canvas)
-   * const camera = new OrthographicCamera(0, 1024, 0, 1024);
+   * const camera = new OrthographicCamera({ left: 0, right: 1024, top: 0, bottom: 1024 });
    * const idetik = new Idetik({
    *   canvas: document.querySelector('canvas')!,
    *   viewports: [{
@@ -118,10 +120,10 @@ export class Idetik {
    *
    * @throws {Error} If viewports have duplicate IDs or shared elements
    */
-  constructor(params: IdetikProps, renderer?: Renderer) {
+  constructor(params: IdetikProps) {
     this.canvas = params.canvas;
 
-    this.renderer_ = renderer ?? new WebGLRenderer(this.canvas);
+    this.renderer_ = params.renderer ?? new WebGLRenderer(this.canvas);
     const memoryLimitMB = params.memoryLimitMB ?? DEFAULT_MEMORY_LIMIT_MB;
     const memoryLimitBytes = memoryLimitMB * 1024 * 1024;
     this.chunkManager_ = new ChunkManager(

--- a/src/layers/image_layer.ts
+++ b/src/layers/image_layer.ts
@@ -16,7 +16,10 @@ import {
   sliceAxesFor,
 } from "../math/axes";
 import { ChunkStoreView, INTERNAL_POLICY_KEY } from "../data/chunk_store_view";
-import { ImageSourcePolicy } from "../core/image_source_policy";
+import {
+  createExplorationPolicy,
+  ImageSourcePolicy,
+} from "../core/image_source_policy";
 import {
   ChannelProps,
   ChannelsEnabled,
@@ -37,7 +40,7 @@ import { Texture } from "../objects/textures/texture";
 export type ImageLayerProps = LayerProps & {
   source: ChunkSource;
   sliceCoords: SliceCoordinates;
-  policy: ImageSourcePolicy;
+  policy?: ImageSourcePolicy;
   orientation?: SliceOrientation;
   channelProps?: ChannelProps[];
   onPickValue?: (info: PointPickingResult) => void;
@@ -101,7 +104,7 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
     super({ blendMode: "additive", ...layerOptions });
     this.setState("initialized");
     this.source_ = source;
-    this.policy_ = policy;
+    this.policy_ = policy ?? createExplorationPolicy();
     this.sliceCoords_ = sliceCoords;
     this.orientation_ = orientation ?? "XY";
     this.axes_ = sliceAxesFor(this.orientation_);

--- a/src/layers/image_layer.ts
+++ b/src/layers/image_layer.ts
@@ -337,12 +337,12 @@ export class ImageLayer extends Layer implements ChannelsEnabled {
   }
 
   private createImage(chunk: Chunk, texture: Texture) {
-    const image = new ImageRenderable(
-      chunk.shape[this.axes_.u],
-      chunk.shape[this.axes_.v],
+    const image = new ImageRenderable({
+      width: chunk.shape[this.axes_.u],
+      height: chunk.shape[this.axes_.v],
       texture,
-      this.getChannelPropsForChunk(chunk)
-    );
+      channelProps: this.getChannelPropsForChunk(chunk),
+    });
     this.updateImageChunk(image, chunk);
     return image;
   }

--- a/src/layers/label_layer.ts
+++ b/src/layers/label_layer.ts
@@ -16,7 +16,10 @@ import {
   sliceAxesFor,
 } from "../math/axes";
 import { ChunkStoreView, INTERNAL_POLICY_KEY } from "../data/chunk_store_view";
-import { ImageSourcePolicy } from "../core/image_source_policy";
+import {
+  createExplorationPolicy,
+  ImageSourcePolicy,
+} from "../core/image_source_policy";
 import {
   LabelColorMap,
   LabelColorMapProps,
@@ -35,7 +38,7 @@ import { poolKeyForImageRenderable } from "./image_layer";
 export type LabelLayerProps = LayerProps & {
   source: ChunkSource;
   sliceCoords: SliceCoordinates;
-  policy: ImageSourcePolicy;
+  policy?: ImageSourcePolicy;
   orientation?: SliceOrientation;
   colorMap?: LabelColorMapProps;
   onPickValue?: (info: PointPickingResult) => void;
@@ -79,7 +82,7 @@ export class LabelLayer extends Layer {
     super(layerOptions);
     this.setState("initialized");
     this.source_ = source;
-    this.policy_ = policy;
+    this.policy_ = policy ?? createExplorationPolicy();
     this.sliceCoords_ = sliceCoords;
     this.orientation_ = orientation ?? "XY";
     this.axes_ = sliceAxesFor(this.orientation_);

--- a/src/layers/volume_layer.ts
+++ b/src/layers/volume_layer.ts
@@ -5,7 +5,10 @@ import { Viewport } from "../core/viewport";
 import { VolumeRenderable } from "../objects/renderable/volume_renderable";
 import { IdetikContext } from "../idetik";
 import { ChunkStoreView, INTERNAL_POLICY_KEY } from "../data/chunk_store_view";
-import { ImageSourcePolicy } from "../core/image_source_policy";
+import {
+  createExplorationPolicy,
+  ImageSourcePolicy,
+} from "../core/image_source_policy";
 import { RenderablePool } from "../utilities/renderable_pool";
 import { vec3 } from "gl-matrix";
 import { sortFrontToBack } from "../math/sort_by_distance";
@@ -18,7 +21,7 @@ import {
 export type VolumeLayerProps = {
   source: ChunkSource;
   sliceCoords: SliceCoordinates;
-  policy: ImageSourcePolicy;
+  policy?: ImageSourcePolicy;
   channelProps?: ChannelProps[];
 };
 
@@ -110,7 +113,7 @@ export class VolumeLayer extends Layer implements ChannelsEnabled {
     super({ blendMode: "premultiplied" });
     this.source_ = source;
     this.sliceCoords_ = sliceCoords;
-    this.policy_ = policy;
+    this.policy_ = policy ?? createExplorationPolicy();
     this.initialChannelProps_ = channelProps;
     this.channelProps_ = channelProps;
     this.setState("initialized");

--- a/src/objects/cameras/orthographic_camera.ts
+++ b/src/objects/cameras/orthographic_camera.ts
@@ -15,7 +15,14 @@ const DEFAULT_HEIGHT = 128 / DEFAULT_ASPECT_RATIO;
 const DEFAULT_NEAR = -1e6;
 const DEFAULT_FAR = 1e6;
 
-type OrthographicCameraProps = {
+type OrthographicCameraFrame = {
+  left: number;
+  right: number;
+  top: number;
+  bottom: number;
+};
+
+type OrthographicCameraProps = OrthographicCameraFrame & {
   near?: number;
   far?: number;
   orientation?: SliceOrientation;
@@ -47,27 +54,18 @@ export class OrthographicCamera extends Camera {
   /**
    * Creates an orthographic camera framing the given world-space rectangle.
    *
-   * @param left - Left edge of the view frame, in world units.
-   * @param right - Right edge of the view frame, in world units.
-   * @param top - Top edge of the view frame, in world units.
-   * @param bottom - Bottom edge of the view frame, in world units.
-   * @param options - Near/far clipping plane distances (default `-1e6` and
-   *   `1e6`) and the slice orientation the camera faces (default `"XY"`).
+   * @param props - The view frame edges in world units, near/far clipping
+   *   plane distances (default `-1e6` and `1e6`), and the slice orientation
+   *   the camera faces (default `"XY"`).
    */
-  constructor(
-    left: number,
-    right: number,
-    top: number,
-    bottom: number,
-    options: OrthographicCameraProps = {}
-  ) {
+  constructor(props: OrthographicCameraProps) {
     super();
-    this.near_ = options.near ?? DEFAULT_NEAR;
-    this.far_ = options.far ?? DEFAULT_FAR;
-    this.orientation_ = options.orientation ?? "XY";
+    this.near_ = props.near ?? DEFAULT_NEAR;
+    this.far_ = props.far ?? DEFAULT_FAR;
+    this.orientation_ = props.orientation ?? "XY";
     this.axes_ = sliceAxesFor(this.orientation_);
     this.rotation_ = orientationRotation(this.axes_);
-    this.setFrame(left, right, bottom, top);
+    this.setFrame(props);
     this.updateProjectionMatrix();
   }
 
@@ -80,7 +78,7 @@ export class OrthographicCamera extends Camera {
     this.updateProjectionMatrix();
   }
 
-  public setFrame(left: number, right: number, bottom: number, top: number) {
+  public setFrame({ left, right, top, bottom }: OrthographicCameraFrame) {
     this.width_ = Math.abs(right - left);
     this.height_ = Math.abs(top - bottom);
     this.updateProjectionMatrix();

--- a/src/objects/cameras/perspective_camera.ts
+++ b/src/objects/cameras/perspective_camera.ts
@@ -19,14 +19,14 @@ export class PerspectiveCamera extends Camera {
   private fov_: number;
   private aspectRatio_: number;
 
-  constructor(options: PerspectiveCameraProps = {}) {
+  constructor(props: PerspectiveCameraProps = {}) {
     const {
       fov = DEFAULT_FOV,
       aspectRatio = DEFAULT_ASPECT_RATIO,
       near = 0.1,
       far = 10000,
       position = vec3.fromValues(0, 0, 0),
-    } = options;
+    } = props;
 
     if (fov < MIN_FOV || fov > MAX_FOV) {
       throw new Error(

--- a/src/objects/renderable/image_renderable.ts
+++ b/src/objects/renderable/image_renderable.ts
@@ -32,7 +32,12 @@ export class ImageRenderable extends RenderableObject {
 
   public worldToTexCoord: mat4 = mat4.create();
 
-  constructor({ width, height, texture, channelProps = [] }: ImageRenderableProps) {
+  constructor({
+    width,
+    height,
+    texture,
+    channelProps = [],
+  }: ImageRenderableProps) {
     super();
     this.geometry = new PlaneGeometry(width, height, 1, 1);
     this.setTexture(0, texture);

--- a/src/objects/renderable/image_renderable.ts
+++ b/src/objects/renderable/image_renderable.ts
@@ -10,6 +10,13 @@ import {
 import { mat4, vec3 } from "gl-matrix";
 import { Shader } from "../../renderers/shaders";
 
+type ImageRenderableProps = {
+  width: number;
+  height: number;
+  texture: Texture;
+  channelProps?: ChannelProps[];
+};
+
 type UniformValues = {
   u_color: vec3;
   u_imageSampler: number;
@@ -25,16 +32,11 @@ export class ImageRenderable extends RenderableObject {
 
   public worldToTexCoord: mat4 = mat4.create();
 
-  constructor(
-    width: number,
-    height: number,
-    texture: Texture,
-    channels: ChannelProps[] = []
-  ) {
+  constructor({ width, height, texture, channelProps = [] }: ImageRenderableProps) {
     super();
     this.geometry = new PlaneGeometry(width, height, 1, 1);
     this.setTexture(0, texture);
-    this.channels_ = validateChannels(texture, channels);
+    this.channels_ = validateChannels(texture, channelProps);
     this.programName = textureToShader(texture);
   }
 

--- a/src/objects/renderable/volume_renderable.ts
+++ b/src/objects/renderable/volume_renderable.ts
@@ -11,6 +11,10 @@ import {
 import { vec3 } from "gl-matrix";
 import type { Chunk } from "../../data/chunk";
 
+type VolumeRenderableProps = {
+  channelProps?: ChannelProps[];
+};
+
 /** @group Renderable Objects */
 export class VolumeRenderable extends RenderableObject {
   public voxelScale: vec3 = vec3.fromValues(1, 1, 1);
@@ -20,12 +24,13 @@ export class VolumeRenderable extends RenderableObject {
 
   private readonly channelToTextureIndex_: Map<number, number> = new Map();
 
-  constructor() {
+  constructor({ channelProps = [] }: VolumeRenderableProps = {}) {
     super();
     this.geometry = new BoxGeometry(1, 1, 1, 1, 1, 1);
     this.cullFaceMode = "front";
     this.depthTest = false;
     this.channels_ = [];
+    this.setChannelProps(channelProps);
   }
 
   public get type() {

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -93,7 +93,7 @@ export function createTestElement(id: string = "test-element"): HTMLElement {
 }
 
 export function createTestCamera(): OrthographicCamera {
-  return new OrthographicCamera(-1, 1, -1, 1);
+  return new OrthographicCamera({ left: -1, right: 1, top: -1, bottom: 1 });
 }
 
 export function createTestContext(): IdetikContext {

--- a/test/idetik.test.ts
+++ b/test/idetik.test.ts
@@ -4,7 +4,12 @@ import { OrthographicCamera } from "@/objects/cameras/orthographic_camera";
 
 test("Runtime initializes with canvas element", () => {
   const canvas = document.createElement("canvas");
-  const camera = new OrthographicCamera(0, 128, 0, 128);
+  const camera = new OrthographicCamera({
+    left: 0,
+    right: 128,
+    top: 0,
+    bottom: 128,
+  });
 
   const idetik = new Idetik({ canvas, viewports: [{ camera }] });
 
@@ -16,7 +21,12 @@ test("Runtime initializes with canvas element", () => {
 
 test("Runtime start/stop controls the animation loop", () => {
   const canvas = document.createElement("canvas");
-  const camera = new OrthographicCamera(0, 128, 0, 128);
+  const camera = new OrthographicCamera({
+    left: 0,
+    right: 128,
+    top: 0,
+    bottom: 128,
+  });
   const idetik = new Idetik({ canvas, viewports: [{ camera }] });
 
   const rafSpy = vi.spyOn(window, "requestAnimationFrame");
@@ -31,7 +41,12 @@ test("Runtime start/stop controls the animation loop", () => {
 test("Width and height properties return (scaled) canvas shape", () => {
   const devicePixelRatio = window.devicePixelRatio;
   const canvas = document.createElement("canvas");
-  const camera = new OrthographicCamera(0, 128, 0, 128);
+  const camera = new OrthographicCamera({
+    left: 0,
+    right: 128,
+    top: 0,
+    bottom: 128,
+  });
   const idetik = new Idetik({ canvas, viewports: [{ camera }] });
 
   expect(idetik.width).toBe(canvas.clientWidth * devicePixelRatio);


### PR DESCRIPTION
### Summary

this PR aligns all public constructors on the options-object style:

- `OrthographicCamera`: replaces the positional (left, right, top, bottom)
  arguments with a props object, and setFrame() now takes the same frame
  fields, removing the inconsistent argument order between the two
- `Idetik`: folds the trailing positional renderer argument into the props
- `ImageRenderable`: replaces positional arguments with a props object and
  renames channels to channelProps to match the rest of the API
- `VolumeRenderable`: accepts optional channelProps at construction
- `PerspectiveCamera`: renames the constructor parameter from options to props

it also makes policy optional on the image, label, and volume layers,
defaulting to the exploration policy, and updates all call sites in tests
and examples.

### Tests & Checks

- all checks have passed.