### PR TITLE
docs: restyle the API reference with a custom TypeDoc theme

### DIFF
--- a/.vitepress/config.mjs
+++ b/.vitepress/config.mjs
@@ -15,6 +15,34 @@ function getLatestVersion() {
   return JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf-8')).version
 }
 
+const headingRegex = /<h(\d*).*?>(.*?<a.*? href="#.*?".*?>.*?<\/a>)<\/h\1>/gi
+const headingContentRegex = /(.*?)<a class="header-anchor" href="#(.*?)".*?>.*?<\/a>/i
+
+function* splitPageIntoSections(html) {
+  const result = html.split(headingRegex)
+  result.shift()
+  let parentTitles = []
+  const clearHtmlTags = (str) => str.replace(/<[^>]*>/g, '')
+  for (let i = 0; i < result.length; i += 3) {
+    const level = Number.parseInt(result[i]) - 1
+    const heading = result[i + 1]
+    const headingResult = headingContentRegex.exec(heading)
+    const title = clearHtmlTags(headingResult?.[1] ?? '').trim()
+    const anchor = headingResult?.[2] ?? ''
+    const content = result[i + 2]
+    if (!title || !content) continue
+    let titles = parentTitles.slice(0, level)
+    titles[level] = title
+    titles = titles.filter(Boolean)
+    yield { anchor, titles, text: clearHtmlTags(content) }
+    if (level === 0) {
+      parentTitles = [title]
+    } else {
+      parentTitles[level] = title
+    }
+  }
+}
+
 export default defineConfig({
   title: 'Idetik',
   description: 'A library for creating interactive viewers for large bioimaging data',
@@ -22,7 +50,18 @@ export default defineConfig({
   srcDir: 'docs',
   appearance: false,
 
-  head: [['link', { rel: 'icon', type: 'image/svg+xml', href: '/icon.svg' }]],
+  head: [
+    ['link', { rel: 'icon', type: 'image/svg+xml', href: '/icon.svg' }],
+    ['link', { rel: 'preconnect', href: 'https://fonts.googleapis.com' }],
+    ['link', { rel: 'preconnect', href: 'https://fonts.gstatic.com', crossorigin: '' }],
+    [
+      'link',
+      {
+        rel: 'stylesheet',
+        href: 'https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap',
+      },
+    ],
+  ],
 
   vite: {
     server: { port: 5174 },
@@ -36,6 +75,16 @@ export default defineConfig({
 
     search: {
       provider: 'local',
+      options: {
+        miniSearch: {
+          // Replaces VitePress's default section splitter, which derives each
+          // section's anchor from the FIRST link in a heading. API member
+          // headings contain type links (e.g. "state" links to LayerState),
+          // which made sections collide on the linked type's anchor. This
+          // version anchors on the permalink (.header-anchor) instead.
+          _splitIntoSections: (_file, html) => splitPageIntoSections(html),
+        },
+      },
     },
 
     nav: [

--- a/.vitepress/theme/custom.css
+++ b/.vitepress/theme/custom.css
@@ -2,6 +2,10 @@
   --vp-font-family-base: 'Inter', ui-sans-serif, system-ui, sans-serif,
     'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
 
+  --vp-code-color: var(--vp-c-text-1);
+  --vp-code-link-color: var(--vp-c-text-1);
+  --vp-code-link-hover-color: var(--vp-c-text-1);
+
   --brand-rgb: 110 79 249;
 
   --vp-c-brand-1: rgb(var(--brand-rgb));
@@ -63,6 +67,50 @@
   font-size: 18px;
   font-weight: 400;
   line-height: 1.6;
+}
+
+.vp-doc blockquote {
+  margin: 28px 0;
+}
+
+.vp-doc table {
+  display: table;
+  width: 100%;
+  max-width: 100%;
+}
+
+.api .vp-doc table :is(th, td):first-child {
+  white-space: nowrap;
+  width: 1%;
+  max-width: 40%;
+}
+
+.api .vp-doc table :is(th, td):last-child {
+  width: 55%;
+  overflow-wrap: anywhere;
+}
+
+.vp-doc a {
+  font-weight: 400;
+  color: var(--vp-c-text-1);
+}
+
+.vp-doc a:hover {
+  color: var(--vp-c-text-1);
+}
+
+.api .vp-doc h3 {
+  font-family: var(--vp-font-family-mono);
+  font-size: 17px;
+  font-weight: 600;
+  color: var(--vp-c-brand-1);
+}
+
+.api .vp-doc h3 .return-type,
+.api .vp-doc h3 .return-type a {
+  font-size: 13px;
+  font-weight: 400;
+  color: var(--vp-c-text-3);
 }
 
 .VPHome {

--- a/.vitepress/typedoc/companion-types.mjs
+++ b/.vitepress/typedoc/companion-types.mjs
@@ -1,0 +1,113 @@
+import { ReflectionKind } from "typedoc";
+import { MemberRouter } from "typedoc-plugin-markdown";
+
+export function collectDeclarationFiles(project) {
+  const files = new Map();
+  for (const reflection of Object.values(project.reflections)) {
+    const file = reflection.sources?.[0]?.fullFileName;
+    if (file) files.set(reflection, file);
+  }
+  return files;
+}
+
+export function foldCompanionAliasesIntoOwnerClasses(
+  project,
+  declarationFiles
+) {
+  const containers = [
+    project,
+    ...(project.children ?? []).filter(
+      (c) => c.kind === ReflectionKind.Module
+    ),
+  ];
+  for (const container of containers) {
+    const children = container.children ?? [];
+    const classes = children.filter((c) => c.kind === ReflectionKind.Class);
+    const aliases = children.filter(
+      (c) => c.kind === ReflectionKind.TypeAlias
+    );
+    for (const alias of aliases) {
+      const owner = companionOwnerOf(alias, classes, declarationFiles);
+      if (!owner) continue;
+      dropModuleGroupTag(alias);
+      moveChildReflection(alias, container, owner);
+    }
+  }
+}
+
+function companionOwnerOf(alias, classes, declarationFiles) {
+  return classes
+    .filter(
+      (cls) =>
+        alias.name.startsWith(cls.name) &&
+        alias.name !== cls.name &&
+        declaredInSameFile(alias, cls, declarationFiles)
+    )
+    .sort(mostSpecificClassFirst)[0];
+}
+
+const mostSpecificClassFirst = (a, b) => b.name.length - a.name.length;
+
+function declaredInSameFile(alias, cls, declarationFiles) {
+  const file = declarationFiles.get(alias);
+  return file !== undefined && file === declarationFiles.get(cls);
+}
+
+function dropModuleGroupTag(alias) {
+  if (!alias.comment) return;
+  alias.comment.blockTags = alias.comment.blockTags.filter(
+    (tag) => tag.tag !== "@group"
+  );
+}
+
+function moveChildReflection(child, from, to) {
+  from.children = from.children.filter((c) => c !== child);
+  from.childrenIncludingDocuments = from.childrenIncludingDocuments?.filter(
+    (c) => c !== child
+  );
+  child.parent = to;
+  to.children = [...(to.children ?? []), child];
+  to.childrenIncludingDocuments = [
+    ...(to.childrenIncludingDocuments ?? []),
+    child,
+  ];
+}
+
+export function isFoldedAlias(reflection) {
+  return (
+    reflection.kind === ReflectionKind.TypeAlias &&
+    reflection.parent?.kind === ReflectionKind.Class
+  );
+}
+
+export class FoldedAliasRouter extends MemberRouter {
+  buildChildPages(reflection, outPages) {
+    if (isFoldedAlias(reflection)) {
+      this.buildAnchors(reflection, reflection.parent);
+      reflection.traverse((child) => {
+        this.buildChildPages(child, outPages);
+        return true;
+      });
+      return;
+    }
+    super.buildChildPages(reflection, outPages);
+  }
+}
+
+export function foldedAliasDescriptionAndProperties(context, model, opts) {
+  const blocks = [];
+  if (model.comment) {
+    blocks.push(
+      context.partials.comment(model.comment, {
+        headingLevel: opts.headingLevel,
+      })
+    );
+  }
+  const properties = (model.children ?? []).filter((child) =>
+    child.isDeclaration()
+  );
+  if (properties.length) {
+    blocks.push(context.partials.propertiesTable(properties));
+  }
+  return blocks.join("\n\n");
+}

--- a/.vitepress/typedoc/index.mjs
+++ b/.vitepress/typedoc/index.mjs
@@ -1,0 +1,53 @@
+import {
+  Application,
+  Converter,
+  OptionDefaults,
+  RendererEvent,
+} from "typedoc";
+import { MarkdownPageEvent } from "typedoc-plugin-markdown";
+import {
+  collectDeclarationFiles,
+  foldCompanionAliasesIntoOwnerClasses,
+  FoldedAliasRouter,
+} from "./companion-types.mjs";
+import {
+  removeInheritedMembers,
+  renameGroupsToDisplayTitles,
+  stripSourcesToSuppressDefinedIn,
+} from "./project-transforms.mjs";
+import { IdetikTheme } from "./theme.mjs";
+
+const UNRENDERED_TAGS = ["@see", "@throws"];
+
+export function load(app) {
+  app.renderer.defineTheme("idetik", IdetikTheme);
+  app.renderer.defineRouter("idetik", FoldedAliasRouter);
+
+  app.on(Application.EVENT_BOOTSTRAP_END, () => {
+    app.options.setValue("excludeTags", [
+      ...OptionDefaults.excludeTags,
+      ...UNRENDERED_TAGS,
+    ]);
+  });
+
+  app.converter.on(Converter.EVENT_RESOLVE_BEGIN, ({ project }) => {
+    removeInheritedMembers(project);
+    const declarationFiles = collectDeclarationFiles(project);
+    stripSourcesToSuppressDefinedIn(project);
+    foldCompanionAliasesIntoOwnerClasses(project, declarationFiles);
+  });
+
+  app.renderer.on(RendererEvent.BEGIN, ({ project }) => {
+    renameGroupsToDisplayTitles(project);
+  });
+
+  app.renderer.on(MarkdownPageEvent.END, (page) => {
+    if (page.contents) page.contents = withApiPageClass(page.contents);
+  });
+}
+
+function withApiPageClass(contents) {
+  return contents.startsWith("---\n")
+    ? contents.replace("---\n", "---\npageClass: api\n")
+    : `---\npageClass: api\n---\n\n${contents}`;
+}

--- a/.vitepress/typedoc/project-transforms.mjs
+++ b/.vitepress/typedoc/project-transforms.mjs
@@ -1,0 +1,42 @@
+import { ReflectionKind } from "typedoc";
+
+const DISPLAY_TITLE_BY_TYPEDOC_GROUP = {
+  "Type Aliases": "Types",
+  Constructors: "Constructor",
+};
+
+export function removeInheritedMembers(project) {
+  for (const reflection of Object.values(project.reflections)) {
+    if (inheritsWithoutOverriding(reflection)) {
+      project.removeReflection(reflection);
+    }
+  }
+}
+
+function inheritsWithoutOverriding(reflection) {
+  return Boolean(
+    reflection.inheritedFrom ||
+      reflection.getSignature?.inheritedFrom ||
+      reflection.setSignature?.inheritedFrom ||
+      (reflection.signatures?.length &&
+        reflection.signatures.every((s) => s.inheritedFrom))
+  );
+}
+
+export function stripSourcesToSuppressDefinedIn(project) {
+  for (const reflection of Object.values(project.reflections)) {
+    if ("sources" in reflection) reflection.sources = undefined;
+    for (const signature of reflection.signatures ?? []) {
+      signature.sources = undefined;
+    }
+  }
+}
+
+export function renameGroupsToDisplayTitles(project) {
+  for (const reflection of Object.values(project.reflections)) {
+    if (reflection.kind !== ReflectionKind.Class) continue;
+    for (const group of reflection.groups ?? []) {
+      group.title = DISPLAY_TITLE_BY_TYPEDOC_GROUP[group.title] ?? group.title;
+    }
+  }
+}

--- a/.vitepress/typedoc/theme.mjs
+++ b/.vitepress/typedoc/theme.mjs
@@ -1,0 +1,219 @@
+import { ReflectionKind } from "typedoc";
+import { MarkdownTheme, MarkdownThemeContext } from "typedoc-plugin-markdown";
+import {
+  foldedAliasDescriptionAndProperties,
+  isFoldedAlias,
+} from "./companion-types.mjs";
+
+export class IdetikTheme extends MarkdownTheme {
+  getRenderContext(page) {
+    return new IdetikThemeContext(this, page, this.application.options);
+  }
+}
+
+const overridesBadgeReplacesInheritanceSection = () => "";
+
+class IdetikThemeContext extends MarkdownThemeContext {
+  constructor(theme, page, options) {
+    super(theme, page, options);
+    const base = this.partials;
+    this.partials = {
+      ...base,
+      hierarchy: (model, opts) =>
+        extendsNoteOrExtendedByList(this, model, opts),
+      memberWithGroups: (model, opts) =>
+        isFoldedAlias(model)
+          ? foldedAliasDescriptionAndProperties(this, model, opts)
+          : base.memberWithGroups(model, opts),
+      members: (model, opts) =>
+        membersWithoutHorizontalRules(this, model, opts),
+      constructor: (model, opts) =>
+        constructorSignaturesWithoutHeading(this, model, opts),
+      signature: (model, opts) =>
+        signatureWithDescriptionFirst(this, model, opts),
+      accessor: (model, opts) =>
+        accessorWithDescriptionFirst(this, model, opts),
+      memberContainer: (model, opts) =>
+        memberWithDecoratedHeading(this, model, opts),
+      inheritance: overridesBadgeReplacesInheritanceSection,
+    };
+  }
+}
+
+const heading = (level, text) => `${"#".repeat(level)} ${text}`;
+
+function extendsNoteOrExtendedByList(context, model, opts) {
+  const blocks = [];
+  for (let level = model; level?.next; level = level.next) {
+    const extendsText = level.isTarget
+      ? null
+      : level.types
+          .map((type) =>
+            context.helpers.getHierarchyType(type, { isTarget: false })
+          )
+          .join(".")
+          .replaceAll("`", "");
+    if (extendsText) {
+      blocks.push(
+        `> Extends ${extendsText} and inherits all public properties and methods.`
+      );
+    } else {
+      blocks.push(
+        heading(opts.headingLevel, "Extended by"),
+        level.next.types
+          .map(
+            (type) =>
+              `- ${context.helpers.getHierarchyType(type, {
+                isTarget: level.next.isTarget || false,
+              })}`
+          )
+          .join("\n")
+      );
+    }
+  }
+  return blocks.join("\n\n");
+}
+
+function memberWithDecoratedHeading(context, model, opts) {
+  const blocks = [];
+  if (
+    !context.router.hasOwnDocument(model) &&
+    model.kind !== ReflectionKind.Constructor
+  ) {
+    blocks.push(
+      heading(opts.headingLevel, decoratedHeadingWithPinnedAnchor(context, model))
+    );
+  }
+  blocks.push(
+    context.partials.member(model, {
+      headingLevel: opts.headingLevel,
+      nested: opts.nested,
+    })
+  );
+  return blocks.join("\n\n");
+}
+
+function decoratedHeadingWithPinnedAnchor(context, model) {
+  const signature = model.signatures?.[0] ?? model.getSignature;
+  const parts = [context.partials.memberTitle(model)];
+  const returnType = returnTypeForHeading(context, signature);
+  if (returnType) {
+    parts.push(`<span class="return-type">${returnType}</span>`);
+  }
+  if (model.overwrites || signature?.overwrites) {
+    parts.push(`<Badge type="info" text="overrides" />`);
+  }
+  const anchor = context.router.hasUrl(model)
+    ? context.router.getAnchor(model)
+    : undefined;
+  if (anchor) {
+    parts.push(`{#${anchor}}`);
+  }
+  return parts.join(" ");
+}
+
+function returnTypeForHeading(context, signature) {
+  if (!signature?.type) return undefined;
+  const inlineHtml = toHeadingSafeInlineHtml(
+    context.partials.someType(signature.type)
+  );
+  return inlineHtml.includes("\n") ? undefined : inlineHtml;
+}
+
+function toHeadingSafeInlineHtml(typeMarkdown) {
+  return typeMarkdown
+    .replaceAll("`", "")
+    .replaceAll(String.raw`\<`, "&lt;")
+    .replaceAll(String.raw`\>`, "&gt;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}
+
+function signatureWithDescriptionFirst(context, model, opts) {
+  const comment = opts.multipleSignatures
+    ? model.comment
+    : model.comment || model.parent?.comment;
+  const description =
+    comment &&
+    context.partials.comment(comment, {
+      headingLevel: opts.headingLevel,
+      showTags: false,
+      showSummary: true,
+    });
+  const codeBlock =
+    !opts.hideTitle &&
+    context.partials.signatureTitle(model, { accessor: opts.accessor });
+  const hasTypeParameters =
+    model.typeParameters?.length &&
+    model.kind !== ReflectionKind.ConstructorSignature;
+  const remainingTags =
+    comment &&
+    context.partials.comment(comment, {
+      headingLevel: opts.headingLevel,
+      showTags: true,
+      showSummary: false,
+    });
+  return [
+    description,
+    codeBlock,
+    hasTypeParameters && heading(opts.headingLevel, "Type Parameters"),
+    hasTypeParameters &&
+      context.partials.typeParametersTable(model.typeParameters),
+    model.parameters?.length &&
+      context.partials.parametersTable(model.parameters),
+    remainingTags,
+  ]
+    .filter(Boolean)
+    .join("\n\n");
+}
+
+function accessorWithDescriptionFirst(context, model, opts) {
+  const blocks = [];
+  for (const [signature, accessor] of [
+    [model.getSignature, "get"],
+    [model.setSignature, "set"],
+  ]) {
+    if (!signature) continue;
+    if (signature.comment) {
+      blocks.push(
+        context.partials.comment(signature.comment, {
+          headingLevel: opts.headingLevel + 1,
+        })
+      );
+    }
+    blocks.push(context.partials.signatureTitle(signature, { accessor }));
+    if (signature.parameters?.length) {
+      blocks.push(context.partials.parametersTable(signature.parameters));
+    }
+  }
+  if (model.comment) {
+    blocks.push(
+      context.partials.comment(model.comment, {
+        headingLevel: opts.headingLevel,
+      })
+    );
+  }
+  return blocks.filter(Boolean).join("\n\n");
+}
+
+function constructorSignaturesWithoutHeading(context, model, opts) {
+  return (model.signatures ?? [])
+    .map((signature) =>
+      context.partials.signature(signature, {
+        headingLevel: opts.headingLevel + 1,
+      })
+    )
+    .join("\n\n");
+}
+
+function membersWithoutHorizontalRules(context, model, opts) {
+  return model
+    .filter((item) => !context.router.hasOwnDocument(item))
+    .map((item) =>
+      context.partials.memberContainer(item, {
+        headingLevel: opts.headingLevel,
+        groupTitle: opts.groupTitle,
+      })
+    )
+    .join("\n\n");
+}

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,6 +1,11 @@
 {
   "$schema": "https://typedoc.org/schema.json",
-  "plugin": ["typedoc-plugin-markdown", "typedoc-vitepress-theme"],
+  "plugin": [
+    "typedoc-plugin-markdown",
+    "typedoc-vitepress-theme",
+    "./.vitepress/typedoc/index.mjs"
+  ],
+  "theme": "idetik",
   "entryPoints": ["src/index.ts"],
   "tsconfig": "tsconfig.json",
   "out": "docs/api",
@@ -12,15 +17,24 @@
     "includeGroups": true
   },
   "groupOrder": [
-    "Runtime",
-    "Data Loading",
-    "Layers",
-    "Layer Configuration",
-    "Renderable Objects",
-    "Cameras & Controls",
+    "Constructors",
+    "Type Aliases",
+    "Properties",
+    "Accessors",
+    "Methods",
     "*"
   ],
+  "sort": ["source-order"],
+  "router": "idetik",
+  "typeAliasPropertiesFormat": "table",
+  "pageTitleTemplates": {
+    "member": "{name}"
+  },
   "hidePageHeader": true,
+  "hideBreadcrumbs": true,
+  "tableColumnSettings": {
+    "hideSources": true
+  },
   "useCodeBlocks": true,
   "expandObjects": true,
   "parametersFormat": "table",


### PR DESCRIPTION
Summary:

this PR restyles the auto-generated API reference to match my vglx docs style.
it adds a local TypeDoc plugin (`.vitepress/typedoc`) that customizes the
`typedoc-plugin-markdown` output:

- class pages document only their own members. inheritance renders as a
  one-line "Extends ..." note instead of listing inherited members
- companion types (e.g. `LayerState`) fold into a `Types` section on their
  class's page instead of getting standalone pages
- member headings show the return type and an "overrides" badge replacing
  the `Returns` and `Overrides` sections and the dividers between members
- signatures render description first, then code, then a parameters table
- breadcrumbs, `Defined in` lines, and `@see/@throws` sections are removed

it also updates the site theme: full-width tables with sensible column
sizing, neutral inline code and link colors with purple member headings,
inter/monospace font loading, and a fix for vitepress local search when
headings contain links.

NOTE: the documentation are still bad. we need to reorganize and regenerate comments. the screenshot
below show an example of the correct documentation formatting.

### Tests & Checks

- all checks have passed
- visual verification

<img width="1648" height="902" alt="Screenshot 2026-08-13 at 10 26 58 AM" src="https://github.com/user-attachments/assets/61a06599-2763-485b-8f1e-e7890500270c" />

---

<img width="1648" height="902" alt="Screenshot 2026-08-13 at 10 27 14 AM" src="https://github.com/user-attachments/assets/34c3d451-0d30-49e7-9586-1ecd98644c09" />

---

<img width="1648" height="901" alt="Screenshot 2026-08-13 at 10 27 26 AM" src="https://github.com/user-attachments/assets/f711a8df-b244-4775-ae71-b0263b38d511" />

