### PR TITLE
fix: restore appearance and color of debug wireframes

### DIFF
--- a/src/renderers/shaders/wireframe_frag.glsl
+++ b/src/renderers/shaders/wireframe_frag.glsl
@@ -5,8 +5,8 @@ precision mediump float;
 layout (location = 0) out vec4 fragColor;
 
 uniform float u_opacity;
-uniform vec3 u_color;
+uniform vec3 u_wireframeColor;
 
 void main() {
-    fragColor = vec4(u_color, u_opacity);
+    fragColor = vec4(u_wireframeColor, u_opacity);
 }

--- a/src/renderers/webgl_renderer.ts
+++ b/src/renderers/webgl_renderer.ts
@@ -197,9 +197,17 @@ export class WebGLRenderer extends Renderer {
     this.drawGeometry(object.geometry, object, layer, program, camera);
 
     if (object.wireframeEnabled) {
+      const stencilTestEnabled = this.state_.stencilTestEnabled;
+      const blendingMode = this.state_.blendingMode;
+      this.state_.setStencilTest(false);
+      this.state_.setBlendingMode("none");
+
       this.bindings_.bindGeometry(object.wireframeGeometry);
       const wireframeProgram = this.programs_.use("wireframe");
-      wireframeProgram.setUniform("u_color", object.wireframeColor.rgb);
+      wireframeProgram.setUniform(
+        "u_wireframeColor",
+        object.wireframeColor.rgb
+      );
       this.drawGeometry(
         object.wireframeGeometry,
         object,
@@ -207,6 +215,9 @@ export class WebGLRenderer extends Renderer {
         wireframeProgram,
         camera
       );
+
+      if (blendingMode !== null) this.state_.setBlendingMode(blendingMode);
+      this.state_.setStencilTest(stencilTestEnabled);
     }
   }
 

--- a/src/renderers/webgl_state.ts
+++ b/src/renderers/webgl_state.ts
@@ -78,6 +78,14 @@ export class WebGLState {
     }
   }
 
+  public get stencilTestEnabled(): boolean {
+    return this.enabledCapabilities_.get(this.gl_.STENCIL_TEST) ?? false;
+  }
+
+  public get blendingMode(): BlendingMode | null {
+    return this.currentBlendingMode_;
+  }
+
   public setBlendingMode(mode: BlendingMode) {
     if (this.currentBlendingMode_ === mode) return;
 


### PR DESCRIPTION
### Summary
Wireframes have been partially broken for a while. The diagonal is rejected by the LOD stenciling, and the color (meant to indicate LOD) is clobbered by the channel color. This restores both.

### Related Issue
Closes N/A

### Tests & Checks
#### `main`
<img width="1257" height="1131" alt="Screenshot 2026-08-25 at 10 12 10 AM" src="https://github.com/user-attachments/assets/a05607b1-2077-4085-bad9-00310ad1f16c" />

#### this PR
<img width="1279" height="1149" alt="Screenshot 2026-08-25 at 10 11 57 AM" src="https://github.com/user-attachments/assets/c85e0d3d-95e2-4ebe-a61b-f60671945c6d" />
