### PR TITLE
docs: document loading policies on a synthetic topic page

### DIFF
--- a/.vitepress/typedoc/companion-types.mjs
+++ b/.vitepress/typedoc/companion-types.mjs
@@ -29,7 +29,11 @@ const ADOPTED_ALIASES = {
   SourceDimensionMap: "OmeZarrImageSource",
   SourceDimension: "OmeZarrImageSource",
   SourceDimensionLod: "OmeZarrImageSource",
+  ImageSourcePolicy: "LoadingPolicies",
+  PriorityCategory: "LoadingPolicies",
 };
+
+const OWNER_KINDS = ReflectionKind.Class | ReflectionKind.Namespace;
 
 export function foldCompanionAliasesIntoOwnerClasses(
   project,
@@ -43,14 +47,14 @@ export function foldCompanionAliasesIntoOwnerClasses(
   ];
   for (const container of containers) {
     const children = container.children ?? [];
-    const classes = children.filter((c) => c.kind === ReflectionKind.Class);
+    const owners = children.filter((c) => c.kindOf(OWNER_KINDS));
     const aliases = children.filter(
       (c) => c.kind === ReflectionKind.TypeAlias
     );
     for (const alias of aliases) {
       const owner =
-        companionOwnerOf(alias, classes, declarationFiles) ??
-        classes.find((cls) => cls.name === ADOPTED_ALIASES[alias.name]);
+        companionOwnerOf(alias, owners, declarationFiles) ??
+        owners.find((cls) => cls.name === ADOPTED_ALIASES[alias.name]);
       if (!owner) continue;
 
       dropModuleGroupTag(alias);
@@ -84,7 +88,7 @@ function dropModuleGroupTag(alias) {
   );
 }
 
-function moveChildReflection(child, from, to) {
+export function moveChildReflection(child, from, to) {
   from.children = from.children.filter((c) => c !== child);
   from.childrenIncludingDocuments = from.childrenIncludingDocuments?.filter(
     (c) => c !== child
@@ -101,11 +105,21 @@ function moveChildReflection(child, from, to) {
 export function isFoldedAlias(reflection) {
   return (
     reflection.kind === ReflectionKind.TypeAlias &&
-    reflection.parent?.kind === ReflectionKind.Class
+    Boolean(reflection.parent?.kindOf(OWNER_KINDS))
   );
 }
 
 export class FoldedAliasRouter extends MemberRouter {
+  getIdealBaseName(reflection) {
+    if (
+      reflection.kind === ReflectionKind.Namespace &&
+      reflection.parent?.isProject()
+    ) {
+      return `${this.directories.get(reflection.kind)}/${this.getReflectionAlias(reflection)}`;
+    }
+    return super.getIdealBaseName(reflection);
+  }
+
   buildChildPages(reflection, outPages) {
     if (isFoldedAlias(reflection)) {
       this.buildAnchors(reflection, reflection.parent);

--- a/.vitepress/typedoc/index.mjs
+++ b/.vitepress/typedoc/index.mjs
@@ -16,6 +16,7 @@ import {
   renameGroupsToDisplayTitles,
   stripSourcesToSuppressDefinedIn,
 } from "./project-transforms.mjs";
+import { createTopicPages } from "./topic-pages.mjs";
 import { IdetikTheme } from "./theme.mjs";
 
 const UNRENDERED_TAGS = ["@see", "@throws"];
@@ -36,6 +37,7 @@ export function load(app) {
     const declarationFiles = collectDeclarationFiles(project);
     removeImplicitConstructors(project, declarationFiles);
     stripSourcesToSuppressDefinedIn(project);
+    createTopicPages(project);
     foldCompanionAliasesIntoOwnerClasses(project, declarationFiles);
   });
 

--- a/.vitepress/typedoc/project-transforms.mjs
+++ b/.vitepress/typedoc/project-transforms.mjs
@@ -45,8 +45,9 @@ export function stripSourcesToSuppressDefinedIn(project) {
 }
 
 export function renameGroupsToDisplayTitles(project) {
+  const kinds = ReflectionKind.Class | ReflectionKind.Namespace;
   for (const reflection of Object.values(project.reflections)) {
-    if (reflection.kind !== ReflectionKind.Class) continue;
+    if (!reflection.kindOf(kinds)) continue;
     for (const group of reflection.groups ?? []) {
       group.title = DISPLAY_TITLE_BY_TYPEDOC_GROUP[group.title] ?? group.title;
     }

--- a/.vitepress/typedoc/topic-pages.mjs
+++ b/.vitepress/typedoc/topic-pages.mjs
@@ -1,0 +1,60 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  Comment,
+  CommentTag,
+  DeclarationReflection,
+  ReflectionKind,
+} from "typedoc";
+import { moveChildReflection } from "./companion-types.mjs";
+
+const TOPIC_PAGES_DIR = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "topic-pages"
+);
+
+const TOPIC_PAGES = [
+  {
+    name: "LoadingPolicies",
+    group: "Data Loading",
+    introFile: "loading_policies.md",
+    members: [
+      "createExplorationPolicy",
+      "createPlaybackPolicy",
+      "createNoPrefetchPolicy",
+      "createImageSourcePolicy",
+    ],
+  },
+];
+
+export function createTopicPages(project) {
+  for (const topic of TOPIC_PAGES) {
+    const intro = readFileSync(
+      join(TOPIC_PAGES_DIR, topic.introFile),
+      "utf8"
+    ).trim();
+
+    const page = new DeclarationReflection(
+      topic.name,
+      ReflectionKind.Namespace,
+      project
+    );
+    page.comment = new Comment(
+      [{ kind: "text", text: intro }],
+      [new CommentTag("@group", [{ kind: "text", text: topic.group }])]
+    );
+
+    project.registerReflection(page, undefined, undefined);
+    project.children = [...(project.children ?? []), page];
+    project.childrenIncludingDocuments = [
+      ...(project.childrenIncludingDocuments ?? []),
+      page,
+    ];
+
+    for (const name of topic.members) {
+      const member = project.children.find((child) => child.name === name);
+      if (member) moveChildReflection(member, project, page);
+    }
+  }
+}

--- a/.vitepress/typedoc/topic-pages/loading_policies.md
+++ b/.vitepress/typedoc/topic-pages/loading_policies.md
@@ -1,0 +1,15 @@
+Factory functions for creating chunk loading policies.
+
+A loading policy controls how layers load image data: how far to
+prefetch beyond the visible region, the order in which chunk requests
+are served, and which levels of detail can load. Every image, label,
+and volume layer takes an optional `policy` at construction and
+defaults to an exploration policy.
+
+```ts
+const layer = new ImageLayer({
+  source,
+  sliceCoords: { z: 0, t: 0, c: undefined },
+  policy: createPlaybackPolicy(),
+});
+```

--- a/src/core/image_source_policy.ts
+++ b/src/core/image_source_policy.ts
@@ -1,13 +1,24 @@
+/**
+ * A category of chunk request ordered by a loading policy.
+ */
+export type PriorityCategory =
+  | "fallbackVisible"
+  | "prefetchTime"
+  | "visibleCurrent"
+  | "fallbackBackground"
+  | "prefetchSpace";
+
 const ALL_CATEGORIES = [
   "fallbackVisible",
   "prefetchTime",
   "visibleCurrent",
   "fallbackBackground",
   "prefetchSpace",
-] as const;
+] as const satisfies readonly PriorityCategory[];
 
-export type PriorityCategory = (typeof ALL_CATEGORIES)[number];
-
+/**
+ * @hidden
+ */
 export type ImageSourcePolicyProps = {
   profile?: string;
   prefetch: {
@@ -24,24 +35,126 @@ export type ImageSourcePolicyProps = {
   };
 };
 
+/**
+ * A resolved and frozen loading policy consumed by layers.
+ *
+ * Create instances with {@link createExplorationPolicy},
+ * {@link createPlaybackPolicy}, {@link createNoPrefetchPolicy}, or
+ * {@link createImageSourcePolicy} rather than by hand.
+ */
 export type ImageSourcePolicy = Readonly<{
+  /** Names the policy in logs and stats. */
   profile: string;
+  /** How far to prefetch beyond the visible region per axis. */
   prefetch: {
+    /** Chunks to prefetch along x. */
     x: number;
+    /** Chunks to prefetch along y. */
     y: number;
+    /** Chunks to prefetch along z. */
     z: number;
+    /** Timepoints to prefetch ahead. */
     t: number;
   };
+  /** Request categories from highest to lowest priority. */
   priorityOrder: readonly PriorityCategory[];
+  /** Priority index per category derived from `priorityOrder`. */
   priorityMap: Readonly<Record<PriorityCategory, number>>;
+  /** Bounds and bias for level of detail selection. */
   lod: {
+    /** Finest level allowed to load. */
     min: number;
+    /** Coarsest level allowed to load. */
     max: number;
+    /** Shifts level selection coarser as it grows. */
     bias: number;
   };
 }>;
 
-/** @hidden */
+/**
+ * Creates a loading policy tuned for interactively browsing a scene.
+ *
+ * Prefetches one chunk beyond the view along each spatial axis and
+ * fills the visible region before prefetching. This is the default
+ * policy for layers constructed without one.
+ *
+ * @param overrides - Properties merged over.
+ */
+export function createExplorationPolicy(
+  overrides: Partial<ImageSourcePolicyProps> = {}
+): ImageSourcePolicy {
+  const base: ImageSourcePolicyProps = {
+    profile: "exploration",
+    prefetch: { x: 1, y: 1, z: 1, t: 0 },
+    priorityOrder: [
+      "fallbackVisible",
+      "visibleCurrent",
+      "prefetchSpace",
+      "prefetchTime",
+      "fallbackBackground",
+    ],
+  };
+  return createImageSourcePolicy(mergeProps(base, overrides));
+}
+
+/**
+ * Creates a loading policy tuned for playing through timepoints.
+ *
+ * Prefetches twenty timepoints ahead and prioritizes time prefetch over
+ * refining the current view, keeping playback smooth at the cost of
+ * sharpness while frames advance.
+ *
+ * @param overrides - Properties merged over.
+ */
+export function createPlaybackPolicy(
+  overrides: Partial<ImageSourcePolicyProps> = {}
+): ImageSourcePolicy {
+  const base: ImageSourcePolicyProps = {
+    profile: "playback",
+    prefetch: { x: 0, y: 0, z: 0, t: 20 },
+    priorityOrder: [
+      "fallbackVisible",
+      "prefetchTime",
+      "visibleCurrent",
+      "fallbackBackground",
+      "prefetchSpace",
+    ],
+  };
+  return createImageSourcePolicy(mergeProps(base, overrides));
+}
+
+/**
+ * Creates a loading policy that loads only visible chunks.
+ *
+ * No spatial or temporal prefetching happens, which minimizes memory
+ * use and network traffic for static scenes.
+ *
+ * @param overrides - Properties merged over.
+ */
+export function createNoPrefetchPolicy(
+  overrides: Partial<ImageSourcePolicyProps> = {}
+): ImageSourcePolicy {
+  const base: ImageSourcePolicyProps = {
+    profile: "no-prefetch",
+    prefetch: { x: 0, y: 0, z: 0, t: 0 },
+    priorityOrder: [
+      "fallbackVisible",
+      "visibleCurrent",
+      "fallbackBackground",
+      "prefetchSpace",
+      "prefetchTime",
+    ],
+  };
+  return createImageSourcePolicy(mergeProps(base, overrides));
+}
+
+/**
+ * Creates a loading policy from explicit properties, validating and
+ * freezing them. Prefer the profile factories for common cases and use
+ * this to build a policy from scratch.
+ *
+ * @param config - Initialization properties.
+ */
 export function createImageSourcePolicy(
   config: ImageSourcePolicyProps
 ): ImageSourcePolicy {
@@ -80,60 +193,6 @@ export function createImageSourcePolicy(
   };
 
   return Object.freeze(resolved);
-}
-
-/** @hidden */
-export function createExplorationPolicy(
-  overrides: Partial<ImageSourcePolicyProps> = {}
-): ImageSourcePolicy {
-  const base: ImageSourcePolicyProps = {
-    profile: "exploration",
-    prefetch: { x: 1, y: 1, z: 1, t: 0 },
-    priorityOrder: [
-      "fallbackVisible",
-      "visibleCurrent",
-      "prefetchSpace",
-      "prefetchTime",
-      "fallbackBackground",
-    ],
-  };
-  return createImageSourcePolicy(mergeProps(base, overrides));
-}
-
-/** @hidden */
-export function createPlaybackPolicy(
-  overrides: Partial<ImageSourcePolicyProps> = {}
-): ImageSourcePolicy {
-  const base: ImageSourcePolicyProps = {
-    profile: "playback",
-    prefetch: { x: 0, y: 0, z: 0, t: 20 },
-    priorityOrder: [
-      "fallbackVisible",
-      "prefetchTime",
-      "visibleCurrent",
-      "fallbackBackground",
-      "prefetchSpace",
-    ],
-  };
-  return createImageSourcePolicy(mergeProps(base, overrides));
-}
-
-/** @hidden */
-export function createNoPrefetchPolicy(
-  overrides: Partial<ImageSourcePolicyProps> = {}
-): ImageSourcePolicy {
-  const base: ImageSourcePolicyProps = {
-    profile: "no-prefetch",
-    prefetch: { x: 0, y: 0, z: 0, t: 0 },
-    priorityOrder: [
-      "fallbackVisible",
-      "visibleCurrent",
-      "fallbackBackground",
-      "prefetchSpace",
-      "prefetchTime",
-    ],
-  };
-  return createImageSourcePolicy(mergeProps(base, overrides));
 }
 
 function validatePolicyProps(config: ImageSourcePolicyProps) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,6 +69,12 @@ export {
   createPlaybackPolicy,
 } from "./core/image_source_policy";
 
+export type {
+  ImageSourcePolicy,
+  ImageSourcePolicyProps,
+  PriorityCategory,
+} from "./core/image_source_policy";
+
 export type { ChannelProps } from "./core/channel";
 export type { LayerState } from "./core/layer";
 export type { IdetikProps, MemoryStats, Overlay } from "./idetik";

--- a/typedoc.json
+++ b/typedoc.json
@@ -26,6 +26,7 @@
     "Renderables",
     "Constructors",
     "Type Aliases",
+    "Functions",
     "Properties",
     "Accessors",
     "Methods",
@@ -33,6 +34,7 @@
   ],
   "sort": ["source-order"],
   "router": "idetik",
+  "membersWithOwnFile": ["Enum", "Variable", "Class", "Interface", "TypeAlias"],
   "typeAliasPropertiesFormat": "table",
   "pageTitleTemplates": {
     "member": "{name}"


### PR DESCRIPTION
### Summary

this PR adds a loading policies page to the docsite. loading policies are free
factory functions so i had to create "topic pages" that can group related functions
into custom pages.

### Tests & Checks

- all checks have passed
- visual verification

<img width="1506" height="948" alt="Screenshot 2026-09-09 at 1 17 40 PM" src="https://github.com/user-attachments/assets/467a5388-2648-45bb-b8d8-76b883b551b8" />
