### PR TITLE
docs: add github star counter to navbar

### DIFF
--- a/.vitepress/theme/GitHubStars.vue
+++ b/.vitepress/theme/GitHubStars.vue
@@ -1,0 +1,64 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+
+const url = 'https://github.com/chanzuckerberg/idetik'
+const stars = ref<string | null>(null)
+
+onMounted(async () => {
+  try {
+    const res = await fetch('https://api.github.com/repos/chanzuckerberg/idetik')
+    if (!res.ok) return
+    const { stargazers_count: n } = await res.json()
+    stars.value = n >= 1000 ? (n / 1000).toFixed(1).replace(/\.0$/, '') + 'k' : `${n}`
+  } catch {
+    // Ignore — the button still links to GitHub.
+  }
+})
+</script>
+
+<template>
+  <div class="github-stars">
+    <a class="btn" :href="url" target="_blank" rel="noopener">
+      <svg class="icon" viewBox="0 0 16 16" width="15" height="15" aria-hidden="true">
+        <path fill="currentColor" d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z" />
+      </svg>
+      Star
+    </a>
+    <a v-if="stars" class="count" :href="`${url}/stargazers`" target="_blank" rel="noopener" :aria-label="`${stars} stargazers`">{{ stars }}</a>
+  </div>
+</template>
+
+<style scoped>
+.github-stars {
+  display: inline-flex;
+  height: 32px;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 8px;
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.btn,
+.count {
+  display: inline-flex;
+  align-items: center;
+  padding: 0 12px;
+  color: var(--vp-c-text-1);
+}
+
+.btn { gap: 6px; }
+.icon { color: #e3b341; }
+
+.count {
+  border-left: 1px solid var(--vp-c-divider);
+  color: var(--vp-c-text-2);
+  font-variant-numeric: tabular-nums;
+  transition: color 0.25s;
+}
+
+.count:hover { color: var(--vp-c-brand-1); }
+
+@media (max-width: 768px) {
+  .github-stars { display: none; }
+}
+</style>

--- a/.vitepress/theme/custom.css
+++ b/.vitepress/theme/custom.css
@@ -122,3 +122,7 @@
 .VPFooter .container .copyright {
   color: #6e6e78;
 }
+
+.VPNavBar .github-stars {
+  margin-left: 20px;
+}

--- a/.vitepress/theme/index.js
+++ b/.vitepress/theme/index.js
@@ -1,9 +1,16 @@
 import DefaultTheme from 'vitepress/theme'
+import { h } from 'vue'
 import VersionBadge from './VersionBadge.vue'
+import GitHubStars from './GitHubStars.vue'
 import './custom.css'
 
 export default {
   extends: DefaultTheme,
+  Layout() {
+    return h(DefaultTheme.Layout, null, {
+      'nav-bar-content-after': () => h(GitHubStars),
+    })
+  },
   enhanceApp({ app }) {
     app.component('VersionBadge', VersionBadge)
   },


### PR DESCRIPTION
summary:

adds a github stars vue component (copied from vglx) that shows a
"star" button with a live stargazer count in the vitepress navbar.
falls back to a plain link if the github api is unavailable and hides on mobile.

<img width="1413" height="812" alt="Screenshot 2026-08-13 at 8 47 53 AM" src="https://github.com/user-attachments/assets/17682e89-4863-4e71-a118-a329f1e357ac" />
