### PR TITLE
docs: render two-column member tables in the API theme

### DIFF
--- a/.vitepress/theme/custom.css
+++ b/.vitepress/theme/custom.css
@@ -73,6 +73,10 @@
   margin: 28px 0;
 }
 
+.vp-doc div[class*='language-'] code {
+  font-size: 13px;
+}
+
 .vp-doc table {
   display: table;
   width: 100%;
@@ -83,6 +87,17 @@
   white-space: nowrap;
   width: 1%;
   max-width: 40%;
+}
+
+.api .vp-doc table td:first-child {
+  font-family: var(--vp-font-family-mono);
+  font-size: var(--vp-code-font-size);
+}
+
+.api .vp-doc table td:first-child code {
+  background: none;
+  border-radius: 0;
+  padding: 0;
 }
 
 .api .vp-doc table :is(th, td):last-child {

--- a/.vitepress/typedoc/companion-types.mjs
+++ b/.vitepress/typedoc/companion-types.mjs
@@ -1,4 +1,5 @@
 import { ReflectionKind } from "typedoc";
+import { foldedPropertiesTable } from "./member-tables.mjs";
 import { MemberRouter } from "typedoc-plugin-markdown";
 
 export function collectDeclarationFiles(project) {
@@ -9,6 +10,15 @@ export function collectDeclarationFiles(project) {
   }
   return files;
 }
+
+const ADOPTED_ALIASES = {
+  Overlay: "Idetik",
+  MemoryStats: "Idetik",
+  QueueStats: "Idetik",
+  ChannelProps: "Layer",
+  SliceCoordinates: "Layer",
+  SliceOrientation: "Layer",
+};
 
 export function foldCompanionAliasesIntoOwnerClasses(
   project,
@@ -27,8 +37,11 @@ export function foldCompanionAliasesIntoOwnerClasses(
       (c) => c.kind === ReflectionKind.TypeAlias
     );
     for (const alias of aliases) {
-      const owner = companionOwnerOf(alias, classes, declarationFiles);
+      const owner =
+        companionOwnerOf(alias, classes, declarationFiles) ??
+        classes.find((cls) => cls.name === ADOPTED_ALIASES[alias.name]);
       if (!owner) continue;
+
       dropModuleGroupTag(alias);
       moveChildReflection(alias, container, owner);
     }
@@ -65,6 +78,7 @@ function moveChildReflection(child, from, to) {
   from.childrenIncludingDocuments = from.childrenIncludingDocuments?.filter(
     (c) => c !== child
   );
+
   child.parent = to;
   to.children = [...(to.children ?? []), child];
   to.childrenIncludingDocuments = [
@@ -94,6 +108,20 @@ export class FoldedAliasRouter extends MemberRouter {
   }
 }
 
+export function foldedAliasDescriptionAndCode(context, model, opts) {
+  const blocks = [];
+  if (model.comment) {
+    blocks.push(
+      context.partials.comment(model.comment, {
+        headingLevel: opts.headingLevel,
+      })
+    );
+  }
+
+  blocks.push(context.partials.declarationTitle(model));
+  return blocks.join("\n\n");
+}
+
 export function foldedAliasDescriptionAndProperties(context, model, opts) {
   const blocks = [];
   if (model.comment) {
@@ -106,8 +134,10 @@ export function foldedAliasDescriptionAndProperties(context, model, opts) {
   const properties = (model.children ?? []).filter((child) =>
     child.isDeclaration()
   );
+
   if (properties.length) {
-    blocks.push(context.partials.propertiesTable(properties));
+    blocks.push(foldedPropertiesTable(context, properties));
   }
+
   return blocks.join("\n\n");
 }

--- a/.vitepress/typedoc/member-tables.mjs
+++ b/.vitepress/typedoc/member-tables.mjs
@@ -1,0 +1,89 @@
+import { ReflectionType } from "typedoc";
+
+const DESTRUCTURED_DEFAULT = "...";
+
+const twoColumnTable = (nameHeader, rows) =>
+  [`| ${nameHeader} | Description |`, "| ------ | ------ |", ...rows].join(
+    "\n"
+  );
+
+const memberCell = (name, isOptional, type) =>
+  `\`${name}${isOptional ? "?" : ""}\`: ${type}`;
+
+const singleLine = (text) => text.replaceAll("\n", " ");
+
+export function foldedPropertiesTable(context, properties) {
+  const rows = context.helpers
+    .getFlattenedDeclarations(properties)
+    .map((property) => {
+      const anchor = context.router.hasUrl(property)
+        ? `<a id="${context.router.getAnchor(property)}"></a> `
+        : "";
+
+      const type = singleLine(context.partials.someType(property.type));
+
+      const description = property.comment
+        ? singleLine(
+            context.partials.comment(property.comment, { isTableColumn: true })
+          )
+        : "";
+
+      const cell = memberCell(property.name, property.flags?.isOptional, type);
+      return `| ${anchor}${cell} | ${description} |`;
+    });
+
+  return twoColumnTable("Property", rows);
+}
+
+export function twoColumnParametersTable(context, model) {
+  const firstOptionalIndex = model.findIndex((p) => p.flags.isOptional);
+
+  const rows = model.flatMap((parameter, index) =>
+    parameterRows(
+      context,
+      parameter,
+      firstOptionalIndex !== -1 && index > firstOptionalIndex
+    )
+  );
+
+  return twoColumnTable("Parameter", rows);
+}
+
+function parameterRows(context, parameter, cascadeOptional, namePrefix = "") {
+  const name = namePrefix ? `${namePrefix}.${parameter.name}` : parameter.name;
+  const isOptional = parameter.flags?.isOptional || cascadeOptional;
+  const rest = parameter.flags?.isRest ? "..." : "";
+
+  const type = parameter.type
+    ? singleLine(
+        parameter.type instanceof ReflectionType
+          ? context.partials.reflectionType(parameter.type, {
+              forceCollapse: true,
+            })
+          : context.partials.someType(parameter.type)
+      )
+    : "";
+
+  let description = parameter.comment
+    ? singleLine(
+        context.partials.comment(parameter.comment, { isTableColumn: true })
+      ).trim()
+    : "";
+  if (
+    parameter.defaultValue &&
+    parameter.defaultValue !== DESTRUCTURED_DEFAULT
+  ) {
+    description =
+      `${description} Defaults to \`${parameter.defaultValue}\`.`.trim();
+  }
+
+  const row = `| ${rest}${memberCell(name, isOptional, type)} | ${description} |`;
+  const children = parameter.type?.declaration?.children ?? [];
+
+  return [
+    row,
+    ...children.flatMap((child) =>
+      parameterRows(context, child, cascadeOptional, name)
+    ),
+  ];
+}

--- a/.vitepress/typedoc/theme.mjs
+++ b/.vitepress/typedoc/theme.mjs
@@ -1,9 +1,11 @@
 import { ReflectionKind } from "typedoc";
 import { MarkdownTheme, MarkdownThemeContext } from "typedoc-plugin-markdown";
 import {
+  foldedAliasDescriptionAndCode,
   foldedAliasDescriptionAndProperties,
   isFoldedAlias,
 } from "./companion-types.mjs";
+import { twoColumnParametersTable } from "./member-tables.mjs";
 
 export class IdetikTheme extends MarkdownTheme {
   getRenderContext(page) {
@@ -25,6 +27,11 @@ class IdetikThemeContext extends MarkdownThemeContext {
         isFoldedAlias(model)
           ? foldedAliasDescriptionAndProperties(this, model, opts)
           : base.memberWithGroups(model, opts),
+      declaration: (model, opts) =>
+        isFoldedAlias(model)
+          ? foldedAliasDescriptionAndCode(this, model, opts)
+          : base.declaration(model, opts),
+      parametersTable: (model) => twoColumnParametersTable(this, model),
       members: (model, opts) =>
         membersWithoutHorizontalRules(this, model, opts),
       constructor: (model, opts) =>
@@ -96,13 +103,16 @@ function memberWithDecoratedHeading(context, model, opts) {
 function decoratedHeadingWithPinnedAnchor(context, model) {
   const signature = model.signatures?.[0] ?? model.getSignature;
   const parts = [context.partials.memberTitle(model)];
+
   const returnType = returnTypeForHeading(context, signature);
   if (returnType) {
     parts.push(`<span class="return-type">${returnType}</span>`);
   }
+
   if (model.overwrites || signature?.overwrites) {
     parts.push(`<Badge type="info" text="overrides" />`);
   }
+
   const anchor = context.router.hasUrl(model)
     ? context.router.getAnchor(model)
     : undefined;
@@ -133,6 +143,7 @@ function signatureWithDescriptionFirst(context, model, opts) {
   const comment = opts.multipleSignatures
     ? model.comment
     : model.comment || model.parent?.comment;
+
   const description =
     comment &&
     context.partials.comment(comment, {
@@ -140,12 +151,15 @@ function signatureWithDescriptionFirst(context, model, opts) {
       showTags: false,
       showSummary: true,
     });
+
   const codeBlock =
     !opts.hideTitle &&
     context.partials.signatureTitle(model, { accessor: opts.accessor });
+
   const hasTypeParameters =
     model.typeParameters?.length &&
     model.kind !== ReflectionKind.ConstructorSignature;
+
   const remainingTags =
     comment &&
     context.partials.comment(comment, {
@@ -153,6 +167,7 @@ function signatureWithDescriptionFirst(context, model, opts) {
       showTags: true,
       showSummary: false,
     });
+
   return [
     description,
     codeBlock,


### PR DESCRIPTION
### Summary

this PR refines how the API reference renders types and parameters:

- property and parameter tables are two columns: the first cell merges the
  member name with its type (links preserved) the second holds the
  description. parameter defaults are appended to the description.
- type aliases folded into a class page now render description first, code
  second, matching every other member
- the plugin gains an ownership map (`ADOPTED_ALIASES`) that folds types into
  a class page across source files.

### Tests & Checks

- all checks have passed
- visual verification (member tables are rendering correctly)

<img width="1481" height="1017" alt="Screenshot 2026-08-31 at 1 18 37 PM" src="https://github.com/user-attachments/assets/ac0ed15c-f794-45df-a1e5-ce988a1117a7" />

