### PR TITLE
refactor: replace the LabelColorMap class with plain color map props

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,10 +16,7 @@ export { VolumeLayer } from "./layers/volume_layer";
 export { LabelLayer } from "./layers/label_layer";
 
 export { ImageRenderable } from "./objects/renderable/image_renderable";
-export {
-  LabelColorMap,
-  LabelImageRenderable,
-} from "./objects/renderable/label_image_renderable";
+export { LabelImageRenderable } from "./objects/renderable/label_image_renderable";
 export { PointsRenderable } from "./objects/renderable/points_renderable";
 export { ProjectedLineRenderable } from "./objects/renderable/projected_line_renderable";
 export { VolumeRenderable } from "./objects/renderable/volume_renderable";

--- a/src/layers/label_layer.ts
+++ b/src/layers/label_layer.ts
@@ -21,8 +21,9 @@ import {
   ImageSourcePolicy,
 } from "../core/image_source_policy";
 import {
-  LabelColorMap,
   LabelColorMapProps,
+  ValidatedLabelColorMap,
+  validateColorMap,
   LabelImageRenderable,
 } from "../objects/renderable/label_image_renderable";
 import { Texture } from "../objects/textures/texture";
@@ -58,7 +59,7 @@ export class LabelLayer extends Layer {
   private readonly outlineSelected_: boolean;
   private readonly visibleChunks_: Map<Chunk, LabelImageRenderable> = new Map();
   private readonly pool_ = new RenderablePool<LabelImageRenderable>();
-  private colorMap_: LabelColorMap;
+  private colorMap_: ValidatedLabelColorMap;
   private selectedValue_: number | null = null;
   private policy_: ImageSourcePolicy;
   private chunkStoreView_?: ChunkStoreView;
@@ -87,7 +88,7 @@ export class LabelLayer extends Layer {
     this.orientation_ = orientation ?? "XY";
     this.axes_ = sliceAxesFor(this.orientation_);
     this.planeRotation_ = orientationRotation(this.axes_);
-    this.colorMap_ = new LabelColorMap(colorMap);
+    this.colorMap_ = validateColorMap(colorMap);
     this.onPickValue_ = onPickValue;
     this.outlineSelected_ = outlineSelected;
   }
@@ -253,12 +254,12 @@ export class LabelLayer extends Layer {
     return { world, value };
   }
 
-  public get colorMap(): LabelColorMap {
+  public get colorMap(): ValidatedLabelColorMap {
     return this.colorMap_;
   }
 
   public setColorMap(colorMap: LabelColorMapProps) {
-    this.colorMap_ = new LabelColorMap(colorMap);
+    this.colorMap_ = validateColorMap(colorMap);
     this.visibleChunks_.forEach((label) => {
       label.setColorMap(this.colorMap_);
     });

--- a/src/layers/label_layer.ts
+++ b/src/layers/label_layer.ts
@@ -22,7 +22,7 @@ import {
 } from "../core/image_source_policy";
 import {
   LabelColorMapProps,
-  ValidatedLabelColorMap,
+  LabelColorMap,
   validateColorMap,
   LabelImageRenderable,
 } from "../objects/renderable/label_image_renderable";
@@ -59,7 +59,7 @@ export class LabelLayer extends Layer {
   private readonly outlineSelected_: boolean;
   private readonly visibleChunks_: Map<Chunk, LabelImageRenderable> = new Map();
   private readonly pool_ = new RenderablePool<LabelImageRenderable>();
-  private colorMap_: ValidatedLabelColorMap;
+  private colorMap_: LabelColorMap;
   private selectedValue_: number | null = null;
   private policy_: ImageSourcePolicy;
   private chunkStoreView_?: ChunkStoreView;
@@ -254,7 +254,7 @@ export class LabelLayer extends Layer {
     return { world, value };
   }
 
-  public get colorMap(): ValidatedLabelColorMap {
+  public get colorMap(): LabelColorMap {
     return this.colorMap_;
   }
 

--- a/src/objects/renderable/label_image_renderable.ts
+++ b/src/objects/renderable/label_image_renderable.ts
@@ -37,14 +37,14 @@ export type LabelColorMapProps = {
   cycle?: ReadonlyArray<ColorLike>;
 };
 
-export type ValidatedLabelColorMap = {
-  lookupTable: ReadonlyMap<number, Color>;
-  cycle: ReadonlyArray<Color>;
+export type LabelColorMap = {
+  readonly lookupTable: ReadonlyMap<number, Color>;
+  readonly cycle: ReadonlyArray<Color>;
 };
 
 export function validateColorMap(
   props: LabelColorMapProps = {}
-): ValidatedLabelColorMap {
+): LabelColorMap {
   return {
     lookupTable: validateLookupTable(props.lookupTable),
     cycle: validateCycle(props.cycle),

--- a/src/objects/renderable/label_image_renderable.ts
+++ b/src/objects/renderable/label_image_renderable.ts
@@ -34,24 +34,28 @@ function validateCycle(cycle?: ReadonlyArray<ColorLike>): ReadonlyArray<Color> {
 
 export type LabelColorMapProps = {
   lookupTable?: ReadonlyMap<number, ColorLike>;
-  cycle?: ColorLike[];
+  cycle?: ReadonlyArray<ColorLike>;
 };
 
-export class LabelColorMap {
-  public readonly lookupTable: ReadonlyMap<number, Color>;
-  public readonly cycle: ReadonlyArray<Color>;
+export type ValidatedLabelColorMap = {
+  lookupTable: ReadonlyMap<number, Color>;
+  cycle: ReadonlyArray<Color>;
+};
 
-  constructor(props: LabelColorMapProps = {}) {
-    this.lookupTable = validateLookupTable(props.lookupTable);
-    this.cycle = validateCycle(props.cycle);
-  }
+export function validateColorMap(
+  props: LabelColorMapProps = {}
+): ValidatedLabelColorMap {
+  return {
+    lookupTable: validateLookupTable(props.lookupTable),
+    cycle: validateCycle(props.cycle),
+  };
 }
 
 type LabelImageRenderableProps = {
   width: number;
   height: number;
   imageData: Texture;
-  colorMap: LabelColorMap;
+  colorMap: LabelColorMapProps;
   outlineSelected?: boolean;
   selectedValue?: number | null;
 };
@@ -95,12 +99,9 @@ export class LabelImageRenderable extends RenderableObject {
     super();
     this.geometry = new PlaneGeometry(props.width, props.height, 1, 1);
     this.setTexture(0, validateImageData(props.imageData));
-    const colorCycleTexture = this.makeColorCycleTexture(props.colorMap.cycle);
-    this.setTexture(1, colorCycleTexture);
-    const colorLookupTableTexture = this.makeColorLookupTableTexture(
-      props.colorMap.lookupTable
-    );
-    this.setTexture(2, colorLookupTableTexture);
+    const colorMap = validateColorMap(props.colorMap);
+    this.setTexture(1, this.makeColorCycleTexture(colorMap.cycle));
+    this.setTexture(2, this.makeColorLookupTableTexture(colorMap.lookupTable));
     this.outlineSelected_ = props.outlineSelected ?? false;
     this.selectedValue_ = props.selectedValue ?? null;
     this.programName = labelTextureToShader(props.imageData);
@@ -121,11 +122,12 @@ export class LabelImageRenderable extends RenderableObject {
     };
   }
 
-  public setColorMap(colorMap: LabelColorMap) {
+  public setColorMap(colorMap: LabelColorMapProps) {
+    const validated = validateColorMap(colorMap);
     this.markStaleTexture(this.textures[1]);
     this.markStaleTexture(this.textures[2]);
-    this.setTexture(1, this.makeColorCycleTexture(colorMap.cycle));
-    this.setTexture(2, this.makeColorLookupTableTexture(colorMap.lookupTable));
+    this.setTexture(1, this.makeColorCycleTexture(validated.cycle));
+    this.setTexture(2, this.makeColorLookupTableTexture(validated.lookupTable));
   }
 
   public setSelectedValue(value: number | null) {


### PR DESCRIPTION
### Summary

this PR removes the `LabelColorMap` class from the public API. color maps are
now plain `LabelColorMapProps` objects validated internally, following the
same pattern as channel props. `LabelLayer` still validates eagerly at
construction, and its `colorMap` getter returns the validated shape.

### Tests & Checks

- all checks have passed