### PR TITLE
feat: add an orthographic/perspective toggle to the `image_2d` example

### DIFF
--- a/examples/image_2d/main.ts
+++ b/examples/image_2d/main.ts
@@ -3,8 +3,10 @@ import {
   Idetik,
   ImageLayer,
   OmeZarrImageSource,
+  OrbitControls,
   OrthographicCamera,
   PanZoomControls,
+  PerspectiveCamera,
   SliceCoordinates,
   createExplorationPolicy,
   createPlaybackPolicy,
@@ -12,6 +14,7 @@ import {
 import { ScaleBar } from "./scale_bar";
 import { addDimensionSlider } from "../lil_gui_utils";
 import GUI from "lil-gui";
+import { vec3 } from "gl-matrix";
 
 // A 2D OME-Zarr image viewer with a dataset selector. Pre-populated with
 // public datasets covering both Zarr v2 (OME-Zarr 0.4) and Zarr v3 (OME-Zarr
@@ -138,12 +141,51 @@ const imageLayer = new ImageLayer({
   channelProps,
 });
 
-const camera = new OrthographicCamera({
-  left: xLod.translation,
-  right: xLod.translation + xLod.scale * xLod.size,
-  top: yLod.translation,
-  bottom: yLod.translation + yLod.scale * yLod.size,
-});
+const xMin = xLod.translation;
+const xMax = xLod.translation + xLod.scale * xLod.size;
+const yMin = yLod.translation;
+const yMax = yLod.translation + yLod.scale * yLod.size;
+
+const FOV_DEGREES = 60;
+const orbitRadius =
+  (yMax - yMin) / 2 / Math.tan((FOV_DEGREES * Math.PI) / 180 / 2);
+const orbitTarget = vec3.fromValues(
+  (xMin + xMax) / 2,
+  (yMin + yMax) / 2,
+  sliceCoords.z ?? 0
+);
+
+type Projection = "orthographic" | "perspective";
+
+const layers = [imageLayer];
+
+function makeViewportProps(projection: Projection) {
+  if (projection === "orthographic") {
+    const camera = new OrthographicCamera({
+      left: xMin,
+      right: xMax,
+      top: yMin,
+      bottom: yMax,
+    });
+    return { camera, cameraControls: new PanZoomControls(camera), layers };
+  }
+
+  const camera = new PerspectiveCamera({
+    fov: FOV_DEGREES,
+    near: orbitRadius / 100,
+    far: orbitRadius * 10,
+  });
+  return {
+    camera,
+    cameraControls: new OrbitControls(camera, {
+      radius: orbitRadius,
+      yaw: 0,
+      pitch: 0,
+      target: orbitTarget,
+    }),
+    layers,
+  };
+}
 
 const timePointDiv = document.querySelector<HTMLDivElement>("#time-point")!;
 if (!tLod) timePointDiv.style.display = "none";
@@ -155,6 +197,7 @@ const timePointOverlay = {
 };
 
 const scaleBar = new ScaleBar({
+  boxDiv: document.querySelector<HTMLDivElement>("#scale-bar-box")!,
   textDiv: document.querySelector<HTMLDivElement>("#scale-bar-text")!,
   lineDiv: document.querySelector<HTMLDivElement>("#scale-bar-line")!,
   unit: dimensions.x.unit ?? "",
@@ -162,13 +205,7 @@ const scaleBar = new ScaleBar({
 
 const idetik = new Idetik({
   canvas: document.querySelector<HTMLCanvasElement>("#canvas")!,
-  viewports: [
-    {
-      camera,
-      cameraControls: new PanZoomControls(camera),
-      layers: [imageLayer],
-    },
-  ],
+  viewports: [makeViewportProps("orthographic")],
   overlays: [timePointOverlay, scaleBar],
   showStats: true,
 });
@@ -286,6 +323,18 @@ function updateChannel() {
 }
 
 const debugFolder = gui.addFolder("Debug");
+
+const projectionState = { projection: "orthographic" as Projection };
+debugFolder
+  .add(projectionState, "projection", ["orthographic", "perspective"])
+  .name("Projection")
+  .onChange((projection: Projection) => {
+    const current = idetik.viewports[0];
+    current.removeAllLayers();
+    idetik.removeViewport(current);
+    idetik.addViewport(makeViewportProps(projection));
+  });
+
 const debugState = { showWireframes: imageLayer.debugMode };
 debugFolder
   .add(debugState, "showWireframes")

--- a/examples/image_2d/scale_bar.ts
+++ b/examples/image_2d/scale_bar.ts
@@ -1,17 +1,20 @@
 import { Idetik, OrthographicCamera } from "@";
 
 type ScaleBarProps = {
+  boxDiv: HTMLDivElement;
   textDiv: HTMLDivElement;
   lineDiv: HTMLDivElement;
   unit?: string;
 };
 
 export class ScaleBar {
+  private boxDiv_: HTMLDivElement;
   private textDiv_: HTMLDivElement;
   private lineDiv_: HTMLDivElement;
   private unit_: string;
 
   constructor(props: ScaleBarProps) {
+    this.boxDiv_ = props.boxDiv;
     this.textDiv_ = props.textDiv;
     this.lineDiv_ = props.lineDiv;
     this.unit_ = props.unit ?? "";
@@ -20,10 +23,11 @@ export class ScaleBar {
   public update(idetik: Idetik, _timestamp?: DOMHighResTimeStamp): void {
     const viewport = idetik.viewports[0];
     const camera = viewport.camera;
-    if (camera.type !== "OrthographicCamera") {
-      console.error("ScaleBar can only be used with OrthographicCamera");
-      return;
-    }
+
+    const isOrthographic = camera.type === "OrthographicCamera";
+    this.boxDiv_.style.display = isOrthographic ? "" : "none";
+    if (!isOrthographic) return;
+
     const orthoCamera = camera as OrthographicCamera;
 
     const cameraWidthWorld =


### PR DESCRIPTION
### Summary
This adds a toggle to the `image_2d` example to swap between orthographic and perspective cameras. This allows us to more easily explore the chunk visibility and LOD selection behavior under the different projection conditions.

### Related Issue
Closes N/A

### Tests & Checks

https://github.com/user-attachments/assets/2cfa187e-dd80-485f-a0cb-b49c4782fcd0

